### PR TITLE
Fix name and version for service definition packaging

### DIFF
--- a/pkg/servicedef.mk
+++ b/pkg/servicedef.mk
@@ -8,6 +8,9 @@ THIS_MAKEFILE := $(notdir $(CURDIR)/$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_
 # RPM and DEB builder for service definitions.
 #
 
+# NAME is typically overridden from the toplevel make:
+#    e.g. make -f servicedef.mk NAME=zenoss-core
+#
 NAME          = product
 FULL_NAME     = $(NAME)-service
 #FROMVERSION  = 0.3.70


### PR DESCRIPTION
This commit also provides back-end build support for naming and versioning our service definitions along Zenoss product lines.

For example, we use to create:

servicedef-zenoss-core_0.3.70+0.8.0-583_all.deb

Now we create:

zenoss-core-service_5.0.0-583_all.deb

The underlying json filename (zenoss-core-5.0.0-*.json) and install path (/opt/serviced/templates) remain unchanged so this should be a 0-impact change to serviced itself.
