### PR TITLE
pass all ipv4 interface IPs to HMaster via CONTROLPLANE_HOST_IPS

### DIFF
--- a/node/agent.go
+++ b/node/agent.go
@@ -703,8 +703,8 @@ func (a *HostAgent) startService(conn coordclient.Connection, procFinished chan<
 // that are used to create and start a container respectively. The information used to populate the structures is pulled from
 // the service, serviceState, and conn values that are passed into configureContainer.
 func configureContainer(a *HostAgent, client *ControlClient, conn coordclient.Connection,
-		procFinished chan<- int, service *service.Service, serviceState *servicestate.ServiceState,
-		virtualAddressSubnet string) (*dockerclient.Config, *dockerclient.HostConfig, error) {
+	procFinished chan<- int, service *service.Service, serviceState *servicestate.ServiceState,
+	virtualAddressSubnet string) (*dockerclient.Config, *dockerclient.HostConfig, error) {
 	cfg := &dockerclient.Config{}
 	hcfg := &dockerclient.HostConfig{}
 
@@ -870,9 +870,9 @@ func configureContainer(a *HostAgent, client *ControlClient, conn coordclient.Co
 	}
 
 	// Get host IP
-	ip, err := utils.GetIPAddress()
+	ips, err := utils.GetIPv4Addresses()
 	if err != nil {
-		glog.Errorf("Error getting host IP address: %v", err)
+		glog.Errorf("Error getting host IP addresses: %v", err)
 		return nil, nil, err
 	}
 
@@ -880,7 +880,7 @@ func configureContainer(a *HostAgent, client *ControlClient, conn coordclient.Co
 	cfg.Env = append([]string{},
 		fmt.Sprintf("CONTROLPLANE_SYSTEM_USER=%s", systemUser.Name),
 		fmt.Sprintf("CONTROLPLANE_SYSTEM_PASSWORD=%s", systemUser.Password),
-		fmt.Sprintf("CONTROLPLANE_HOST_IP=%s", ip),
+		fmt.Sprintf("CONTROLPLANE_HOST_IPS='%s'", strings.Join(ips, " ")),
 		fmt.Sprintf("SERVICED_VIRTUAL_ADDRESS_SUBNET=%s", virtualAddressSubnet),
 		fmt.Sprintf("SERVICED_IS_SERVICE_SHELL=false"),
 		fmt.Sprintf("SERVICED_NOREGISTRY=%s", os.Getenv("SERVICED_NOREGISTRY")),

--- a/utils/host_utils.go
+++ b/utils/host_utils.go
@@ -43,6 +43,28 @@ func GetIPAddress() (ip string, err error) {
 	}
 }
 
+// GetIPAddresses returns a list of all IPv4 interface addresses
+func GetIPv4Addresses() (ips []string, err error) {
+	ips = []string{}
+
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, fmt.Errorf("unable to use InterfaceAddrs to find local ipv4 addresses: %v", err)
+	}
+
+	for _, a := range addrs {
+		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && nil != ipnet.IP.To4() {
+			ips = append(ips, ipnet.IP.String())
+		}
+	}
+
+	if len(ips) == 0 {
+		return ips, fmt.Errorf("unable to identify local ip address")
+	}
+
+	return ips, nil
+}
+
 // GetMemorySize attempts to get the size of the installed RAM.
 func GetMemorySize() (size uint64, err error) {
 	file, err := os.Open(meminfoFile)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -29,3 +29,18 @@ func TestGetMemorySize(t *testing.T) {
 		t.Fail()
 	}
 }
+
+// Test GetIPv4Addresses()
+func TestGetIPv4Addresses(t *testing.T) {
+	ips, err := GetIPv4Addresses()
+	if err != nil {
+		t.Errorf("Failed to get ipv4 addresses: %s", err)
+		t.Fail()
+	}
+
+	expectedMinimumLen := 1
+	if len(ips) < expectedMinimumLen {
+		t.Errorf("minimum IPs expected %d > retrieved %d  ips:%v", expectedMinimumLen, len(ips), ips)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
also need this https://github.com/zenoss/platform-build/pull/169

PREVIOUSLY:

```
# plu@plu-9: serviced service attach HMaster 
root@localhost:/# cat /etc/hosts
172.17.2.207    localhost
127.0.0.1   localhost
::1 localhost ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
10.3.0.2 zk2
10.3.0.3 zk3
10.3.0.4 zk1
10.87.110.39 localhost
172.17.42.1 localhost
```

DEMO:

```
# plu@plu-9: ip addr show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 18:03:73:3f:b5:d8 brd ff:ff:ff:ff:ff:ff
    inet 10.87.110.39/24 brd 10.87.110.255 scope global eth0
    ...
    inet 10.5.0.1/16 scope global eth0
    ...
    inet6 fe80::1a03:73ff:fe3f:b5d8/64 scope link 
    ...
# plu@plu-9: ip addr show eth1
3: eth1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc pfifo_fast state DOWN group default qlen 1000
    link/ether 18:03:73:3f:b5:d9 brd ff:ff:ff:ff:ff:ff
# plu@plu-9: ip addr show docker0
4: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether 56:84:7a:fe:97:99 brd ff:ff:ff:ff:ff:ff
    inet 172.17.42.1/16 scope global docker0
       ...
    inet6 fe80::5484:7aff:fefe:9799/64 scope link 
       ...
# plu@plu-9: serviced service attach HMaster 
root@localhost:/# grep IPS /etc/profile.d/controlcenter.sh 
export CONTROLPLANE_HOST_IPS='10.87.110.39 10.5.0.1 172.17.42.1'
root@localhost:/# cat /etc/hosts
172.17.3.65 localhost
127.0.0.1   localhost
::1 localhost ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
10.3.0.2 zk2
10.3.0.3 zk3
10.3.0.4 zk1
10.87.110.39 localhost
10.5.0.1 localhost
172.17.42.1 localhost
172.17.42.1 localhost
root@localhost:/# 
```
