### PR TITLE
Links in simpleResponse struct needs to be public so it gets marshalled ...

### DIFF
--- a/web/util.go
+++ b/web/util.go
@@ -29,13 +29,13 @@ func init() {
 
 type simpleResponse struct {
 	Detail string
-	links  []link
+	Links  []link
 }
 
 type link struct {
 	Name   string
 	Method string
-	URL    string
+	Url    string
 }
 
 type login struct {


### PR DESCRIPTION
...into JSON.

Also changed URL -> Url because that's what it was before
