### PR TITLE
fixes ZEN-13029: put parseLog warnings into warnings.log in the exported...

### DIFF
--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -84,5 +84,5 @@ type API interface {
 	RegistrySync() error
 
 	// Logs
-	ExportLogs(serviceIds []string, to, from, outfile string) error
+	ExportLogs(config ExportLogsConfig) error
 }

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -6,8 +6,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
 	"os"
+
+	"github.com/codegangsta/cli"
+	"github.com/control-center/serviced/cli/api"
 )
 
 // Initializer for serviced log
@@ -60,9 +62,16 @@ func (c *ServicedCli) cmdExportLogs(ctx *cli.Context) {
 	from := ctx.String("from")
 	to := ctx.String("to")
 	outfile := ctx.String("out")
-	serviceIds := ctx.StringSlice("service")
+	serviceIDs := ctx.StringSlice("service")
 
-	if err := c.driver.ExportLogs(serviceIds, from, to, outfile); err != nil {
+	cfg := api.ExportLogsConfig{
+		ServiceIDs: serviceIDs,
+		FromDate:   from,
+		ToDate:     to,
+		Outfile:    outfile,
+	}
+
+	if err := c.driver.ExportLogs(cfg); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
 }


### PR DESCRIPTION
... tgz

this feature is needed before additional troubleshooting of https://jira.zenoss.com/browse/ZEN-12806

DEMO1 - when there are no parse warnings:

```
# plu@plu-9: serviced log export
I0725 17:23:22.113158 07068 logs.go:149] Starting part 1 of 3: process logstash elasticsearch results using temporary dir: /tmp/serviced-log-export-440586749
I0725 17:23:22.127860 07068 logs.go:217] Starting part 2 of 3: sort output files
I0725 17:23:22.136321 07068 logs.go:255] Starting part 3 of 3: generate tar file: /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/serviced-log-export.tgz
```

DEMO2 - when there are parse warnings:

```
# plu@plu-9: serviced log export
I0725 17:20:44.568955 06374 logs.go:149] Starting part 1 of 3: process logstash elasticsearch results using temporary dir: /tmp/serviced-log-export-249754172
I0725 17:20:44.595071 06374 logs.go:218] Starting part 2 of 3: sort output files
I0725 17:20:44.605151 06374 logs.go:256] Starting part 3 of 3: generate tar file: /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/serviced-log-export.tgz
W0725 17:20:44.609587 06374 logs.go:264] warnings for log parse are included in the tar file as: serviced-log-export-249754172/warnings.log
# plu@plu-9: tar -xzf serviced-log-export.tgz
~/src/europa/src/golang/src/github.com/control-center/serviced
# plu@plu-9: ls -l serviced-log-export-249754172
total 20
-rw-rw-r-- 1 plu plu 3200 Jul 25 17:20 000.log
-rw-rw-r-- 1 plu plu 4662 Jul 25 17:20 000.log.tmp
-rw-r--r-- 1 plu plu   97 Jul 25 17:20 index.txt
-rw-rw-r-- 1 plu plu  330 Jul 25 17:20 warnings.log
```
