### PR TITLE
remove warning about endpoint not existing during proxy setup, another w...

### DIFF
--- a/serviced/proxy.go
+++ b/serviced/proxy.go
@@ -143,7 +143,6 @@ func (cli *ServicedCli) CmdProxy(args ...string) error {
 
 				for key, endpointList := range endpoints {
 					if len(endpointList) <= 0 {
-						glog.Warningf("No endpoints found for %s", key)
 						if proxy, ok := proxies[key]; ok {
 							emptyAddressList := make([]string, 0)
 							proxy.SetNewAddresses(emptyAddressList)


### PR DESCRIPTION
...arning is created when actual connections hit the proxy anyway.
