### PR TITLE
reordered priority of status|list to be: --ascii, stdout pipe, SERVICED_...

### DIFF
--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -347,6 +347,17 @@ func (c *ServicedCli) searchForServices(keywords []string) ([]*service.Service, 
 	return services, nil
 }
 
+// cmdSetTreeCharset sets the default behavior for --ASCII, SERVICED_TREE_ASCII, and stdout pipe
+func cmdSetTreeCharset(ctx *cli.Context) {
+	if ctx.Bool("ascii") {
+		treeCharset = treeASCII
+	} else if !isatty(os.Stdout) {
+		treeCharset = treeSPACE
+	} else if configBool("TREE_ASCII", false) {
+		treeCharset = treeASCII
+	}
+}
+
 // serviced service status
 func (c *ServicedCli) cmdServiceStatus(ctx *cli.Context) {
 	services, err := c.driver.GetServices()
@@ -463,17 +474,7 @@ func (c *ServicedCli) cmdServiceStatus(ctx *cli.Context) {
 		}
 	}
 
-	useTreeAscii := configBool("TREE_ASCII", false)
-	if ctx.Bool("ascii") {
-		useTreeAscii = true
-	}
-
-	isTTY := isatty(os.Stdout)
-	if useTreeAscii {
-		treeCharset = treeASCII
-	} else if !isTTY {
-		treeCharset = treeSPACE
-	}
+	cmdSetTreeCharset(ctx)
 
 	childMap[""] = top
 	tableService := newtable(0, 8, 2)
