### PR TITLE
endpoint applications need anchored pattern when calling GetHostEndpoint...

### DIFF
--- a/dao/elasticsearch/controlplanedao.go
+++ b/dao/elasticsearch/controlplanedao.go
@@ -378,7 +378,7 @@ func (this *ControlPlaneDao) GetServiceEndpoints(serviceId string, response *map
 		for _, endpoint := range service_imports {
 			glog.V(2).Infof("Finding exports for import: %s %+v", endpoint.Application, endpoint)
 			matchedEndpoint := false
-			applicationRegex, err := regexp.Compile(endpoint.Application)
+			applicationRegex, err := regexp.Compile(fmt.Sprintf("^%s$", endpoint.Application))
 			if err != nil {
 				continue //Don't spam error message; it was reported at validation time
 			}


### PR DESCRIPTION
...Info()

PROBLEM: 'rabbitmq' application name was matching 'rabbitmq' and 'rabbitmq admin'
