### PR TITLE
Fix/smoke for attach

### DIFF
--- a/smoke.sh
+++ b/smoke.sh
@@ -37,6 +37,14 @@ install_prereqs() {
             fail "ERROR: nsenter is not installed - serviced attach tests will fail"
         fi
     fi
+
+    local wget_image="zenoss/ubuntu:wget"
+    if ! docker inspect "${wget_image}" >/dev/null; then
+        docker pull "${wget_image}"
+       if ! docker inspect "${wget_image}" >/dev/null; then
+            fail "ERROR: docker image "${wget_image}" is not available - wget tests will fail"
+       fi
+    fi
 }
 
 # Add the vhost to /etc/hosts so we can resolve it for the test


### PR DESCRIPTION
ISSUE #3 from https://github.com/zenoss/serviced/pull/553

```
===== SUCCESS =====
-CONFIGS- file was successfully injected
===================

====== FAIL ======
Either unable to attach to container or endpoint was not imported
==================
```

the problem is that docker 1.0 changed nsinit and now it fails when taking flags to commands:

```
  nsinit exec bash   # works
  nsinit exec -- bash   # works
  nsinit exec -- bash -c echo  #  does not work due to nsinit trying to interpret -c
```

DEMO:

```
nsenter is not installed - installing nsenter
...
Setting up docker-smuggle (2.24.2-1) ...
Starting serviced...
...
===== SUCCESS =====
-CONFIGS- file was successfully injected
===================
===== SUCCESS =====
Attached and hit imported port correctly
===================
```
