### PR TITLE
Feature/zen 12947

### DIFF
--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -337,7 +337,7 @@ func (c *ServicedCli) searchForServices(keywords []string) ([]*service.Service, 
 	}
 
 	if len(services) == 0 {
-		return nil, fmt.Errorf("no services found")
+		return nil, fmt.Errorf("no service found")
 	}
 
 	return services, nil

--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -441,7 +441,7 @@ func ExampleServicedCLI_CmdServiceRemove_err() {
 	pipeStderr(InitServiceAPITest, "serviced", "service", "remove", "test-service-0")
 
 	// Output:
-	// test-service-0: no service found
+	// no service found
 }
 
 func ExampleServicedCLI_CmdServiceRemove_complete() {
@@ -547,7 +547,7 @@ func ExampleServicedCLI_CmdServiceAssignIPs_err() {
 	pipeStderr(InitServiceAPITest, "serviced", "service", "assign-ip", "test-service-0", "100.99.88.1")
 
 	// Output:
-	//
+	// service not found
 }
 
 func ExampleServicedCLI_CmdServiceStart() {
@@ -588,7 +588,7 @@ func ExampleServicedCLI_CmdServiceStart_err() {
 	pipeStderr(InitServiceAPITest, "serviced", "service", "start", "test-service-0")
 
 	// Output:
-	// no service found
+	// service not found
 }
 
 func ExampleServicedCLI_CmdServiceStop() {
@@ -620,7 +620,7 @@ func ExampleServicedCLI_CmdServiceStop_err() {
 	pipeStderr(InitServiceAPITest, "serviced", "service", "stop", "test-service-0")
 
 	// Output:
-	// no service found
+	// service not found
 }
 
 func ExampleServicedCLI_CmdServiceProxy_usage() {
@@ -689,7 +689,7 @@ func ExampleServicedCLI_CmdServiceShell_err() {
 	pipeStderr(InitServiceAPITest, "serviced", "service", "shell", "test-service-0", "some", "command")
 
 	// Output:
-	// no service found
+	// service not found
 }
 
 func ExampleServicedCLI_CmdServiceRun_list() {
@@ -735,7 +735,7 @@ func ExampleServicedCLI_CmdServiceRun_err() {
 	pipeStderr(InitServiceAPITest, "serviced", "service", "run", "test-service-0", "goodbye")
 
 	// Output:
-	// no service found
+	// service not found
 }
 
 func ExampleServicedCLI_CmdServiceRun_complete() {
@@ -789,7 +789,7 @@ func ExampleServicedCLI_CmdServiceListSnapshots_fail() {
 	pipeStderr(InitServiceAPITest, "serviced", "service", "list-snapshots", "test-service-1")
 
 	// Output:
-	// invalid snapshot
+	// invalid service
 }
 
 func ExampleServicedCLI_CmdServiceListSnapshots_err() {
@@ -830,12 +830,12 @@ func ExampleServicedCLI_CmdServiceSnapshot_fail() {
 	pipeStderr(InitServiceAPITest, "serviced", "service", "snapshot", "test-service-1")
 
 	// Output:
-	// invalid snapshot
+	// invalid service
 }
 
 func ExampleServicedCLI_CmdServiceSnapshot_err() {
 	pipeStderr(InitServiceAPITest, "serviced", "service", "snapshot", "test-service-0")
 
 	// Output:
-	// received nil snapshot
+	// service not found
 }


### PR DESCRIPTION
DEMO:

```
# plu@plu-9: serviced service attach a0fa4e7e1ee7  # notice docker short name
/
# root@a0fa4e7e1ee7: exit

# plu@plu-9: serviced service attach rabbitmq   # notice lowercase instead of RabbitMQ
/
# root@a0fa4e7e1ee7: exit

# plu@plu-9: serviced service start redis
Service scheduled to start.
# plu@plu-9: serviced service stop redis
Service scheduled to stop.

...
```
