### PR TITLE
fixes ZEN-13228: do not allow multiple matching services to be removed

### DIFF
--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -422,7 +422,7 @@ func ExampleServicedCLI_CmdServiceRemove_usage() {
 	//    command remove [command options] [arguments...]
 	//
 	// DESCRIPTION:
-	//    serviced service remove SERVICEID ...
+	//    serviced service remove SERVICEID
 	//
 	// OPTIONS:
 	//    --remove-snapshots, -R	Remove snapshots associated with removed service
@@ -433,7 +433,7 @@ func ExampleServicedCLI_CmdServiceRemove_err() {
 	pipeStderr(InitServiceAPITest, "serviced", "service", "remove", "test-service-0")
 
 	// Output:
-	// no service found
+	// service not found
 }
 
 func ExampleServicedCLI_CmdServiceRemove_complete() {


### PR DESCRIPTION
DEMO:

```
# plu@plu-9: serviced service list |egrep 'Zenoss|redis'
  Zenoss.resmgr     82hpjqpvmc21325x29oikptf7   0                   default     1   auto    zenoss
    redis       61lpxf7e7h9qdzs2mlwokm6ee   1   .../82hpjqp.../resmgr-unstable  default     1   auto    zenoss
        collectorredis  eg51xuij9dt2ii9ahpi2h1hmc   1   .../82hpjqp.../resmgr-unstable  default     1   auto    zenoss
  Zenoss.resmgr     8v89qvy5is9450utgu71s4f7l   0                   default     1   auto    Test
        collectorredis  6be7wyn4g03cm91z221ivatc2   1   .../8v89qvy.../resmgr-unstable  default     1   auto    Test
    redis       61vo8wlc63pwi374mybe82jwt   1   .../8v89qvy.../resmgr-unstable  default     1   auto    Test

# plu@plu-9: serviced service remove redis
NAME    SERVICEID
redis   61lpxf7e7h9qdzs2mlwokm6ee
redis   61vo8wlc63pwi374mybe82jwt
multiple results found; select one from list

# plu@plu-9: serviced service remove 61vo8wlc63pwi374mybe82jwt
61vo8wlc63pwi374mybe82jwt

# plu@plu-9: serviced service list |egrep 'Zenoss|redis'
  Zenoss.resmgr     82hpjqpvmc21325x29oikptf7   0                   default     1   auto    zenoss
    redis       61lpxf7e7h9qdzs2mlwokm6ee   1   .../82hpjqp.../resmgr-unstable  default     1   auto    zenoss
        collectorredis  eg51xuij9dt2ii9ahpi2h1hmc   1   .../82hpjqp.../resmgr-unstable  default     1   auto    zenoss
  Zenoss.resmgr     8v89qvy5is9450utgu71s4f7l   0                   default     1   auto    Test
        collectorredis  6be7wyn4g03cm91z221ivatc2   1   .../8v89qvy.../resmgr-unstable  default     1   auto    Test

```
