### PR TITLE
Use timestamp parameters on GET requests

### DIFF
--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -227,7 +227,7 @@ function ResourcesService($http, $location, $notification) {
     var cached_services_map; // map of services by by Id, with children attached
 
     var _get_services_tree = function(callback) {
-        $http.get('/services').
+        $http({url: '/services', method: 'GET', params: {'time': new Date().getTime()}}).
             success(function(data, status) {
                 if(DEBUG) console.log('Retrieved list of services');
                 cached_services = [];
@@ -259,7 +259,7 @@ function ResourcesService($http, $location, $notification) {
     };
 
     var _get_app_templates = function(callback) {
-        $http.get('/templates').
+        $http({url: '/templates', method: 'GET', params: {'time': new Date().getTime()}}).
             success(function(data, status) {
                 if(DEBUG) console.log('Retrieved list of application templates');
                 cached_app_templates = data;
@@ -276,7 +276,7 @@ function ResourcesService($http, $location, $notification) {
 
     // Real implementation for acquiring list of resource pools
     var _get_pools = function(callback) {
-        $http.get('/pools').
+        $http({url: '/pools', method: 'GET', params: {'time': new Date().getTime()}}).
             success(function(data, status) {
                 if(DEBUG) console.log('Retrieved list of pools');
                 cached_pools = data;
@@ -292,7 +292,7 @@ function ResourcesService($http, $location, $notification) {
     };
 
     var _get_hosts_for_pool = function(poolID, callback) {
-        $http.get('/pools/' + poolID + '/hosts').
+        $http({url: '/pools/' + poolID + '/hosts', method: 'GET', params: {'time': new Date().getTime()}}).
             success(function(data, status) {
                 if(DEBUG) console.log('Retrieved hosts for pool %s', poolID);
                 cached_hosts_for_pool[poolID] = data;
@@ -308,7 +308,7 @@ function ResourcesService($http, $location, $notification) {
     };
 
     var _get_hosts = function(callback) {
-        $http.get('/hosts').
+        $http({url: '/hosts', method: 'GET', params: {'time': new Date().getTime()}}).
             success(function(data, status) {
                 if(DEBUG) console.log('Retrieved host details');
                 cached_hosts = data;
@@ -377,7 +377,7 @@ function ResourcesService($http, $location, $notification) {
          * @param {function} callback Pool data is passed to a callback on success.
          */
         get_pool: function(poolID, callback) {
-            $http.get('/pools/' + poolID).
+            $http({url: '/pools', method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     if(DEBUG) console.log('Retrieved %s for %s', data, poolID);
                     callback(data);
@@ -398,7 +398,7 @@ function ResourcesService($http, $location, $notification) {
          * @param {function} callback Pool data is passed to a callback on success.
          */
         get_pool_ips: function(poolID, callback) {
-            $http.get('/pools/' + poolID + "/ips").
+            $http({url: '/pools/' + poolID + "/ips", method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     if(DEBUG) console.log('Retrieved %s for %s', data, poolID);
                     callback(data);
@@ -419,7 +419,7 @@ function ResourcesService($http, $location, $notification) {
          * @param {function} callback Running services are passed to callback on success.
          */
         get_running_services_for_service: function(serviceId, callback) {
-            $http.get('/services/' + serviceId + '/running').
+            $http({url: '/services/' + serviceId + '/running', method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     if(DEBUG) console.log('Retrieved running services for %s', serviceId);
                     callback(data);
@@ -440,7 +440,7 @@ function ResourcesService($http, $location, $notification) {
          * @param {function} callback virtual hosts are passed to callback on success.
          */
         get_vhosts: function(callback) {
-            $http.get('/vhosts').
+            $http({url: '/vhosts', method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     if(DEBUG) console.log('Retrieved list of virtual hosts');
                     callback(data);
@@ -501,7 +501,7 @@ function ResourcesService($http, $location, $notification) {
          * @param {function} callback Running services are passed to callback on success.
          */
         get_running_services_for_host: function(hostId, callback) {
-            $http.get('/hosts/' + hostId + '/running').
+            $http({url: '/hosts/' + hostId + '/running', method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     if(DEBUG) console.log('Retrieved running services for %s', hostId);
                     callback(data);
@@ -522,7 +522,7 @@ function ResourcesService($http, $location, $notification) {
          * @param {function} callback Running services are passed to callback on success.
          */
         get_running_services: function(callback) {
-            $http.get('/running').
+            $http({url: '/running', method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     callback(data);
                 }).
@@ -689,7 +689,7 @@ function ResourcesService($http, $location, $notification) {
          * @param {function} callback host data is passed to a callback on success.
          */
         get_host: function(hostID, callback) {
-            $http.get('/hosts/' + hostID).
+            $http({url: '/hosts/' + hostID, method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     if(DEBUG) console.log('Retrieved %s for %s', data, hostID);
                     callback(data);
@@ -814,7 +814,7 @@ function ResourcesService($http, $location, $notification) {
          * @param {function} callback Log data passed to callback on success.
          */
         get_service_logs: function(serviceId, callback) {
-            $http.get('/services/' + serviceId + '/logs').
+            $http({url: '/services/' + serviceId + '/logs', method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     callback(data);
                 }).
@@ -834,7 +834,7 @@ function ResourcesService($http, $location, $notification) {
          * @param {function} callback Log data passed to callback on success.
          */
         get_service_state_logs: function(serviceId, serviceStateId, callback) {
-            $http.get('/services/' + serviceId + '/' + serviceStateId + '/logs').
+            $http({url: '/services/' + serviceId + '/' + serviceStateId + '/logs', method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     callback(data);
                 }).
@@ -964,7 +964,7 @@ function ResourcesService($http, $location, $notification) {
          * @param {function} callback Response passed to callback on success.
          */
         snapshot_service: function(serviceId, callback) {
-            $http.get('/services/' + serviceId + '/snapshot').
+            $http({url: '/services/' + serviceId + '/snapshot', method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     callback(data);
                 }).
@@ -1040,7 +1040,7 @@ function ResourcesService($http, $location, $notification) {
          * Gets the Serviced version from the server
          */
         get_version: function(callback){
-            $http.get('/version').
+            $http({url: '/version', method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     callback(data);
                 }).
@@ -1057,7 +1057,7 @@ function ResourcesService($http, $location, $notification) {
          * Creates a backup file of serviced
          */
         create_backup: function(callback){
-            $http.get('/backup/create').
+            $http({url: '/backup/create', method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     callback(data);
                 }).
@@ -1088,7 +1088,7 @@ function ResourcesService($http, $location, $notification) {
         },
 
         get_backup_files: function(callback){
-            $http.get('/backup/list').
+            $http({url: '/backup/list', method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     if(DEBUG) console.log('Retrieved list of backup files.');
                     callback(data);
@@ -1105,7 +1105,7 @@ function ResourcesService($http, $location, $notification) {
         get_backup_status: function(successCallback, failCallback){
             failCallback = failCallback || angular.noop;
 
-            $http({url: '/backup/status', method: "GET", params: {'time': new Date().getTime()}}).
+            $http({url: '/backup/status', method: 'GET', params: {'time': new Date().getTime()}}).
                 success(function(data, status) {
                     if(DEBUG) console.log('Retrieved status of backup.');
                     successCallback(data);

--- a/web/static/js/modules/serviceHealth.js
+++ b/web/static/js/modules/serviceHealth.js
@@ -50,7 +50,7 @@
             // don't so use our own promises
             var servicesDeferred = $q.defer();
             var runningServicesDeferred = $q.defer();
-            var healthCheckDeferred = $http.get("/servicehealth");
+            var healthCheckDeferred = $http({url: "/servicehealth", method: 'GET', params: {'time': new Date().getTime()}});
 
             servicesService.get_services(true, function(top, mapped){
                 servicesDeferred.resolve(mapped);


### PR DESCRIPTION
Gets around IE's super-aggressive caching
