### PR TITLE
insert tenantId into image to match when bind mounting

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -587,6 +587,11 @@ func (a *HostAgent) startService(conn *zk.Conn, procFinished chan<- int, ssStats
 				containerPath = splitMount[2]
 			}
 
+			// insert tenantId into requestedImage - see dao.DeployService
+			path := strings.SplitN(requestedImage, "/", 3)
+			path[len(path)-1] = tenantId + "_" + path[len(path)-1]
+			requestedImage = strings.Join(path, "/")
+
 			if requestedImage == service.ImageId {
 				requestedMount += " -v " + hostPath + ":" + containerPath
 			}


### PR DESCRIPTION
mimic:
  https://github.com/zenoss/serviced/blob/develop/dao/elasticsearch/controlplanedao.go#L1353-L1357

zendev serviced adds: -mount zendev/devimg

but when a service is deployed, the image used is:
   zendev/84bc9478-47ad-12f8-52a1-a7da2161761d_devimg 
