### PR TITLE
use godep to make build predictable by locking third party dependencies

### DIFF
--- a/isvcs/consumer/makefile
+++ b/isvcs/consumer/makefile
@@ -7,7 +7,7 @@ default: tarball
 
 tarball:
 	@mkdir -p /opt/zenoss && mkdir -p /opt/zenoss/log && mkdir -p /opt/zenoss/etc/supervisor && mkdir /opt/zenoss/var
-	@wget -qO- http://zenpip.zendev.org/packages/metric-consumer-app-$(CONSUMER_VERSION)-zapp.tar.gz | tar -C /opt/zenoss -xz
+	@wget -qO- https://s3.amazonaws.com/pip.zenoss/packages/metric-consumer-app-$(CONSUMER_VERSION)-zapp.tar.gz | tar -C /opt/zenoss -xz
 	@chmod a+x /opt/zenoss/bin/metric-consumer-app.sh
 	@ln -s /opt/zenoss/etc/metric-consumer-app/metric-consumer-app_supervisor.conf /opt/zenoss/etc/supervisor
 	@sed -i 's/\(authEnabled:.*\)true/\1false/' /opt/zenoss/etc/metric-consumer-app/configuration.yaml

--- a/isvcs/query/makefile
+++ b/isvcs/query/makefile
@@ -7,7 +7,7 @@ default: tarball
 
 tarball:
 	mkdir /opt/zenoss && mkdir /opt/zenoss/log && mkdir -p /opt/zenoss/etc/supervisor && mkdir /opt/zenoss/var
-	wget -qO- http://zenpip.zendev.org/packages/central-query-$(QUERY_VERSION)-zapp.tar.gz | tar -C /opt/zenoss -xz
+	wget -qO- https://s3.amazonaws.com/pip.zenoss/packages/central-query-$(QUERY_VERSION)-zapp.tar.gz | tar -C /opt/zenoss -xz
 	chmod a+x /opt/zenoss/bin/central-query.sh
 	ln -s /opt/zenoss/etc/central-query/central-query_supervisor.conf /opt/zenoss/etc/supervisor
 	sed -i 's/\(authEnabled:.*\)true/\1false/' /opt/zenoss/etc/central-query/configuration.yaml

--- a/makefile
+++ b/makefile
@@ -17,8 +17,7 @@ install:
 	go install github.com/serviced/serviced
 
 build_binary:
-	go get github.com/zenoss/serviced/serviced
-	cd serviced && go build
+	cd serviced && ./godep restore && go build
 	cd isvcs && make
 	cd dao && make
 

--- a/serviced/Godeps
+++ b/serviced/Godeps
@@ -1,0 +1,57 @@
+{
+	"ImportPath": "github.com/zenoss/serviced/serviced",
+	"GoVersion": "go1.2",
+	"Deps": [
+		{
+			"ImportPath": "code.google.com/p/go.crypto/ssh/terminal",
+			"Comment": "null-187",
+			"Rev": "ebfe91cdc0348163deedb0e75d680c9305e4f1ff"
+		},
+		{
+			"ImportPath": "github.com/ant0ine/go-json-rest",
+			"Rev": "a6396a924a69ca86f6ea7c5318b2ce8f1da7d3a1"
+		},
+		{
+			"ImportPath": "github.com/araddon/gou",
+			"Rev": "60fd543d979a4ad532fafb8bc24426d4f48181c4"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient",
+			"Comment": "0.2.1-25-g08fe80a",
+			"Rev": "08fe80a1c0c8ef39e40c6b275564eb34b3589ef7"
+		},
+		{
+			"ImportPath": "github.com/gorilla/websocket",
+			"Rev": "92334662baa9cbebc2e6e68b8d56bc1233f85a4c"
+		},
+		{
+			"ImportPath": "github.com/mattbaird/elastigo/api",
+			"Rev": "041b88c1fcf6489a5721ede24378ce1253b9159d"
+		},
+		{
+			"ImportPath": "github.com/mattbaird/elastigo/cluster",
+			"Rev": "041b88c1fcf6489a5721ede24378ce1253b9159d"
+		},
+		{
+			"ImportPath": "github.com/mattbaird/elastigo/core",
+			"Rev": "041b88c1fcf6489a5721ede24378ce1253b9159d"
+		},
+		{
+			"ImportPath": "github.com/mattbaird/elastigo/search",
+			"Rev": "041b88c1fcf6489a5721ede24378ce1253b9159d"
+		},
+		{
+			"ImportPath": "github.com/samuel/go-zookeeper/zk",
+			"Rev": "897888e14f7bd6c1c9a70e2973d0f5fbdb28bde0"
+		},
+		{
+			"ImportPath": "github.com/zenoss/glog",
+			"Rev": "776492278b0bca8f9bad17bfdfd27b8e189c5d28"
+		},
+		{
+			"ImportPath": "github.com/zenoss/serviced",
+			"Comment": "0.1-602-gbe5294f",
+			"Rev": "be5294fabaf63a240b3423266329a0f7d95c6c6c"
+		}
+	]
+}

--- a/serviced/godep
+++ b/serviced/godep
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+if ! godep help > /dev/null 2>&1 ; then
+	go get github.com/kr/godep
+fi 
+godep "$@"

--- a/serviced/makefile
+++ b/serviced/makefile
@@ -13,8 +13,7 @@ install:
 	go install
 
 build:
-	go get github.com/ant0ine/go-json-rest
-	go get code.google.com/p/go.crypto/ssh/terminal
+	./godep restore
 	go build
 
 test: build


### PR DESCRIPTION
This pull request adds the use of godep:

https://github.com/kr/godep

This creates a file called serviced/Godep. Godep contains references to all the third party repositories and the versions associated with them. This file must be updated using the command: godep save -nocopy 
