### PR TITLE
Fix registry pull

### DIFF
--- a/commons/docker.go
+++ b/commons/docker.go
@@ -128,15 +128,17 @@ func pullImageFromRegistry(registry DockerRegistry, client *dockerclient.Client,
 		return nil
 	}
 
-	repoName, tag, err := repoNameAndTag(name)
+	imageID, err := ParseImageID(name)
 	if err != nil {
 		return err
 	}
+	tag := imageID.Tag
 	if tag == "" {
 		tag = "latest"
 	}
+
 	opts := dockerclient.PullImageOptions{
-		Repository: repoName,
+		Repository: imageID.BaseName(),
 		Tag:        tag,
 		Registry:   registry.String(),
 	}

--- a/commons/imageid.go
+++ b/commons/imageid.go
@@ -222,6 +222,17 @@ func ParseImageID(iid string) (*ImageID, error) {
 
 // String returns a string representation of the ImageID structure
 func (iid ImageID) String() string {
+	name := iid.BaseName()
+
+	if iid.Tag != "" {
+		name = name + ":" + iid.Tag
+	}
+
+	return name
+}
+
+// BaseName returns a string representation of the ImageID structure sans tag
+func (iid ImageID) BaseName() string {
 	s := []string{}
 
 	if iid.Host != "" {
@@ -237,10 +248,6 @@ func (iid ImageID) String() string {
 	}
 
 	s = append(s, iid.Repo)
-
-	if iid.Tag != "" {
-		s = append(s, ":", iid.Tag)
-	}
 
 	return strings.Join(s, "")
 }


### PR DESCRIPTION
Ensure that repository is included in PullImageOptions.Repository.
  Before: 11qm6k6uebjw3v12v8pl5gr6x/zenoss-resmgr-testing
  After:  ip-10-111-2-219:5000/11qm6k6uebjw3v12v8pl5gr6x/zenoss-resmgr-testing
