### PR TITLE
fix first table row color for striped tables

### DIFF
--- a/web/static/css/main.css
+++ b/web/static/css/main.css
@@ -112,11 +112,11 @@ table > thead.light {
 
 .table-striped > tbody > tr:nth-child(even) > td,
 .table-striped > tbody > tr:nth-child(even) > th {
-    background-color: #F0F3F7;
+    background-color: white;
 }
 .table-striped > tbody > tr:nth-child(odd) > td,
 .table-striped > tbody > tr:nth-child(odd) > th {
-    background-color: white;
+    background-color: #F0F3F7;
 }
 
 .table-bordered {


### PR DESCRIPTION
adding loading indicators to tables offsets the odd/even styling for zebra stripes, so this swaps odd and even to return it back to the previous look.
