### PR TITLE
Avoid simultaneous instances of elasticsearch

### DIFF
--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -26,6 +26,7 @@ import (
 	userdomain "github.com/control-center/serviced/domain/user"
 	"github.com/control-center/serviced/facade"
 	"github.com/control-center/serviced/isvcs"
+	"github.com/control-center/serviced/utils"
 	_ "github.com/control-center/serviced/volume"
 	_ "github.com/control-center/serviced/volume/btrfs"
 	_ "github.com/control-center/serviced/volume/rsync"
@@ -68,6 +69,14 @@ func (dt *DaoTest) SetUpSuite(c *C) {
 	dt.Port = 9202
 	isvcs.Init()
 	isvcs.Mgr.SetVolumesDir("/tmp/serviced-test")
+	esServicedClusterName, _ := utils.NewUUID36()
+	if err := isvcs.Mgr.SetConfigurationOption("elasticsearch-serviced", "cluster", esServicedClusterName); err != nil {
+		c.Fatalf("Could not set elasticsearch-serviced clustername: %s", err)
+	}
+	esLogstashClusterName, _ := utils.NewUUID36()
+	if err := isvcs.Mgr.SetConfigurationOption("elasticsearch-logstash", "cluster", esLogstashClusterName); err != nil {
+		c.Fatalf("Could not set elasticsearch-logstash clustername: %s", err)
+	}
 	isvcs.Mgr.Wipe()
 	if err := isvcs.Mgr.Start(); err != nil {
 		c.Fatalf("Could not start es container: %s", err)

--- a/isvcs/celery.go
+++ b/isvcs/celery.go
@@ -12,12 +12,13 @@ var celery *Container
 
 func init() {
 	var err error
+	command := "supervisord -n -c /opt/celery/etc/supervisor.conf"
 	celery, err = NewContainer(
 		ContainerDescription{
 			Name:    "celery",
 			Repo:    IMAGE_REPO,
 			Tag:     IMAGE_TAG,
-			Command: "supervisord -n -c /opt/celery/etc/supervisor.conf",
+			Command: func() string {return command},
 			Ports:   []int{},
 			Volumes: map[string]string{"celery": "/opt/celery/var"},
 		})

--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -10,12 +10,12 @@
 package isvcs
 
 import (
-	"github.com/rcrowley/go-metrics"
-	"github.com/zenoss/glog"
-	dockerclient "github.com/zenoss/go-dockerclient"
 	"github.com/control-center/serviced/commons/circular"
 	"github.com/control-center/serviced/stats/cgroup"
 	"github.com/control-center/serviced/utils"
+	"github.com/rcrowley/go-metrics"
+	"github.com/zenoss/glog"
+	dockerclient "github.com/zenoss/go-dockerclient"
 
 	"bytes"
 	"encoding/json"
@@ -58,11 +58,11 @@ type ContainerDescription struct {
 	Name          string                              // name of the container (used for docker named containers)
 	Repo          string                              // the repository the image for this container uses
 	Tag           string                              // the repository tag this container uses
-	Command       string                              // the actual command to run inside the container
+	Command       func() string                       // the actual command to run inside the container
 	Volumes       map[string]string                   // Volumes to bind mount in to the containers
 	Ports         []int                               // Ports to expose to the host
 	HealthCheck   func() error                        // A function to verify that the service is healthy
-	Configuration interface{}                         // A container specific configuration
+	Configuration map[string]interface{}              // A container specific configuration
 	Notify        func(*Container, interface{}) error // A function to run when notified of a data event
 	volumesDir    string                              // directory to store volume data
 }
@@ -80,10 +80,13 @@ func NewContainer(cd ContainerDescription) (*Container, error) {
 		return nil, err
 	}
 
-	if len(cd.Name) == 0 || len(cd.Repo) == 0 || len(cd.Tag) == 0 || len(cd.Command) == 0 {
+	if len(cd.Name) == 0 || len(cd.Repo) == 0 || len(cd.Tag) == 0 || cd.Command == nil {
 		return nil, ErrBadContainerSpec
 	}
 
+	if cd.Configuration == nil {
+		cd.Configuration = make(map[string]interface{})
+	}
 	c := Container{
 		ContainerDescription: cd,
 
@@ -143,12 +146,24 @@ func (c *Container) loop() {
 				c.stop()                // stop the container, if it's not stoppped
 				c.rm()                  // remove it if it was not already removed
 				cmd, exitChan = c.run() // run the actual container
-				if c.HealthCheck != nil {
-					req.response <- c.HealthCheck() // run the HealthCheck if it exists
-				} else {
-					req.response <- nil
+
+				healthCheckChan := make(chan error)
+				go func() {
+					if c.HealthCheck != nil {
+						healthCheckChan <- c.HealthCheck() // run the HealthCheck if it exists
+					} else {
+						healthCheckChan <- nil
+					}
+				}()
+				select {
+				case exited := <-exitChan:
+					req.response <- exited
+				case healthCheck := <-healthCheckChan:
+					if healthCheck == nil {
+						go c.doStats(statsExitChan)
+					}
+					req.response <- healthCheck
 				}
-				go c.doStats(statsExitChan)
 			}
 		case exitErr := <-exitChan:
 			glog.Errorf("Unexpected failure of %s, got %s", c.Name, exitErr)
@@ -316,7 +331,7 @@ func (c *Container) run() (*exec.Cmd, chan error) {
 	}
 
 	// set the image and command to run
-	args = append(args, c.Repo+":"+c.Tag, "/bin/sh", "-c", c.Command)
+	args = append(args, c.Repo+":"+c.Tag, "/bin/sh", "-c", c.Command())
 
 	glog.V(1).Infof("Executing docker %s", args)
 	var cmd *exec.Cmd
@@ -342,7 +357,7 @@ func (c *Container) run() (*exec.Cmd, chan error) {
 				glog.Errorf("Could not start: %s", c.Name)
 				c.stop()
 				c.rm()
-				time.Sleep(time.Second * 1)
+				time.Sleep(time.Second * 5)
 			} else {
 				break
 			}

--- a/isvcs/docker_registry.go
+++ b/isvcs/docker_registry.go
@@ -18,12 +18,13 @@ const registryPort = 5000
 
 func init() {
 	var err error
+	command := `DOCKER_REGISTRY_CONFIG=/docker-registry/config/config_sample.yml SETTINGS_FLAVOR=serviced docker-registry`
 	dockerRegistry, err = NewContainer(
 		ContainerDescription{
 			Name:        "docker-registry",
 			Repo:        IMAGE_REPO,
 			Tag:         IMAGE_TAG,
-			Command:     `DOCKER_REGISTRY_CONFIG=/docker-registry/config/config_sample.yml SETTINGS_FLAVOR=serviced docker-registry`,
+			Command:     func() string {return command},
 			Ports:       []int{registryPort},
 			Volumes:     map[string]string{"registry": "/tmp/registry"},
 			HealthCheck: registryHealthCheck,

--- a/isvcs/logstash.go
+++ b/isvcs/logstash.go
@@ -17,12 +17,13 @@ var logstash *Container
 
 func init() {
 	var err error
+	command := "/opt/logstash-1.4.2/bin/logstash agent -f /usr/local/serviced/resources/logstash/logstash.conf"
 	logstash, err = NewContainer(
 		ContainerDescription{
 			Name:    "logstash",
 			Repo:    IMAGE_REPO,
 			Tag:     IMAGE_TAG,
-			Command: "/opt/logstash-1.4.2/bin/logstash agent -f /usr/local/serviced/resources/logstash/logstash.conf",
+			Command: func() string {return command},
 			Ports:   []int{5042, 5043, 9292},
 			Volumes: map[string]string{},
 			Notify:  notifyLogstashConfigChange,

--- a/isvcs/manager.go
+++ b/isvcs/manager.go
@@ -110,6 +110,16 @@ func (m *Manager) SetVolumesDir(dir string) {
 	m.volumesDir = dir
 }
 
+func (m *Manager) SetConfigurationOption(container, key string, value interface{}) error {
+	c, found := m.containers[container]
+	if !found {
+		return errors.New("could not find container")
+	}
+	glog.Infof("setting %s, %s: %s", container, key, value)
+	c.Configuration[key] = value
+	return nil
+}
+
 // checks for the existence of all the container images
 func (m *Manager) allImagesExist() error {
 	for _, c := range m.containers {

--- a/isvcs/manager_test.go
+++ b/isvcs/manager_test.go
@@ -33,7 +33,7 @@ func TestManager(t *testing.T) {
 		Name:    "test1",
 		Repo:    "ubuntu",
 		Tag:     "latest",
-		Command: `/bin/sh -c "while true; do echo hello world; sleep 1; done"`,
+		Command: func() string { return `/bin/sh -c "while true; do echo hello world; sleep 1; done"` },
 	}
 	container, err := NewContainer(cd1)
 	if err != nil {
@@ -45,7 +45,7 @@ func TestManager(t *testing.T) {
 		Name:    "test2",
 		Repo:    "ubuntu",
 		Tag:     "latest",
-		Command: `/bin/sh -c "while true; do echo hello world; sleep 1; done"`,
+		Command: func() string { return `/bin/sh -c "while true; do echo hello world; sleep 1; done"` },
 	}
 	container2, err := NewContainer(cd2)
 	if err != nil {

--- a/isvcs/opentsdb.go
+++ b/isvcs/opentsdb.go
@@ -17,12 +17,13 @@ var opentsdb *Container
 
 func init() {
 	var err error
+	command := `cd /opt/zenoss && exec supervisord -n -c /opt/zenoss/etc/supervisor.conf`
 	opentsdb, err = NewContainer(
 		ContainerDescription{
 			Name:    "opentsdb",
 			Repo:    IMAGE_REPO,
 			Tag:     IMAGE_TAG,
-			Command: `cd /opt/zenoss && exec supervisord -n -c /opt/zenoss/etc/supervisor.conf`,
+			Command: func() string {return command},
 			//only expose 8443 (the consumer port to the host)
 			Ports:   []int{4242, 8443, 8888, 9090},
 			Volumes: map[string]string{"hbase": "/opt/zenoss/var/hbase"},

--- a/isvcs/zk.go
+++ b/isvcs/zk.go
@@ -22,13 +22,13 @@ var zookeeper *Container
 func init() {
 
 	var err error
-
+	command :=  "/opt/zookeeper-3.4.5/bin/zkServer.sh start-foreground"
 	zookeeper, err = NewContainer(
 		ContainerDescription{
 			Name:        "zookeeper",
 			Repo:        IMAGE_REPO,
 			Tag:         IMAGE_TAG,
-			Command:     "/opt/zookeeper-3.4.5/bin/zkServer.sh start-foreground",
+			Command:     func() string {return command},
 			Ports:       []int{2181, 12181},
 			Volumes:     map[string]string{"data": "/tmp"},
 			HealthCheck: zkHealthCheck,


### PR DESCRIPTION
Fixes ZEN-13808
1) Check return code from isvcs runs concurrently with healthcheck
2) Add node name to ES commands
3) Add cluster names to ES commands
4) ES cluster name stored per install

cf https://github.com/control-center/serviced/tree/feature/ZEN-13808
