### PR TITLE
Add CSS for table rows

### DIFF
--- a/web/static/css/main.css
+++ b/web/static/css/main.css
@@ -36,6 +36,11 @@ table > thead {
     border-left: 0px;
     border-top: 0px;
 }
+
+.table-hover tbody tr:hover td, .table-hover tbody tr:hover th {
+    background-color: #ddffdd;
+}
+
 .toggle .btn.active {
     padding-right: 10px;
 }


### PR DESCRIPTION
Fixes ZEN-8869.  Adds a CSS definition to highlight rows green on over for table-hover classed tables