@@ -527,17 +528,7 @@ func (c *ServicedCli) cmdServiceList(ctx *cli.Context) {
 		}
 	} else {
 
-		useTreeAscii := configBool("TREE_ASCII", false)
-		if ctx.Bool("ascii") {
-			useTreeAscii = true
-		}
-
-		isTTY := isatty(os.Stdout)
-		if useTreeAscii {
-			treeCharset = treeASCII
-		} else if !isTTY {
-			treeCharset = treeSPACE
-		}
+		cmdSetTreeCharset(ctx)
 
 		servicemap := api.NewServiceMap(services)
 		tableService := newtable(0, 8, 2)


### PR DESCRIPTION
...TREE_ASCII=true

DEMO:

```
# plu@plu-9: serviced service status 
NAME            ID              STATUS      HOST    DOCKER_ID
└─Zenoss.core       bst8y9zhc43rdmf5368tnaqmd   stopped         
  ├─CentralQuery    1ebt5xf2vvcckbbmbndmlyako   stopped         
  ├─redis       29wjs2tv3z9espox12ysuf4cm   stopped         
  ├─localhost       586hwicu60qw2c19svi0xwud1   stopped         
  │ ├─zenhub      4n8tdcjsgz5uk1d26x0p0gmyh   stopped         
  │ └─localhost       9r36znryetwn5edw6z6pm3y96   stopped         
  │   ├─zentrap       11c05rldpynv94qbuq66sklw2   stopped         
  │   ├─zenprocess    1zz41wonvnf6qjgsrgdqh69k0   stopped         
  │   ├─zencommand    4ae62xdioqsd6oogje2g2n622   stopped         
  │   ├─zensyslog 4jlgxhc6a5sel99est41yn27a   stopped         
  │   ├─zenping       7dpxh58rs0hd14s9wpaoqcnhn   stopped         
  │   ├─zenstatus b5vdje3nqdfevgv3temcv4w8w   stopped         
  │   ├─zenjmx        db2569q13fv3ts1s2re89srlj   stopped         
  │   ├─zenperfsnmp   dunx1w2k7plqzmewoesuytpy5   stopped         
  │   ├─zenmodeler    dyqb4ngma1ttxlh47elim3jea   stopped         
  │   └─zenpython e2ptg0oqy3c4plboc0zwvu1d9   stopped         
  ├─RabbitMQ        599jce2svt2iwq5ifxluayuks   stopped         
  ├─HBase       5rixhscd4kadrvx792fotdq2    stopped         
  │ ├─ZooKeeper       1et7xsufohwlalelncn65m76f   stopped         
  │ ├─RegionServer    8h5c4b8jx5hzoimj4kfcbfl2t   stopped         
  │ └─HMaster     axsegkdato4ms8nehihetqeh8   stopped         
  ├─zenjobs     67vlsugnu52vydmmjjextm4i1   stopped         
  ├─MySQL       6t8x7p2cyn2sc3aq02fhg0je1   stopped         
  ├─zeneventd       73oz63qlrpvi61gewh59i46gn   stopped         
  ├─MetricConsumer  8o6unvovxnttm99pk9wyxvesb   stopped         
  ├─memcached       9b4ad09p9occf94vgclgkwnqe   stopped         
  ├─zenactiond      9g486yts28npx573jkcu3gjoa   stopped         
  ├─zproxy      9ikgqichvyrjkh3wssbfar9jf   stopped         
  ├─MetricShipper   9lv1jahg32l9845lpw6g6kxuq   stopped         
  ├─Zauth       c6sw26hs8qqslhuv9jqz1go64   stopped         
  ├─Zope        cb460soyeii6rouof6pv4spwy   stopped         
  ├─opentsdb        g8rpklb5rlj0d2723wdglfc7    stopped         
  │ ├─reader      1r1j4ntq8q2cpgaaconxdp8oi   stopped         
  │ └─writer      3l3a1vsx0g3n3j4jx9txrhcof   stopped         
  └─zeneventserver  j9a3hu5eql0bx5qma9erf1vi    stopped         

# plu@plu-9: serviced service status  | cat
NAME            ID              STATUS      HOST    DOCKER_ID
  Zenoss.core       bst8y9zhc43rdmf5368tnaqmd   stopped         
    CentralQuery    1ebt5xf2vvcckbbmbndmlyako   stopped         
    redis       29wjs2tv3z9espox12ysuf4cm   stopped         
    localhost       586hwicu60qw2c19svi0xwud1   stopped         
      zenhub        4n8tdcjsgz5uk1d26x0p0gmyh   stopped         
      localhost     9r36znryetwn5edw6z6pm3y96   stopped         
        zentrap     11c05rldpynv94qbuq66sklw2   stopped         
        zenprocess  1zz41wonvnf6qjgsrgdqh69k0   stopped         
        zencommand  4ae62xdioqsd6oogje2g2n622   stopped         
        zensyslog   4jlgxhc6a5sel99est41yn27a   stopped         
        zenping     7dpxh58rs0hd14s9wpaoqcnhn   stopped         
        zenstatus   b5vdje3nqdfevgv3temcv4w8w   stopped         
        zenjmx      db2569q13fv3ts1s2re89srlj   stopped         
        zenperfsnmp dunx1w2k7plqzmewoesuytpy5   stopped         
        zenmodeler  dyqb4ngma1ttxlh47elim3jea   stopped         
        zenpython   e2ptg0oqy3c4plboc0zwvu1d9   stopped         
    RabbitMQ        599jce2svt2iwq5ifxluayuks   stopped         
    HBase       5rixhscd4kadrvx792fotdq2    stopped         
      ZooKeeper     1et7xsufohwlalelncn65m76f   stopped         
      RegionServer  8h5c4b8jx5hzoimj4kfcbfl2t   stopped         
      HMaster       axsegkdato4ms8nehihetqeh8   stopped         
    zenjobs     67vlsugnu52vydmmjjextm4i1   stopped         
    MySQL       6t8x7p2cyn2sc3aq02fhg0je1   stopped         
    zeneventd       73oz63qlrpvi61gewh59i46gn   stopped         
    MetricConsumer  8o6unvovxnttm99pk9wyxvesb   stopped         
    memcached       9b4ad09p9occf94vgclgkwnqe   stopped         
    zenactiond      9g486yts28npx573jkcu3gjoa   stopped         
    zproxy      9ikgqichvyrjkh3wssbfar9jf   stopped         
    MetricShipper   9lv1jahg32l9845lpw6g6kxuq   stopped         
    Zauth       c6sw26hs8qqslhuv9jqz1go64   stopped         
    Zope        cb460soyeii6rouof6pv4spwy   stopped         
    opentsdb        g8rpklb5rlj0d2723wdglfc7    stopped         
      reader        1r1j4ntq8q2cpgaaconxdp8oi   stopped         
      writer        3l3a1vsx0g3n3j4jx9txrhcof   stopped         
    zeneventserver  j9a3hu5eql0bx5qma9erf1vi    stopped         

# plu@plu-9: serviced service status  --ascii
NAME            ID              STATUS      HOST    DOCKER_ID
+-Zenoss.core       bst8y9zhc43rdmf5368tnaqmd   stopped         
  |-CentralQuery    1ebt5xf2vvcckbbmbndmlyako   stopped         
  |-redis       29wjs2tv3z9espox12ysuf4cm   stopped         
  |-localhost       586hwicu60qw2c19svi0xwud1   stopped         
  | |-zenhub        4n8tdcjsgz5uk1d26x0p0gmyh   stopped         
  | +-localhost     9r36znryetwn5edw6z6pm3y96   stopped         
  |   |-zentrap     11c05rldpynv94qbuq66sklw2   stopped         
  |   |-zenprocess  1zz41wonvnf6qjgsrgdqh69k0   stopped         
  |   |-zencommand  4ae62xdioqsd6oogje2g2n622   stopped         
  |   |-zensyslog   4jlgxhc6a5sel99est41yn27a   stopped         
  |   |-zenping     7dpxh58rs0hd14s9wpaoqcnhn   stopped         
  |   |-zenstatus   b5vdje3nqdfevgv3temcv4w8w   stopped         
  |   |-zenjmx      db2569q13fv3ts1s2re89srlj   stopped         
  |   |-zenperfsnmp dunx1w2k7plqzmewoesuytpy5   stopped         
  |   |-zenmodeler  dyqb4ngma1ttxlh47elim3jea   stopped         
  |   +-zenpython   e2ptg0oqy3c4plboc0zwvu1d9   stopped         
  |-RabbitMQ        599jce2svt2iwq5ifxluayuks   stopped         
  |-HBase       5rixhscd4kadrvx792fotdq2    stopped         
  | |-ZooKeeper     1et7xsufohwlalelncn65m76f   stopped         
  | |-RegionServer  8h5c4b8jx5hzoimj4kfcbfl2t   stopped         
  | +-HMaster       axsegkdato4ms8nehihetqeh8   stopped         
  |-zenjobs     67vlsugnu52vydmmjjextm4i1   stopped         
  |-MySQL       6t8x7p2cyn2sc3aq02fhg0je1   stopped         
  |-zeneventd       73oz63qlrpvi61gewh59i46gn   stopped         
  |-MetricConsumer  8o6unvovxnttm99pk9wyxvesb   stopped         
  |-memcached       9b4ad09p9occf94vgclgkwnqe   stopped         
  |-zenactiond      9g486yts28npx573jkcu3gjoa   stopped         
  |-zproxy      9ikgqichvyrjkh3wssbfar9jf   stopped         
  |-MetricShipper   9lv1jahg32l9845lpw6g6kxuq   stopped         
  |-Zauth       c6sw26hs8qqslhuv9jqz1go64   stopped         
  |-Zope        cb460soyeii6rouof6pv4spwy   stopped         
  |-opentsdb        g8rpklb5rlj0d2723wdglfc7    stopped         
  | |-reader        1r1j4ntq8q2cpgaaconxdp8oi   stopped         
  | +-writer        3l3a1vsx0g3n3j4jx9txrhcof   stopped         
  +-zeneventserver  j9a3hu5eql0bx5qma9erf1vi    stopped         

# plu@plu-9: SERVICED_TREE_ASCII=true serviced service status 
NAME            ID              STATUS      HOST    DOCKER_ID
+-Zenoss.core       bst8y9zhc43rdmf5368tnaqmd   stopped         
  |-CentralQuery    1ebt5xf2vvcckbbmbndmlyako   stopped         
  |-redis       29wjs2tv3z9espox12ysuf4cm   stopped         
  |-localhost       586hwicu60qw2c19svi0xwud1   stopped         
  | |-zenhub        4n8tdcjsgz5uk1d26x0p0gmyh   stopped         
  | +-localhost     9r36znryetwn5edw6z6pm3y96   stopped         
  |   |-zentrap     11c05rldpynv94qbuq66sklw2   stopped         
  |   |-zenprocess  1zz41wonvnf6qjgsrgdqh69k0   stopped         
  |   |-zencommand  4ae62xdioqsd6oogje2g2n622   stopped         
  |   |-zensyslog   4jlgxhc6a5sel99est41yn27a   stopped         
  |   |-zenping     7dpxh58rs0hd14s9wpaoqcnhn   stopped         
  |   |-zenstatus   b5vdje3nqdfevgv3temcv4w8w   stopped         
  |   |-zenjmx      db2569q13fv3ts1s2re89srlj   stopped         
  |   |-zenperfsnmp dunx1w2k7plqzmewoesuytpy5   stopped         
  |   |-zenmodeler  dyqb4ngma1ttxlh47elim3jea   stopped         
  |   +-zenpython   e2ptg0oqy3c4plboc0zwvu1d9   stopped         
  |-RabbitMQ        599jce2svt2iwq5ifxluayuks   stopped         
  |-HBase       5rixhscd4kadrvx792fotdq2    stopped         
  | |-ZooKeeper     1et7xsufohwlalelncn65m76f   stopped         
  | |-RegionServer  8h5c4b8jx5hzoimj4kfcbfl2t   stopped         
  | +-HMaster       axsegkdato4ms8nehihetqeh8   stopped         
  |-zenjobs     67vlsugnu52vydmmjjextm4i1   stopped         
  |-MySQL       6t8x7p2cyn2sc3aq02fhg0je1   stopped         
  |-zeneventd       73oz63qlrpvi61gewh59i46gn   stopped         
  |-MetricConsumer  8o6unvovxnttm99pk9wyxvesb   stopped         
  |-memcached       9b4ad09p9occf94vgclgkwnqe   stopped         
  |-zenactiond      9g486yts28npx573jkcu3gjoa   stopped         
  |-zproxy      9ikgqichvyrjkh3wssbfar9jf   stopped         
  |-MetricShipper   9lv1jahg32l9845lpw6g6kxuq   stopped         
  |-Zauth       c6sw26hs8qqslhuv9jqz1go64   stopped         
  |-Zope        cb460soyeii6rouof6pv4spwy   stopped         
  |-opentsdb        g8rpklb5rlj0d2723wdglfc7    stopped         
  | |-reader        1r1j4ntq8q2cpgaaconxdp8oi   stopped         
  | +-writer        3l3a1vsx0g3n3j4jx9txrhcof   stopped         
  +-zeneventserver  j9a3hu5eql0bx5qma9erf1vi    stopped         

# plu@plu-9: SERVICED_TREE_ASCII=true serviced service status  | cat
NAME            ID              STATUS      HOST    DOCKER_ID
  Zenoss.core       bst8y9zhc43rdmf5368tnaqmd   stopped         
    CentralQuery    1ebt5xf2vvcckbbmbndmlyako   stopped         
    redis       29wjs2tv3z9espox12ysuf4cm   stopped         
    localhost       586hwicu60qw2c19svi0xwud1   stopped         
      zenhub        4n8tdcjsgz5uk1d26x0p0gmyh   stopped         
      localhost     9r36znryetwn5edw6z6pm3y96   stopped         
        zentrap     11c05rldpynv94qbuq66sklw2   stopped         
        zenprocess  1zz41wonvnf6qjgsrgdqh69k0   stopped         
        zencommand  4ae62xdioqsd6oogje2g2n622   stopped         
        zensyslog   4jlgxhc6a5sel99est41yn27a   stopped         
        zenping     7dpxh58rs0hd14s9wpaoqcnhn   stopped         
        zenstatus   b5vdje3nqdfevgv3temcv4w8w   stopped         
        zenjmx      db2569q13fv3ts1s2re89srlj   stopped         
        zenperfsnmp dunx1w2k7plqzmewoesuytpy5   stopped         
        zenmodeler  dyqb4ngma1ttxlh47elim3jea   stopped         
        zenpython   e2ptg0oqy3c4plboc0zwvu1d9   stopped         
    RabbitMQ        599jce2svt2iwq5ifxluayuks   stopped         
    HBase       5rixhscd4kadrvx792fotdq2    stopped         
      ZooKeeper     1et7xsufohwlalelncn65m76f   stopped         
      RegionServer  8h5c4b8jx5hzoimj4kfcbfl2t   stopped         
      HMaster       axsegkdato4ms8nehihetqeh8   stopped         
    zenjobs     67vlsugnu52vydmmjjextm4i1   stopped         
    MySQL       6t8x7p2cyn2sc3aq02fhg0je1   stopped         
    zeneventd       73oz63qlrpvi61gewh59i46gn   stopped         
    MetricConsumer  8o6unvovxnttm99pk9wyxvesb   stopped         
    memcached       9b4ad09p9occf94vgclgkwnqe   stopped         
    zenactiond      9g486yts28npx573jkcu3gjoa   stopped         
    zproxy      9ikgqichvyrjkh3wssbfar9jf   stopped         
    MetricShipper   9lv1jahg32l9845lpw6g6kxuq   stopped         
    Zauth       c6sw26hs8qqslhuv9jqz1go64   stopped         
    Zope        cb460soyeii6rouof6pv4spwy   stopped         
    opentsdb        g8rpklb5rlj0d2723wdglfc7    stopped         
      reader        1r1j4ntq8q2cpgaaconxdp8oi   stopped         
      writer        3l3a1vsx0g3n3j4jx9txrhcof   stopped         
    zeneventserver  j9a3hu5eql0bx5qma9erf1vi    stopped         
```
