### PR TITLE
added Type to Volumes; for Type=tmp, append to tmpVolumes, for dfs, setu...

### DIFF
--- a/domain/servicedefinition/servicedefinition.go
+++ b/domain/servicedefinition/servicedefinition.go
@@ -79,6 +79,7 @@ type Volume struct {
 	Permission    string //Resource Path permissions, eg what you pass to chmod
 	ResourcePath  string //Resource Pool Path, shared across all hosts in a resource pool
 	ContainerPath string //Container bind-mount path
+	Type          string //Path use, i.e. "dfs" or "tmp"
 }
 
 // ConfigFile config file for a service

--- a/node/agent.go
+++ b/node/agent.go
@@ -684,6 +684,10 @@ func configureContainer(a *HostAgent, client *ControlClient,
 	}
 
 	for _, volume := range svc.Volumes {
+		if volume.Type != "" && volume.Type != "dfs" {
+			continue
+		}
+
 		resourcePath, err := a.setupVolume(tenantID, svc, volume)
 		if err != nil {
 			glog.Fatalf("%s", err)
@@ -715,6 +719,11 @@ func configureContainer(a *HostAgent, client *ControlClient,
 
 	// specify temporary volume paths for docker to create
 	tmpVolumes := []string{"/tmp"}
+	for _, volume := range svc.Volumes {
+		if volume.Type == "tmp" {
+			tmpVolumes = append(tmpVolumes, volume.ContainerPath)
+		}
+	}
 	for _, path := range tmpVolumes {
 		cfg.Volumes[path] = struct{}{}
 		glog.V(0).Infof("added temporary docker container path: %s", path)

--- a/node/agent_proxy.go
+++ b/node/agent_proxy.go
@@ -270,6 +270,10 @@ func (a *HostAgent) GetServiceBindMounts(serviceID string, bindmounts *map[strin
 
 	response := map[string]string{}
 	for _, volume := range service.Volumes {
+		if volume.Type != "" && volume.Type != "dfs" {
+			continue
+		}
+
 		resourcePath, err := a.setupVolume(tenantID, &service, volume)
 		if err != nil {
 			return err


### PR DESCRIPTION
...pVolumes

PART 2 of https://rally1.rallydev.com/#/12213835864d/detail/task/20181556292
 (depends on PART 1 https://github.com/zenoss/serviced/pull/691)

DEMO1 - dfs is still working (zenjobs dir is bindmounted):

```
# plu@plu-9: serviced service attach zenjobs df -Ha
Filesystem                                              Size  Used Avail Use% Mounted on
rootfs                                                   68G   25G   40G  39% /
none                                                     68G   25G   40G  39% /
proc                                                       0     0     0    - /proc
sysfs                                                      0     0     0    - /sys
tmpfs                                                    17G     0   17G   0% /dev
shm                                                      68M     0   68M   0% /dev/shm
devpts                                                     0     0     0    - /dev/pts
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /.dockerinit
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /etc/resolv.conf
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /etc/hostname
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /etc/hosts
/dev/sda6                                               180G  8.4G  163G   5% /mnt/src
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /opt/zenoss/log/jobs
/dev/sda6                                               180G  8.4G  163G   5% /serviced
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /tmp
/dev/sda6                                               180G  8.4G  163G   5% /usr/local/serviced/resources/logstash
proc                                                       0     0     0    - /proc/sys
proc                                                       0     0     0    - /proc/sysrq-trigger
proc                                                       0     0     0    - /proc/irq
proc                                                       0     0     0    - /proc/bus
tmpfs                                                    17G     0   17G   0% /proc/kcore
# plu@plu-9: tree /tmp/serviced-root/var/volumes/default/7qjmyaa6dfobfytwwi1ig2tef/
/tmp/serviced-root/var/volumes/default/7qjmyaa6dfobfytwwi1ig2tef/
└── zenjobs
    └── README.txt

1 directory, 1 file
```

DEMO2 - if /var/log as "tmp" is added to redis/service.json:

```
diff --git a/services/Zenoss.core/redis/service.json b/services/Zenoss.core/redis/service.json
index 371c917..25f479b 100644
--- a/services/Zenoss.core/redis/service.json
+++ b/services/Zenoss.core/redis/service.json
@@ -25,6 +25,12 @@
     ],
+    "Volumes": [
+        {
+            "ContainerPath": "/var/log",
+            "Type": "tmp"
+        }
+    ],
     "HealthChecks": {

# plu@plu-9: serviced service attach redis df -Ha
Filesystem                                              Size  Used Avail Use% Mounted on
rootfs                                                   68G   25G   40G  39% /
none                                                     68G   25G   40G  39% /
proc                                                       0     0     0    - /proc
sysfs                                                      0     0     0    - /sys
tmpfs                                                    17G     0   17G   0% /dev
shm                                                      68M     0   68M   0% /dev/shm
devpts                                                     0     0     0    - /dev/pts
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /.dockerinit
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /etc/resolv.conf
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /etc/hostname
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /etc/hosts
/dev/sda6                                               180G  8.4G  163G   5% /mnt/src
/dev/sda6                                               180G  8.4G  163G   5% /serviced
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /tmp
/dev/sda6                                               180G  8.4G  163G   5% /usr/local/serviced/resources/logstash
/dev/disk/by-uuid/0aa45c20-94c0-4476-ae7f-dffcf8f6e690   68G   25G   40G  39% /var/log
proc                                                       0     0     0    - /proc/sys
proc                                                       0     0     0    - /proc/sysrq-trigger
proc                                                       0     0     0    - /proc/irq
proc                                                       0     0     0    - /proc/bus
tmpfs                                                    17G     0   17G   0% /proc/kcore
# plu@plu-9: serviced service attach redis ls -altr /var/log
total 440
drwxrwx---  2 root     root              4096 Aug  1  2013 supervisor
drwxr-xr-x  2 root     root              4096 Aug 14  2013 sa
drwxr-sr-x  2 root     systemd-journal   4096 Mar  5 06:51 journal
-rw-r--r--  1 root     root              1040 Mar  5 06:51 README
-rw-------  1 root     root                 0 Apr  9 13:11 tallylog
drwxr-xr-x 40 root     root              4096 Apr  9 13:11 ..
-rw-rw-r--  1 root     utmp                 0 Apr  9 13:11 wtmp
-rw-------  1 root     utmp                 0 Apr  9 13:11 btmp
drwxr-x---  2 mysql    mysql             4096 Apr 17 15:57 mariadb
-rw-r--r--  1 root     root            390696 Jul  8 08:11 lastlog
-rw-------  1 root     root             20239 Jul  8 08:11 yum.log
drwxr-xr-x  2 redis    root              4096 Jul  8 08:11 redis
drwxr-x---  2 rabbitmq rabbitmq          4096 Jul  8 08:11 rabbitmq
drwxr-xr-x  8 root     root              4096 Jul  9 22:10 .
# plu@plu-9: 
```
