### PR TITLE
show push of image for better visibility

### DIFF
--- a/commons/docker.go
+++ b/commons/docker.go
@@ -182,7 +182,7 @@ func pushImageToRegistry(registry DockerRegistry, client *dockerclient.Client, n
 		Tag:      imageID.Tag,
 		Registry: registry.String(),
 	}
-	glog.V(2).Infof("pushing image: %s", opts)
+	glog.Infof("pushing image: %+v", opts)
 	return client.PushImage(opts, auth)
 }
 


### PR DESCRIPTION
pushing images takes about 10 minutes minimum.  show it.

```
I0602 15:53:55.055580 23599 docker.go:184] pushing image: {Name:plu-9:5000/zenossinc/daily-zenoss5-resmgr Registry:plu-9:5000 Tag:5.0.0_421 OutputStream:<nil>}

I0602 15:59:31.145736 23599 docker.go:184] pushing image: {Name:plu-9:5000/zenossinc/hbase Registry:plu-9:5000 Tag: OutputStream:<nil>}
I0602 16:00:55.121647 23599 docker.go:184] pushing image: {Name:plu-9:5000/zenossinc/opentsdb Registry:plu-9:5000 Tag: OutputStream:<nil>}

I0602 16:03:58.364344 23599 docker.go:184] pushing image: {Name:plu-9:5000/80989df4aeda9dae953e806ff110a490aa8f22362bf1acad2b31392939e44c05 Registry:plu-9:5000 Tag: OutputStream:<nil>}
I0602 16:04:00.800149 23599 docker.go:184] pushing image: {Name:plu-9:5000/a2e23a37d6ae37db6c43c0931057764d4ebcc1cf7783b9cb3e745c21816bf18a Registry:plu-9:5000 Tag: OutputStream:<nil>}
I0602 16:04:04.878166 23599 docker.go:184] pushing image: {Name:plu-9:5000/e6cece58d8d1d7c7cbe49427c7fc384de433a7d0f07c93422aab24d2294c3891 Registry:plu-9:5000 Tag: OutputStream:<nil>}
I0602 16:04:07.367682 23599 pool.go:253] Facade.GetPoolIPs: default
```
