### PR TITLE
fix add vhost modal remembering previous values after submit

### DIFF
--- a/web/static/js/controllers/HostsControl.js
+++ b/web/static/js/controllers/HostsControl.js
@@ -33,6 +33,7 @@ function HostsControl($scope, $routeParams, $location, $filter, $timeout, resour
                             $scope.add_host();
                             // NOTE: should wait for success before closing
                             this.close();
+                            $scope.newHost = {};
                         }
                     }
                 }


### PR DESCRIPTION
the add vhost modal binds to `$scope.newHost`, which must be cleared whenever the modal is closed. This ensures that it is cleared on success as it is already cleared on fail.
