### PR TITLE
moves SERVICED_HOME to /opt for serviced/supervisord for rpm hosts

### DIFF
--- a/pkg/serviced.service
+++ b/pkg/serviced.service
@@ -3,7 +3,7 @@ Description=Zenoss ServiceD
 
 [Service]
 EnvironmentFile=/etc/default/serviced
-ExecStart=/usr/local/serviced/bin/serviced -agent -master
+ExecStart=/opt/serviced/bin/serviced -agent -master
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/serviced.supervisord
+++ b/pkg/serviced.supervisord
@@ -1,5 +1,5 @@
 [program:serviced]
 command=bin/serviced -agent -master
-directory=/usr/local/serviced
+directory=/opt/serviced
 redirect_stderr=true
 environment=


### PR DESCRIPTION
additional moves that probably should have been done along with this work:
  https://github.com/zenoss/serviced/pull/226
