### PR TITLE
display host and full path in backup file list.

### DIFF
--- a/web/static/partials/view-backuprestore.html
+++ b/web/static/partials/view-backuprestore.html
@@ -26,7 +26,7 @@
             <td colspan="100%" align="center"><img src="/static/img/loading.gif"></td>
         </tr>
         <tr ng-repeat="fileInfo in backupFiles | orderBy:'mod_time':true">
-            <td>{{fileInfo.name}}</td>
+            <td>{{fileInfo.full_path}}</td>
             <td>{{fileInfo.mod_time | date: 'medium'}}</td>
             <td>
                     <button class="btn btn-link action" ng-click="restoreBackup(fileInfo.name)">


### PR DESCRIPTION
Because the path/filepath module was pulled in, I renamed all of the 'filepath' variables to 'filePath' so they wouldn't be shadowed by the import. The interesting changes are in the RestBackupFileList function (and the corresponsding change in the .html file to pick up and display the new value).
