### PR TITLE
sort output for ExampleServicedCLI_CmdServiceRun_list

### DIFF
--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"testing"
 
@@ -694,11 +695,17 @@ func ExampleServicedCLI_CmdServiceShell_err() {
 }
 
 func ExampleServicedCLI_CmdServiceRun_list() {
-	InitServiceAPITest("serviced", "service", "run", "test-service-1")
+	output := pipe(InitServiceAPITest, "serviced", "service", "run", "test-service-1")
+	actual := strings.Split(string(output[:]), "\n")
+	sort.Strings(actual)
+
+	for _, item := range actual {
+		fmt.Printf("%s\n", item)
+	}
 
 	// Output:
-	// hello
 	// goodbye
+	// hello
 }
 
 func ExampleServicedCLI_CmdServiceRun_exec() {


### PR DESCRIPTION
ISSUE:

```
~/src/europa/src/golang/src/github.com/control-center/serviced/cli/cmd
# plu@plu-9: go test
--- FAIL: ExampleServicedCLI_CmdServiceRun_list (2.62724ms)
got:
goodbye
hello
want:
hello
goodbye
FAIL
exit status 1
FAIL    github.com/control-center/serviced/cli/cmd  0.417s
```

DEMO - no errors:

```
~/src/europa/src/golang/src/github.com/control-center/serviced/cli/cmd
# plu@plu-9: go testPASS
ok      github.com/control-center/serviced/cli/cmd  0.462s
```
