### PR TITLE
make /tmp in service containers temporary docker volumes

### DIFF
--- a/node/agent.go
+++ b/node/agent.go
@@ -713,6 +713,13 @@ func configureContainer(a *HostAgent, client *ControlClient,
 		glog.V(1).Infof("added logstash bind mount: %s", binding)
 	}
 
+	// specify temporary volume paths for docker to create
+	tmpVolumes := []string{"/tmp"}
+	for _, path := range tmpVolumes {
+		cfg.Volumes[path] = struct{}{}
+		glog.V(0).Infof("added temporary docker container path: %s", path)
+	}
+
 	// add arguments to mount requested directory (if requested)
 	glog.V(2).Infof("Checking Mount options for service %#v", svc)
 	for _, bindMountString := range a.mount {


### PR DESCRIPTION
PART 1 of US10557

BEFORE:

```
# plu@plu-9: serviced service attach redis df -Ha
Filesystem                                              Size  Used Avail Use% Mounted on
rootfs                                                   68G   25G   40G  39% /
none                                                     68G   25G   40G  39% /
proc                                                       0     0     0    - /proc
sysfs                                                      0     0     0    - /sys
tmpfs                                                    17G     0   17G   0% /dev
shm                                                      68M     0   68M   0% /dev/shm
devpts                                                     0     0     0    - /dev/pts
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /.dockerinit
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /etc/resolv.conf
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /etc/hostname
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /etc/hosts
/dev/sda6                                               180G  8.4G  163G   5% /mnt/src
/dev/sda6                                               180G  8.4G  163G   5% /serviced
/dev/sda6                                               180G  8.4G  163G   5% /usr/local/serviced/resources/logstash
proc                                                       0     0     0    - /proc/sys
proc                                                       0     0     0    - /proc/sysrq-trigger
proc                                                       0     0     0    - /proc/irq
proc                                                       0     0     0    - /proc/bus
tmpfs                                                    17G     0   17G   0% /proc/kcore
# plu@plu-9: serviced service attach redis ls -ald /tmp
drwxrwxrwx 8 root root 4096 Jul  9 20:11 /tmp
```

AFTER:

```
# plu@plu-9: serviced service attach redis df -Ha
Filesystem                                              Size  Used Avail Use% Mounted on
rootfs                                                   68G   25G   40G  39% /
none                                                     68G   25G   40G  39% /
proc                                                       0     0     0    - /proc
sysfs                                                      0     0     0    - /sys
tmpfs                                                    17G     0   17G   0% /dev
shm                                                      68M     0   68M   0% /dev/shm
devpts                                                     0     0     0    - /dev/pts
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /.dockerinit
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /etc/resolv.conf
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /etc/hostname
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /etc/hosts
/dev/sda6                                               180G  8.4G  163G   5% /mnt/src
/dev/sda6                                               180G  8.4G  163G   5% /serviced
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /tmp
/dev/sda6                                               180G  8.4G  163G   5% /usr/local/serviced/resources/logstash
proc                                                       0     0     0    - /proc/sys
proc                                                       0     0     0    - /proc/sysrq-trigger
proc                                                       0     0     0    - /proc/irq
proc                                                       0     0     0    - /proc/bus
tmpfs                                                    17G     0   17G   0% /proc/kcore
# plu@plu-9: serviced service attach redis ls -ald /tmp
drwxrwxrwx 4 root root 4096 Jul  9 20:51 /tmp
```
