### PR TITLE
improve status while service is coming up

### DIFF
--- a/web/static/js/modules/serviceHealth.js
+++ b/web/static/js/modules/serviceHealth.js
@@ -107,7 +107,7 @@
                 healthChecksRollup = {
                     passing: false,
                     failing: false,
-                    unknown: false,
+                    unknown: true,
                     down: false
                 };
 


### PR DESCRIPTION
defaults unknown to true, so that if no health checks are present for a service, it will begin in "unknown" status.
