### PR TITLE
fixed index panic error when #offsets is one less than #lines

### DIFF
--- a/cli/api/logs.go
+++ b/cli/api/logs.go
@@ -18,10 +18,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/control-center/serviced/domain/service"
 	elastigo "github.com/zenoss/elastigo/api"
 	"github.com/zenoss/elastigo/core"
 	"github.com/zenoss/glog"
-	"github.com/control-center/serviced/domain/service"
 )
 
 // ExportLogs exports logs from ElasticSearch.
@@ -339,7 +339,7 @@ func parseLogSource(source []byte) (string, string, []compactLogLine, error) {
 		glog.Warningf("number of offsets for %s:%s (numLines:%d numOffsets:%d) is one less than number of lines: %s", multiLine.Host, multiLine.File, len(messages), len(offsets), source)
 		numLines := len(messages)
 		if numLines > 1 {
-			lastOffset := uint64(len(messages[numLines-2])) + offsets[numLines-1]
+			lastOffset := uint64(len(messages[numLines-2])) + offsets[numLines-2]
 			offsets = append(offsets, lastOffset)
 		}
 	} else if len(offsets) > len(messages) {
@@ -352,7 +352,7 @@ func parseLogSource(source []byte) (string, string, []compactLogLine, error) {
 
 	// deal with offsets that are not sorted in increasing order
 	if !uint64sAreSorted(offsets) {
-		glog.Warningf("offsets are not sorted: %s", offsets)
+		glog.Warningf("offsets are not sorted: %v", offsets)
 		offsets = generateOffsets(messages, offsets)
 		glog.Warningf("new offsets: %v", offsets)
 	}


### PR DESCRIPTION
ISSUE:

```
W0721 16:50:18.665193 10900 logs.go:355] offsets are not sorted: [%!s(uint64=1633) %!s(uint64=1499) %!s(uint64=1572)]
W0721 16:50:18.665244 10900 logs.go:357] new offsets: [1499 1500 1501]
W0721 16:50:18.668818 10900 logs.go:339] number of offsets for 0c2fa00d5aa2:/opt/zenoss/log/zenjobs.log (numLines:5 numOffsets:4) is one less than number of lines: {"message":"--- ***** ----- \n\n -------------- celery@0c2fa00d5aa2 v3.0.15 (Chiastic Slide)\n2014-07-21 16:04:24,801 INFO celery.redirected: Starting CeleryZenWorker\n -------------- celery@0c2fa00d5aa2 v3.0.15 (Chiastic Slide)","@version":"1","@timestamp":"2014-07-21T16:08:07.931Z","file":"/opt/zenoss/log/zenjobs.log","host":"0c2fa00d5aa2","offset":["2084","2101","1572","1499"],"service":"abngac0eqkphwmqlagwpy7ig9","type":"zenjobs","tags":["_grokparsefailure","multiline"],"timestamp":["2014-07-21 16:04:24,801","2014-07-21 16:04:24,801"],"loglevel":["INFO","INFO"],"logger":["celery.redirected","celery.redirected"]}
panic: runtime error: index out of range

goroutine 1 [running]:
runtime.panic(0x96f980, 0x13a2997)
    /usr/local/go/src/pkg/runtime/panic.c:266 +0xb6
github.com/control-center/serviced/cli/api.parseLogSource(0xc210323280, 0x26f, 0x26f, 0x6e, 0x0, ...)
    /go/src/github.com/control-center/serviced/cli/api/logs.go:342 +0x10ba
github.com/control-center/serviced/cli/api.(*api).ExportLogs(0xc210095d50, 0x13c6900, 0x0, 0x0, 0xc2100d3bf0, ...)
```
