### PR TITLE
Feature/zen 12636

### DIFF
--- a/cli/api/logs_test.go
+++ b/cli/api/logs_test.go
@@ -1,11 +1,12 @@
 package api
 
 import (
+	"math"
 	"reflect"
 	"testing"
 )
 
-func testConvertOffsets(t *testing.T, received []string, expected []int64) {
+func testConvertOffsets(t *testing.T, received []string, expected []uint64) {
 	converted, err := convertOffsets(received)
 	if err != nil {
 		t.Fatalf("unexpected error converting offsets: %s", err)
@@ -15,26 +16,37 @@ func testConvertOffsets(t *testing.T, received []string, expected []int64) {
 	}
 }
 
-func testInt64sAreSorted(t *testing.T, values []int64, expected bool) {
-	if int64sAreSorted(values) != expected {
+func testUint64sAreSorted(t *testing.T, values []uint64, expected bool) {
+	if uint64sAreSorted(values) != expected {
 		t.Fatalf("expected %v for sortedness for values: %v", expected, values)
 	}
 }
 
-func testGenerateOffsets(t *testing.T, received, expected []int64) {
-	converted := generateOffsets(received)
-	if !reflect.DeepEqual(converted, expected) {
-		t.Fatalf("unexpected error generating offsets got %v expected %v", converted, expected)
+func testGetMinValue(t *testing.T, values []uint64, expected uint64) {
+	if getMinValue(values) != expected {
+		t.Fatalf("expected min value %v from values: %v", expected, values)
 	}
 }
 
-func TestLogs_ConvertOffsets(t *testing.T) {
-	testConvertOffsets(t, []string{"123", "456", "789"}, []int64{123, 456, 789})
-	testConvertOffsets(t, []string{"456", "123", "789"}, []int64{456, 123, 789})
+func testGenerateOffsets(t *testing.T, inMessages []string, inOffsets, expected []uint64) {
+	converted := generateOffsets(inMessages, inOffsets)
+	if !reflect.DeepEqual(converted, expected) {
+		t.Fatalf("unexpected error generating offsets from %v:%v got %v expected %v", inMessages, inOffsets, converted, expected)
+	}
+}
 
-	testInt64sAreSorted(t, []int64{123, 124, 125}, true)
-	testInt64sAreSorted(t, []int64{123, 125, 124}, false)
-	testInt64sAreSorted(t, []int64{125, 123, 124}, false)
+func TestLogs_Offsets(t *testing.T) {
+	testConvertOffsets(t, []string{"123", "456", "789"}, []uint64{123, 456, 789})
+	testConvertOffsets(t, []string{"456", "123", "789"}, []uint64{456, 123, 789})
 
-	testGenerateOffsets(t, []int64{456, 123, 789}, []int64{123, 124, 125})
+	testUint64sAreSorted(t, []uint64{123, 124, 125}, true)
+	testUint64sAreSorted(t, []uint64{123, 125, 124}, false)
+	testUint64sAreSorted(t, []uint64{125, 123, 124}, false)
+
+	testGetMinValue(t, []uint64{}, math.MaxUint64)
+	testGetMinValue(t, []uint64{125, 123, 124}, 123)
+
+	testGenerateOffsets(t, []string{}, []uint64{}, []uint64{})
+	testGenerateOffsets(t, []string{"abc", "def", "ghi"}, []uint64{456, 123, 789}, []uint64{123, 124, 125})
+	testGenerateOffsets(t, []string{"abc", "def", "ghi"}, []uint64{456, 124}, []uint64{124, 125, 126})
 }


### PR DESCRIPTION
Fix for :
0. #lines is 1+#elastic offsets, add to last offset #bytes of 2nd to last line
1. #lines != #elastic offsets, generate offsets
2. elastic offsets not monotonically increasing,generate offsets
3. otherwise, use current method of using elastic offsets
