### PR TITLE
use correct file in /proc to read vmstat

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -79,7 +79,7 @@
 		},
 		{
 			"ImportPath": "github.com/daniel-garcia/go-procfs/linux",
-			"Rev": "9b6007f69cbec987a8495ffaccd730cda0316e34"
+			"Rev": "a3573a8f7dd1186d5c617abdd7ca68ae429804e6"
 		},
 		{
 			"ImportPath": "github.com/zenoss/go-dockerclient",


### PR DESCRIPTION
fixed in upstream https://github.com/daniel-garcia/go-procfs/commit/4e4c3c0186db5142ac60e541df472ca0c189677e#diff-0e09b0679534b3fc3551e18c59b81109R10
