### PR TITLE
fixes CC-76: instead of waiting for docker0 (down after reboot), before ...

### DIFF
--- a/pkg/serviced.upstart
+++ b/pkg/serviced.upstart
@@ -1,6 +1,7 @@
 description "Zenoss ServiceD"
 
-start on (filesystem and started docker and net-device-up IFACE=docker0)
+start on (filesystem and started docker and (started network-interface or started network-manager or started networking) )
+
 stop on run level [!2345]
 kill timeout 60
 


### PR DESCRIPTION
...starting serviced, wait for networking started instead

ISSUE - notice that serviced is not started upon reboot and that docker0 is down:

```
root@ip-10-111-2-192:~# reboot
...
root@ip-10-111-2-192:~# pgrep -fla bin/serviced
root@ip-10-111-2-192:~# date;uptime;ip addr 
Thu Aug 28 18:39:01 UTC 2014
 18:39:01 up 0 min,  1 user,  load average: 0.52, 0.14, 0.05
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default 
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 12:82:94:25:aa:ae brd ff:ff:ff:ff:ff:ff
    inet 10.111.2.192/24 brd 10.111.2.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::1082:94ff:fe25:aaae/64 scope link 
       valid_lft forever preferred_lft forever
3: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
    link/ether 56:84:7a:fe:97:99 brd ff:ff:ff:ff:ff:ff
    inet 172.17.42.1/16 scope global docker0
       valid_lft forever preferred_lft forever
root@ip-10-111-2-192:~# 
```

DEMO - notice that serviced is started and that docker0 goes up due to serviced starting:

```
root@ip-10-111-2-192:~# reboot
...
root@ip-10-111-2-192:~# pgrep -fla bin/serviced
1462 ./bin/serviced
root@ip-10-111-2-192:~# date;uptime;ip addr show docker0
Thu Aug 28 18:45:41 UTC 2014
 18:45:41 up 4 min,  1 user,  load average: 3.70, 2.72, 1.20
3: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether 56:84:7a:fe:97:99 brd ff:ff:ff:ff:ff:ff
    inet 172.17.42.1/16 scope global docker0
       valid_lft forever preferred_lft forever
    inet6 fe80::5484:7aff:fefe:9799/64 scope link 
       valid_lft forever preferred_lft forever
root@ip-10-111-2-192:~# 
```
