### PR TITLE
added commit hash for docker/dotcloud 0.10.1-hotfixes 2014-04-08

### DIFF
--- a/serviced/Godeps
+++ b/serviced/Godeps
@@ -37,6 +37,15 @@
 			"Rev": "3454319be2ebde8481aa0804a801f4d07de705b5"
 		},
 		{
+			"ImportPath": "github.com/coreos/go-systemd/activation",
+			"#### ImportPath also affected:": "github.com/coreos/go-systemd/dbus",
+			"Rev": "8514b9fc57569e6dfc5e88a6411be351afcc69b4"
+		},
+		{
+			"ImportPath": "github.com/godbus/dbus",
+			"Rev": "cb98efbb933d8389ab549a060e880ea3c375d213"
+		},
+		{
 			"ImportPath": "github.com/mattbaird/elastigo/api",
 			"Rev": "041b88c1fcf6489a5721ede24378ce1253b9159d"
 		},


### PR DESCRIPTION
fixes this when using docker 0.10.0:

```
root@plu-ubuntu:/var/lib/docker/execdriver/native/4a88f0096ae073f6703f25d3096aef701a5330a118cec2da78a6f139a61a5b2f# /home/plu/src/europa/src/golang/bin/nsinit exec bash
2014/04/12 08:06:04 json: cannot unmarshal object into Go value of type string
```
