### PR TITLE
Remove call to controlClient.GetServiceEndpoints

### DIFF
--- a/container/controller.go
+++ b/container/controller.go
@@ -684,6 +684,8 @@ func (c *Controller) handleControlCenterImports(rpcdead chan struct{}) error {
 
 	// TODO: instead of getting all endpoints, via GetServiceEndpoints(), create a new call
 	//       that returns only special "controlplane" imported endpoints
+	//	Note: GetServiceEndpoints has been modified to return only special controlplane endpoints.
+	//		We should rename it and clean up the filtering code below.
 
 	epchan := make(chan map[string][]*dao.ApplicationEndpoint)
 	timeout := make(chan struct{})

--- a/facade/service.go
+++ b/facade/service.go
@@ -181,6 +181,7 @@ func (f *Facade) GetTenantID(ctx datastore.Context, serviceID string) (string, e
 
 // Get a service endpoint.
 func (f *Facade) GetServiceEndpoints(ctx datastore.Context, serviceId string) (map[string][]*dao.ApplicationEndpoint, error) {
+	// TODO: this function is obsolete.  Remove it.
 	glog.V(2).Infof("Facade.GetServiceEndpoints serviceId=%s", serviceId)
 	result := make(map[string][]*dao.ApplicationEndpoint)
 	myService, err := f.getService(ctx, serviceId)

--- a/node/agent_proxy.go
+++ b/node/agent_proxy.go
@@ -46,21 +46,13 @@ func (a *HostAgent) Ping(waitFor time.Duration, timestamp *time.Time) error {
 }
 
 func (a *HostAgent) GetServiceEndpoints(serviceId string, response *map[string][]*dao.ApplicationEndpoint) (err error) {
-	controlClient, err := NewControlClient(a.master)
-	if err != nil {
-		glog.Errorf("Could not start ControlPlane client %v", err)
-		return
-	}
-	defer controlClient.Close()
+	myList := make(map[string][]*dao.ApplicationEndpoint)
 
-	err = controlClient.GetServiceEndpoints(serviceId, response)
-	if err != nil {
-		return err
-	}
+	a.addControlPlaneEndpoint(myList)
+	a.addControlPlaneConsumerEndpoint(myList)
+	a.addLogstashEndpoint(myList)
 
-	a.addControlPlaneEndpoint(*response)
-	a.addControlPlaneConsumerEndpoint(*response)
-	a.addLogstashEndpoint(*response)
+	*response = myList
 	return nil
 }
 


### PR DESCRIPTION
Fixes ZEN-13511
facade.service.GetServiceEndpoints was throwing an error, due to the fact
that it was filtering on service states within the same pool as this
service, and this service is running in a separate pool.  Because
agent_proxy.GetServiceEndpoints was exiting early (due to the error), we
were never getting a list of the control-plane specific endpoints in
handleControlCenterImports, which is all it needs.  The non-control-plane
specific results were being filtered out anyway, so there is no need to
gather them.
