### PR TITLE
Freeze elastigo at our necessary revision

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -50,19 +50,19 @@
 			"Rev": "cb98efbb933d8389ab549a060e880ea3c375d213"
 		},
 		{
-			"ImportPath": "github.com/mattbaird/elastigo/api",
+			"ImportPath": "github.com/zenoss/elastigo/api",
 			"Rev": "041b88c1fcf6489a5721ede24378ce1253b9159d"
 		},
 		{
-			"ImportPath": "github.com/mattbaird/elastigo/cluster",
+			"ImportPath": "github.com/zenoss/elastigo/cluster",
 			"Rev": "041b88c1fcf6489a5721ede24378ce1253b9159d"
 		},
 		{
-			"ImportPath": "github.com/mattbaird/elastigo/core",
+			"ImportPath": "github.com/zenoss/elastigo/core",
 			"Rev": "041b88c1fcf6489a5721ede24378ce1253b9159d"
 		},
 		{
-			"ImportPath": "github.com/mattbaird/elastigo/search",
+			"ImportPath": "github.com/zenoss/elastigo/search",
 			"Rev": "041b88c1fcf6489a5721ede24378ce1253b9159d"
 		},
 		{


### PR DESCRIPTION
the elastigo repo underwent a huge refactor at https://github.com/mattbaird/elastigo/commit/c87b68ee40066d2cc2eeb9b2f4d8bb5088d41c59, making godep not work for it anymore. Froze it at the revision we need.
