### PR TITLE
fixed one more corner case where elastic does not return any Offset for ...

### DIFF
--- a/cli/api/logs.go
+++ b/cli/api/logs.go
@@ -305,9 +305,13 @@ func parseLogSource(source []byte) (string, string, []compactLogLine, error) {
 	// attempt to unmarshal into singleLine
 	var line logSingleLine
 	if e := json.Unmarshal(source, &line); e == nil {
-		offset, e := strconv.ParseUint(line.Offset, 10, 64)
-		if e != nil {
-			return "", "", nil, fmt.Errorf("failed to parse offset \"%s\" in \"%s\": %s", line.Offset, source, e)
+		offset := uint64(0)
+		if len(line.Offset) != 0 {
+			var e error
+			offset, e = strconv.ParseUint(line.Offset, 10, 64)
+			if e != nil {
+				return "", "", nil, fmt.Errorf("failed to parse offset \"%s\" in \"%s\": %s", line.Offset, source, e)
+			}
 		}
 		compactLine := compactLogLine{
 			Timestamp: truncateToMinute(line.Timestamp.UnixNano()),


### PR DESCRIPTION
...single line

ISSUE:

```
# plu@plu-9: serviced log export
failed to parse offset "" in "{"type":"controller-5incc4maf9olptz0q3wid7z6k-0","message":"W0717 00:00:47.303910 00001 controller.go:562] Health check zenhub_answering failed.","@version":"1","@timestamp":"2014-07-17T00:00:47.304Z","host":"172.17.42.1:51291"}": strconv.ParseUint: parsing "": invalid syntax
```

DEMO:

``````
# plu@plu-9: serviced log export

# plu@plu-9: ls -altr serviced-log-export*
-rw-rw-r-- 1 plu plu 44701 Jul 16 23:58 serviced-log-export.tgz

# plu@plu-9: tar -xzf serviced-log-export.tgz

# plu@plu-9: ls -altr serviced-log-export*
-rw-rw-r-- 1 plu plu 44701 Jul 16 23:58 serviced-log-export.tgz

serviced-log-export-693399840:
total 596
-rw-r--r--  1 plu plu    285 Jul 16 23:58 index.txt
-rw-rw-r--  1 plu plu    156 Jul 16 23:58 005.log
-rw-rw-r--  1 plu plu   1401 Jul 16 23:58 004.log
-rw-rw-r--  1 plu plu    608 Jul 16 23:58 003.log
-rw-rw-r--  1 plu plu 138223 Jul 16 23:58 002.log
-rw-rw-r--  1 plu plu 441162 Jul 16 23:58 001.log
-rw-rw-r--  1 plu plu   2858 Jul 16 23:58 000.log
drwx------  2 plu plu   4096 Jul 16 23:58 .
drwxrwxr-x 33 plu plu   4096 Jul 17 00:03 ..

# plu@plu-9: cat serviced-log-export-693399840/index.txt
INDEX OF LOG FILES
File    Host    Original Filename
000.log "aa7fa764ce31"  "/var/log/redis/redis.log"
001.log "896bd9a525df"  "/var/log/rabbitmq/rabbit@localhost.log"
002.log "172.17.42.1:39130" ""
003.log "172.17.42.1:39112" ""
004.log "172.17.42.1:58277" ""
005.log "172.17.42.1:39022" ""

# plu@plu-9: cat serviced-log-export-693399840/000.log
                _._                                                  
           _.-``__ ''-._                                             
      _.-``    `.  `_.  ''-._           Redis 2.6.16 (00000000/0) 64 bit
  .-`` .-```.  ```\/    _.,_ ''-._                                   
 (    '      ,       .-`  | `,    )     Running in stand alone mode
 |`-._`-...-` __...-.``-._|'` _.-'|     Port: 6379
 |    `-._   `._    /     _.-'    |     PID: 20
  `-._    `-._  `-./  _.-'    _.-'                                   
 |`-._`-._    `-.__.-'    _.-'_.-'|                                  
 |    `-._`-._        _.-'_.-'    |           http://redis.io        
  `-._    `-._`-.__.-'_.-'    _.-'                                   
 |`-._`-._    `-.__.-'    _.-'_.-'|                                  
 |    `-._`-._        _.-'_.-'    |                                  
  `-._    `-._`-.__.-'_.-'    _.-'                                   
      `-._    `-.__.-'    _.-'                                       
          `-._        _.-'                                           
              `-.__.-'                                               

[20] 17 Jul 04:30:17.992 # Server started, Redis version 2.6.16
                _._                                                  
           _.-``__ ''-._                                             
      _.-``    `.  `_.  ''-._           Redis 2.6.16 (00000000/0) 64 bit
  .-`` .-```.  ```\/    _.,_ ''-._                                   
 (    '      ,       .-`  | `,    )     Running in stand alone mode
 |`-._`-...-` __...-.``-._|'` _.-'|     Port: 6379
 |    `-._   `._    /     _.-'    |     PID: 20
  `-._    `-._  `-./  _.-'    _.-'                                   
 |`-._`-._    `-.__.-'    _.-'_.-'|                                  
 |    `-._`-._        _.-'_.-'    |           http://redis.io        
  `-._    `-._`-.__.-'_.-'    _.-'                                   
 |`-._`-._    `-.__.-'    _.-'_.-'|                                  
 |    `-._`-._        _.-'_.-'    |                                  
  `-._    `-._`-.__.-'_.-'    _.-'                                   
      `-._    `-.__.-'    _.-'                                       
          `-._        _.-'                                           
              `-.__.-'                                               

[20] 17 Jul 04:30:17.992 # Server started, Redis version 2.6.16
[20] 17 Jul 04:30:17.993 # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
[20] 17 Jul 04:30:17.993 * DB loaded from disk: 0.000 seconds
[20] 17 Jul 04:30:17.993 * The server is now ready to accept connections on port 6379
``````
