### PR TITLE
added underscore and period to image tag

### DIFF
--- a/commons/imageid.go
+++ b/commons/imageid.go
@@ -57,7 +57,7 @@ func init() {
 // reponame = [user'/']repo
 // user     = {alpha|digit|'-'|'_'}+
 // repo     = {alpha|digit|'-'|'_'}+
-// tag      = {alpha|digit|'-'}+
+// tag      = {alpha|digit|'-'|'_'|'.'}+
 // The grammar is ambiguous so the parser is a little messy in places.
 func ParseImageID(iid string) (*ImageID, error) {
 	scanner := bufio.NewScanner(strings.NewReader(iid))
@@ -170,10 +170,10 @@ func ParseImageID(iid string) (*ImageID, error) {
 			}
 		case scanningTag:
 			switch {
-			case unicode.IsLetter(rune), unicode.IsDigit(rune), rune == dash:
+			case unicode.IsLetter(rune), unicode.IsDigit(rune), rune == dash, rune == underscore, rune == period:
 				tokbuf = append(tokbuf, byte(rune))
 			default:
-				return nil, fmt.Errorf("invalid ImageID %s: bad tag", iid)
+				return nil, fmt.Errorf("invalid ImageID %s: bad tag (rune:'%c')", iid, rune)
 			}
 		case scanningPortOrTag:
 			switch {

--- a/commons/imageid_test.go
+++ b/commons/imageid_test.go
@@ -203,6 +203,16 @@ var imgidtests = []ImageIDTest{
 		},
 		"",
 	},
+	{
+		"quay.io/zenossinc/daily-zenoss5-resmgr:5.0.0_421",
+		&ImageID{
+			Host: "quay.io",
+			User: "zenossinc",
+			Repo: "daily-zenoss5-resmgr",
+			Tag:  "5.0.0_421",
+		},
+		"",
+	},
 }
 
 func DoTest(t *testing.T, parse func(string) (*ImageID, error), name string, tests []ImageIDTest) {


### PR DESCRIPTION
ISSUE when deploying template:

```
E0602 14:14:21.960360 15833 servicetemplate.go:230] invalid image name: quay.io/zenossinc/daily-zenoss5-resmgr:5.0.0_421, error: invalid ImageID quay.io/zenossinc/daily-zenoss5-resmgr:5.0.0_421: bad tag
```
