### PR TITLE
fix the fix to force IE into standards mode

### DIFF
--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html lang="en" ng-app="controlplane">
   <head>
+
+    <!-- force IE to standards mode -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="{{'brand_zcp'|translate}}">
@@ -15,9 +19,6 @@
 
     <!-- Custom styles for this template -->
     <link href="/static/css/main.css" rel="stylesheet" />
-
-    <!-- force IE to standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
IE will not switch to standards mode if the meta tag that forces it isnt at the beginning of the head tag :/
