### PR TITLE
fixes ZEN-13443: change the service read from file to have desired state...

### DIFF
--- a/dfs/dfs.go
+++ b/dfs/dfs.go
@@ -462,10 +462,10 @@ func (d *DistributedFileSystem) RollbackServices(restorePath string) error {
 		existingServiceMap[service.ID] = service
 	}
 	for _, svc := range services {
-		// Verify the service has stopped
+		// Change the service read from file to have desired state of stopped
 		if svc.DesiredState != service.SVCStop {
-			glog.Errorf("Service %s (%s) is running; stop all services before restoring from backup", svc.Name, svc.ID)
-			return fmt.Errorf("service %s (%s) is running", svc.Name, svc.ID)
+			glog.V(2).Infof("Service %s (%s) was running (svc.DesiredState:%v).  Setting desired state to SVCStop", svc.Name, svc.ID, svc.DesiredState)
+			svc.DesiredState = service.SVCStop
 		}
 
 		if existingService := existingServiceMap[svc.ID]; existingService != nil {


### PR DESCRIPTION
... of stopped

ISSUE:

```
# plu@plu-9: serviced -v=5 restore backup-2014-08-06-213500.tgz
I0808 14:43:17.150246 23838 cp_client.go:39] Connecting to 10.87.110.39:4979
service Zenoss.resmgr (c32qpc9b12uwptwrqsfnn3idz) is running
# plu@plu-9: 

========== serviced.log
I0808 14:44:07.188848 21778 dfs.go:419] DistributedFileSystem.RollbackServices from path: /tmp/serviced-root/var/restore/snapshots/c32qpc9b12uwptwrqsfnn3idz_20140806-213911
I0808 14:44:07.669080 21778 dfs.go:455] caching to existingPools: &{default   [] 0 0 0 12 33659494400 38117834752 2014-08-08 14:37:29.291643808 -0500 CDT 2014-08-08 14:37:29.291643808 -0500 CDT {[] [] []}}
E0808 14:44:07.669170 21778 dfs.go:467] Service Zenoss.resmgr (c32qpc9b12uwptwrqsfnn3idz) is running; stop all services before restoring from backup
E0808 14:44:07.669195 21778 backup.go:701] Could not rollback services: service Zenoss.resmgr (c32qpc9b12uwptwrqsfnn3idz) is running
```

lines 465 to 469 should not check that the service was stopped - there is already a global check earlier in this function (lines 426-434) that check that all services are stopped.  simply set the desired state to be stopped before restoring this service.

DEMO:

```
# plu@plu-9: serviced -v=5 restore backup-2014-08-06-213500.tgz
I0808 15:38:38.474165 02642 cp_client.go:39] Connecting to 10.87.110.39:4979
I0808 15:39:34.195026 02642 kernel.go:1018] sending map[status:stop id:33e5ae80991adcb8e321f8361b4556726b56063f07fb70ef3608747e42cb15ff from:zenoss/serviced-isvcs:v12 time:1.407530374e+09] to kernel
I0808 15:39:34.429585 02642 kernel.go:1018] sending map[status:die id:33e5ae80991adcb8e321f8361b4556726b56063f07fb70ef3608747e42cb15ff from:zenoss/serviced-isvcs:v12 time:1.407530374e+09] to kernel
I0808 15:39:34.957309 02642 kernel.go:1018] sending map[status:destroy id:33e5ae80991adcb8e321f8361b4556726b56063f07fb70ef3608747e42cb15ff from:zenoss/serviced-isvcs:v12 time:1.407530374e+09] to kernel
I0808 15:39:36.249832 02642 kernel.go:1018] sending map[status:create id:3d522e6354ce37b051b3a37d08bddf1a9e164c300686b87a9ece5b1bc0955911 from:zenoss/serviced-isvcs:v12 time:1.407530376e+09] to kernel
I0808 15:39:37.091611 02642 kernel.go:1018] sending map[id:3d522e6354ce37b051b3a37d08bddf1a9e164c300686b87a9ece5b1bc0955911 from:zenoss/serviced-isvcs:v12 time:1.407530377e+09 status:start] to kernel 
```
