### PR TITLE
hmm.  not sure how these got nix'd.  adding back zzk unit tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -392,6 +392,9 @@ test: build docker_ok
 	cd coordinator/client && go test $(GOTEST_FLAGS)
 	cd coordinator/storage && go test $(GOTEST_FLAGS)
 	cd validation && go test $(GOTEST_FLAGS)
+	cd zzk/snapshot && go test $(GOTEST_FLAGS)
+	cd zzk/service && go test $(GOTEST_FLAGS)
+	cd zzk/docker && go test $(GOTEST_FLAGS)
 
 smoketest: build docker_ok
 	/bin/bash smoke.sh


### PR DESCRIPTION
These were deleted with my 'serviced make install' feature

https://github.com/zenoss/serviced/commit/e2a96c18887adaa39ea706bb38e91e380e90c55e
