### PR TITLE
fixes ZEN-13394: honor env var SERVICED_MAX_CONTAINER_AGE and --max-cont...

### DIFF
--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -198,6 +198,7 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 		MCPasswd:             ctx.GlobalString("mc-password"),
 		Verbosity:            ctx.GlobalInt("v"),
 		CPUProfile:           ctx.GlobalString("cpuprofile"),
+		MaxContainerAge:      ctx.GlobalInt("max-container-age"),
 		VirtualAddressSubnet: ctx.GlobalString("virtual-address-subnet"),
 		MasterPoolID:         ctx.GlobalString("master-pool-id"),
 		OutboundIP:           ctx.GlobalString("outbound"),

--- a/dita/topics/config-defaults.dita
+++ b/dita/topics/config-defaults.dita
@@ -146,8 +146,8 @@ SERVICED_MASTER=1</codeblock></li>
         </dlentry>
         <dlentry>
           <dt><codeph>SERVICED_MAX_CONTAINER_AGE</codeph></dt>
-          <dd>Default: <codeph>1</codeph></dd> 
-          <dd>The maximum number of days <cmdname>serviced</cmdname>
+          <dd>Default: <codeph>24*60*60  # 1 day</codeph></dd> 
+          <dd>The maximum number of seconds <cmdname>serviced</cmdname>
             waits before removing a stopped container.</dd>
         </dlentry>
         <dlentry>

--- a/node/agent.go
+++ b/node/agent.go
@@ -270,6 +270,8 @@ func reapContainers(maxAge time.Duration) error {
 }
 
 func (a *HostAgent) reapOldContainersLoop(interval time.Duration, shutdown <-chan interface{}) {
+	glog.V(1).Infof("will reap stopped containers older than age of %v", a.maxContainerAge)
+
 	for {
 		select {
 		case <-time.After(interval):

--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -56,8 +56,8 @@
 # Set the aliases for this host (use in vhost muxing)
 # export SERVICED_VHOST_ALIASES=foobar.com,example.com
 
-# Set the max stopped container age before serviced will remove it
-# export SERVICED_MAX_CONTAINER_AGE=60
+# Set the max stopped container age (in seconds) before serviced will remove it
+# export SERVICED_MAX_CONTAINER_AGE==`expr 24*60*60`
 
 # Set the subnet that dynamic endpoints use, inside the containers
 # export SERVICED_VIRTUAL_ADDRESS_SUBNET=10.3


### PR DESCRIPTION
...ainer-age when calling reapContainers()

DEMO1:

```
/home/plu/src/europa/src/golang/bin/serviced -v=1 --master --agent
...
I0806 21:17:14.252714 14145 agent.go:771] reapOldContainersLoop starting
I0806 21:17:14.252738 14145 agent.go:274] will reap stopped containers older than age of 24h0m0s
```

DEMO2:

```
/home/plu/src/europa/src/golang/bin/serviced -v=1 --master --agent --max-container-age 120
…
I0806 21:11:15.225928 09782 agent.go:771] reapOldContainersLoop starting
I0806 21:11:15.225945 09782 agent.go:274] will reap stopped containers older than age of 2m0s
```

DEMO3:

```
root@plu-9:~# SERVICED_MAX_CONTAINER_AGE=240 /home/plu/src/europa/src/golang/bin/serviced -v=1 --master --agent
...
I0806 21:27:05.613669 16964 agent.go:771] reapOldContainersLoop starting
I0806 21:27:05.613679 16964 agent.go:274] will reap stopped containers older than age of 4m0s
```
