### PR TITLE
remove serviced subdir if it exists - issue with jenkins serviced-pullre...

### DIFF
--- a/makefile
+++ b/makefile
@@ -117,6 +117,10 @@ FORCE:
 
 serviced: $(Godeps_restored)
 serviced: FORCE
+	if [ -d $@ ]; then \
+		echo removing serviced subdir $(shell pwd)/$@; \
+		rm -fr $(shell pwd)/$@; \
+	fi
 	go build
 	go install
 


### PR DESCRIPTION
...quests build

ISSUE - http://jenkins.zendev.org/job/serviced-pullrequests/1360/console:

```
go build
go install github.com/zenoss/serviced: build output "serviced" already exists and is a directory
make: *** [serviced] Error 1
```

DEMO1:

```
~/src/europa/src/golang/src/github.com/zenoss/serviced
# plu@plu-9: ls -l serviced
total 28280
-rwxrwxr-x 1 plu plu  8173989 Jun 30 08:44 nsinit
-rwxrwxr-x 1 plu plu 20779514 Jun 30 08:44 serviced
~/src/europa/src/golang/src/github.com/zenoss/serviced
# plu@plu-9: make
cd isvcs && make IN_DOCKER=0
make[1]: Entering directory `/home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/isvcs'
go build
if [ -z "$(docker images quay.io/zenossinc/isvcs 2>/dev/null | awk {'print $2'} | grep v10)" ]; then \
        docker pull quay.io/zenossinc/isvcs:v10; \
    fi; \
    if [ -z "$(docker images quay.io/zenossinc/isvcs 2>/dev/null | awk {'print $2'} | grep v10)" ]; then \
        make  build/es.tar.gz  build/zk.tar.gz  build/opentsdb.tar.gz  build/logstash.tar.gz  build/query.tar.gz  build/consumer.tar.gz  build/celery.tar.gz; \
        docker build -t quay.io/zenossinc/isvcs:v10 build; \
    fi
make[1]: Leaving directory `/home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/isvcs'
cd web && make build_js
make[1]: Entering directory `/home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/web'
make[1]: Nothing to be done for `build_js'.
make[1]: Leaving directory `/home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/web'
if [ -d serviced ]; then \
        echo removing serviced subdir /home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/serviced; \
        rm -fr /home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/serviced; \
    fi
removing serviced subdir /home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/serviced
go build
go install
~/src/europa/src/golang/src/github.com/zenoss/serviced
# plu@plu-9: ls -l serviced
-rwxrwxr-x 1 plu plu 20779514 Jun 30 08:44 serviced
```

DEMO2:

```
~/src/europa/src/golang/src/github.com/zenoss/serviced
# plu@plu-9: make
cd isvcs && make IN_DOCKER=0
make[1]: Entering directory `/home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/isvcs'
go build
if [ -z "$(docker images quay.io/zenossinc/isvcs 2>/dev/null | awk {'print $2'} | grep v10)" ]; then \
        docker pull quay.io/zenossinc/isvcs:v10; \
    fi; \
    if [ -z "$(docker images quay.io/zenossinc/isvcs 2>/dev/null | awk {'print $2'} | grep v10)" ]; then \
        make  build/es.tar.gz  build/zk.tar.gz  build/opentsdb.tar.gz  build/logstash.tar.gz  build/query.tar.gz  build/consumer.tar.gz  build/celery.tar.gz; \
        docker build -t quay.io/zenossinc/isvcs:v10 build; \
    fi
make[1]: Leaving directory `/home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/isvcs'
cd web && make build_js
make[1]: Entering directory `/home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/web'
make[1]: Nothing to be done for `build_js'.
make[1]: Leaving directory `/home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/web'
if [ -d serviced ]; then \
        echo removing serviced subdir /home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/serviced; \
        rm -fr /home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/serviced; \
    fi
go build
go install
~/src/europa/src/golang/src/github.com/zenoss/serviced
# plu@plu-9: ls -l serviced
-rwxrwxr-x 1 plu plu 20779514 Jun 30 08:45 serviced
```
