### PR TITLE
added post-stop stanza to wait for serviced to stop

### DIFF
--- a/pkg/serviced.upstart
+++ b/pkg/serviced.upstart
@@ -23,3 +23,11 @@ script
     cd $SERVICED_HOME && ./bin/serviced -agent -master
 end script
 
+post-stop script
+    echo "$(date): waiting for serviced to stop"
+    while pgrep -fl 'bin/serviced -agent -master'; do
+        sleep 5
+    done
+    echo "$(date): serviced is now stopped - done with post-stop"
+end script
+


### PR DESCRIPTION
ISSUE - for 'restart serviced', serviced is not stopped before upstart tries to start it:

```
I0530 12:50:34.144961 06077 api.go:77] StartServer: [] (0)
F0530 12:50:34.147849 06077 daemon.go:87] Could not bind to port listen tcp :4979: bind: address already in use. Is another instance running
```

FIX - wait for serviced to stop:

```
Fri May 30 16:41:32 CDT 2014: waiting for serviced to stop
16373 serviced
...
16373 serviced
Fri May 30 16:43:25 CDT 2014: serviced is now stopped - done with post-stop
Fri May 30 16:43:25 CDT 2014: waiting for docker
...
I0530 16:44:33.288192 19027 leader.go:50] Processing leader duties
```

my experience with this fix is that stop will take about 30 seconds:
  sudo stop serviced
and restart will take about 2 minutes:
  sudo restart serviced
