### PR TITLE
Quote shell arguments

### DIFF
--- a/container/controller.go
+++ b/container/controller.go
@@ -422,6 +422,7 @@ func (c *Controller) forwardSignal(sig os.Signal) {
 	}
 }
 
+
 // Run executes the controller's main loop and block until the service exits
 // according to it's restart policy or Close() is called.
 func (c *Controller) Run() (err error) {
@@ -443,7 +444,7 @@ func (c *Controller) Run() (err error) {
 		return err
 	}
 
-	args := []string{"-c", "exec " + strings.Join(c.options.Service.Command, " ")}
+	args := []string{"-c", "exec " + utils.ShellQuoteArgs(c.options.Service.Command)}
 
 	startService := func() (*subprocess.Instance, chan error) {
 		service, serviceExited, _ := subprocess.New(time.Second*10, env, "/bin/sh", args...)

--- a/shell/interfaces.go
+++ b/shell/interfaces.go
@@ -31,6 +31,7 @@ type ProcessConfig struct {
 	Envv        []string
 	Mount       []string
 	Command     string
+	Args        []string
 	LogToStderr bool // log the command output for stderr
 	LogStash    struct {
 		Enable        bool          //enable log stash

--- a/shell/server.go
+++ b/shell/server.go
@@ -356,27 +356,31 @@ func StartDocker(cfg *ProcessConfig, port string) (*exec.Cmd, error) {
 
 	// get the shell command
 	shellcmd := cfg.Command
+	shellargs := cfg.Args
 	if cfg.Command == "" {
-		shellcmd = "su -"
+		shellcmd = "su"
+		shellargs = []string{"-"}
 	}
 
 	// get the serviced command
 	svcdcmd := fmt.Sprintf("/serviced/%s", bin)
 
 	// get the proxy command
-	proxycmd := []string{
-		svcdcmd,
-		fmt.Sprintf("--logtostderr=%t", cfg.LogToStderr),
-		"service",
-		"proxy",
-		"--autorestart=false",
-		fmt.Sprintf("--logstash=%t", cfg.LogStash.Enable),
-		fmt.Sprintf("--logstash-idle-flush-time=%s", cfg.LogStash.IdleFlushTime),
-		fmt.Sprintf("--logstash-settle-time=%s", cfg.LogStash.SettleTime),
-		svc.ID,
-		"0",
-		shellcmd,
-	}
+	proxycmd := append(
+		[]string{
+			svcdcmd,
+			fmt.Sprintf("--logtostderr=%t", cfg.LogToStderr),
+			"service",
+			"proxy",
+			"--autorestart=false",
+			fmt.Sprintf("--logstash=%t", cfg.LogStash.Enable),
+			fmt.Sprintf("--logstash-idle-flush-time=%s", cfg.LogStash.IdleFlushTime),
+			fmt.Sprintf("--logstash-settle-time=%s", cfg.LogStash.SettleTime),
+			svc.ID,
+			"0",
+			shellcmd,
+		},
+		shellargs...)
 
 	// get the docker start command
 	docker, err := exec.LookPath("docker")
@@ -427,6 +431,6 @@ func StartDocker(cfg *ProcessConfig, port string) (*exec.Cmd, error) {
 	cp.ReadyDFS(false, nil)
 	glog.Infof("Acquired!  Starting shell")
 
-	glog.V(1).Infof("command: docker %+v", argv)
+	glog.V(1).Infof("command: docker [%s]", strings.Join(argv, ","))
 	return exec.Command(docker, argv...), nil
 }

--- a/utils/shell_quote.go
+++ b/utils/shell_quote.go
@@ -1,0 +1,28 @@
+/*****************************************************************************
+ * 
+ * Copyright (C) Zenoss, Inc. 2014, all rights reserved.
+ * 
+ * This content is made available according to terms specified in
+ * License.zenoss under the directory where your Zenoss product is installed.
+ * 
+ ****************************************************************************/
+ 
+ 
+package utils
+
+import "strings"
+
+// Quote a single argument
+func ShellQuoteArg(arg string) string {
+	// wrap with single quotes; put existing single quotes into double quotes
+	return "'" + strings.Replace(arg, "'", "'\"'\"'", -1) + "'"
+}
+
+// Quote a list of arguments and join them with spaces
+func ShellQuoteArgs(args []string) string {
+	quotedArgs := []string{}
+	for _, arg := range args {
+		quotedArgs = append(quotedArgs, ShellQuoteArg(arg))
+	}
+	return strings.Join(quotedArgs, " ")
+}


### PR DESCRIPTION
Fixes ZEN-10805

Quote individual arguments to container command before joining them;
Service 'Shell' and 'Run' arguments are passed through without concatenating
Shared functions for quoting arguments
