### PR TITLE
fix build error by referencing in Godeps: nsinit, gocapability

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,16 +13,12 @@ dockercache := /tmp/serviced-dind-$(pwdchecksum)
 
 default: build_binary
 
-install: build_binary install-nsinit
+install: build_binary
 	go install github.com/zenoss/serviced/serviced
-
-install-nsinit:
-	# use go install to install nsinit to $GOBIN
 	go install github.com/dotcloud/docker/pkg/libcontainer/nsinit/nsinit
 
 
 build_binary:
-	make install-nsinit
 	cd serviced && make
 	cd isvcs && make
 

--- a/serviced/Godeps
+++ b/serviced/Godeps
@@ -29,7 +29,12 @@
 		},
 		{
 			"ImportPath": "github.com/dotcloud/docker/pkg/proxy",
+			"#### ImportPath also affected:": "github.com/dotcloud/docker/pkg/libcontainer/nsinit/nsinit",
 			"Rev": "867b2a90c228f62cdcd44907ceef279a2d8f1ac5"
+		},
+		{
+			"ImportPath": "github.com/syndtr/gocapability/capability",
+			"Rev": "3454319be2ebde8481aa0804a801f4d07de705b5"
 		},
 		{
 			"ImportPath": "github.com/mattbaird/elastigo/api",


### PR DESCRIPTION
DEMO:

```
~/src/europa/src/golang/src/github.com/zenoss/serviced
# plu@plu-9: rm -fr ../../syndtr/; rm -fr ../../dotcloud/; rm $(which nsinit); rm $(which serviced)
~/src/europa/src/golang/src/github.com/zenoss/serviced
# plu@plu-9: make install
cd serviced && make
make[1]: Entering directory `/home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/serviced'
./godep restore
go build
make[1]: Leaving directory `/home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/serviced'
cd isvcs && make
make[1]: Entering directory `/home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/isvcs'
go build
make[1]: Leaving directory `/home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/isvcs'
go install github.com/zenoss/serviced/serviced
go install github.com/dotcloud/docker/pkg/libcontainer/nsinit/nsinit
~/src/europa/src/golang/src/github.com/zenoss/serviced
# plu@plu-9: which nsinit
/home/plu/src/europa/src/golang/bin/nsinit
~/src/europa/src/golang/src/github.com/zenoss/serviced
# plu@plu-9: which serviced
/home/plu/src/europa/src/golang/bin/serviced
~/src/europa/src/golang/src/github.com/zenoss/serviced

```
