### PR TITLE
log connection information when getting mux error

### DIFF
--- a/proxy/mux.go
+++ b/proxy/mux.go
@@ -116,7 +116,7 @@ func (mux *TCPMux) muxConnection(conn net.Conn) {
 
 	svc, err := net.Dial("tcp4", line)
 	if err != nil {
-		glog.Errorf("could not dial to '%s' : %s", line, err)
+		glog.Errorf("got %s => %s, could not dial to '%s' : %s", conn.LocalAddr(), conn.RemoteAddr(), line, err)
 		conn.Close()
 		return
 	}


### PR DESCRIPTION
This will help debugging mux errors. Needed this information during a session with QA.
