### PR TITLE
allow * for image name when bind mounting

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -51,7 +51,7 @@ type HostAgent struct {
 	hostId          string   // the hostID of the current host
 	dockerDns       []string // docker dns addresses
 	varPath         string   // directory to store serviced	 data
-	mount           []string // each element is in the form: container_image:host_path:container_path
+	mount           []string // each element is in the form: dockerImage,hostPath,containerPath
 	vfs             string   // driver for container volumes
 	zookeepers      []string
 	currentServices map[string]*exec.Cmd // the current running services

--- a/serviced/cmd.go
+++ b/serviced/cmd.go
@@ -135,7 +135,7 @@ func init() {
 	flag.StringVar(&options.mcusername, "mcusername", "scott", "Username for the Zenoss metric consumer")
 	flag.StringVar(&options.mcpasswd, "mcpasswd", "tiger", "Password for the Zenoss metric consumer")
 	options.mount = make(ListOpts, 0)
-	flag.Var(&options.mount, "mount", "bind mount: container_image,host_path,container_path (e.g. -mount zenoss/zenoss5x:latest,/home/zenoss/zenhome/zenoss/Products/,/opt/zenoss/Products/)")
+	flag.Var(&options.mount, "mount", "bind mount: dockerImage,hostPath,containerPath (e.g. -mount zenoss/zenoss5x:latest,$HOME/src/europa/src,/mnt/src) dockerImage can be '*'")
 	flag.StringVar(&options.vfs, "vfs", "rsync", "file system for container volumes")
 	flag.StringVar(&options.hostaliases, "hostaliases", "", "list of aliases for this host, e.g., localhost:goldmine:goldmine.net")
 


### PR DESCRIPTION
```
allow '*' for image name, i.e:
  serviced -agent -master -mount "*,$(zendev root)/src,/mnt/src"
```
