### PR TITLE
truncate offsets if those are greater than #messages

### DIFF
--- a/cli/api/logs.go
+++ b/cli/api/logs.go
@@ -125,6 +125,8 @@ func (a *api) ExportLogs(serviceIds []string, from, to, outfile string) (err err
 	if e != nil {
 		return e
 	}
+
+	glog.Infof("Starting part 1 of 3: process logstash elasticsearch results using temporary dir: %s", tempdir)
 	foundIndexedDay := false
 	for _, yyyymmdd := range days {
 		// Skip the indexes that are filtered out by the date range
@@ -185,6 +187,8 @@ func (a *api) ExportLogs(serviceIds []string, from, to, outfile string) (err err
 		return fmt.Errorf("no logstash indexes exist for the given date range %s - %s", from, to)
 	}
 
+	glog.Infof("Starting part 2 of 3: sort output files")
+
 	indexData := []string{}
 	for host, logfileIndex := range fileIndex {
 		for logfile, i := range logfileIndex {
@@ -214,10 +218,13 @@ func (a *api) ExportLogs(serviceIds []string, from, to, outfile string) (err err
 		return fmt.Errorf("failed writing to %s: %s", indexFile, e)
 	}
 
+	glog.Infof("Starting part 3 of 3: generate tar file: %s", outfile)
+
 	cmd := exec.Command("tar", "-czf", outfile, "-C", filepath.Dir(tempdir), filepath.Base(tempdir))
 	if output, e := cmd.CombinedOutput(); e != nil {
 		return fmt.Errorf("failed to write tgz cmd:%+v, error:%v, output:%s", cmd, e, string(output))
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Dependent on:
  https://github.com/control-center/serviced/pull/743

ISSUE:

```
W0721 22:07:01.569829 04252 logs.go:346] number of offsets for c279d63256b4:/opt/zenoss/log/central-query.log (numLines:6 numOffsets:10) is greater than number of lines: {"message":"INFO  2014-07-21 16:17:40,909 com.yammer.metrics.httpclient.InstrumentedHttpClient: Retrying request\nERROR 2014-07-21 16:17:42,044 org.zenoss.metrics.reporter.ZenossMetricsReporter: Error posting metrics\n! org.apache.http.client.HttpResponseException: Service Temporarily Unavailable\n! at org.apache.http.impl.client.BasicResponseHandler.handleResponse(BasicResponseHandler.java:68) ~central-query-0.0.7-SNAPSHOT.jar:na\n! at org.zenoss.metrics.reporter.HttpPoster$AuthResponseHandler.handleResponse(HttpPoster.java:117) ~central-query-0.0.7-SNAPSHOT.jar:na\n! at org.zenoss.metrics.reporter.HttpPoster$AuthResponseHandler.handleResponse(HttpPoster.java:112) ~central-query-0.0.7-SNAPSHOT.jar:na","@version":"1","@timestamp":"2014-07-21T18:26:55.884Z","file":"/opt/zenoss/log/central-query.log","host":"c279d63256b4","offset":["132663","132766","132871","132951","133089","133228","135276","135356","135494","135633"],"service":"4xmo6p334ds7l0h3qdf5cgm64","type":"centralquery","tags":["_grokparsefailure","multiline"],"loglevel":["ERROR","ERROR"],"logger":["org.zenoss.metrics.reporter.ZenossMetricsReporter","org.zenoss.metrics.reporter.ZenossMetricsReporter"]}
```
