### PR TITLE
fallback to docker exec for attach when nsenter is not available

### DIFF
--- a/utils/docker_exec.go
+++ b/utils/docker_exec.go
@@ -1,0 +1,110 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/zenoss/glog"
+)
+
+// ExecDockerExec execs the command using docker exec
+func ExecDockerExec(containerID string, bashcmd []string) error {
+	command, err := generateDockerExecCommand(containerID, bashcmd, false)
+	if err != nil {
+		return err
+	}
+	glog.V(1).Infof("exec command for container:%v command: %v\n", containerID, command)
+	return syscall.Exec(command[0], command[0:], os.Environ())
+}
+
+// RunDockerExec runs the command using docker exec
+func RunDockerExec(containerID string, bashcmd []string) ([]byte, error) {
+	command, err := generateDockerExecCommand(containerID, bashcmd, true)
+	if err != nil {
+		return nil, err
+	}
+	thecmd := exec.Command(command[0], command[1:]...)
+	output, err := thecmd.CombinedOutput()
+	if err != nil {
+		glog.Errorf("Error running command:'%s' output: %s  error: %s\n", command, output, err)
+		return output, err
+	}
+	glog.V(1).Infof("Successfully ran command:'%s' output: %s\n", command, output)
+	return output, nil
+}
+
+// generateDockerExecCommand returns a slice containing docker exec command to exec
+func generateDockerExecCommand(containerID string, bashcmd []string, prependBash bool) ([]string, error) {
+	if containerID == "" {
+		return []string{}, fmt.Errorf("will not attach to container with empty containerID")
+	}
+
+	exeMap, err := exePaths([]string{"docker"})
+	if err != nil {
+		return []string{}, err
+	}
+
+	// TODO: add '-h' hostname to specify the container hostname when that
+	// feature becomes available
+	attachCmd := []string{exeMap["docker"], "exec", "-i", "-t", containerID, "--"}
+	if prependBash {
+		attachCmd = append(attachCmd, "/bin/bash", "-c", fmt.Sprintf("%s", strings.Join(bashcmd, " ")))
+	} else {
+		attachCmd = append(attachCmd, bashcmd...)
+	}
+	glog.V(1).Infof("attach command for container:%v command: %v\n", containerID, attachCmd)
+	return attachCmd, nil
+}
+
+// AttachAndRun attaches to a container and runs the command
+func AttachAndRun(containerID string, bashcmd []string) ([]byte, error) {
+	_, err := exec.LookPath("nsenter")
+	if err == nil {
+		return RunNSEnter(containerID, bashcmd)
+	}
+
+	return RunDockerExec(containerID, bashcmd)
+}
+
+// AttachAndExec attaches to a container and execs the command
+func AttachAndExec(containerID string, bashcmd []string) error {
+	_, err := exec.LookPath("nsenter")
+	if err == nil {
+		return ExecNSEnter(containerID, bashcmd)
+	}
+
+	return ExecDockerExec(containerID, bashcmd)
+}
+
+// exePaths returns the full path to the given executables in a map
+func exePaths(exes []string) (map[string]string, error) {
+	exeMap := map[string]string{}
+
+	for _, exe := range exes {
+		path, err := exec.LookPath(exe)
+		if err != nil {
+			glog.Errorf("exe:'%v' not found error:%v\n", exe, err)
+			return nil, err
+		}
+
+		exeMap[exe] = path
+	}
+
+	return exeMap, nil
+}

--- a/utils/nsenter.go
+++ b/utils/nsenter.go
@@ -109,39 +109,4 @@ func generateNSEnterCommand(containerID string, bashcmd []string, prependBash bo
 	return attachCmd, nil
 }
 
-// AttachAndRun attaches to a container and runs the command
-func AttachAndRun(containerID string, bashcmd []string) ([]byte, error) {
-	_, err := exec.LookPath("nsenter")
-	if err != nil {
-		return nil, fmt.Errorf("unable to find nsenter exe:%v", err)
-	}
 
-	return RunNSEnter(containerID, bashcmd)
-}
-
-// AttachAndExec attaches to a container and execs the command
-func AttachAndExec(containerID string, bashcmd []string) error {
-	_, err := exec.LookPath("nsenter")
-	if err != nil {
-		return fmt.Errorf("unable to find nsenter exe:%v", err)
-	}
-
-	return ExecNSEnter(containerID, bashcmd)
-}
-
-// exePaths returns the full path to the given executables in a map
-func exePaths(exes []string) (map[string]string, error) {
-	exeMap := map[string]string{}
-
-	for _, exe := range exes {
-		path, err := exec.LookPath(exe)
-		if err != nil {
-			glog.Errorf("exe:'%v' not found error:%v\n", exe, err)
-			return nil, err
-		}
-
-		exeMap[exe] = path
-	}
-
-	return exeMap, nil
-}


### PR DESCRIPTION
waiting for docker to release 'docker exec' (should be in 1.2.x):
  https://github.com/docker/docker/pull/7409

DEMO1 - if nsenter is installed, use it:

```
# plu@plu-9: which nsenter
/usr/bin/nsenter

# plu@plu-9: serviced -v=1 service attach redis
I0829 10:01:48.160994 15143 nsenter.go:108] attach command for container:549d8e81fe32d9c8ff0f7b7465ac0188b4acd3e0dc450c1566e16ac5cdee3848 command: [/usr/bin/sudo /usr/bin/nsenter -m -u -i -n -p -t 15073 -- /bin/bash]
I0829 10:01:48.161077 15143 nsenter.go:66] exec command for container:549d8e81fe32d9c8ff0f7b7465ac0188b4acd3e0dc450c1566e16ac5cdee3848 command: [/usr/bin/sudo /usr/bin/nsenter -m -u -i -n -p -t 15073 -- /bin/bash]
[sudo] password for plu: 
/
# root@549d8e81fe32: exit
```

DEMO2 - if nsenter is not installed, use docker exec (should fail now, but see how command to use it is correct):

```

# plu@plu-9: which nsenter

# plu@plu-9: serviced -v=1 service attach redis
I0829 10:05:38.391571 16117 docker_exec.go:71] attach command for container:549d8e81fe32d9c8ff0f7b7465ac0188b4acd3e0dc450c1566e16ac5cdee3848 command: [/usr/bin/docker exec -i -t 549d8e81fe32d9c8ff0f7b7465ac0188b4acd3e0dc450c1566e16ac5cdee3848 -- /bin/bash]
I0829 10:05:38.391704 16117 docker_exec.go:32] exec command for container:549d8e81fe32d9c8ff0f7b7465ac0188b4acd3e0dc450c1566e16ac5cdee3848 command: [/usr/bin/docker exec -i -t 549d8e81fe32d9c8ff0f7b7465ac0188b4acd3e0dc450c1566e16ac5cdee3848 -- /bin/bash]
Error: Command not found: exec
Error: Command not found: -i
Usage: docker [OPTIONS] COMMAND [arg...]
 -H=[unix:///var/run/docker.sock]: tcp://host:port to bind/connect to or unix://path/to/socket to use

```
