### PR TITLE
fixes ZEN-13225: show POOL and DEPID columns when multiple services matc...

### DIFF
--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -303,9 +303,9 @@ func (c *ServicedCli) searchForService(keyword string) (*service.Service, error)
 	}
 
 	matches := newtable(0, 8, 2)
-	matches.printrow("NAME", "SERVICEID")
+	matches.printrow("NAME", "SERVICEID", "POOL", "DEPID")
 	for _, row := range services {
-		matches.printrow(row.Name, row.ID)
+		matches.printrow(row.Name, row.ID, row.PoolID, row.DeploymentID)
 	}
 	matches.flush()
 	return nil, fmt.Errorf("multiple results found; select one from list")


### PR DESCRIPTION
...hed

DEMO:

```
# plu@plu-9: serviced service list |egrep 'Zenoss|redis'
  Zenoss.resmgr     82hpjqpvmc21325x29oikptf7   0                   default     1   auto    zenoss
    redis       61lpxf7e7h9qdzs2mlwokm6ee   1   .../82hpjqp.../resmgr-unstable  default     1   auto    zenoss
        collectorredis  eg51xuij9dt2ii9ahpi2h1hmc   1   .../82hpjqp.../resmgr-unstable  default     1   auto    zenoss
  Zenoss.resmgr     8v89qvy5is9450utgu71s4f7l   0                   default     1   auto    Test
        collectorredis  6be7wyn4g03cm91z221ivatc2   1   .../8v89qvy.../resmgr-unstable  default     1   auto    Test
    redis       61vo8wlc63pwi374mybe82jwt   1   .../8v89qvy.../resmgr-unstable  default     1   auto    Test

# plu@plu-9: serviced service list redis
NAME    SERVICEID           POOL        DEPID
redis   61lpxf7e7h9qdzs2mlwokm6ee   default     zenoss
redis   61vo8wlc63pwi374mybe82jwt   default     Test
multiple results found; select one from list

```
