### PR TITLE
Remove svg width from main.css

### DIFF
--- a/web/static/css/main.css
+++ b/web/static/css/main.css
@@ -700,7 +700,6 @@ input.startup {
 
 svg {
   border: 0px;
-  width: 1140px;
   height: 600px;
 }
 

--- a/web/static/i18n/en_US.json
+++ b/web/static/i18n/en_US.json
@@ -23,8 +23,6 @@
     "restore_complete": "Restore Complete",
     "restore_running": "Restoring from Backup",
 
-    "brand_cp": "Control Plane",
-    "brand_zcp": "Zenoss Control Plane",
     "breadcrumb_deployed": "Deployed Apps",
     "breadcrumb_home": "Home",
     "breadcrumb_hosts": "Hosts",

--- a/web/static/i18n/es_US.json
+++ b/web/static/i18n/es_US.json
@@ -18,8 +18,6 @@
     "backup_restore": "Restaurar respaldo",
     "backup_running": "Creación respaldo",
     "restore_running": "Restauración a partir de un respaldo",
-    "brand_cp": "Panel de Control",
-    "brand_zcp": "Panel de Control de Zenoss",
     "breadcrumb_deployed": "Aplicaciones Instaladas",
     "breadcrumb_home": "Home",
     "breadcrumb_hosts": "Servidores",


### PR DESCRIPTION
SVG width is already set to 100% in nvd3.  Setting a specific width in main.css is breaking firefox.  This fix has been checked in Firefox, Chrome, and IE
