### PR TITLE
fixes CC-12: return error instead of panic when listing invalid template...

### DIFF
--- a/cli/api/template.go
+++ b/cli/api/template.go
@@ -63,6 +63,9 @@ func (a *api) GetServiceTemplate(id string) (*template.ServiceTemplate, error) {
 		return nil, err
 	}
 
+	if _, ok := templatemap[id]; !ok {
+		return nil, fmt.Errorf("unable to find template by id: %s", id)
+	}
 	t := templatemap[id]
 	(*t).ID = id
 


### PR DESCRIPTION
... id

DEMO:

```
# plu@plu-9: serviced template list
TEMPLATEID              NAME        DESCRIPTION
0b05fed05123a6167d3858e9f58d8a5e    Zenoss.core 

# plu@plu-9: serviced template list doesnotexist
unable to find template by id: doesnotexist
```
