### PR TITLE
more idiomatic makefile, faster build

### DIFF
--- a/makefile
+++ b/makefile
@@ -10,17 +10,11 @@
 default: build
 
 install:
-	cd serviced && make install
+	go install github.com/serviced/serviced
 
 build:
-	go get github.com/zenoss/glog
-	go get github.com/samuel/go-zookeeper/zk
-	go get github.com/araddon/gou
-	go get github.com/mattbaird/elastigo
-	go build
-	cd web && make
-	cd dao && make
-	cd serviced && make
+	go get github.com/zenoss/serviced/serviced
+	cd serviced && go build
 
 pkgs:
 	cd pkg && make rpm && make deb
@@ -32,9 +26,9 @@ dockerbuild: docker_ok
 
 test: build docker_ok
 	go test
-	cd web && make test
-	cd dao && make test
-	cd serviced && make test
+	cd web && go test
+	cd dao && go test
+	cd serviced && go test
 
 docker_ok:
 	if docker ps >/dev/null; then \
@@ -45,9 +39,6 @@ docker_ok:
 	fi
 
 clean:
-	go clean
-	cd serviced && make clean
-	cd web && make clean
-	cd dao && make clean
-	cd pkg && make clean
+	go get github.com/zenoss/serviced/serviced # make sure dependencies exist
+	cd serviced && go clean -r # this cleans all dependencies
 


### PR DESCRIPTION
This makes the build faster and does automatic fetching of all dependencies and cleaning of all object files. 

...~/mygo/src/github.com/zenoss/serviced$ time make
go get github.com/zenoss/serviced/serviced
cd serviced && go build

real    0ms
user    0m1.164s
sys 0m0.228s

VS old make ---------------------------------------------------
.../mygo/src/github.com/zenoss/serviced$ time make
....

real    0m2.629s
user    0m2.140s
sys 0m0.448s
