### PR TITLE
fixes ZEN-13733: fix variable shadowing of endpoints

### DIFF
--- a/container/controller.go
+++ b/container/controller.go
@@ -732,8 +732,8 @@ func (c *Controller) handleControlCenterImports(rpcdead chan struct{}) error {
 		close(epchan)
 		timeout <- struct{}{}
 		return fmt.Errorf("RPC Service has gone away")
-	case endpoints := <-epchan:
-		glog.V(2).Infof("Got service endpoints for %s: %+v", c.options.Service.ID, endpoints)
+	case endpoints = <-epchan:
+		glog.Infof("Got service endpoints for %s: %+v", c.options.Service.ID, endpoints)
 	}
 
 	// convert keys set by GetServiceEndpoints to tenantID_endpointID


### PR DESCRIPTION
DEMO:

```
zenny@ip-10-111-3-87:~$ serviced service start redis
Service scheduled to start.
zenny@ip-10-111-3-87:~$ serviced service attach redis
bash-4.2# netstat -plant  |grep LIST
tcp        0      0 0.0.0.0:6379            0.0.0.0:*               LISTEN      19/redis-server *:6 
tcp        0      0 0.0.0.0:5042            0.0.0.0:*               LISTEN      1/serviced          
tcp        0      0 0.0.0.0:5043            0.0.0.0:*               LISTEN      1/serviced          
tcp        0      0 0.0.0.0:443             0.0.0.0:*               LISTEN      1/serviced          
tcp        0      0 0.0.0.0:8444            0.0.0.0:*               LISTEN      1/serviced          
tcp6       0      0 :::6379                 :::*                    LISTEN      19/redis-server *:6 
tcp6       0      0 :::22350                :::*                    LISTEN      1/serviced          
```
