### PR TITLE
added logging for proxy connect and reconnect

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -166,8 +166,8 @@ func (p *Proxy) proxy(local net.Conn, address string) {
 
 	var remote net.Conn
 
-	glog.Infof("Dialing hostAgent:%v to proxy %v<->%v",
-		remoteAddr, local.LocalAddr(), address)
+	glog.Infof("Dialing hostAgent:%v to proxy %v<->%v<->%v",
+		remoteAddr, local.LocalAddr(), local.RemoteAddr(), address)
 	if p.useTLS && (p.tcpMuxPort > 0) { // Only do TLS if connecting to a TCPMux
 		config := tls.Config{InsecureSkipVerify: true}
 		remote, err = tls.Dial("tcp4", remoteAddr, &config)


### PR DESCRIPTION
necessary to try to troubleshoot network connect/reconnect
  https://dev.zenoss.com/tracint/pastebin/5336

such as:
I0309 02:49:48.275875 00001 proxy.go:175] Dialing hostAgent:10.0.1.19:22250 to proxy 127.0.0.1:8084<->127.0.0.1:39975<->10.0.1.19:49171
I0309 02:49:48.290862 00001 proxy.go:192] Using   hostAgent:10.0.1.19:22250 to proxy 127.0.0.1:8084<->127.0.0.1:39975<->172.17.0.51:44318<->10.0.1.19:49171
