### PR TITLE
added to CLI: serviced docker sync to push all unique images used by ser...

### DIFF
--- a/cli/api/docker.go
+++ b/cli/api/docker.go
@@ -5,7 +5,12 @@
 package api
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/control-center/serviced/commons/docker"
 	"github.com/control-center/serviced/commons/layer"
+	"github.com/zenoss/glog"
 )
 
 // Squash flattens the image (or at least down the to optional downToLayer).
@@ -18,4 +23,40 @@ func (a *api) Squash(imageName, downToLayer, newName, tempDir string) (resultIma
 	}
 
 	return layer.Squash(client, imageName, downToLayer, newName, tempDir)
+}
+
+// RegistrySync walks the service tree and syncs all images from docker to local registry
+func (a *api) RegistrySync() (err error) {
+	client, err := a.connectDocker()
+	if err != nil {
+		return err
+	}
+
+	services, err := a.GetServices()
+	if err != nil {
+		return err
+	} else if services == nil || len(services) == 0 {
+		return fmt.Errorf("no services found")
+	}
+
+	glog.V(2).Infof("RegistrySync from local docker repo %+v", client)
+	synced := map[string]bool{}
+	for _, svc := range services {
+		if len(svc.ImageID) == 0 {
+			continue
+		}
+
+		if _, ok := synced[svc.ImageID]; ok {
+			continue
+		}
+
+		fmt.Fprintf(os.Stderr, "Syncing image to local docker registry: %s ...", svc.ImageID)
+		if err := docker.PushImage(svc.ImageID); err != nil {
+			return err
+		}
+		synced[svc.ImageID] = true
+	}
+
+	fmt.Printf("images synced to local docker registry")
+	return nil
 }

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -81,6 +81,7 @@ type API interface {
 
 	// Docker
 	Squash(imageName, downToLayer, newName, tempDir string) (string, error)
+	RegistrySync() error
 
 	// Logs
 	ExportLogs(serviceIds []string, to, from, outfile string) error

--- a/cli/cmd/docker.go
+++ b/cli/cmd/docker.go
@@ -28,6 +28,15 @@ func (c *ServicedCli) initDocker() {
 					cli.StringFlag{"tempdir", "", "temp directory"},
 				},
 			},
+			{
+				Name:        "sync",
+				Usage:       "serviced docker sync",
+				Description: "sync pushes all images to local registry - allows single host to easily be made master for multi-host",
+				Action:      c.cmdRegistrySync,
+				Flags: []cli.Flag{
+					cli.StringFlag{"endpoint", "unix:///var/run/docker.sock", "docker endpoint"},
+				},
+			},
 		},
 	})
 }
@@ -58,4 +67,13 @@ func (c *ServicedCli) cmdSquash(ctx *cli.Context) {
 		glog.Fatalf("error squashing: %s", err)
 	}
 	fmt.Println(imageID)
+}
+
+// serviced docker sync
+func (c *ServicedCli) cmdRegistrySync(ctx *cli.Context) {
+
+	err := c.driver.RegistrySync()
+	if err != nil {
+		glog.Fatalf("error syncing docker images to local registry: %s", err)
+	}
 }


### PR DESCRIPTION
...vices to local registry

DEMO:

```
# plu@plu-9: serviced service list |grep Zenoss
  Zenoss.core       anai9vxxporc1c22b5ct9nex2   0                   default     1   auto    HBase

# plu@plu-9: docker images |grep anai9vxxporc1c22b5ct9nex2
plu-9:5000/anai9vxxporc1c22b5ct9nex2/devimg     latest              33a12f6ffe58        6 days ago          3.329 GB
plu-9:5000/anai9vxxporc1c22b5ct9nex2/hbase      latest              4a01c657faa4        2 weeks ago         560.9 MB
plu-9:5000/anai9vxxporc1c22b5ct9nex2/opentsdb   latest              ca43a978631e        7 weeks ago         1.386 GB

# plu@plu-9: ./serviced docker sync
Syncing image to local docker registry: plu-9:5000/anai9vxxporc1c22b5ct9nex2/devimg ...
Syncing image to local docker registry: plu-9:5000/anai9vxxporc1c22b5ct9nex2/opentsdb ...
Syncing image to local docker registry: plu-9:5000/anai9vxxporc1c22b5ct9nex2/hbase ...
images synced to local docker registry
```
