### PR TITLE
serviced was failing at boot because docker was not getting ready fast e...

### DIFF
--- a/pkg/serviced.upstart
+++ b/pkg/serviced.upstart
@@ -10,6 +10,8 @@ pre-start script
     echo "$(date): waiting for docker"
     while ! pgrep -fl /usr/bin/docker; do date ; sleep 1 ; done
     echo "$(date): docker is now ready - done with pre-start"
+    sleep 1s
+    /sbin/ifconfig
 end script
 
 script


### PR DESCRIPTION
...nough

due to this issue:
Fri Mar  7 08:09:10 CST 2014: waiting for docker^M
Fri Mar  7 08:09:11 CST 2014^M
1085 /usr/bin/docker -d^M
Fri Mar  7 08:09:12 CST 2014: docker is now ready - done with pre-start^M
panic: dial udp4 8.8.8.8:53: network is unreachable^M
^M
