### PR TITLE
hack for host add: depend on default port - pass only IP_ADDR to rpc.mas...

### DIFF
--- a/serviced/api/host.go
+++ b/serviced/api/host.go
@@ -40,7 +40,12 @@ func (a *api) AddHost(config HostConfig) (*host.Host, error) {
 	}
 
 	req := agent.BuildHostRequest{
-		IP:          config.Address.String(),
+		// HACK BEGIN: domain/host HostAdd fails when IP is set to IP_ADDR:PORT
+		//			when given config.Address.String().  As a temporary workaround,
+		//			simply pass IP_ADDR via config.Address.Host
+		IP: config.Address.Host,
+		// HACK END
+
 		PoolID:      config.PoolID,
 		IPResources: config.IPs,
 	}


### PR DESCRIPTION
...ter.AddHost()

ISSUE:

```
# plu@plu-9: serviced host add 172.17.42.1:4979 default
requested IP 172.17.42.1:4979 is not available on host
```

DEMO:

```
# plu@plu-9: serviced host list
no hosts found
# plu@plu-9: serviced host add 172.17.42.1:4979 default
570a276e
# plu@plu-9: serviced host list
ID      POOL        NAME    ADDR        CORES   MEM     NETWORK         
570a276e    default     plu-9   172.17.42.1 12  33660448768 172.17.0.0/255.255.0.0  
```
