### PR TITLE
fixed subprocess so it will exit with correct error from exec.Run()

### DIFF
--- a/commons/subprocess/instance.go
+++ b/commons/subprocess/instance.go
@@ -87,9 +87,9 @@ func (s *Instance) loop() {
 		case s := <-s.signalChan:
 			cmd.Process.Signal(s)
 
-		case <-s.commandExit:
+		case exitError := <-s.commandExit:
 			select {
-			case s.commandExit <- nil:
+			case s.commandExit <- exitError:
 			default:
 			}
 			return

--- a/container/controller.go
+++ b/container/controller.go
@@ -429,9 +429,9 @@ func (c *Controller) Run() (err error) {
 			startAfter = time.After(time.Millisecond * 1)
 
 		case exitError := <-serviceExited:
-			glog.Infof("Service process exited.")
 			if !c.options.Service.Autorestart {
 				exitStatus := getExitStatus(exitError)
+				glog.Infof("Exiting with status:%d due to %+v", exitStatus, exitError)
 				os.Exit(exitStatus)
 			}
 			glog.Infof("Restarting service process in 10 seconds.")


### PR DESCRIPTION
DEMO:

```

# plu@plu-9: serviced service run $(serviced service list | awk '/Zope/{print $2;exit}') help testdiscard
I0626 15:06:23.122605 22678 server.go:331] Connected to the control plane at port 10.87.110.39:4979
I0626 15:06:23.142567 22678 server.go:414] Acquiring image from the dfs...
I0626 15:06:23.142777 22678 server.go:416] Acquired!  Starting shell


    This is an example template for a 'serviced run ...' command.  
    Each custom script must include a function '__DEFAULT__', which 
    defines the default action to be performed by the host when the 
    command completes and functions for each custom command that 
    requires a specific action from the host.

    Defined Commands:
        testcommit    testdiscard


signaling host to discard the container ...
I0626 15:06:24.508783 22678 shell.go:144] Command failed (exit code 1)

# plu@plu-9: serviced service run $(serviced service list | awk '/Zope/{print $2;exit}') help testcommit
I0626 15:07:01.710219 22817 server.go:331] Connected to the control plane at port 10.87.110.39:4979
I0626 15:07:01.723866 22817 server.go:414] Acquiring image from the dfs...
I0626 15:07:01.724091 22817 server.go:416] Acquired!  Starting shell


    This is an example template for a 'serviced run ...' command.  
    Each custom script must include a function '__DEFAULT__', which 
    defines the default action to be performed by the host when the 
    command completes and functions for each custom command that 
    requires a specific action from the host.

    Defined Commands:
        testcommit    testdiscard


signaling host to commit the container ...
I0626 15:07:03.127838 22817 shell.go:138] Committing container
```
