### PR TITLE
mimic serviced/cmd.go for setting varPath; show rsync command

### DIFF
--- a/dao/elasticsearch/controlplanedao.go
+++ b/dao/elasticsearch/controlplanedao.go
@@ -1385,20 +1385,20 @@ func getSubvolume(vfs, poolId, tenantId string) (*volume.Volume, error) {
 	if err != nil {
 		return nil, err
 	}
-	glog.V(0).Infof("controlplanedao: Mounting vfs:%v tenantId:%v baseDir:%v\n", vfs, tenantId, baseDir)
+	glog.Infof("Mounting vfs:%v tenantId:%v baseDir:%v\n", vfs, tenantId, baseDir)
 	return volume.Mount(vfs, tenantId, baseDir)
 }
 
 func varPath() string {
 	if len(os.Getenv("SERVICED_HOME")) > 0 {
 		return path.Join(os.Getenv("SERVICED_HOME"), "var")
+	} else if user, err := user.Current(); err == nil {
+		return path.Join(os.TempDir(), "serviced-"+user.Username, "var")
 	} else {
-		if user, err := user.Current(); err == nil {
-			return path.Join(os.TempDir(), "serviced-"+user.Username, "var")
-		}
+		defaultPath := "/tmp/serviced/var"
+		glog.Warningf("Defaulting varPath to:%v\n", defaultPath)
+		return defaultPath
 	}
-
-	return "/tmp/serviced/var"
 }
 
 func (this *ControlPlaneDao) Snapshots(serviceId string, labels *[]string) error {

--- a/volume/rsync/rsync.go
+++ b/volume/rsync/rsync.go
@@ -72,7 +72,7 @@ func (c *RsyncConn) Snapshot(label string) (err error) {
 		return err
 	}
 	argv := []string{"-a", c.Path() + "/", dest + "/"}
-	glog.V(0).Infof("Performing snapshot rsync command: %s %s", exe, argv)
+	glog.Infof("Performing snapshot rsync command: %s %s", exe, argv)
 	rsync := exec.Command(exe, argv...)
 	if output, err := rsync.CombinedOutput(); err != nil {
 		glog.V(2).Infof("Could not perform rsync: %s", string(output))


### PR DESCRIPTION
test log:
  https://dev.zenoss.com/tracint/pastebin/5234
