### PR TITLE
fixes ZEN-13575: only pause/resume services that have Snapshot.(Pause|Re...

### DIFF
--- a/facade/service.go
+++ b/facade/service.go
@@ -322,19 +322,14 @@ func (f *Facade) StartService(ctx datastore.Context, serviceId string) error {
 // pause the provided service
 func (f *Facade) PauseService(ctx datastore.Context, serviceID string) error {
 	glog.V(4).Infof("Facade.PauseService %s", serviceID)
-	// f will traverse all the services
-	err := f.validateService(ctx, serviceID)
-	glog.V(4).Infof("Facace.PauseService validate service result %v", err)
-	if err != nil {
-		return err
-	}
 
 	visitor := func(svc *service.Service) error {
 		svc.DesiredState = service.SVCPause
 		if err := f.updateService(ctx, svc); err != nil {
+			glog.Errorf("could not update service %+v due to error %s", svc, err)
 			return err
 		}
-		glog.V(4).Infof("Facade.PauseService update service %v, %v: %v", svc.Name, svc.ID, err)
+		glog.V(4).Infof("Facade.PauseService update service %v, %v", svc.Name, svc.ID)
 		return nil
 	}
 
@@ -664,6 +659,7 @@ func (f *Facade) validateService(ctx datastore.Context, serviceId string) error 
 
 	// traverse all the services
 	if err := f.walkServices(ctx, serviceId, visitor); err != nil {
+		glog.Errorf("unable to walk services for service %s", serviceId)
 		return err
 	}
 

--- a/node/agent.go
+++ b/node/agent.go
@@ -206,12 +206,20 @@ func (a *HostAgent) AttachService(done chan<- interface{}, service *service.Serv
 
 // PauseService pauses a running service
 func (a *HostAgent) PauseService(service *service.Service, state *servicestate.ServiceState) error {
-	return attachAndRun(state.DockerID, service.Snapshot.Pause)
+	if len(service.Snapshot.Pause) > 0 {
+		return attachAndRun(state.DockerID, service.Snapshot.Pause)
+	}
+
+	return nil
 }
 
 // ResumeService resumes a paused service
 func (a *HostAgent) ResumeService(service *service.Service, state *servicestate.ServiceState) error {
-	return attachAndRun(state.DockerID, service.Snapshot.Resume)
+	if len(service.Snapshot.Resume) > 0 {
+		return attachAndRun(state.DockerID, service.Snapshot.Resume)
+	}
+
+	return nil
 }
 
 func attachAndRun(dockerID, command string) error {

--- a/zzk/service/service.go
+++ b/zzk/service/service.go
@@ -160,7 +160,7 @@ func (l *ServiceListener) sync(svc *service.Service, rss []*dao.RunningService) 
 	for _, state := range rss {
 		// resumeInstance updates the service state ONLY if it has a PAUSED DesiredState
 		if err := resumeInstance(l.conn, state.HostID, state.ID); err != nil {
-			glog.Warningf("Could not resume paused service instance %s on host %s: %s", state.ID, state.HostID, err)
+			glog.Warningf("Could not resume paused service instance %s (%s) for service %s on host %s: %s", state.ID, state.Name, state.ServiceID, state.HostID, err)
 		}
 	}
 
@@ -237,10 +237,10 @@ func (l *ServiceListener) start(svc *service.Service, instanceIDs []int) {
 func (l *ServiceListener) stop(rss []*dao.RunningService) {
 	for _, state := range rss {
 		if err := StopServiceInstance(l.conn, state.HostID, state.ID); err != nil {
-			glog.Warningf("Service instance %s from %s (%s) won't die: %s", state.ID, state.Name, state.ServiceID, err)
+			glog.Warningf("Service instance %s (%s) from service %s won't die: %s", state.ID, state.Name, state.ServiceID, err)
 			continue
 		}
-		glog.V(2).Infof("Stopping service instance %s for service %s on host %s", state.ID, state.ServiceID, state.HostID)
+		glog.V(2).Infof("Stopping service instance %s (%s) for service %s on host %s", state.ID, state.Name, state.ServiceID, state.HostID)
 	}
 }
 
@@ -248,10 +248,10 @@ func (l *ServiceListener) pause(rss []*dao.RunningService) {
 	for _, state := range rss {
 		// pauseInstance updates the service state ONLY if it has a RUN DesiredState
 		if err := pauseInstance(l.conn, state.HostID, state.ID); err != nil {
-			glog.Warningf("Could not pause service instance %s for service %s (%s): %s", state.ID, state.ServiceID, state.Name, err)
+			glog.Warningf("Could not pause service instance %s (%s) for service %s: %s", state.ID, state.Name, state.ServiceID, err)
 			continue
 		}
-		glog.V(2).Infof("Pausing service instance %s for service %s on host %s", state.ID, state.ServiceID, state.HostID)
+		glog.V(2).Infof("Pausing service instance %s (%s) for service %s on host %s", state.ID, state.Name, state.ServiceID, state.HostID)
 	}
 }
 


### PR DESCRIPTION
...sume) defined

DEMO1 - install with minimal services started:

```
# plu@plu-9: serviced service status 
NAME            ID              STATUS      UPTIME      HOST    DOCKER_ID
└─Zenoss.core       swcbene230d5rp91k8czk0y9                        
  ├─opentsdb        16vpyf77lg2g93bk5n9srm1g7                       
  │ ├─reader      azsl9g2xlydqtibhfebqjqxcs   Stopped                 
  │ └─writer      bl31f85c179ewur3mg2p1redx   Stopped                 
  ├─zeneventserver  1nn16n30expakpd3zfdn5znh8   Running     41.958639147s   plu-9   97af521d7743
  ├─redis       3dbqulbcj0yw1f1ucj4dkp50m   Running     59.904882554s   plu-9   d30ae161db9c
  ├─zenjobs     5c1bz728iim65duq5c2qqmohi   Stopped                 
  ├─MetricConsumer  5o9ozlh7102hqlltxhgxeirbe   Stopped                 
  ├─MySQL       5wto1vktlr29xyvx70raxp6o8   Running     53.000211858s   plu-9   b4c701a46e88
  ├─HBase       8zb4whzmeeybll6jr0qnrb6hs                       
  │ ├─HMaster     51vh0eiqtvbibkegii0jkaju2   Stopped                 
  │ ├─ZooKeeper       6qahmolqmdd5rhnrqkxbu603k   Stopped                 
  │ └─RegionServer    9t9b1vyc1nrt77le4291fjkil   Stopped                 
  ├─CentralQuery    94r85ozdgbeglk07x3w6gxveh   Stopped                 
  ├─Zope        9lbhggb2vsbtu53s3salqwa7q   Stopped                 
  ├─RabbitMQ        9ubqpbd7e9mdgj3cqahbvvt9p   Running     47.453365213s   plu-9   ae6ae8f1ccba
  ├─zenactiond      9xuyy407wxlhvn8rdic509jwp   Stopped                 
  ├─memcached       aujvalerz75nxcn1sygplhy52   Running     59.380924809s   plu-9   6bc7b2e7f639
  ├─zeneventd       bn1kpqxpq1304zbxgae07qvce   Stopped                 
  ├─localhost       crerare6hipg86xc9kiwmiodl                       
  │ ├─localhost       7sm5uoipbefewlutobjibuz4z                       
  │ │ ├─MetricShipper   2adevaa42e0yt98bazis3d3r0   Stopped                 
  │ │ ├─zenmodeler  5gl1fy2t540bk2ffh5ue3djjs   Stopped                 
  │ │ ├─zenperfsnmp 5ojhsl9kxreq8uye4l9zspu5t   Stopped                 
  │ │ ├─zenprocess  7r8mbhvubipzprg6192vpmyk5   Stopped                 
  │ │ ├─zencommand  9m4xl0uoe9ek24piua2l270jx   Stopped                 
  │ │ ├─zenstatus   bbf3zkjv15niexpk5l867twin   Stopped                 
  │ │ ├─zenping     blye38xictugvatddi55nxhbg   Stopped                 
  │ │ ├─zentrap     c6geufxfzes92rg72ovkgvp6f   Stopped                 
  │ │ ├─collectorredis  cb021jricdcpqmufkcuvlvtfq   Stopped                 
  │ │ ├─zenpython   d1bvtmmihefet0b0t38xzpz95   Stopped                 
  │ │ ├─zensyslog   e54p2d839ako9sirq6alx6e9f   Stopped                 
  │ │ └─zenjmx      iyh4tznvs3qagk12mmcnrlkm    Stopped                 
  │ └─zenhub      af85cyggoub38qaqk7e87l1pw   Stopped                 
  ├─zproxy      cyh8hdd97itc18angx7w3xfq0   Stopped                 
  └─Zauth       q0xc7l890huatuoqagvgco4r    Stopped                 

# plu@plu-9: serviced service run Zope zenpack install dist/ZenPacks.zenoss.AdvancedSearch-1.1.3-py2.7.egg
...
2014-08-12 21:33:24,769 INFO zen.HookReportLoader: Loading reports from /opt/zenoss/ZenPacks/ZenPacks.zenoss.AdvancedSearch-1.1.3-py2.7.egg/ZenPacks/zenoss/AdvancedSearch/reports
I0812 15:33:30.998450 17765 shell.go:201] Committing container

# plu@plu-9: serviced service status 
NAME            ID              STATUS      UPTIME          HOST    DOCKER_ID
└─Zenoss.core       swcbene230d5rp91k8czk0y9                            
  ├─opentsdb        16vpyf77lg2g93bk5n9srm1g7                           
  │ ├─reader      azsl9g2xlydqtibhfebqjqxcs   Stopped                     
  │ └─writer      bl31f85c179ewur3mg2p1redx   Stopped                     
  ├─zeneventserver  1nn16n30expakpd3zfdn5znh8   Running     3m46.520680049s     plu-9   97af521d7743
  ├─redis       3dbqulbcj0yw1f1ucj4dkp50m   Running     4m4.585036238s      plu-9   d30ae161db9c
  ├─zenjobs     5c1bz728iim65duq5c2qqmohi   Stopped                     
  ├─MetricConsumer  5o9ozlh7102hqlltxhgxeirbe   Stopped                     
  ├─MySQL       5wto1vktlr29xyvx70raxp6o8   Running     3m57.621875094s     plu-9   b4c701a46e88
  ├─HBase       8zb4whzmeeybll6jr0qnrb6hs                           
  │ ├─HMaster     51vh0eiqtvbibkegii0jkaju2   Stopped                     
  │ ├─ZooKeeper       6qahmolqmdd5rhnrqkxbu603k   Stopped                     
  │ └─RegionServer    9t9b1vyc1nrt77le4291fjkil   Stopped                     
  ├─CentralQuery    94r85ozdgbeglk07x3w6gxveh   Stopped                     
  ├─Zope        9lbhggb2vsbtu53s3salqwa7q   Stopped                     
  ├─RabbitMQ        9ubqpbd7e9mdgj3cqahbvvt9p   Running     3m52.045029555s     plu-9   ae6ae8f1ccba
  ├─zenactiond      9xuyy407wxlhvn8rdic509jwp   Stopped                     
  ├─memcached       aujvalerz75nxcn1sygplhy52   Running     4m4.031951724s      plu-9   6bc7b2e7f639
  ├─zeneventd       bn1kpqxpq1304zbxgae07qvce   Stopped                     
  ├─localhost       crerare6hipg86xc9kiwmiodl                           
  │ ├─localhost       7sm5uoipbefewlutobjibuz4z                           
  │ │ ├─MetricShipper   2adevaa42e0yt98bazis3d3r0   Stopped                     
  │ │ ├─zenmodeler  5gl1fy2t540bk2ffh5ue3djjs   Stopped                     
  │ │ ├─zenperfsnmp 5ojhsl9kxreq8uye4l9zspu5t   Stopped                     
  │ │ ├─zenprocess  7r8mbhvubipzprg6192vpmyk5   Stopped                     
  │ │ ├─zencommand  9m4xl0uoe9ek24piua2l270jx   Stopped                     
  │ │ ├─zenstatus   bbf3zkjv15niexpk5l867twin   Stopped                     
  │ │ ├─zenping     blye38xictugvatddi55nxhbg   Stopped                     
  │ │ ├─zentrap     c6geufxfzes92rg72ovkgvp6f   Stopped                     
  │ │ ├─collectorredis  cb021jricdcpqmufkcuvlvtfq   Stopped                     
  │ │ ├─zenpython   d1bvtmmihefet0b0t38xzpz95   Stopped                     
  │ │ ├─zensyslog   e54p2d839ako9sirq6alx6e9f   Stopped                     
  │ │ └─zenjmx      iyh4tznvs3qagk12mmcnrlkm    Stopped                     
  │ └─zenhub      af85cyggoub38qaqk7e87l1pw   Stopped                     
  ├─zproxy      cyh8hdd97itc18angx7w3xfq0   Stopped                     
  └─Zauth       q0xc7l890huatuoqagvgco4r    Stopped 

================== serviced.log:
I0812 15:33:31.402228 13202 filesystem.go:162] Mounting vfs:rsync tenantId:swcbene230d5rp91k8czk0y9 baseDir:/tmp/serviced-root/var/volumes/default
I0812 15:33:31.892055 13202 host.go:264] Pausing service instance 7aruh1b50m7ucbjsyjqr7grji for service redis (3dbqulbcj0yw1f1ucj4dkp50m)
I0812 15:33:32.981294 13202 host.go:264] Pausing service instance 3ktqxnfbheeqtvxdsfn0mw869 for service memcached (aujvalerz75nxcn1sygplhy52)
I0812 15:33:34.068174 13202 host.go:264] Pausing service instance a00c5rqzlxem9qv02csv49jy1 for service MySQL (5wto1vktlr29xyvx70raxp6o8)
I0812 15:33:37.170779 13202 host.go:264] Pausing service instance eag05lau2synifwog2pus1l5z for service RabbitMQ (9ubqpbd7e9mdgj3cqahbvvt9p)
I0812 15:33:44.319771 13202 host.go:264] Pausing service instance 4uol79xvja2y5uek3kafcupzw for service zeneventserver (1nn16n30expakpd3zfdn5znh8)
I0812 15:33:45.339931 13202 filesystem.go:162] Mounting vfs:rsync tenantId:swcbene230d5rp91k8czk0y9 baseDir:/tmp/serviced-root/var/volumes/default
I0812 15:33:45.340013 13202 dfs.go:135] DistributedFileSystem.Snapshot service=swcbene230d5rp91k8czk0y9 label=swcbene230d5rp91k8czk0y9_20140812-203345 volume={Conn:0xc2097a63c0}
I0812 15:33:45.340125 13202 rsync.go:111] Performing snapshot rsync command: /usr/bin/rsync [-a /tmp/serviced-root/var/volumes/default/swcbene230d5rp91k8czk0y9/ /tmp/serviced-root/var/volumes/default/swcbene230d5rp91k8czk0y9_20140812-203345/]
I0812 15:33:47.998496 13202 dfs.go:167] Successfully created snapshot for service Id:swcbene230d5rp91k8czk0y9 Name:Zenoss.core Label:swcbene230d5rp91k8czk0y9_20140812-203345
```

DEMO2 - install with all services started:

```
# plu@plu-9: serviced service status
NAME            ID              STATUS      UPTIME          HOST    DOCKER_ID
└─Zenoss.core       6nopptlmmm9me6a57rzlriaue                           
  ├─zenactiond      2soueao0jn8fy405bdbobp29d   Scheduled                   
  ├─zeneventserver  3poveiacf2mkowi0712s4217x   Running     1m42.308079505s     plu-9   8a8b67d0e90a
  ├─zeneventd       5dr8ehxqvkoikywj4rodr81jl   Running     3m6.311026957s      plu-9   9c6805f5475a
  ├─RabbitMQ        5mfmzsavlxu633ag03qgzc0yt   Running     1m48.379324802s     plu-9   d5587aac9b30
  ├─MySQL       6315nema21bh1b24te34gfsc0   Running     1m53.847232884s     plu-9   f5b7b33e25a7
  ├─CentralQuery    66oqxxxdj46zdrz2673ouomtk   Running     2m54.91443283s      plu-9   ef5505f93358
  ├─opentsdb        67cygkd9qwd5e3n2ihoqihetx                           
  │ ├─reader      39qcidhgcarymhfmezhvceasn   Running     2m52.809313865s     plu-9   b4104db0c610
  │ └─writer      bdx4z77e25dz2x1myz7m02dbp   Running     2m51.615040294s     plu-9   5080297e2880
  ├─Zope_0      6bcbbxgshqgb1m351s05f7h6b_0 Running     2m44.811626694s     plu-9   e00215d25de1
  ├─Zope_1      6bcbbxgshqgb1m351s05f7h6b_1 Running     2m28.152653864s     plu-9   0cd9646666db
  ├─memcached       7p9a3v51h7h2cchotd43ftegu   Running     2m54.066799227s     plu-9   001b9eaa8a77
  ├─MetricConsumer  8s62y6xad4qjy5ah7t7kvp6uw   Running     3m7.273463163s      plu-9   7d863af18aec
  ├─localhost       bhxdo0l25id17e3gkclg7y9qg                           
  │ ├─zenhub      927am7enum5kbta782mny5vwt   Running     2m57.740356687s     plu-9   08e845fad1c3
  │ └─localhost       er0ihbjfzrm589dv4vd8l5qrd                           
  │   ├─zensyslog 3cg1g8mq64z0xb1laho1uwpq4   Running     2m59.233571276s     plu-9   e529d5d72a74
  │   ├─MetricShipper 4yyet68zig3uejx82cj86imee   Running     3m4.695175782s      plu-9   f030c93e230f
  │   ├─zenpython 5vkk3ut6dxvwhrxw3tdcwqzk1   Running     2m59.355543055s     plu-9   9220ccba794d
  │   ├─zentrap       6okaybc9zc8boi2nc86fn6c96   Running     2m58.897914138s     plu-9   f5e0a1eb7d79
  │   ├─zenmodeler    74pgou9aulwexlmdl82mj7f2p   Running     3m3.135688751s      plu-9   d07bd674f466
  │   ├─zenjmx        9geyh5achsylakpzzq57lr21f   Running     3m1.947132451s      plu-9   e8bcf5559d90
  │   ├─zenstatus b90vz2rn4i1t3wna7da0rmu11   Running     3m5.129099104s      plu-9   945b4d4ae9b6
  │   ├─zenprocess    cueow89lc1clq3vrlqtwbb71v   Running     3m5.671334566s      plu-9   a21a691ff2b7
  │   ├─zencommand    cyxty6slg5nmq6gnycwtn1zv    Running     3m0.580490481s      plu-9   751dc3c38c98
  │   ├─zenping       d4c3so51ra5gf4ls6a6q827di   Running     3m5.938141587s      plu-9   c89a8ec51559
  │   ├─zenperfsnmp   eawya0yxttyow4um6m4e8cm73   Running     3m2.674777684s      plu-9   a3af4ccb243c
  │   └─collectorredis    ngj1ufq078vvdry1393naqu     Running     3m3.900347677s      plu-9   d3b3c71b49ba
  ├─HBase       br9y430jl6i1eq07enzm4dtt0                           
  │ ├─RegionServer_0  2flaoxztngw7mok1pb6md35oc_0 Running     1m36.920279963s     plu-9   d8f9767395e3
  │ ├─RegionServer_1  2flaoxztngw7mok1pb6md35oc_1 Running     1m31.198792283s     plu-9   1f13d166cecc
  │ ├─RegionServer_2  2flaoxztngw7mok1pb6md35oc_2 Running     2m22.722352654s     plu-9   aa0eb180b943
  │ ├─HMaster     2isj7llm5wajwj9stpldpou5d   Running     2m17.10643837s      plu-9   969b1b4ddd4c
  │ ├─ZooKeeper_0 5zjlwhftms0tjkv68aqc78ezh_0 Running     2m11.458270143s     plu-9   7789019dce6e
  │ ├─ZooKeeper_1 5zjlwhftms0tjkv68aqc78ezh_1 Running     2m5.700515809s      plu-9   b0547d134ada
  │ └─ZooKeeper_2 5zjlwhftms0tjkv68aqc78ezh_2 Running     2m0.066169112s      plu-9   a3265e5fb65e
  ├─Zauth       cxagbdz73lhx5ll5y2wcsrnyc   Running     2m45.359368496s     plu-9   e77b8ef43ba8
  ├─redis       diz227srj4dr67txpygd9ij70   Running     3m7.511336542s      plu-9   9f6b396120a3
  ├─zenjobs     ehv5sav58f7jcvzh8qjsd8ds4   Running     3m1.643214185s      plu-9   1ab8fb3df794
  └─zproxy      f2t7cieify4x1cfwyug4ug0lj   Running     1m49.047257757s     plu-9   257c556fb141

~/src/europa/src/enterprise_zenpacks/ZenPacks.zenoss.AdvancedSearch
# plu@plu-9: serviced service run Zope zenpack install dist/ZenPacks.zenoss.AdvancedSearch-1.1.3-py2.7.egg
...
2014-08-13 16:52:28,351 INFO zen.HookReportLoader: Loading reports from /opt/zenoss/ZenPacks/ZenPacks.zenoss.AdvancedSearch-1.1.3-py2.7.egg/ZenPacks/zenoss/AdvancedSearch/reports
I0813 10:52:34.634733 22428 shell.go:201] Committing container

# plu@plu-9: serviced service status
NAME            ID              STATUS      UPTIME          HOST    DOCKER_ID
└─Zenoss.core       6nopptlmmm9me6a57rzlriaue                           
  ├─zenactiond      2soueao0jn8fy405bdbobp29d   Running     2m21.550534539s     plu-9   446c02f4ef94
  ├─zeneventserver  3poveiacf2mkowi0712s4217x   Running     5m15.207569025s     plu-9   8a8b67d0e90a
  ├─zeneventd       5dr8ehxqvkoikywj4rodr81jl   Running     6m39.245107541s     plu-9   9c6805f5475a
  ├─RabbitMQ        5mfmzsavlxu633ag03qgzc0yt   Running     5m20.556006831s     plu-9   d5587aac9b30
  ├─MySQL       6315nema21bh1b24te34gfsc0   Running     5m26.00013333s      plu-9   f5b7b33e25a7
  ├─CentralQuery    66oqxxxdj46zdrz2673ouomtk   Running     6m27.166712121s     plu-9   ef5505f93358
  ├─opentsdb        67cygkd9qwd5e3n2ihoqihetx                           
  │ ├─reader      39qcidhgcarymhfmezhvceasn   Paused      6m25.002573043s     plu-9   b4104db0c610
  │ └─writer      bdx4z77e25dz2x1myz7m02dbp   Running     6m23.910992572s     plu-9   5080297e2880
  ├─Zope_0      6bcbbxgshqgb1m351s05f7h6b_0 Running     6m17.268509463s     plu-9   e00215d25de1
  ├─Zope_1      6bcbbxgshqgb1m351s05f7h6b_1 Running     6m0.609536527s      plu-9   0cd9646666db
  ├─memcached       7p9a3v51h7h2cchotd43ftegu   Running     6m26.400042167s     plu-9   001b9eaa8a77
  ├─MetricConsumer  8s62y6xad4qjy5ah7t7kvp6uw   Running     6m40.188593282s     plu-9   7d863af18aec
  ├─localhost       bhxdo0l25id17e3gkclg7y9qg                           
  │ ├─zenhub      927am7enum5kbta782mny5vwt   Running     6m30.219777146s     plu-9   08e845fad1c3
  │ └─localhost       er0ihbjfzrm589dv4vd8l5qrd                           
  │   ├─zensyslog 3cg1g8mq64z0xb1laho1uwpq4   Running     6m31.695934923s     plu-9   e529d5d72a74
  │   ├─MetricShipper 4yyet68zig3uejx82cj86imee   Running     6m37.386296746s     plu-9   f030c93e230f
  │   ├─zenpython 5vkk3ut6dxvwhrxw3tdcwqzk1   Running     6m31.916150847s     plu-9   9220ccba794d
  │   ├─zentrap       6okaybc9zc8boi2nc86fn6c96   Running     6m31.362202551s     plu-9   f5e0a1eb7d79
  │   ├─zenmodeler    74pgou9aulwexlmdl82mj7f2p   Running     6m35.808000853s     plu-9   d07bd674f466
  │   ├─zenjmx        9geyh5achsylakpzzq57lr21f   Running     6m34.594646472s     plu-9   e8bcf5559d90
  │   ├─zenstatus b90vz2rn4i1t3wna7da0rmu11   Running     6m37.820175675s     plu-9   945b4d4ae9b6
  │   ├─zenprocess    cueow89lc1clq3vrlqtwbb71v   Running     6m38.363152018s     plu-9   a21a691ff2b7
  │   ├─zencommand    cyxty6slg5nmq6gnycwtn1zv    Running     6m33.257987489s     plu-9   751dc3c38c98
  │   ├─zenping       d4c3so51ra5gf4ls6a6q827di   Running     6m38.618704736s     plu-9   c89a8ec51559
  │   ├─zenperfsnmp   eawya0yxttyow4um6m4e8cm73   Running     6m35.349654368s     plu-9   a3af4ccb243c
  │   └─collectorredis    ngj1ufq078vvdry1393naqu     Running     6m36.764085349s     plu-9   d3b3c71b49ba
  ├─HBase       br9y430jl6i1eq07enzm4dtt0                           
  │ ├─RegionServer_0  2flaoxztngw7mok1pb6md35oc_0 Running     5m9.120808724s      plu-9   d8f9767395e3
  │ ├─RegionServer_1  2flaoxztngw7mok1pb6md35oc_1 Running     5m3.399319585s      plu-9   1f13d166cecc
  │ ├─RegionServer_2  2flaoxztngw7mok1pb6md35oc_2 Running     5m54.922881734s     plu-9   aa0eb180b943
  │ ├─HMaster     2isj7llm5wajwj9stpldpou5d   Paused      5m49.208580517s     plu-9   969b1b4ddd4c
  │ ├─ZooKeeper_0 5zjlwhftms0tjkv68aqc78ezh_0 Running     5m43.653605973s     plu-9   7789019dce6e
  │ ├─ZooKeeper_1 5zjlwhftms0tjkv68aqc78ezh_1 Running     5m37.895850708s     plu-9   b0547d134ada
  │ └─ZooKeeper_2 5zjlwhftms0tjkv68aqc78ezh_2 Running     5m32.261483416s     plu-9   a3265e5fb65e
  ├─Zauth       cxagbdz73lhx5ll5y2wcsrnyc   Running     6m17.543795942s     plu-9   e77b8ef43ba8
  ├─redis       diz227srj4dr67txpygd9ij70   Running     6m40.493985934s     plu-9   9f6b396120a3
  ├─zenjobs     ehv5sav58f7jcvzh8qjsd8ds4   Running     6m34.59698578s      plu-9   1ab8fb3df794
  └─zproxy      f2t7cieify4x1cfwyug4ug0lj   Paused      5m21.1170569s       plu-9   257c556fb141

================== serviced.log:
I0813 10:52:35.757085 13331 filesystem.go:162] Mounting vfs:rsync tenantId:6nopptlmmm9me6a57rzlriaue baseDir:/tmp/serviced-root/var/volumes/default
I0813 10:52:36.273663 13331 host.go:264] Pausing service instance cxem9toua06k3vajzjf7zzf8r for service redis (diz227srj4dr67txpygd9ij70)
I0813 10:52:37.342163 13331 host.go:264] Pausing service instance 442jr9lyxjamk607xm02f4d7s for service zenjobs (ehv5sav58f7jcvzh8qjsd8ds4)
I0813 10:52:38.455876 13331 host.go:264] Pausing service instance 37wkd8wedb8llhhbb0ho6gaax for service zeneventd (5dr8ehxqvkoikywj4rodr81jl)
I0813 10:52:39.643820 13331 host.go:264] Pausing service instance etml043bx4i0h6okovylizi06 for service MetricConsumer (8s62y6xad4qjy5ah7t7kvp6uw)
I0813 10:52:40.811727 13331 host.go:264] Pausing service instance 618q4q7rm0d0jvspmb9szw3qt for service zeneventserver (3poveiacf2mkowi0712s4217x)
I0813 10:52:42.083484 13331 host.go:264] Pausing service instance 5y0rtsdghut8vwsorp36yau91 for service collectorredis (ngj1ufq078vvdry1393naqu)
I0813 10:52:42.130595 13331 host.go:264] Pausing service instance 9ztbjef3qd4jo5ssxeba59emi for service zenmodeler (74pgou9aulwexlmdl82mj7f2p)
I0813 10:52:42.182696 13331 host.go:264] Pausing service instance 5puttzqm6r81g8vw4qr05dxwz for service zenping (d4c3so51ra5gf4ls6a6q827di)
I0813 10:52:42.236918 13331 host.go:264] Pausing service instance 7cy9am5bwmhvet3if1mimbrbf for service zenperfsnmp (eawya0yxttyow4um6m4e8cm73)
I0813 10:52:42.286307 13331 host.go:264] Pausing service instance 9n5px3f0l09htor665f1oubz7 for service zenjmx (9geyh5achsylakpzzq57lr21f)
I0813 10:52:42.316789 13331 host.go:264] Pausing service instance 81vufuswsrgyn5n0g1pux8huk for service zencommand (cyxty6slg5nmq6gnycwtn1zv)
I0813 10:52:42.348657 13331 host.go:264] Pausing service instance e3y9trcm4373c3ldg5l36j6vx for service zenprocess (cueow89lc1clq3vrlqtwbb71v)
I0813 10:52:42.399442 13331 host.go:264] Pausing service instance qbz9tvknggj5vwh32vxgt3kh for service zenstatus (b90vz2rn4i1t3wna7da0rmu11)
I0813 10:52:42.446262 13331 host.go:264] Pausing service instance 84v6bxv3p66gh4nl5tr8c2ld3 for service MetricShipper (4yyet68zig3uejx82cj86imee)
I0813 10:52:42.499691 13331 host.go:264] Pausing service instance 7bsk91pk1ulhrfwc164n0x064 for service zensyslog (3cg1g8mq64z0xb1laho1uwpq4)
I0813 10:52:42.542858 13331 host.go:264] Pausing service instance 9tdnwm50ebj3e85gd1s3ksxlr for service zentrap (6okaybc9zc8boi2nc86fn6c96)
I0813 10:52:42.577719 13331 host.go:264] Pausing service instance 9htabzdin61eakkjy4bn7merp for service zenpython (5vkk3ut6dxvwhrxw3tdcwqzk1)
I0813 10:52:42.660830 13331 host.go:264] Pausing service instance 2sceauswb73rfned6nl2wemq3 for service zenhub (927am7enum5kbta782mny5vwt)
I0813 10:52:43.610277 13331 host.go:264] Pausing service instance 8y3pgw0kdjsj4n4lboncb1cop for service Zope (6bcbbxgshqgb1m351s05f7h6b)
I0813 10:52:43.616766 13331 host.go:264] Pausing service instance 9hpje5xo3nicaeavqvzfu68e0 for service Zope (6bcbbxgshqgb1m351s05f7h6b)
I0813 10:52:43.702336 13331 host.go:264] Pausing service instance 5hh823f7eb6nkh8raks0wa4xh for service CentralQuery (66oqxxxdj46zdrz2673ouomtk)
I0813 10:52:43.730037 13331 host.go:264] Pausing service instance 6vhzkbekvkbdk4mh5krbwfeql for service memcached (7p9a3v51h7h2cchotd43ftegu)
I0813 10:52:43.815448 13331 host.go:264] Pausing service instance 7v76yo5x1ebawpyrnp8l4c9si for service reader (39qcidhgcarymhfmezhvceasn)
I0813 10:52:43.841201 13331 host.go:264] Pausing service instance 2vzox3y5xurdodllechr4jgbh for service writer (bdx4z77e25dz2x1myz7m02dbp)
I0813 10:52:43.872947 13331 host.go:264] Pausing service instance dyh56u9now8425550n4k9k8iu for service MySQL (6315nema21bh1b24te34gfsc0)
I0813 10:52:43.905601 13331 host.go:264] Pausing service instance 4ytmdx99j39u762wjco15trl3 for service Zauth (cxagbdz73lhx5ll5y2wcsrnyc)
I0813 10:52:43.926292 13331 host.go:264] Pausing service instance e5z4hkto5uhoidoz0coq0p2tx for service zproxy (f2t7cieify4x1cfwyug4ug0lj)
I0813 10:52:43.996476 13331 host.go:264] Pausing service instance d2zfo1gjn1jp549i4udi6phxy for service RegionServer (2flaoxztngw7mok1pb6md35oc)
I0813 10:52:43.998882 13331 host.go:264] Pausing service instance 44qa6up2lecwcyo0l9r1ec61f for service RegionServer (2flaoxztngw7mok1pb6md35oc)
I0813 10:52:44.000966 13331 host.go:264] Pausing service instance 28iugofeuvrblw6o98lib53yu for service RegionServer (2flaoxztngw7mok1pb6md35oc)
I0813 10:52:44.026667 13331 host.go:264] Pausing service instance 4vkaqxh1amiqzfdh6pz5q6xz3 for service HMaster (2isj7llm5wajwj9stpldpou5d)
I0813 10:52:44.096325 13331 host.go:264] Pausing service instance o1e3vc7wkepg3fexcil3ksry for service ZooKeeper (5zjlwhftms0tjkv68aqc78ezh)
I0813 10:52:44.099450 13331 host.go:264] Pausing service instance 7ifhtn1gjg02nzqrph59ak3ek for service ZooKeeper (5zjlwhftms0tjkv68aqc78ezh)
I0813 10:52:44.103640 13331 host.go:264] Pausing service instance 2cd9qucgcimd6sgtup9ggk179 for service ZooKeeper (5zjlwhftms0tjkv68aqc78ezh)
I0813 10:52:44.512322 13331 host.go:264] Pausing service instance fkevy4i5x628pkb616zfreyf for service RabbitMQ (5mfmzsavlxu633ag03qgzc0yt)
I0813 10:52:52.872038 13331 filesystem.go:162] Mounting vfs:rsync tenantId:6nopptlmmm9me6a57rzlriaue baseDir:/tmp/serviced-root/var/volumes/default
I0813 10:52:52.872107 13331 dfs.go:135] DistributedFileSystem.Snapshot service=6nopptlmmm9me6a57rzlriaue label=6nopptlmmm9me6a57rzlriaue_20140813-155252 volume={Conn:0xc209d69dd0}
I0813 10:52:52.872191 13331 rsync.go:111] Performing snapshot rsync command: /usr/bin/rsync [-a /tmp/serviced-root/var/volumes/default/6nopptlmmm9me6a57rzlriaue/ /tmp/serviced-root/var/volumes/default/6nopptlmmm9me6a57rzlriaue_20140813-155252/]
I0813 10:52:56.916670 13331 dfs.go:167] Successfully created snapshot for service Id:6nopptlmmm9me6a57rzlriaue Name:Zenoss.core Label:6nopptlmmm9me6a57rzlriaue_20140813-155252

```
