### PR TITLE
use specified imported endpoint port, only if non-zero

### DIFF
--- a/container/endpoint.go
+++ b/container/endpoint.go
@@ -448,7 +448,7 @@ func (c *Controller) processTenantEndpoint(conn coordclient.Connection, parentPa
 			}
 			endpoints[ii] = &endpointNode.ApplicationEndpoint
 			if ep.port != 0 {
-				glog.Infof("overriding ContainerPort with imported port:%v for endpoint: %+v", ep.port, endpointNode)
+				glog.V(2).Infof("overriding ContainerPort with imported port:%v for endpoint: %+v", ep.port, endpointNode)
 				endpoints[ii].ContainerPort = ep.port
 			} else {
 				glog.Infof("not overriding ContainerPort with imported port:%v for endpoint: %+v", ep.port, endpointNode)


### PR DESCRIPTION
Imported endpoints may have unspecified PortNumber:
  https://github.com/zenoss/platform-build/blob/develop/services/Zenoss.core/Zope/service.json#L11-L15

In those cases, use the registered exported endpoint in ZK instead of imported portnumber in service definition.
