### PR TITLE
don't sort in flattenTree by default

### DIFF
--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -1086,7 +1086,7 @@ function StatsService($http, $location) {
  * building a flattened array where each node has a depth
  * tracking field 'zendepth'.
  */
-function flattenTree(depth, current) {
+function flattenTree(depth, current, sortFunction) {
     // Exclude the root node
     var retVal = (depth === 0)? [] : [current];
     current.zendepth = depth;
@@ -1094,7 +1094,9 @@ function flattenTree(depth, current) {
     if (!current.children) {
         return retVal;
     }
-    current.children.sort(function(a, b) {return a.Name.toLowerCase() < b.Name.toLowerCase() ? -1 : 1});
+    if (sortFunction !== undefined) {
+        current.children.sort(sortFunction);
+    }
     for (var i=0; i < current.children.length; i++) {
         retVal = retVal.concat(flattenTree(depth + 1, current.children[i]))
     }
@@ -1234,7 +1236,9 @@ function refreshServices($scope, servicesService, cacheOk, extraCallback) {
 
             // we need a flattened view of all children
             if ($scope.services.current && $scope.services.current.children) {
-                $scope.services.subservices = flattenTree(0, $scope.services.current);
+                $scope.services.subservices = flattenTree(0, $scope.services.current, function(a, b) {
+                    return a.Name.toLowerCase() < b.Name.toLowerCase() ? -1 : 1
+                });
             }
 
             // aggregate virtual ip and virtual host data


### PR DESCRIPTION
flattenTree sorting wasn't taking into account that pools are also flattened. This fixes that oversight, and leaves room for sorting pools in the future.
