### PR TITLE
added test_started and test_attached to see if services started and if a...

### DIFF
--- a/smoke.sh
+++ b/smoke.sh
@@ -106,7 +106,7 @@ test_started() {
     for line in $(${SERVICED} service list | tr -cd '\000-\177' | awk '/s[12]/{print $1 ":" $2}'); do
         name=$(echo $line | cut -f1 -d:)
         id=$(echo $line | cut -f2 -d:)
-        docker ps --no-trunc |grep 'proxy $id'
+        docker ps --no-trunc | grep "proxy $id" &>/dev/null
         status=$?
         if [ "$status" != "0" ]; then
             echo "Unable to find service {Name:$name ID:$id} container in docker ps"


### PR DESCRIPTION
...ttach is working

DEMO1 - provide more details about what is failing - (service s2 is not starting):

```
===== SUCCESS =====
Deployed service successfully
===================
...
===== SUCCESS =====
Started service
===================
Unable to find service {Name:s2 ID:c2do5owrkc0fh3ot4n7xnf3oa} in docker ps
Unable to find service {Name:s2 ID:c2do5owrkc0fh3ot4n7xnf3oa} in docker ps
Unable to find service {Name:s2 ID:c2do5owrkc0fh3ot4n7xnf3oa} in docker ps
Unable to find service {Name:s2 ID:c2do5owrkc0fh3ot4n7xnf3oa} in docker ps
Unable to find service {Name:s2 ID:c2do5owrkc0fh3ot4n7xnf3oa} in docker ps
Unable to find service {Name:s2 ID:c2do5owrkc0fh3ot4n7xnf3oa} in docker ps
I0709 14:00:16.356081 14023 container.go:138] containerOpStart(): logstash
Unable to find service {Name:s2 ID:c2do5owrkc0fh3ot4n7xnf3oa} in docker ps
Unable to find service {Name:s2 ID:c2do5owrkc0fh3ot4n7xnf3oa} in docker ps
Unable to find service {Name:s2 ID:c2do5owrkc0fh3ot4n7xnf3oa} in docker ps
Unable to find service {Name:s2 ID:c2do5owrkc0fh3ot4n7xnf3oa} in docker ps
Output of /home/plu/src/europa/src/golang/src/github.com/zenoss/serviced/serviced service list:
NAME        SERVICEID           INST    IMAGEID         POOL        DSTATE  LAUNCH  DEPID
└─testsvc   1o7dntyvbb5n2kbn6418vu3v2   0               default     1   auto    testsvc
  ├─s2      c2do5owrkc0fh3ot4n7xnf3oa   1   .../1o7dnty.../ubuntu   default     1   auto    testsvc
  └─s1      cua1ocgoovlzo7dzym8nceswb   1   .../1o7dnty.../ubuntu   default     1   auto    testsvc

Output of docker ps --no-trunc | grep -v isvcs:
CONTAINER ID                                                       IMAGE                         COMMAND                                                                                                                                  CREATED             STATUS              PORTS                                                                                            NAMES
====== FAIL ======
Unable to see service containers
==================
```

DEMO1:

```
===== SUCCESS =====
Started service
===================
...
===== SUCCESS =====
Service containers started
===================
...
===== SUCCESS =====
Attached to container
===================
```
