### PR TITLE
Forward SERVICED_NOREGISTRY to shell container

### DIFF
--- a/shell/server.go
+++ b/shell/server.go
@@ -404,6 +404,7 @@ func StartDocker(registry commons.DockerRegistry, dockerClient *dockerclient.Cli
 	}
 	argv = append(argv, "-e", fmt.Sprintf("CONTROLPLANE_SYSTEM_USER=%s ", systemUser.Name))
 	argv = append(argv, "-e", fmt.Sprintf("CONTROLPLANE_SYSTEM_PASSWORD=%s ", systemUser.Password))
+	argv = append(argv, "-e", fmt.Sprintf("SERVICED_NOREGISTRY=%s", os.Getenv("SERVICED_NOREGISTRY")))
 
 	argv = append(argv, svc.ImageID)
 	argv = append(argv, proxycmd...)


### PR DESCRIPTION
Pass SERVICED_NOREGISTRY environment variable to containers started
for serviced 'shell' and 'run' commands
