### PR TITLE
fixes CC-76: wait for docker0 interface and docker ps

### DIFF
--- a/pkg/serviced.upstart
+++ b/pkg/serviced.upstart
@@ -1,16 +1,15 @@
 description "Zenoss ServiceD"
 
-start on (filesystem and started docker and started lxc-net)
+start on (filesystem and started docker and net-device-up IFACE=docker0)
 stop on run level [!2345]
 kill timeout 60
 
 limit nofile 1048576 1048576
 
-# this pre-start script is necessary because the above start on
-# directive to wait for docker and lxc-net is not working
+# this pre-start script is necessary to wait for docker
 pre-start script
     echo "$(date): waiting for docker"
-    while ! pgrep -fl /usr/bin/docker; do date ; sleep 1 ; done
+    while ! /usr/bin/docker ps; do date ; sleep 1 ; done
     echo "$(date): docker is now ready - done with pre-start"
     sleep 1s
     /sbin/ifconfig


### PR DESCRIPTION
ISSUE - after reboot:

```
zenny@ip-10-111-3-204:~$ ps -wef |grep serviced
zenny     1732  1713  0 17:14 pts/0    00:00:00 grep --color=auto serviced
```

DEMO - after reboot:

```
zenny@ip-10-111-3-87:~$ ps -wef |grep serviced
root      1459   949  0 17:15 ?        00:00:00 /bin/sh -c DOCKER_REGISTRY_CONFIG=/docker-registry/config/config_sample.yml SETTINGS_FLAVOR=serviced docker-registry
root      1535   949  0 17:15 ?        00:00:00 /bin/sh -c /opt/elasticsearch-0.90.9/bin/elasticsearch -f -Des.node.name=elasticsearch-serviced  -Des.cluster.name=8j4sopotba4y1hm6x516wwnxd 
root      1568  1535  1 17:15 ?        00:00:08 /usr/bin/java -Xms256m -Xmx1g -Xss256k -Djava.awt.headless=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError -Delasticsearch -Des.foreground=yes -Des.path.home=/opt/elasticsearch-0.90.9 -cp :/opt/elasticsearch-0.90.9/lib/elasticsearch-0.90.9.jar:/opt/elasticsearch-0.90.9/lib/*:/opt/elasticsearch-0.90.9/lib/sigar/* -Des.node.name=elasticsearch-serviced -Des.cluster.name=8j4sopotba4y1hm6x516wwnxd org.elasticsearch.bootstrap.ElasticSearch
root      1581   949  0 17:15 ?        00:00:00 /bin/sh -c /opt/logstash-1.4.2/bin/logstash agent -f /usr/local/serviced/resources/logstash/logstash.conf
root      1619  1581  6 17:15 ?        00:00:34 /usr/bin/java -Xmx500m -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -Djava.awt.headless=true -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -jar /opt/logstash-1.4.2/vendor/jar/jruby-complete-1.7.11.jar -I/opt/logstash-1.4.2/lib /opt/logstash-1.4.2/lib/logstash/runner.rb agent -f /usr/local/serviced/resources/logstash/logstash.conf
zenny     2991  2016  0 17:24 pts/0    00:00:00 grep --color=auto serviced
```
