### PR TITLE
fixes ZEN-13209: set controlplane_service_id to serviced if container.se...

### DIFF
--- a/stats/stats.go
+++ b/stats/stats.go
@@ -7,14 +7,14 @@
 package stats
 
 import (
-	"github.com/daniel-garcia/go-procfs/linux"
-	"github.com/rcrowley/go-metrics"
-	"github.com/zenoss/glog"
 	coordclient "github.com/control-center/serviced/coordinator/client"
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/stats/cgroup"
 	"github.com/control-center/serviced/utils"
 	zkservice "github.com/control-center/serviced/zzk/service"
+	"github.com/daniel-garcia/go-procfs/linux"
+	"github.com/rcrowley/go-metrics"
+	"github.com/zenoss/glog"
 
 	"bytes"
 	"encoding/json"
@@ -65,7 +65,8 @@ func NewStatsReporter(destination string, interval time.Duration, conn coordclie
 		containerRegistries: make(map[registryKey]metrics.Registry),
 		hostID:              hostID,
 	}
-	sr.hostRegistry = sr.getOrCreateContainerRegistry("", 0)
+
+	sr.hostRegistry = metrics.NewRegistry()
 	go sr.report(interval)
 	return &sr, nil
 }


### PR DESCRIPTION
...rviceID is null

ISSUE - this warning is output every minute:

```
WARN  [2014-07-31 21:55:16,549] org.zenoss.lib.tsdb.OpenTsdbClientFactory: Client returned error: put: illegal argument: invalid tag: controlplane_service_id=
...
WARN  [2014-07-31 21:56:26,549] org.zenoss.lib.tsdb.OpenTsdbClientFactory: Client returned error: put: illegal argument: invalid tag: controlplane_service_id=
...
```

DEMO - no longer any warnings:

```
# plu@plu-9: dockerid=$(docker ps --no-trunc | awk '/opentsdb/{print $1;exit}'); echo $dockerid
a27545aec5caf967bb6f580de550c7f05d69c40fb990331847b40751443e6b5b
~/src/europa
# plu@plu-9: pid=$(docker inspect --format '{{.State.Pid}}' $dockerid); echo $pid
9226
~/src/europa
# plu@plu-9: sudo nsenter -m -u -i -n -p -t $pid -- bash
root@a27545aec5ca:/# tail -f /opt/zenoss/log/metric-consumer-app.log
172.17.42.1 - - [31/Jul/2014:22:12:11 +0000] "POST /api/metrics/store HTTP/1.1" 200 48 21 21
...
INFO  [2014-07-31 22:12:41,670] org.zenoss.app.consumer.metric.impl.OpenTsdbWriter: Shutting down writer due to dearth of work
172.17.42.1 - - [31/Jul/2014:22:12:41 +0000] "POST /api/metrics/store HTTP/1.1" 200 48 24 24
INFO  [2014-07-31 22:12:41,689] org.zenoss.app.consumer.metric.impl.OpenTsdbWriterManager: Created 1 new writers
INFO  [2014-07-31 22:12:41,690] org.zenoss.app.consumer.metric.impl.OpenTsdbWriter: Starting writer
172.17.42.1 - - [31/Jul/2014:22:12:51 +0000] "POST /api/metrics/store HTTP/1.1" 200 48 21 21
172.17.42.1 - - [31/Jul/2014:22:13:01 +0000] "POST /api/metrics/store HTTP/1.1" 200 48 18 18
...
172.17.42.1 - - [31/Jul/2014:22:13:51 +0000] "POST /api/metrics/store HTTP/1.1" 200 48 20 20
...
172.17.42.1 - - [31/Jul/2014:22:14:01 +0000] "POST /api/metrics/store HTTP/1.1" 200 48 17 17
...
172.17.42.1 - - [31/Jul/2014:22:15:01 +0000] "POST /api/metrics/store HTTP/1.1" 200 48 17 17
...
```
