### PR TITLE
fixes ZEN-13416: replicate ConfigFiles when replicating collectors and h...

### DIFF
--- a/web/resources.go
+++ b/web/resources.go
@@ -363,6 +363,7 @@ func restAddService(w *rest.ResponseWriter, r *rest.Request, client *node.Contro
 	svc.Launch = payload.Launch
 	svc.Endpoints = payload.Endpoints
 	svc.ConfigFiles = payload.ConfigFiles
+	svc.OriginalConfigs = payload.OriginalConfigs
 	svc.Volumes = payload.Volumes
 	svc.CreatedAt = now
 	svc.UpdatedAt = now


### PR DESCRIPTION
...ubs in addService

DEMO1 - sample serviced.log (LOG_LEVEL=2) when deploying templates:

```
...
I0807 20:06:06.031830 16880 service.go:64] Facade.AddService: calling zk.updateService for MetricShipper 0 ConfigFiles
I0807 20:06:06.286297 16880 service.go:59] Facade.AddService: calling updateService for collectorredis due to OriginalConfigs of /etc/redis.conf
...
```

DEMO2 - sample serviced.log (LOG_LEVEL=2) when adding a collector (in DEMO3):

```
...
I0807 20:17:20.800778 16880 service.go:64] Facade.AddService: calling zk.updateService for MetricShipper 0 ConfigFiles
2014/08/07 20:18:04 200 2.148974674s GET /services/9k5d2n0n4nxuisowkqzz0zl29
I0807 20:18:04.245557 16880 service.go:59] Facade.AddService: calling updateService for collectorredis due to OriginalConfigs of /etc/redis.conf
...
```

DEMO3 - create collector and compare 6379 ports:

```

# plu@plu-9: serviced service list collectorredis
NAME        SERVICEID           POOL        DEPID
collectorredis  9k5d2n0n4nxuisowkqzz0zl29   default     demo
collectorredis  ac7xacf9nw0g0ihe971utxlzw   default     
multiple results found; select one from list

# plu@plu-9: serviced service attach 9k5d2n0n4nxuisowkqzz0zl29 netstat -plan |grep 6379.*LISTEN
tcp        0      0 0.0.0.0:6379            0.0.0.0:*               LISTEN      21/redis-server *:6 
tcp6       0      0 :::6379                 :::*                    LISTEN      21/redis-server *:6 

# plu@plu-9: serviced service attach ac7xacf9nw0g0ihe971utxlzw netstat -plan |grep 6379.*LISTEN
tcp        0      0 0.0.0.0:6379            0.0.0.0:*               LISTEN      19/redis-server *:6 
tcp6       0      0 :::6379                 :::*                    LISTEN      19/redis-server *:6 

# plu@plu-9: serviced service attach 9k5d2n0n4nxuisowkqzz0zl29 egrep '^port|^bind' /etc/redis.conf
port 6379
# plu@plu-9: serviced service attach ac7xacf9nw0g0ihe971utxlzw egrep '^port|^bind' /etc/redis.conf
port 6379

# plu@plu-9: serviced service attach 9k5d2n0n4nxuisowkqzz0zl29 ps -wwef |grep 6379
root        21     1  0 02:07 ?        00:00:01 /usr/bin/redis-server *:6379
# plu@plu-9: serviced service attach ac7xacf9nw0g0ihe971utxlzw ps -wwef |grep 6379
root        19     1  0 02:10 ?        00:00:00 /usr/bin/redis-server *:6379

# plu@plu-9: serviced service attach zope/0 su - zenoss -c "dc-admin add-collector col2"
added collector col2 to hub localhost for pool default

```
