### PR TITLE
Set HOME in /etc/default/serviced so .dockercfg can be found

### DIFF
--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -1,0 +1,2 @@
+# Need to set $HOME so Docker client can find .dockercfg
+export HOME=/root


### PR DESCRIPTION
Sadly, docker does not allow passing in a path to an auth file. It always looks in $HOME.
