### PR TITLE
replace gobrpc with jsonrpc encoding

### DIFF
--- a/cli/api/attach.go
+++ b/cli/api/attach.go
@@ -27,13 +27,13 @@ type AttachConfig struct {
 	Args    []string
 }
 
-func (a *api) GetRunningServices() ([]*dao.RunningService, error) {
+func (a *api) GetRunningServices() ([]dao.RunningService, error) {
 	client, err := a.connectDAO()
 	if err != nil {
 		return nil, err
 	}
 
-	var rss []*dao.RunningService
+	var rss []dao.RunningService
 	if err := client.GetRunningServices(&empty, &rss); err != nil {
 		return nil, err
 	}

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -48,11 +48,11 @@ type API interface {
 	RemoveVirtualIP(pool.VirtualIP) error
 
 	// Services
-	GetServices() ([]*service.Service, error)
-	GetServiceStates(string) ([]*servicestate.ServiceState, error)
-	GetServiceStatus(string) (map[*servicestate.ServiceState]dao.Status, error)
+	GetServices() ([]service.Service, error)
+	GetServiceStates(string) ([]servicestate.ServiceState, error)
+	GetServiceStatus(string) (map[string]dao.ServiceStatus, error)
 	GetService(string) (*service.Service, error)
-	GetServicesByName(string) ([]*service.Service, error)
+	GetServicesByName(string) ([]service.Service, error)
 	AddService(ServiceConfig) (*service.Service, error)
 	RemoveService(RemoveServiceConfig) error
 	UpdateService(io.Reader) (*service.Service, error)
@@ -61,7 +61,7 @@ type API interface {
 	AssignIP(IPConfig) error
 
 	// RunningServices (ServiceStates)
-	GetRunningServices() ([]*dao.RunningService, error)
+	GetRunningServices() ([]dao.RunningService, error)
 	Attach(AttachConfig) error
 	Action(AttachConfig) error
 
@@ -78,7 +78,7 @@ type API interface {
 	Rollback(string) error
 
 	// Templates
-	GetServiceTemplates() ([]*template.ServiceTemplate, error)
+	GetServiceTemplates() ([]template.ServiceTemplate, error)
 	GetServiceTemplate(string) (*template.ServiceTemplate, error)
 	AddServiceTemplate(io.Reader) (*template.ServiceTemplate, error)
 	RemoveServiceTemplate(string) error

--- a/cli/api/logs.go
+++ b/cli/api/logs.go
@@ -102,7 +102,7 @@ func (a *api) ExportLogs(config ExportLogsConfig) (err error) {
 		if e != nil {
 			return e
 		}
-		serviceMap := make(map[string]*service.Service)
+		serviceMap := make(map[string]service.Service)
 		for _, service := range services {
 			serviceMap[service.ID] = service
 		}

--- a/cli/api/options.go
+++ b/cli/api/options.go
@@ -108,10 +108,10 @@ func (m *PortMap) String() string {
 }
 
 // ServiceMap maps services by its service id
-type ServiceMap map[string]*service.Service
+type ServiceMap map[string]service.Service
 
 // NewServiceMap creates a new service map from a slice of services
-func NewServiceMap(services []*service.Service) ServiceMap {
+func NewServiceMap(services []service.Service) ServiceMap {
 	var smap = make(ServiceMap)
 	for _, s := range services {
 		smap.Add(s)
@@ -120,10 +120,10 @@ func NewServiceMap(services []*service.Service) ServiceMap {
 }
 
 // Get gets a service from the service map identified by its service id
-func (m ServiceMap) Get(serviceID string) *service.Service { return m[serviceID] }
+func (m ServiceMap) Get(serviceID string) service.Service { return m[serviceID] }
 
 // Add appends a service to the service map
-func (m ServiceMap) Add(service *service.Service) error {
+func (m ServiceMap) Add(service service.Service) error {
 	if _, ok := m[service.ID]; ok {
 		return fmt.Errorf("service already exists")
 	}
@@ -133,7 +133,7 @@ func (m ServiceMap) Add(service *service.Service) error {
 
 // Update updates an existing service within the ServiceMap.  If the service
 // not exist, it gets created.
-func (m ServiceMap) Update(service *service.Service) {
+func (m ServiceMap) Update(service service.Service) {
 	m[service.ID] = service
 }
 

--- a/cli/api/service.go
+++ b/cli/api/service.go
@@ -59,13 +59,13 @@ type RunningService struct {
 }
 
 // Gets all of the available services
-func (a *api) GetServices() ([]*service.Service, error) {
+func (a *api) GetServices() ([]service.Service, error) {
 	client, err := a.connectDAO()
 	if err != nil {
 		return nil, err
 	}
 
-	var services []*service.Service
+	var services []service.Service
 	if err := client.GetServices(&empty, &services); err != nil {
 		return nil, err
 	}
@@ -74,13 +74,13 @@ func (a *api) GetServices() ([]*service.Service, error) {
 }
 
 // Gets all of the available services
-func (a *api) GetServiceStates(serviceID string) ([]*servicestate.ServiceState, error) {
+func (a *api) GetServiceStates(serviceID string) ([]servicestate.ServiceState, error) {
 	client, err := a.connectDAO()
 	if err != nil {
 		return nil, err
 	}
 
-	var states []*servicestate.ServiceState
+	var states []servicestate.ServiceState
 	if err := client.GetServiceStates(serviceID, &states); err != nil {
 		return nil, err
 	}
@@ -88,13 +88,13 @@ func (a *api) GetServiceStates(serviceID string) ([]*servicestate.ServiceState, 
 	return states, nil
 }
 
-func (a *api) GetServiceStatus(serviceID string) (map[*servicestate.ServiceState]dao.Status, error) {
+func (a *api) GetServiceStatus(serviceID string) (map[string]dao.ServiceStatus, error) {
 	client, err := a.connectDAO()
 	if err != nil {
 		return nil, err
 	}
 
-	var status map[*servicestate.ServiceState]dao.Status
+	var status map[string]dao.ServiceStatus
 	if err := client.GetServiceStatus(serviceID, &status); err != nil {
 		return nil, err
 	}
@@ -118,13 +118,13 @@ func (a *api) GetService(id string) (*service.Service, error) {
 }
 
 // Gets the service definition identified by its service Name
-func (a *api) GetServicesByName(name string) ([]*service.Service, error) {
+func (a *api) GetServicesByName(name string) ([]service.Service, error) {
 	allServices, err := a.GetServices()
 	if err != nil {
 		return nil, err
 	}
 
-	var services []*service.Service
+	var services []service.Service
 	for i, s := range allServices {
 		if s.Name == name || s.ID == name {
 			services = append(services, allServices[i])

--- a/cli/api/template.go
+++ b/cli/api/template.go
@@ -39,20 +39,20 @@ type CompileTemplateConfig struct {
 }
 
 // Gets all available service templates
-func (a *api) GetServiceTemplates() ([]*template.ServiceTemplate, error) {
+func (a *api) GetServiceTemplates() ([]template.ServiceTemplate, error) {
 	client, err := a.connectDAO()
 	if err != nil {
 		return nil, err
 	}
 
-	templatemap := make(map[string]*template.ServiceTemplate)
+	templatemap := make(map[string]template.ServiceTemplate)
 	if err := client.GetServiceTemplates(unusedInt, &templatemap); err != nil {
 		return nil, err
 	}
-	templates := make([]*template.ServiceTemplate, len(templatemap))
+	templates := make([]template.ServiceTemplate, len(templatemap))
 	i := 0
 	for id, t := range templatemap {
-		(*t).ID = id
+		t.ID = id
 		templates[i] = t
 		i++
 	}
@@ -67,7 +67,7 @@ func (a *api) GetServiceTemplate(id string) (*template.ServiceTemplate, error) {
 		return nil, err
 	}
 
-	templatemap := make(map[string]*template.ServiceTemplate)
+	templatemap := make(map[string]template.ServiceTemplate)
 	if err := client.GetServiceTemplates(unusedInt, &templatemap); err != nil {
 		return nil, err
 	}
@@ -76,9 +76,9 @@ func (a *api) GetServiceTemplate(id string) (*template.ServiceTemplate, error) {
 		return nil, fmt.Errorf("unable to find template by id: %s", id)
 	}
 	t := templatemap[id]
-	(*t).ID = id
+	t.ID = id
 
-	return t, nil
+	return &t, nil
 }
 
 // Adds a new service template

--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -38,7 +38,7 @@ var DefaultServiceAPITest = ServiceAPITest{
 	snapshots: DefaultTestSnapshots,
 }
 
-var DefaultTestServices = []*service.Service{
+var DefaultTestServices = []service.Service{
 	{
 		ID:             "test-service-1",
 		Name:           "Zenoss",
@@ -88,7 +88,7 @@ var (
 type ServiceAPITest struct {
 	api.API
 	fail      bool
-	services  []*service.Service
+	services  []service.Service
 	pools     []*pool.ResourcePool
 	snapshots []string
 }
@@ -97,7 +97,7 @@ func InitServiceAPITest(args ...string) {
 	New(DefaultServiceAPITest).Run(args)
 }
 
-func (t ServiceAPITest) GetServices() ([]*service.Service, error) {
+func (t ServiceAPITest) GetServices() ([]service.Service, error) {
 	if t.fail {
 		return nil, ErrInvalidService
 	}
@@ -116,9 +116,9 @@ func (t ServiceAPITest) GetService(id string) (*service.Service, error) {
 		return nil, ErrInvalidService
 	}
 
-	for _, s := range t.services {
+	for i, s := range t.services {
 		if s.ID == id {
-			return s, nil
+			return &t.services[i], nil
 		}
 	}
 
@@ -312,7 +312,7 @@ func TestServicedCLI_CmdServiceList_all(t *testing.T) {
 		t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
 	}
 	for i := range actual {
-		if !actual[i].Equals(expected[i]) {
+		if !actual[i].Equals(&expected[i]) {
 			t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
 		}
 	}

--- a/cli/cmd/template_test.go
+++ b/cli/cmd/template_test.go
@@ -31,7 +31,7 @@ const (
 
 var DefaultTemplateAPITest = TemplateAPITest{templates: DefaultTestTemplates}
 
-var DefaultTestTemplates = []*template.ServiceTemplate{
+var DefaultTestTemplates = []template.ServiceTemplate{
 	{
 		ID:          "test-template-1",
 		Name:        "Alpha",
@@ -55,14 +55,14 @@ var (
 type TemplateAPITest struct {
 	api.API
 	fail      bool
-	templates []*template.ServiceTemplate
+	templates []template.ServiceTemplate
 }
 
 func InitTemplateAPITest(args ...string) {
 	New(DefaultTemplateAPITest).Run(args)
 }
 
-func (t TemplateAPITest) GetServiceTemplates() ([]*template.ServiceTemplate, error) {
+func (t TemplateAPITest) GetServiceTemplates() ([]template.ServiceTemplate, error) {
 	if t.fail {
 		return nil, ErrInvalidTemplate
 	}
@@ -76,7 +76,7 @@ func (t TemplateAPITest) GetServiceTemplate(id string) (*template.ServiceTemplat
 
 	for i, template := range t.templates {
 		if template.ID == id {
-			return t.templates[i], nil
+			return &t.templates[i], nil
 		}
 	}
 
@@ -167,7 +167,7 @@ func TestServicedCLI_CmdTemplateList_all(t *testing.T) {
 		t.Fatalf("got:\n%+v\nwant:\n%+v", actual, expected)
 	}
 	for i := range actual {
-		if !actual[i].Equals(expected[i]) {
+		if !actual[i].Equals(&expected[i]) {
 			t.Fatalf("got:\n%+v\nwant:\n%+v", actual, expected)
 		}
 	}

--- a/container/controller.go
+++ b/container/controller.go
@@ -88,7 +88,7 @@ type ControllerOptions struct {
 		RemoteEndoint string // The url to forward metric queries
 	}
 	VirtualAddressSubnet string // The subnet of virtual addresses, 10.3
-	MetricForwarding	bool // Whether or not the Controller should forward metrics
+	MetricForwarding     bool   // Whether or not the Controller should forward metrics
 }
 
 // Controller is a object to manage the operations withing a container. For example,
@@ -341,7 +341,7 @@ func NewController(options ControllerOptions) (*Controller, error) {
 	metricRedirect := options.Metric.RemoteEndoint
 	if len(metricRedirect) == 0 {
 		glog.V(1).Infof("container.Controller does not have metric forwarding")
-	} else if ! options.MetricForwarding {
+	} else if !options.MetricForwarding {
 		glog.V(1).Infof("Not forwarding metrics for this container (%v)", c.tenantID)
 	} else {
 		if len(c.tenantID) <= 0 {
@@ -699,11 +699,11 @@ func (c *Controller) handleControlCenterImports(rpcdead chan struct{}) error {
 	//	Note: GetServiceEndpoints has been modified to return only special controlplane endpoints.
 	//		We should rename it and clean up the filtering code below.
 
-	epchan := make(chan map[string][]*dao.ApplicationEndpoint)
+	epchan := make(chan map[string][]dao.ApplicationEndpoint)
 	timeout := make(chan struct{})
 
-	go func(c *node.LBClient, svcid string, epc chan map[string][]*dao.ApplicationEndpoint, timeout chan struct{}) {
-		var endpoints map[string][]*dao.ApplicationEndpoint
+	go func(c *node.LBClient, svcid string, epc chan map[string][]dao.ApplicationEndpoint, timeout chan struct{}) {
+		var endpoints map[string][]dao.ApplicationEndpoint
 	RetryGetServiceEndpoints:
 		for {
 			err = c.GetServiceEndpoints(svcid, &endpoints)
@@ -735,7 +735,7 @@ func (c *Controller) handleControlCenterImports(rpcdead chan struct{}) error {
 		}
 	}(client, c.options.Service.ID, epchan, timeout)
 
-	var endpoints map[string][]*dao.ApplicationEndpoint
+	var endpoints map[string][]dao.ApplicationEndpoint
 	select {
 	case <-time.After(1 * time.Minute):
 		close(epchan)
@@ -751,7 +751,7 @@ func (c *Controller) handleControlCenterImports(rpcdead chan struct{}) error {
 	}
 
 	// convert keys set by GetServiceEndpoints to tenantID_endpointID
-	tmp := make(map[string][]*dao.ApplicationEndpoint)
+	tmp := make(map[string][]dao.ApplicationEndpoint)
 	for key, endpointList := range endpoints {
 		if len(endpointList) <= 0 {
 			glog.Warningf("ignoring key: %s with empty endpointList", key)

--- a/container/endpoint.go
+++ b/container/endpoint.go
@@ -54,7 +54,7 @@ var funcmap = template.FuncMap{
 }
 
 type export struct {
-	endpoint     *dao.ApplicationEndpoint
+	endpoint     dao.ApplicationEndpoint
 	vhosts       []string
 	endpointName string
 }
@@ -88,7 +88,7 @@ func getAgentZkInfo(lbClientPort string) (node.ZkInfo, error) {
 }
 
 // getServiceState gets the service states for a serviceID
-func getServiceStates(conn coordclient.Connection, serviceID string) ([]*servicestate.ServiceState, error) {
+func getServiceStates(conn coordclient.Connection, serviceID string) ([]servicestate.ServiceState, error) {
 	return zkservice.GetServiceStates(conn, serviceID)
 }
 
@@ -110,7 +110,7 @@ func getServiceState(conn coordclient.Connection, serviceID, instanceIDStr strin
 
 		for ii, ss := range serviceStates {
 			if ss.InstanceID == instanceID && ss.PrivateIP != "" {
-				return serviceStates[ii], nil
+				return &serviceStates[ii], nil
 			}
 		}
 
@@ -247,7 +247,7 @@ func buildImportedEndpoints(conn coordclient.Connection, tenantID string, state 
 }
 
 // buildApplicationEndpoint converts a ServiceEndpoint to an ApplicationEndpoint
-func buildApplicationEndpoint(state *servicestate.ServiceState, endpoint *service.ServiceEndpoint) (*dao.ApplicationEndpoint, error) {
+func buildApplicationEndpoint(state *servicestate.ServiceState, endpoint *service.ServiceEndpoint) (dao.ApplicationEndpoint, error) {
 	var ae dao.ApplicationEndpoint
 
 	ae.ServiceID = state.ServiceID
@@ -279,7 +279,7 @@ func buildApplicationEndpoint(state *servicestate.ServiceState, endpoint *servic
 			port, err := strconv.Atoi(pm[0].HostPort)
 			if err != nil {
 				glog.Errorf("Unable to interpret HostPort: %s", pm[0].HostPort)
-				return nil, err
+				return ae, err
 			}
 			ae.HostPort = uint16(port)
 		}
@@ -289,7 +289,7 @@ func buildApplicationEndpoint(state *servicestate.ServiceState, endpoint *servic
 
 	glog.V(2).Infof("  built ApplicationEndpoint: %+v", ae)
 
-	return &ae, nil
+	return ae, nil
 }
 
 // setImportedEndpoint sets an imported endpoint
@@ -447,14 +447,14 @@ func (c *Controller) processTenantEndpoint(conn coordclient.Connection, parentPa
 	tenantEndpointID := parts[len(parts)-1]
 
 	if ep := c.getMatchingEndpoint(tenantEndpointID); ep != nil {
-		endpoints := make([]*dao.ApplicationEndpoint, len(hostContainerIDs))
+		endpoints := make([]dao.ApplicationEndpoint, len(hostContainerIDs))
 		for ii, hostContainerID := range hostContainerIDs {
 			path := fmt.Sprintf("%s/%s", parentPath, hostContainerID)
 			endpointNode, err := endpointRegistry.GetItem(conn, path)
 			if err != nil {
 				glog.Errorf("error getting endpoint node at %s: %v", path, err)
 			}
-			endpoints[ii] = &endpointNode.ApplicationEndpoint
+			endpoints[ii] = endpointNode.ApplicationEndpoint
 			if ep.port != 0 {
 				glog.V(2).Infof("overriding ContainerPort with imported port:%v for endpoint: %+v", ep.port, endpointNode)
 				endpoints[ii].ContainerPort = ep.port
@@ -467,7 +467,7 @@ func (c *Controller) processTenantEndpoint(conn coordclient.Connection, parentPa
 }
 
 // setProxyAddresses tells the proxies to update with addresses
-func (c *Controller) setProxyAddresses(tenantEndpointID string, endpoints []*dao.ApplicationEndpoint, importVirtualAddress, purpose string) {
+func (c *Controller) setProxyAddresses(tenantEndpointID string, endpoints []dao.ApplicationEndpoint, importVirtualAddress, purpose string) {
 	glog.Infof("starting setProxyAddresses(tenantEndpointID: %s, purpose: %s)", tenantEndpointID, purpose)
 	proxiesLock.Lock()
 	defer proxiesLock.Unlock()
@@ -535,7 +535,7 @@ func (c *Controller) setProxyAddresses(tenantEndpointID string, endpoints []*dao
 	for instanceID, proxyKey := range proxyKeys {
 		prxy, ok := proxies[proxyKey]
 		if !ok {
-			var endpoint *dao.ApplicationEndpoint
+			var endpoint dao.ApplicationEndpoint
 			for _, ep := range endpoints {
 				if ep.InstanceID == instanceID {
 					endpoint = ep
@@ -574,7 +574,7 @@ func (c *Controller) setProxyAddresses(tenantEndpointID string, endpoints []*dao
 }
 
 // createNewProxy creates a new proxy
-func createNewProxy(tenantEndpointID string, endpoint *dao.ApplicationEndpoint) (*proxy, error) {
+func createNewProxy(tenantEndpointID string, endpoint dao.ApplicationEndpoint) (*proxy, error) {
 	glog.Infof("Attempting port map for: %s -> %+v", tenantEndpointID, endpoint)
 
 	// setup a new proxy
@@ -624,16 +624,16 @@ func (c *Controller) registerExportedEndpoints() {
 			for _, vhost := range export.vhosts {
 				epName := fmt.Sprintf("%s_%v", export.endpointName, export.endpoint.InstanceID)
 				var path string
-				if path, err = vhostRegistry.SetItem(conn, vhost, registry.NewVhostEndpoint(epName, *endpoint)); err != nil {
+				if path, err = vhostRegistry.SetItem(conn, vhost, registry.NewVhostEndpoint(epName, endpoint)); err != nil {
 					glog.Errorf("could not register vhost %s for %s: %v", vhost, epName, err)
 				}
 				glog.Infof("Registered vhost %s for %s at %s", vhost, epName, path)
 			}
 
-			glog.Infof("Registering exported endpoint[%s]: %+v", key, *endpoint)
-			path, err := endpointRegistry.SetItem(conn, registry.NewEndpointNode(c.tenantID, export.endpoint.Application, c.hostID, c.dockerID, *endpoint))
+			glog.Infof("Registering exported endpoint[%s]: %+v", key, endpoint)
+			path, err := endpointRegistry.SetItem(conn, registry.NewEndpointNode(c.tenantID, export.endpoint.Application, c.hostID, c.dockerID, endpoint))
 			if err != nil {
-				glog.Errorf("  unable to add endpoint: %+v %v", *endpoint, err)
+				glog.Errorf("  unable to add endpoint: %+v %v", endpoint, err)
 				continue
 			}
 

--- a/dao/elasticsearch/addressassignment.go
+++ b/dao/elasticsearch/addressassignment.go
@@ -19,7 +19,7 @@ import (
 )
 
 // GetServiceAddressAssignments fills in all AddressAssignments for the specified serviced id.
-func (this *ControlPlaneDao) GetServiceAddressAssignments(serviceID string, assignments *[]*addressassignment.AddressAssignment) error {
+func (this *ControlPlaneDao) GetServiceAddressAssignments(serviceID string, assignments *[]addressassignment.AddressAssignment) error {
 	return this.facade.GetServiceAddressAssignments(datastore.Get(), serviceID, assignments)
 }
 

--- a/dao/elasticsearch/backup.go
+++ b/dao/elasticsearch/backup.go
@@ -392,7 +392,7 @@ func utcNow() time.Time {
 }
 
 // Find all docker images referenced by a template or service
-func dockerImageSet(templates map[string]*servicetemplate.ServiceTemplate, services []*service.Service) map[string]bool {
+func dockerImageSet(templates map[string]servicetemplate.ServiceTemplate, services []service.Service) map[string]bool {
 	imageSet := make(map[string]bool)
 	var visit func(*[]servicedefinition.ServiceDefinition)
 	visit = func(defs *[]servicedefinition.ServiceDefinition) {
@@ -472,8 +472,8 @@ func (cp *ControlPlaneDao) Backup(backupsDirectory string, backupFilePath *strin
 	backupOutput <- "Starting backup"
 
 	var (
-		templates      map[string]*servicetemplate.ServiceTemplate
-		services       []*service.Service
+		templates      map[string]servicetemplate.ServiceTemplate
+		services       []service.Service
 		imagesNameTags [][]string
 	)
 	backupName := utcNow().Format("backup-2006-01-02-150405")
@@ -594,7 +594,7 @@ func (cp *ControlPlaneDao) Backup(backupsDirectory string, backupFilePath *strin
 	}
 
 	// Dump all snapshots
-	snapshotToTgzFile := func(service *service.Service) (filename string, err error) {
+	snapshotToTgzFile := func(service service.Service) (filename string, err error) {
 		glog.V(0).Infof("snapshotToTgzFile(%v)", service.ID)
 		backupOutput <- fmt.Sprintf("Taking snapshot of service: %v", service.Name)
 		var snapshotID string
@@ -721,7 +721,7 @@ func (cp *ControlPlaneDao) Restore(backupFilePath string, unused *int) (err erro
 
 	// Do not restore if there are running services
 	var empty interface{}
-	var rss []*dao.RunningService
+	var rss []dao.RunningService
 	if e := cp.GetRunningServices(empty, &rss); e != nil {
 		glog.Errorf("Error trying to find running services: %s", err)
 		restoreError <- e.Error()
@@ -738,7 +738,7 @@ func (cp *ControlPlaneDao) Restore(backupFilePath string, unused *int) (err erro
 	//TODO: acquire restore mutex, defer release
 	var (
 		doReloadLogstashContainer bool
-		templates                 map[string]*servicetemplate.ServiceTemplate
+		templates                 map[string]servicetemplate.ServiceTemplate
 		imagesNameTags            [][]string
 	)
 	defer func() {
@@ -793,7 +793,7 @@ func (cp *ControlPlaneDao) Restore(backupFilePath string, unused *int) (err erro
 	for templateID, template := range templates {
 		template.ID = templateID
 		restoreOutput <- fmt.Sprintf("Restoring service template: %v", template.ID)
-		if e := cp.UpdateServiceTemplate(*template, unused); e != nil {
+		if e := cp.UpdateServiceTemplate(template, unused); e != nil {
 			glog.Errorf("Could not update template %s: %v", templateID, e)
 			restoreError <- e.Error()
 			return e

--- a/dao/elasticsearch/backup_test.go
+++ b/dao/elasticsearch/backup_test.go
@@ -324,8 +324,8 @@ func (dt *DaoTest) TestBackup_IntegrationTest(t *C) {
 		templateId     string
 		serviceId      string
 		backupFilePath string
-		templates      map[string]*servicetemplate.ServiceTemplate
-		services       []*service.Service
+		templates      map[string]servicetemplate.ServiceTemplate
+		services       []service.Service
 	)
 
 	// Create a minimal docker image

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -288,7 +288,7 @@ func (dt *DaoTest) TestDao_GetServices(t *C) {
 	err := dt.Dao.AddService(*svc, &id)
 	t.Assert(err, IsNil)
 
-	var result []*service.Service
+	var result []service.Service
 	err = dt.Dao.GetServices(new(dao.EntityRequest), &result)
 	t.Assert(err, IsNil)
 	t.Assert(len(result), Equals, 1)
@@ -361,7 +361,7 @@ func (dt *DaoTest) TestStoppingParentStopsChildren(t *C) {
 	}
 	// verify the children have all stopped
 	query := fmt.Sprintf("ParentServiceID:%s AND NOT Launch:manual", id)
-	var services []*service.Service
+	var services []service.Service
 	err = dt.Dao.GetServices(query, &services)
 	for _, subService := range services {
 		if subService.DesiredState == service.SVCRun && subService.ParentServiceID == id {
@@ -567,7 +567,7 @@ func (dt *DaoTest) TestDaoAutoAssignIPs(t *C) {
 		t.Errorf("AssignIPs failed: %v", err)
 	}
 
-	assignments := []*addressassignment.AddressAssignment{}
+	assignments := []addressassignment.AddressAssignment{}
 	err = dt.Dao.GetServiceAddressAssignments(testService.ID, &assignments)
 	if err != nil {
 		t.Error("GetServiceAddressAssignments failed: %v", err)
@@ -668,7 +668,7 @@ func (dt *DaoTest) TestDao_ServiceTemplate(t *C) {
 	var (
 		unused     int
 		templateId string
-		templates  map[string]*servicetemplate.ServiceTemplate
+		templates  map[string]servicetemplate.ServiceTemplate
 	)
 
 	// Clean up old templates...
@@ -697,7 +697,7 @@ func (dt *DaoTest) TestDao_ServiceTemplate(t *C) {
 	if len(templates) != 1 {
 		t.Fatalf("Expected 1 template. Found %d", len(templates))
 	}
-	if templates[templateId] == nil {
+	if _, ok := templates[templateId]; !ok {
 		t.Fatalf("Expected to find template that was added (%s), but did not.", templateId)
 	}
 	if templates[templateId].Name != "test_template" {
@@ -714,7 +714,7 @@ func (dt *DaoTest) TestDao_ServiceTemplate(t *C) {
 	if len(templates) != 1 {
 		t.Fatalf("Expected 1 template. Found %d", len(templates))
 	}
-	if templates[templateId] == nil {
+	if _, ok := templates[templateId]; !ok {
 		t.Fatalf("Expected to find template that was updated (%s), but did not.", templateId)
 	}
 	if templates[templateId].Name != "test_template" {
@@ -742,7 +742,7 @@ func (dt *DaoTest) TestDao_ServiceTemplate(t *C) {
 	if len(templates) != 1 {
 		t.Fatalf("Expected 1 template. Found %d", len(templates))
 	}
-	if templates[templateId] == nil {
+	if _, ok := templates[templateId]; !ok {
 		t.Fatalf("Expected to find template that was updated (%s), but did not.", templateId)
 	}
 	if templates[templateId].Name != "test_template" {

--- a/dao/elasticsearch/logs.go
+++ b/dao/elasticsearch/logs.go
@@ -14,15 +14,15 @@
 package elasticsearch
 
 import (
-	"github.com/zenoss/glog"
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/domain/servicestate"
 	"github.com/control-center/serviced/rpc/agent"
+	"github.com/zenoss/glog"
 )
 
 func (this *ControlPlaneDao) GetServiceLogs(serviceID string, logs *string) error {
 	glog.V(3).Info("ControlPlaneDao.GetServiceLogs serviceID=", serviceID)
-	var serviceStates []*servicestate.ServiceState
+	var serviceStates []servicestate.ServiceState
 	if err := this.GetServiceStates(serviceID, &serviceStates); err != nil {
 		glog.Errorf("ControlPlaneDao.GetServiceLogs failed: %v", err)
 		return err

--- a/dao/elasticsearch/runningservice.go
+++ b/dao/elasticsearch/runningservice.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 )
 
-func (this *ControlPlaneDao) GetRunningServices(request dao.EntityRequest, allRunningServices *[]*dao.RunningService) error {
+func (this *ControlPlaneDao) GetRunningServices(request dao.EntityRequest, allRunningServices *[]dao.RunningService) error {
 	allPools, err := this.facade.GetResourcePools(datastore.Get())
 	if err != nil {
 		glog.Error("runningservice.go failed to get resource pool")
@@ -40,20 +40,22 @@ func (this *ControlPlaneDao) GetRunningServices(request dao.EntityRequest, allRu
 			return err
 		}
 
-		singlePoolRunningServices := []*dao.RunningService{}
+		singlePoolRunningServices := []dao.RunningService{}
 		singlePoolRunningServices, err = zkservice.LoadRunningServices(poolBasedConn)
 		if err != nil {
 			glog.Errorf("Failed GetAllRunningServices: %v", err)
 			return err
 		}
 
-		*allRunningServices = append(*allRunningServices, singlePoolRunningServices...)
+		for _, rs := range singlePoolRunningServices {
+			*allRunningServices = append(*allRunningServices, rs)
+		}
 	}
 
 	return nil
 }
 
-func (this *ControlPlaneDao) GetRunningServicesForHost(hostID string, services *[]*dao.RunningService) error {
+func (this *ControlPlaneDao) GetRunningServicesForHost(hostID string, services *[]dao.RunningService) error {
 	myHost, err := this.facade.GetHost(datastore.Get(), hostID)
 	if err != nil {
 		glog.Errorf("Unable to get host %v: %v", hostID, err)
@@ -77,7 +79,7 @@ func (this *ControlPlaneDao) GetRunningServicesForHost(hostID string, services *
 	return nil
 }
 
-func (this *ControlPlaneDao) GetRunningServicesForService(serviceID string, services *[]*dao.RunningService) error {
+func (this *ControlPlaneDao) GetRunningServicesForService(serviceID string, services *[]dao.RunningService) error {
 	myService, err := this.facade.GetService(datastore.Get(), serviceID)
 	if err != nil {
 		glog.Errorf("Unable to get service %v: %v", serviceID, err)
@@ -90,10 +92,14 @@ func (this *ControlPlaneDao) GetRunningServicesForService(serviceID string, serv
 		return err
 	}
 
-	*services, err = zkservice.LoadRunningServicesByService(poolBasedConn, serviceID)
+	svcs, err := zkservice.LoadRunningServicesByService(poolBasedConn, serviceID)
 	if err != nil {
 		glog.Errorf("LoadRunningServicesByService failed (conn: %+v serviceID: %v): %v", poolBasedConn, serviceID, err)
 		return err
+	}
+
+	for _, svc := range svcs {
+		*services = append(*services, svc)
 	}
 
 	return nil
@@ -114,10 +120,11 @@ func (this *ControlPlaneDao) GetRunningService(request dao.ServiceStateRequest, 
 		return err
 	}
 
-	running, err = zkservice.LoadRunningService(poolBasedConn, request.ServiceID, request.ServiceStateID)
-	if err != nil {
+	if thisRunning, err := zkservice.LoadRunningService(poolBasedConn, request.ServiceID, request.ServiceStateID); err != nil {
 		glog.Errorf("zkservice.LoadRunningService failed (conn: %+v serviceID: %v): %v", poolBasedConn, request.ServiceID, err)
 		return err
+	} else {
+		*running = *thisRunning
 	}
 
 	return nil

--- a/dao/elasticsearch/service.go
+++ b/dao/elasticsearch/service.go
@@ -55,7 +55,7 @@ func (this *ControlPlaneDao) GetService(id string, myService *service.Service) e
 }
 
 // TODO FIXME no need for the request argument
-func (this *ControlPlaneDao) GetServices(request dao.EntityRequest, services *[]*service.Service) error {
+func (this *ControlPlaneDao) GetServices(request dao.EntityRequest, services *[]service.Service) error {
 	if svcs, err := this.facade.GetServices(datastore.Get()); err == nil {
 		*services = svcs
 		return nil
@@ -75,7 +75,7 @@ func (this *ControlPlaneDao) FindChildService(request dao.FindChildRequest, serv
 }
 
 //
-func (this *ControlPlaneDao) GetTaggedServices(request dao.EntityRequest, services *[]*service.Service) error {
+func (this *ControlPlaneDao) GetTaggedServices(request dao.EntityRequest, services *[]service.Service) error {
 	if svcs, err := this.facade.GetTaggedServices(datastore.Get(), request); err == nil {
 		*services = svcs
 		return nil
@@ -95,7 +95,7 @@ func (this *ControlPlaneDao) GetTenantId(serviceID string, tenantId *string) err
 }
 
 // Get a service endpoint.
-func (this *ControlPlaneDao) GetServiceEndpoints(serviceID string, response *map[string][]*dao.ApplicationEndpoint) (err error) {
+func (this *ControlPlaneDao) GetServiceEndpoints(serviceID string, response *map[string][]dao.ApplicationEndpoint) (err error) {
 	if result, err := this.facade.GetServiceEndpoints(datastore.Get(), serviceID); err == nil {
 		*response = result
 		return nil

--- a/dao/elasticsearch/servicestate.go
+++ b/dao/elasticsearch/servicestate.go
@@ -43,7 +43,7 @@ func (this *ControlPlaneDao) GetServiceState(request dao.ServiceStateRequest, se
 	return zkservice.GetServiceState(poolBasedConn, serviceState, request.ServiceID, request.ServiceStateID)
 }
 
-func (this *ControlPlaneDao) GetServiceStates(serviceId string, serviceStates *[]*servicestate.ServiceState) error {
+func (this *ControlPlaneDao) GetServiceStates(serviceId string, serviceStates *[]servicestate.ServiceState) error {
 	glog.V(2).Infof("ControlPlaneDao.GetServiceStates: serviceId=%s", serviceId)
 
 	myService, err := this.facade.GetService(datastore.Get(), serviceId)
@@ -63,7 +63,7 @@ func (this *ControlPlaneDao) GetServiceStates(serviceId string, serviceStates *[
 }
 
 /* This method assumes that if a service instance exists, it has not yet been terminated */
-func (this *ControlPlaneDao) getNonTerminatedServiceStates(serviceId string, serviceStates *[]*servicestate.ServiceState) error {
+func (this *ControlPlaneDao) getNonTerminatedServiceStates(serviceId string, serviceStates *[]servicestate.ServiceState) error {
 	glog.V(2).Infof("ControlPlaneDao.getNonTerminatedServiceStates: serviceId=%s", serviceId)
 
 	myService, err := this.facade.GetService(datastore.Get(), serviceId)
@@ -122,7 +122,7 @@ func (this *ControlPlaneDao) StopRunningInstance(request dao.HostServiceRequest,
 	return nil
 }
 
-func (this *ControlPlaneDao) GetServiceStatus(serviceID string, status *map[*servicestate.ServiceState]dao.Status) error {
+func (this *ControlPlaneDao) GetServiceStatus(serviceID string, status *map[string]dao.ServiceStatus) error {
 	svc, err := this.facade.GetService(datastore.Get(), serviceID)
 	if err != nil {
 		glog.Errorf("Unable to get service %s: %s", serviceID, err)

--- a/dao/elasticsearch/servicetemplate.go
+++ b/dao/elasticsearch/servicetemplate.go
@@ -33,7 +33,7 @@ func (this *ControlPlaneDao) RemoveServiceTemplate(id string, unused *int) error
 	return this.facade.RemoveServiceTemplate(datastore.Get(), id)
 }
 
-func (this *ControlPlaneDao) GetServiceTemplates(unused int, templates *map[string]*servicetemplate.ServiceTemplate) error {
+func (this *ControlPlaneDao) GetServiceTemplates(unused int, templates *map[string]servicetemplate.ServiceTemplate) error {
 	templatemap, err := this.facade.GetServiceTemplates(datastore.Get())
 	*templates = templatemap
 	return err

--- a/dao/interface.go
+++ b/dao/interface.go
@@ -82,22 +82,22 @@ type ControlPlane interface {
 	GetService(serviceId string, service *service.Service) error
 
 	// Get a list of services from serviced
-	GetServices(request EntityRequest, services *[]*service.Service) error
+	GetServices(request EntityRequest, services *[]service.Service) error
 
 	// Find a child service with the given name
 	FindChildService(request FindChildRequest, service *service.Service) error
 
 	// Get services with the given tag(s)
-	GetTaggedServices(request EntityRequest, services *[]*service.Service) error
+	GetTaggedServices(request EntityRequest, services *[]service.Service) error
 
 	// Find all service endpoint matches
-	GetServiceEndpoints(serviceId string, response *map[string][]*ApplicationEndpoint) error
+	GetServiceEndpoints(serviceId string, response *map[string][]ApplicationEndpoint) error
 
 	// Assign IP addresses to all services at and below the provided service
 	AssignIPs(assignmentRequest AssignmentRequest, _ *struct{}) (err error)
 
 	// Get the IP addresses assigned to an service
-	GetServiceAddressAssignments(serviceID string, addresses *[]*addressassignment.AddressAssignment) error
+	GetServiceAddressAssignments(serviceID string, addresses *[]addressassignment.AddressAssignment) error
 
 	//---------------------------------------------------------------------------
 	//ServiceState CRUD
@@ -118,10 +118,10 @@ type ControlPlane interface {
 	UpdateServiceState(state servicestate.ServiceState, unused *int) error
 
 	// Computes the status of the service based on its service instances
-	GetServiceStatus(serviceID string, statusmap *map[*servicestate.ServiceState]Status) error
+	GetServiceStatus(serviceID string, statusmap *map[string]ServiceStatus) error
 
 	// Get the services instances for a given service
-	GetServiceStates(serviceId string, states *[]*servicestate.ServiceState) error
+	GetServiceStates(serviceId string, states *[]servicestate.ServiceState) error
 
 	// Get logs for the given app
 	GetServiceLogs(serviceId string, logs *string) error
@@ -130,13 +130,13 @@ type ControlPlane interface {
 	GetServiceStateLogs(request ServiceStateRequest, logs *string) error
 
 	// Get all running services
-	GetRunningServices(request EntityRequest, runningServices *[]*RunningService) error
+	GetRunningServices(request EntityRequest, runningServices *[]RunningService) error
 
 	// Get the services instances for a given service
-	GetRunningServicesForHost(hostId string, runningServices *[]*RunningService) error
+	GetRunningServicesForHost(hostId string, runningServices *[]RunningService) error
 
 	// Get the service instances for a given service
-	GetRunningServicesForService(serviceId string, runningServices *[]*RunningService) error
+	GetRunningServicesForService(serviceId string, runningServices *[]RunningService) error
 
 	// Attach to a running container with a predefined action
 	Action(request AttachRequest, unused *int) error
@@ -157,7 +157,7 @@ type ControlPlane interface {
 	RemoveServiceTemplate(serviceTemplateID string, unused *int) error
 
 	// Get a list of ServiceTemplates
-	GetServiceTemplates(unused int, serviceTemplates *map[string]*servicetemplate.ServiceTemplate) error
+	GetServiceTemplates(unused int, serviceTemplates *map[string]servicetemplate.ServiceTemplate) error
 
 	//---------------------------------------------------------------------------
 	// Service CRUD
@@ -205,5 +205,5 @@ type ControlPlane interface {
 	LogHealthCheck(result domain.HealthCheckResult, unused *int) error
 
 	// Return the number of layers in an image
-	ImageLayerCount(imageUUID string, layers* int) error
+	ImageLayerCount(imageUUID string, layers *int) error
 }

--- a/dao/logstashfilters.go
+++ b/dao/logstashfilters.go
@@ -43,7 +43,7 @@ func resourcesDir() string {
 
 // WriteConfigurationFile takes a map of ServiceTemplates and writes them to the
 // appropriate place in the logstash.conf.
-func WriteConfigurationFile(templates map[string]*servicetemplate.ServiceTemplate) error {
+func WriteConfigurationFile(templates map[string]servicetemplate.ServiceTemplate) error {
 	// the definitions are a map of filter name to content
 	// they are found by recursively going through all the service definitions
 	filterDefs := make(map[string]string)

--- a/dao/model.go
+++ b/dao/model.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/control-center/serviced/domain"
 	"github.com/control-center/serviced/domain/servicedefinition"
+	"github.com/control-center/serviced/domain/servicestate"
 	"github.com/control-center/serviced/utils"
 )
 
@@ -106,6 +107,11 @@ var (
 	Stopping  = Status{7, "Stopping"}
 	Stopped   = Status{8, "Stopped"}
 )
+
+type ServiceStatus struct {
+	State  servicestate.ServiceState
+	Status Status
+}
 
 // An instantiation of a Snapshot request
 type SnapshotRequest struct {

--- a/domain/addressassignment/addressassignmentstore.go
+++ b/domain/addressassignment/addressassignmentstore.go
@@ -29,7 +29,7 @@ type Store struct {
 	datastore.DataStore
 }
 
-func (s *Store) GetServiceAddressAssignments(ctx datastore.Context, serviceID string) ([]*AddressAssignment, error) {
+func (s *Store) GetServiceAddressAssignments(ctx datastore.Context, serviceID string) ([]AddressAssignment, error) {
 	query := fmt.Sprintf("ServiceID:%s", serviceID)
 	q := datastore.NewQuery(ctx)
 	elasticQuery := search.Query().Search(query)
@@ -46,8 +46,8 @@ func Key(id string) datastore.Key {
 	return datastore.NewKey(kind, id)
 }
 
-func convert(results datastore.Results) ([]*AddressAssignment, error) {
-	assignments := make([]*AddressAssignment, results.Len())
+func convert(results datastore.Results) ([]AddressAssignment, error) {
+	assignments := make([]AddressAssignment, results.Len())
 	for idx := range assignments {
 		var aa AddressAssignment
 		err := results.Get(idx, &aa)
@@ -55,7 +55,7 @@ func convert(results datastore.Results) ([]*AddressAssignment, error) {
 			return nil, err
 		}
 
-		assignments[idx] = &aa
+		assignments[idx] = aa
 	}
 	return assignments, nil
 }

--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -310,11 +310,11 @@ func (s Service) GetPath(gs GetService) (string, error) {
 }
 
 //SetAssignment sets the AddressAssignment for the endpoint
-func (se *ServiceEndpoint) SetAssignment(aa *addressassignment.AddressAssignment) error {
+func (se *ServiceEndpoint) SetAssignment(aa addressassignment.AddressAssignment) error {
 	if se.AddressConfig.Port == 0 {
 		return errors.New("cannot assign address to endpoint without AddressResourceConfig")
 	}
-	se.AddressAssignment = *aa
+	se.AddressAssignment = aa
 	return nil
 }
 

--- a/domain/service/serviceeval_test.go
+++ b/domain/service/serviceeval_test.go
@@ -266,7 +266,7 @@ func (s *S) findChild(svcID, childName string) (Service, error) {
 	}
 	for _, x := range svcs {
 		if x.Name == childName {
-			return *x, nil
+			return x, nil
 		}
 	}
 	return svc, nil

--- a/domain/service/servicestore.go
+++ b/domain/service/servicestore.go
@@ -60,12 +60,12 @@ func (s *Store) Delete(ctx datastore.Context, id string) error {
 }
 
 //GetServices returns all services
-func (s *Store) GetServices(ctx datastore.Context) ([]*Service, error) {
+func (s *Store) GetServices(ctx datastore.Context) ([]Service, error) {
 	return query(ctx, "_exists_:ID")
 }
 
 //GetTaggedServices returns services with the given tags
-func (s *Store) GetTaggedServices(ctx datastore.Context, tags ...string) ([]*Service, error) {
+func (s *Store) GetTaggedServices(ctx datastore.Context, tags ...string) ([]Service, error) {
 	if len(tags) == 0 {
 		return nil, errors.New("empty tags not allowed")
 	}
@@ -74,7 +74,7 @@ func (s *Store) GetTaggedServices(ctx datastore.Context, tags ...string) ([]*Ser
 }
 
 //GetServicesByPool returns services with the given pool id
-func (s *Store) GetServicesByPool(ctx datastore.Context, poolID string) ([]*Service, error) {
+func (s *Store) GetServicesByPool(ctx datastore.Context, poolID string) ([]Service, error) {
 	id := strings.TrimSpace(poolID)
 	if id == "" {
 		return nil, errors.New("empty poolID not allowed")
@@ -84,7 +84,7 @@ func (s *Store) GetServicesByPool(ctx datastore.Context, poolID string) ([]*Serv
 }
 
 //GetServicesByDeployment returns services with the given deployment id
-func (s *Store) GetServicesByDeployment(ctx datastore.Context, deploymentID string) ([]*Service, error) {
+func (s *Store) GetServicesByDeployment(ctx datastore.Context, deploymentID string) ([]Service, error) {
 	id := strings.TrimSpace(deploymentID)
 	if id == "" {
 		return nil, errors.New("empty deploymentID not allowed")
@@ -94,7 +94,7 @@ func (s *Store) GetServicesByDeployment(ctx datastore.Context, deploymentID stri
 }
 
 //GetChildServices returns services that are children of the given parent service id
-func (s *Store) GetChildServices(ctx datastore.Context, parentID string) ([]*Service, error) {
+func (s *Store) GetChildServices(ctx datastore.Context, parentID string) ([]Service, error) {
 	id := strings.TrimSpace(parentID)
 	if id == "" {
 		return nil, errors.New("empty parent service id not allowed")
@@ -104,7 +104,7 @@ func (s *Store) GetChildServices(ctx datastore.Context, parentID string) ([]*Ser
 	return query(ctx, queryString)
 }
 
-func query(ctx datastore.Context, query string) ([]*Service, error) {
+func query(ctx datastore.Context, query string) ([]Service, error) {
 	q := datastore.NewQuery(ctx)
 	elasticQuery := search.Query().Search(query)
 	search := search.Search("controlplane").Type(kind).Size("50000").Query(elasticQuery)
@@ -122,8 +122,8 @@ func fillConfig(svc *Service) {
 	}
 }
 
-func convert(results datastore.Results) ([]*Service, error) {
-	svcs := make([]*Service, results.Len())
+func convert(results datastore.Results) ([]Service, error) {
+	svcs := make([]Service, results.Len())
 	for idx := range svcs {
 		var svc Service
 		err := results.Get(idx, &svc)
@@ -131,7 +131,7 @@ func convert(results datastore.Results) ([]*Service, error) {
 			return nil, err
 		}
 		fillConfig(&svc)
-		svcs[idx] = &svc
+		svcs[idx] = svc
 	}
 	return svcs, nil
 }

--- a/domain/service/walk.go
+++ b/domain/service/walk.go
@@ -17,7 +17,7 @@ package service
 type Visit func(svc *Service) error
 
 //GetChildServices returns a list of services that are children to the parentID, return empty list if none found
-type GetChildServices func(parentID string) ([]*Service, error)
+type GetChildServices func(parentID string) ([]Service, error)
 
 //GetService return a service, return error if not found
 type GetService func(serviceID string) (Service, error)

--- a/facade/addressassignment.go
+++ b/facade/addressassignment.go
@@ -15,7 +15,7 @@ import (
 )
 
 // GetServiceAddressAssignments fills in all AddressAssignments for the specified serviced id.
-func (f *Facade) GetServiceAddressAssignments(ctx datastore.Context, serviceID string, assignments *[]*addressassignment.AddressAssignment) error {
+func (f *Facade) GetServiceAddressAssignments(ctx datastore.Context, serviceID string, assignments *[]addressassignment.AddressAssignment) error {
 	store := addressassignment.NewStore()
 
 	results, err := store.GetServiceAddressAssignments(ctx, serviceID)
@@ -174,13 +174,13 @@ func (f *Facade) validEndpoint(ctx datastore.Context, serviceId string, endpoint
 }
 
 // getEndpointAddressAssignments returns the AddressAssignment for the service and endpoint, if no assignments the AddressAssignment will be nil
-func (f *Facade) getAddressAssignments(ctx datastore.Context, serviceID string) (map[string]*addressassignment.AddressAssignment, error) {
-	assignments := []*addressassignment.AddressAssignment{}
+func (f *Facade) getAddressAssignments(ctx datastore.Context, serviceID string) (map[string]addressassignment.AddressAssignment, error) {
+	assignments := []addressassignment.AddressAssignment{}
 	if err := f.GetServiceAddressAssignments(ctx, serviceID, &assignments); err != nil {
 		return nil, err
 	}
 
-	addrs := make(map[string]*addressassignment.AddressAssignment)
+	addrs := make(map[string]addressassignment.AddressAssignment)
 	for _, result := range assignments {
 		addrs[result.EndpointName] = result
 	}
@@ -195,7 +195,7 @@ func (f *Facade) getEndpointAddressAssignments(ctx datastore.Context, serviceID 
 	}
 
 	if addr, found := assignments[endpointName]; found {
-		return addr, nil
+		return &addr, nil
 	}
 	return nil, nil
 }

--- a/facade/host_test.go
+++ b/facade/host_test.go
@@ -145,7 +145,7 @@ func (s *FacadeTest) Test_HostRemove(t *C) {
 	s1.Endpoints[0].Name = "name"
 	s1.Endpoints[0].AddressConfig = servicedefinition.AddressResourceConfig{Port: 123, Protocol: "tcp"}
 	aa := addressassignment.AddressAssignment{ID: "id", HostID: "h1"}
-	s1.Endpoints[0].SetAssignment(&aa)
+	s1.Endpoints[0].SetAssignment(aa)
 	err = s.Facade.AddService(s.CTX, *s1)
 	if err != nil {
 		t.Fatalf("Failed to add service %+v: %s", s1, err)

--- a/facade/service.go
+++ b/facade/service.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -23,7 +22,6 @@ import (
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/domain/serviceconfigfile"
 	"github.com/control-center/serviced/domain/servicedefinition"
-	"github.com/control-center/serviced/domain/servicestate"
 )
 
 // AddService adds a service; return error if service already exists
@@ -140,7 +138,7 @@ func (f *Facade) GetService(ctx datastore.Context, id string) (*service.Service,
 }
 
 //
-func (f *Facade) GetServices(ctx datastore.Context) ([]*service.Service, error) {
+func (f *Facade) GetServices(ctx datastore.Context) ([]service.Service, error) {
 	glog.V(3).Infof("Facade.GetServices")
 	store := f.serviceStore
 	results, err := store.GetServices(ctx)
@@ -155,7 +153,7 @@ func (f *Facade) GetServices(ctx datastore.Context) ([]*service.Service, error) 
 }
 
 // GetServicesByPool looks up all services in a particular pool
-func (f *Facade) GetServicesByPool(ctx datastore.Context, poolID string) ([]*service.Service, error) {
+func (f *Facade) GetServicesByPool(ctx datastore.Context, poolID string) ([]service.Service, error) {
 	glog.V(3).Infof("Facade.GetServicesByPool")
 	store := f.serviceStore
 	results, err := store.GetServicesByPool(ctx, poolID)
@@ -170,7 +168,7 @@ func (f *Facade) GetServicesByPool(ctx datastore.Context, poolID string) ([]*ser
 }
 
 //
-func (f *Facade) GetTaggedServices(ctx datastore.Context, request dao.EntityRequest) ([]*service.Service, error) {
+func (f *Facade) GetTaggedServices(ctx datastore.Context, request dao.EntityRequest) ([]service.Service, error) {
 	glog.V(3).Infof("Facade.GetTaggedServices")
 
 	store := f.serviceStore
@@ -189,7 +187,7 @@ func (f *Facade) GetTaggedServices(ctx datastore.Context, request dao.EntityRequ
 	default:
 		err := fmt.Errorf("Bad request type: %v", v)
 		glog.V(2).Info("Facade.GetTaggedServices: err=", err)
-		return []*service.Service{}, err
+		return []service.Service{}, err
 	}
 }
 
@@ -203,88 +201,10 @@ func (f *Facade) GetTenantID(ctx datastore.Context, serviceID string) (string, e
 }
 
 // Get a service endpoint.
-func (f *Facade) GetServiceEndpoints(ctx datastore.Context, serviceId string) (map[string][]*dao.ApplicationEndpoint, error) {
+func (f *Facade) GetServiceEndpoints(ctx datastore.Context, serviceId string) (map[string][]dao.ApplicationEndpoint, error) {
 	// TODO: this function is obsolete.  Remove it.
-	glog.V(2).Infof("Facade.GetServiceEndpoints serviceId=%s", serviceId)
-	result := make(map[string][]*dao.ApplicationEndpoint)
-	myService, err := f.getService(ctx, serviceId)
-	if err != nil {
-		glog.V(2).Infof("Facade.GetServiceEndpoints service=%+v err=%s", myService, err)
-		return result, err
-	}
-
-	service_imports := myService.GetServiceImports()
-	if len(service_imports) > 0 {
-		glog.V(2).Infof("%+v service imports=%+v", myService, service_imports)
-
-		servicesList, err := f.getServices(ctx)
-		if err != nil {
-			return result, err
-		}
-
-		// Map all services by Id so we can construct a tree for the current service ID
-		glog.V(2).Infof("ServicesList: %d", len(servicesList))
-		topService := f.getServiceTree(serviceId, &servicesList)
-		// We should now have the top-level service for the current service ID
-
-		//build 'OR' query to grab all service states with in "service" tree
-		relatedServiceIDs := walkTree(topService)
-		var states []*servicestate.ServiceState
-		err = zkAPI(f).GetServiceStates(myService.PoolID, &states, relatedServiceIDs...)
-		if err != nil {
-			return result, err
-		}
-
-		//delay getting addresses as long as possible
-		f.fillServiceAddr(ctx, &myService)
-
-		// for each proxied port, find list of potential remote endpoints
-		for _, endpoint := range service_imports {
-			glog.V(2).Infof("Finding exports for import: %s %+v", endpoint.Application, endpoint)
-			matchedEndpoint := false
-			applicationRegex, err := regexp.Compile(fmt.Sprintf("^%s$", endpoint.Application))
-			if err != nil {
-				continue //Don't spam error message; it was reported at validation time
-			}
-			for _, ss := range states {
-				hostPort, containerPort, protocol, match := ss.GetHostEndpointInfo(applicationRegex)
-				if match {
-					glog.V(1).Infof("Matched endpoint: %s.%s -> %s:%d (%s/%d)",
-						myService.Name, endpoint.Application, ss.HostIP, hostPort, protocol, containerPort)
-					// if port/protocol undefined in the import, use the export's values
-					if endpoint.PortNumber != 0 {
-						containerPort = endpoint.PortNumber
-					}
-					if endpoint.Protocol != "" {
-						protocol = endpoint.Protocol
-					}
-					var ep dao.ApplicationEndpoint
-					ep.Application = endpoint.Application
-					ep.ServiceID = ss.ServiceID
-					ep.ContainerPort = containerPort
-					ep.HostPort = hostPort
-					ep.HostIP = ss.HostIP
-					ep.ContainerIP = ss.PrivateIP
-					ep.Protocol = protocol
-					ep.VirtualAddress = endpoint.VirtualAddress
-					ep.InstanceID = ss.InstanceID
-
-					key := fmt.Sprintf("%s:%d", protocol, containerPort)
-					if _, exists := result[key]; !exists {
-						result[key] = make([]*dao.ApplicationEndpoint, 0)
-					}
-					result[key] = append(result[key], &ep)
-					matchedEndpoint = true
-				}
-			}
-			if !matchedEndpoint {
-				glog.V(1).Infof("Unmatched endpoint %s.%s", myService.Name, endpoint.Application)
-			}
-		}
-
-		glog.V(2).Infof("Return for %s is %+v", serviceId, result)
-	}
-	return result, nil
+	result := make(map[string][]dao.ApplicationEndpoint)
+	return result, fmt.Errorf("facade.GetServiceEndpoints is obsolete - do not use it")
 }
 
 // foundchild is an error used exclusively to short-circuit the service walking
@@ -461,7 +381,7 @@ func (f *Facade) AssignIPs(ctx datastore.Context, assignmentRequest dao.Assignme
 
 	glog.Infof("Attempting to set IP address(es) to %s", assignmentRequest.IPAddress)
 
-	assignments := []*addressassignment.AddressAssignment{}
+	assignments := []addressassignment.AddressAssignment{}
 	if err := f.GetServiceAddressAssignments(ctx, assignmentRequest.ServiceID, &assignments); err != nil {
 		glog.Errorf("controlPlaneDao.GetServiceAddressAssignments failed in anonymous function: %v", err)
 		return err
@@ -537,7 +457,7 @@ func (f *Facade) getService(ctx datastore.Context, id string) (service.Service, 
 
 //getServices is an internal method that returns all Services without filling in all related service data like address assignments
 //and modified config files
-func (f *Facade) getServices(ctx datastore.Context) ([]*service.Service, error) {
+func (f *Facade) getServices(ctx datastore.Context) ([]service.Service, error) {
 	glog.V(3).Infof("Facade.GetServices")
 	store := f.serviceStore
 	results, err := store.GetServices(ctx)
@@ -570,7 +490,7 @@ func (f *Facade) getTenantIDAndPath(ctx datastore.Context, svc service.Service) 
 // traverse all the services (including the children of the provided service)
 func (f *Facade) walkServices(ctx datastore.Context, serviceID string, visitFn service.Visit) error {
 	store := f.serviceStore
-	getChildren := func(parentID string) ([]*service.Service, error) {
+	getChildren := func(parentID string) ([]service.Service, error) {
 		return store.GetChildServices(ctx, parentID)
 	}
 	getService := func(svcID string) (service.Service, error) {
@@ -606,7 +526,7 @@ type treenode struct {
 
 // getServiceTree creates the service hierarchy tree containing serviceId, serviceList is used to create the tree.
 // Returns a pointer the root of the service hierarchy
-func (f *Facade) getServiceTree(serviceId string, servicesList *[]*service.Service) *treenode {
+func (f *Facade) getServiceTree(serviceId string, servicesList *[]service.Service) *treenode {
 	glog.V(2).Infof(" getServiceTree = %s", serviceId)
 	servicesMap := make(map[string]*treenode)
 	for _, svc := range *servicesList {
@@ -705,9 +625,9 @@ func (f *Facade) fillOutService(ctx datastore.Context, svc *service.Service) err
 	return nil
 }
 
-func (f *Facade) fillOutServices(ctx datastore.Context, svcs []*service.Service) error {
-	for _, svc := range svcs {
-		if err := f.fillOutService(ctx, svc); err != nil {
+func (f *Facade) fillOutServices(ctx datastore.Context, svcs []service.Service) error {
+	for i := range svcs {
+		if err := f.fillOutService(ctx, &svcs[i]); err != nil {
 			return err
 		}
 	}

--- a/facade/servicetemplate.go
+++ b/facade/servicetemplate.go
@@ -89,16 +89,16 @@ func (f *Facade) RemoveServiceTemplate(ctx datastore.Context, id string) error {
 	return nil
 }
 
-func (f *Facade) GetServiceTemplates(ctx datastore.Context) (map[string]*servicetemplate.ServiceTemplate, error) {
+func (f *Facade) GetServiceTemplates(ctx datastore.Context) (map[string]servicetemplate.ServiceTemplate, error) {
 	glog.V(2).Infof("Facade.GetServiceTemplates")
 	results, err := f.templateStore.GetServiceTemplates(ctx)
-	templateMap := make(map[string]*servicetemplate.ServiceTemplate)
+	templateMap := make(map[string]servicetemplate.ServiceTemplate)
 	if err != nil {
 		glog.V(2).Infof("Facade.GetServiceTemplates: err=%s", err)
 		return templateMap, err
 	}
 	for _, st := range results {
-		templateMap[st.ID] = st
+		templateMap[st.ID] = *st
 	}
 	return templateMap, nil
 }
@@ -378,7 +378,7 @@ func renameImageID(dockerRegistry, imageId, tenantId string) (string, error) {
 // writeLogstashConfiguration takes all the available
 // services and writes out the filters section for logstash.
 // This is required before logstash startsup
-func writeLogstashConfiguration(templates map[string]*servicetemplate.ServiceTemplate) error {
+func writeLogstashConfiguration(templates map[string]servicetemplate.ServiceTemplate) error {
 	// FIXME: eventually this file should live in the DFS or the config should
 	// live in zookeeper to allow the agents to get to this
 	if err := dao.WriteConfigurationFile(templates); err != nil {

--- a/facade/testutils.go
+++ b/facade/testutils.go
@@ -73,7 +73,7 @@ func (z *zkMock) RemoveService(svc *service.Service) error {
 	return nil
 }
 
-func (z *zkMock) GetServiceStates(poolID string, serviceStates *[]*servicestate.ServiceState, serviceIds ...string) error {
+func (z *zkMock) GetServiceStates(poolID string, serviceStates *[]servicestate.ServiceState, serviceIds ...string) error {
 	return nil
 }
 

--- a/facade/zkapi.go
+++ b/facade/zkapi.go
@@ -39,7 +39,7 @@ var zkAPI func(f *Facade) zkfuncs = getZKAPI
 type zkfuncs interface {
 	UpdateService(service *service.Service) error
 	RemoveService(service *service.Service) error
-	GetServiceStates(poolID string, states *[]*servicestate.ServiceState, serviceIDs ...string) error
+	GetServiceStates(poolID string, states *[]servicestate.ServiceState, serviceIDs ...string) error
 	CheckRunningVHost(vhostName, serviceID string) error
 	AddHost(host *host.Host) error
 	UpdateHost(host *host.Host) error
@@ -86,7 +86,7 @@ func (zk *zkf) RemoveService(service *service.Service) error {
 	return <-errC
 }
 
-func (zk *zkf) GetServiceStates(poolID string, states *[]*servicestate.ServiceState, serviceIDs ...string) error {
+func (zk *zkf) GetServiceStates(poolID string, states *[]servicestate.ServiceState, serviceIDs ...string) error {
 	conn, err := zzk.GetLocalConnection(zzk.GeneratePoolPath(poolID))
 	if err != nil {
 		return err

--- a/node/agent_client.go
+++ b/node/agent_client.go
@@ -19,7 +19,9 @@
 package node
 
 import (
+	"net"
 	"net/rpc"
+	"net/rpc/jsonrpc"
 )
 
 // AgentClient is an interface that the serviced agent implements to provide
@@ -33,7 +35,10 @@ type AgentClient struct {
 func NewAgentClient(addr string) (s *AgentClient, err error) {
 	s = new(AgentClient)
 	s.addr = addr
-	rpcClient, err := rpc.DialHTTP("tcp", s.addr)
-	s.rpcClient = rpcClient
-	return s, err
+	conn, err := net.Dial("tcp", s.addr)
+	if err != nil {
+		return nil, err
+	}
+	s.rpcClient = jsonrpc.NewClient(conn)
+	return s, nil
 }

--- a/node/agent_proxy.go
+++ b/node/agent_proxy.go
@@ -54,8 +54,8 @@ func (a *HostAgent) Ping(waitFor time.Duration, timestamp *time.Time) error {
 	return nil
 }
 
-func (a *HostAgent) GetServiceEndpoints(serviceId string, response *map[string][]*dao.ApplicationEndpoint) (err error) {
-	myList := make(map[string][]*dao.ApplicationEndpoint)
+func (a *HostAgent) GetServiceEndpoints(serviceId string, response *map[string][]dao.ApplicationEndpoint) (err error) {
+	myList := make(map[string][]dao.ApplicationEndpoint)
 
 	a.addControlPlaneEndpoint(myList)
 	a.addControlPlaneConsumerEndpoint(myList)
@@ -189,7 +189,7 @@ func (a *HostAgent) LogHealthCheck(result domain.HealthCheckResult, unused *int)
 }
 
 // addControlPlaneEndpoint adds an application endpoint mapping for the master control plane api
-func (a *HostAgent) addControlPlaneEndpoint(endpoints map[string][]*dao.ApplicationEndpoint) {
+func (a *HostAgent) addControlPlaneEndpoint(endpoints map[string][]dao.ApplicationEndpoint) {
 	key := "tcp" + a.uiport
 	endpoint := dao.ApplicationEndpoint{}
 	endpoint.ServiceID = "controlplane"
@@ -208,7 +208,7 @@ func (a *HostAgent) addControlPlaneEndpoint(endpoints map[string][]*dao.Applicat
 }
 
 // addControlPlaneConsumerEndpoint adds an application endpoint mapping for the master control plane api
-func (a *HostAgent) addControlPlaneConsumerEndpoint(endpoints map[string][]*dao.ApplicationEndpoint) {
+func (a *HostAgent) addControlPlaneConsumerEndpoint(endpoints map[string][]dao.ApplicationEndpoint) {
 	key := "tcp:8444"
 	endpoint := dao.ApplicationEndpoint{}
 	endpoint.ServiceID = "controlplane_consumer"
@@ -222,7 +222,7 @@ func (a *HostAgent) addControlPlaneConsumerEndpoint(endpoints map[string][]*dao.
 }
 
 // addLogstashEndpoint adds an application endpoint mapping for the master control plane api
-func (a *HostAgent) addLogstashEndpoint(endpoints map[string][]*dao.ApplicationEndpoint) {
+func (a *HostAgent) addLogstashEndpoint(endpoints map[string][]dao.ApplicationEndpoint) {
 	tcp_endpoint := dao.ApplicationEndpoint{
 		ServiceID:     "controlplane_logstash_tcp",
 		Application:   "controlplane_logstash_tcp",
@@ -247,18 +247,18 @@ func (a *HostAgent) addLogstashEndpoint(endpoints map[string][]*dao.ApplicationE
 }
 
 // addEndpoint adds a mapping to defined application, if a mapping does not exist this method creates the list and adds the first element
-func (a *HostAgent) addEndpoint(key string, endpoint dao.ApplicationEndpoint, endpoints map[string][]*dao.ApplicationEndpoint) {
+func (a *HostAgent) addEndpoint(key string, endpoint dao.ApplicationEndpoint, endpoints map[string][]dao.ApplicationEndpoint) {
 	if _, ok := endpoints[key]; !ok {
-		endpoints[key] = make([]*dao.ApplicationEndpoint, 0)
+		endpoints[key] = make([]dao.ApplicationEndpoint, 0)
 	} else {
 		if len(endpoints[key]) > 0 {
 			glog.Warningf("Service %s has duplicate internal endpoint for key %s len(endpointList)=%d", endpoint.ServiceID, key, len(endpoints[key]))
 			for _, ep := range endpoints[key] {
-				glog.Warningf(" %+v", *ep)
+				glog.Warningf(" %+v", ep)
 			}
 		}
 	}
-	endpoints[key] = append(endpoints[key], &endpoint)
+	endpoints[key] = append(endpoints[key], endpoint)
 }
 
 // GetHostID returns the agent's host id

--- a/node/agent_proxy_test.go
+++ b/node/agent_proxy_test.go
@@ -32,7 +32,7 @@ func TestAddControlPlaneEndpoints(t *testing.T) {
 	agent := &HostAgent{}
 	agent.master = "127.0.0.1:0"
 	agent.uiport = ":443"
-	endpoints := make(map[string][]*dao.ApplicationEndpoint)
+	endpoints := make(map[string][]dao.ApplicationEndpoint)
 
 	consumer_endpoint := dao.ApplicationEndpoint{}
 	consumer_endpoint.ServiceID = "controlplane_consumer"
@@ -71,11 +71,11 @@ func TestAddControlPlaneEndpoints(t *testing.T) {
 		t.Fatalf(" mapping failed len(\"tcp:443\"])=%d expected 1", len(endpoints["tcp:443"]))
 	}
 
-	if *endpoints["tcp:8444"][0] != consumer_endpoint {
-		t.Fatalf(" mapping failed %+v expected %+v", *endpoints["tcp:8444"][0], consumer_endpoint)
+	if endpoints["tcp:8444"][0] != consumer_endpoint {
+		t.Fatalf(" mapping failed %+v expected %+v", endpoints["tcp:8444"][0], consumer_endpoint)
 	}
 
-	if *endpoints["tcp:443"][0] != controlplane_endpoint {
-		t.Fatalf(" mapping failed %+v expected %+v", *endpoints["tcp:443"][0], controlplane_endpoint)
+	if endpoints["tcp:443"][0] != controlplane_endpoint {
+		t.Fatalf(" mapping failed %+v expected %+v", endpoints["tcp:443"][0], controlplane_endpoint)
 	}
 }

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -101,7 +101,7 @@ type LoadBalancer interface {
 	// SendLogMessage allows the proxy to send messages/logs to the master (to be displayed on the serviced master)
 	SendLogMessage(serviceLogInfo ServiceLogInfo, _ *struct{}) error
 
-	GetServiceEndpoints(serviceId string, endpoints *map[string][]*dao.ApplicationEndpoint) error
+	GetServiceEndpoints(serviceId string, endpoints *map[string][]dao.ApplicationEndpoint) error
 
 	// GetProxySnapshotQuiece blocks until there is a snapshot request
 	GetProxySnapshotQuiece(serviceId string, snapshotId *string) error

--- a/node/lbClient.go
+++ b/node/lbClient.go
@@ -19,7 +19,9 @@ import (
 	"github.com/control-center/serviced/domain/service"
 	"github.com/zenoss/glog"
 
+	"net"
 	"net/rpc"
+	"net/rpc/jsonrpc"
 	"time"
 )
 
@@ -36,9 +38,12 @@ var _ LoadBalancer = &LBClient{}
 func NewLBClient(addr string) (s *LBClient, err error) {
 	s = new(LBClient)
 	s.addr = addr
-	rpcClient, err := rpc.DialHTTP("tcp", s.addr)
-	s.rpcClient = rpcClient
-	return s, err
+	conn, err := net.Dial("tcp", s.addr)
+	if err != nil {
+		return nil, err
+	}
+	s.rpcClient = jsonrpc.NewClient(conn)
+	return s, nil
 }
 
 func (a *LBClient) Close() error {
@@ -58,7 +63,7 @@ func (a *LBClient) SendLogMessage(serviceLogInfo ServiceLogInfo, _ *struct{}) er
 }
 
 // GetServiceEndpoints returns a list of endpoints for the given service endpoint request.
-func (a *LBClient) GetServiceEndpoints(serviceId string, endpoints *map[string][]*dao.ApplicationEndpoint) error {
+func (a *LBClient) GetServiceEndpoints(serviceId string, endpoints *map[string][]dao.ApplicationEndpoint) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetServiceEndpoints()")
 	return a.rpcClient.Call("ControlPlaneAgent.GetServiceEndpoints", serviceId, endpoints)
 }

--- a/rpc/agent/agent_client.go
+++ b/rpc/agent/agent_client.go
@@ -14,10 +14,12 @@
 package agent
 
 import (
-	"github.com/zenoss/glog"
 	"github.com/control-center/serviced/domain/host"
+	"github.com/zenoss/glog"
 
+	"net"
 	"net/rpc"
+	"net/rpc/jsonrpc"
 )
 
 // Client rpc client to interact with agent
@@ -31,9 +33,12 @@ func NewClient(addr string) (*Client, error) {
 	s := new(Client)
 	s.addr = addr
 	glog.V(4).Infof("Agent connecting to %s", addr)
-	rpcClient, err := rpc.DialHTTP("tcp", s.addr)
-	s.rpcClient = rpcClient
-	return s, err
+	conn, err := net.Dial("tcp", s.addr)
+	if err != nil {
+		return nil, err
+	}
+	s.rpcClient = jsonrpc.NewClient(conn)
+	return s, nil
 }
 
 // Close closes rpc client

--- a/rpc/master/client.go
+++ b/rpc/master/client.go
@@ -16,7 +16,9 @@ package master
 import (
 	"github.com/zenoss/glog"
 
+	"net"
 	"net/rpc"
+	"net/rpc/jsonrpc"
 )
 
 var (
@@ -34,9 +36,12 @@ func NewClient(addr string) (*Client, error) {
 	s := new(Client)
 	s.addr = addr
 	glog.V(4).Infof("Connecting to %s", addr)
-	rpcClient, err := rpc.DialHTTP("tcp", s.addr)
-	s.rpcClient = rpcClient
-	return s, err
+	conn, err := net.Dial("tcp", s.addr)
+	if err != nil {
+		return nil, err
+	}
+	s.rpcClient = jsonrpc.NewClient(conn)
+	return s, nil
 }
 
 func (c *Client) call(name string, request interface{}, response interface{}) error {

--- a/scheduler/hostinfo.go
+++ b/scheduler/hostinfo.go
@@ -29,15 +29,15 @@ import (
 type HostInfo interface {
 	AvailableRAM(*host.Host, chan *hostitem, <-chan bool)
 	PrioritizeByMemory([]*host.Host) ([]*host.Host, error)
-	ServicesOnHost(*host.Host) []*dao.RunningService
+	ServicesOnHost(*host.Host) []dao.RunningService
 }
 
 type DAOHostInfo struct {
 	dao dao.ControlPlane
 }
 
-func (hi *DAOHostInfo) ServicesOnHost(h *host.Host) []*dao.RunningService {
-	rss := []*dao.RunningService{}
+func (hi *DAOHostInfo) ServicesOnHost(h *host.Host) []dao.RunningService {
+	rss := []dao.RunningService{}
 	if err := hi.dao.GetRunningServicesForHost(h.ID, &rss); err != nil {
 		glog.Errorf("cannot retrieve running services for host: %s (%v)", h.ID, err)
 	}
@@ -48,7 +48,7 @@ func (hi *DAOHostInfo) ServicesOnHost(h *host.Host) []*dao.RunningService {
 // subtracting the sum of the RAM commitments of each of its running services
 // from its total memory.
 func (hi *DAOHostInfo) AvailableRAM(host *host.Host, result chan *hostitem, done <-chan bool) {
-	rss := []*dao.RunningService{}
+	rss := []dao.RunningService{}
 	if err := hi.dao.GetRunningServicesForHost(host.ID, &rss); err != nil {
 		glog.Errorf("cannot retrieve running services for host: %s (%v)", host.ID, err)
 		return // this host won't be scheduled

--- a/scheduler/hostpolicy_test.go
+++ b/scheduler/hostpolicy_test.go
@@ -55,10 +55,10 @@ func (t *TestHostInfo) PrioritizeByMemory(hosts []*host.Host) ([]*host.Host, err
 }
 
 // Don't go to ZooKeeper, just look at our local manually constructed service state.
-func (t *TestHostInfo) ServicesOnHost(h *host.Host) []*dao.RunningService {
-	result := []*dao.RunningService{}
+func (t *TestHostInfo) ServicesOnHost(h *host.Host) []dao.RunningService {
+	result := []dao.RunningService{}
 	for _, s := range t.services[h] {
-		result = append(result, &dao.RunningService{ServiceID: s})
+		result = append(result, dao.RunningService{ServiceID: s})
 	}
 	return result
 }

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -176,7 +176,7 @@ func (sr StatsReporter) updateStats() {
 	// Stats for host.
 	sr.updateHostStats()
 	// Stats for the containers.
-	var running []*dao.RunningService
+	var running []dao.RunningService
 	running, err := zkservice.LoadRunningServicesByHost(sr.conn, sr.hostID)
 	if err != nil {
 		glog.Errorf("updateStats: zkservice.LoadRunningServicesByHost (conn: %+v hostID: %v) failed: %v", sr.conn, sr.hostID, err)

--- a/web/resources.go
+++ b/web/resources.go
@@ -48,7 +48,7 @@ func restDockerIsLoggedIn(w *rest.ResponseWriter, r *rest.Request, client *node.
 
 func restGetAppTemplates(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClient) {
 	var unused int
-	var templatesMap map[string]*servicetemplate.ServiceTemplate
+	var templatesMap map[string]servicetemplate.ServiceTemplate
 	client.GetServiceTemplates(unused, &templatesMap)
 	w.WriteJson(&templatesMap)
 }
@@ -159,14 +159,14 @@ func restDeployAppTemplateActive(w *rest.ResponseWriter, r *rest.Request, client
 	w.WriteJson(&active)
 }
 
-func filterByNameRegex(nmregex string, services []*service.Service) ([]*service.Service, error) {
+func filterByNameRegex(nmregex string, services []service.Service) ([]service.Service, error) {
 	r, err := regexp.Compile(nmregex)
 	if err != nil {
 		glog.Errorf("Bad name regexp :%s", nmregex)
 		return nil, err
 	}
 
-	matches := []*service.Service{}
+	matches := []service.Service{}
 	for _, service := range services {
 		if r.MatchString(service.Name) {
 			matches = append(matches, service)
@@ -176,8 +176,8 @@ func filterByNameRegex(nmregex string, services []*service.Service) ([]*service.
 	return matches, nil
 }
 
-func getTaggedServices(client *node.ControlClient, tags, nmregex string) ([]*service.Service, error) {
-	services := []*service.Service{}
+func getTaggedServices(client *node.ControlClient, tags, nmregex string) ([]service.Service, error) {
+	services := []service.Service{}
 	var ts interface{}
 	ts = strings.Split(tags, ",")
 	if err := client.GetTaggedServices(&ts, &services); err != nil {
@@ -192,8 +192,8 @@ func getTaggedServices(client *node.ControlClient, tags, nmregex string) ([]*ser
 	return services, nil
 }
 
-func getNamedServices(client *node.ControlClient, nmregex string) ([]*service.Service, error) {
-	services := []*service.Service{}
+func getNamedServices(client *node.ControlClient, nmregex string) ([]service.Service, error) {
+	services := []service.Service{}
 	if err := client.GetServices(&empty, &services); err != nil {
 		glog.Errorf("Could not get named services: %v", err)
 		return nil, err
@@ -202,8 +202,8 @@ func getNamedServices(client *node.ControlClient, nmregex string) ([]*service.Se
 	return filterByNameRegex(nmregex, services)
 }
 
-func getServices(client *node.ControlClient) ([]*service.Service, error) {
-	services := []*service.Service{}
+func getServices(client *node.ControlClient) ([]service.Service, error) {
+	services := []service.Service{}
 	if err := client.GetServices(&empty, &services); err != nil {
 		glog.Errorf("Could not get services: %v", err)
 		return nil, err
@@ -213,27 +213,27 @@ func getServices(client *node.ControlClient) ([]*service.Service, error) {
 	return services, nil
 }
 
-func getISVCS() []*service.Service {
-	services := []*service.Service{}
-	services = append(services, &isvcs.InternalServicesISVC)
-	services = append(services, &isvcs.ElasticsearchISVC)
-	services = append(services, &isvcs.ZookeeperISVC)
-	services = append(services, &isvcs.LogstashISVC)
-	services = append(services, &isvcs.OpentsdbISVC)
-	services = append(services, &isvcs.CeleryISVC)
-	services = append(services, &isvcs.DockerRegistryISVC)
+func getISVCS() []service.Service {
+	services := []service.Service{}
+	services = append(services, isvcs.InternalServicesISVC)
+	services = append(services, isvcs.ElasticsearchISVC)
+	services = append(services, isvcs.ZookeeperISVC)
+	services = append(services, isvcs.LogstashISVC)
+	services = append(services, isvcs.OpentsdbISVC)
+	services = append(services, isvcs.CeleryISVC)
+	services = append(services, isvcs.DockerRegistryISVC)
 	return services
 }
 
-func getIRS() []*dao.RunningService {
-	services := []*dao.RunningService{}
-	services = append(services, &isvcs.InternalServicesIRS)
-	services = append(services, &isvcs.ElasticsearchIRS)
-	services = append(services, &isvcs.ZookeeperIRS)
-	services = append(services, &isvcs.LogstashIRS)
-	services = append(services, &isvcs.OpentsdbIRS)
-	services = append(services, &isvcs.CeleryIRS)
-	services = append(services, &isvcs.DockerRegistryIRS)
+func getIRS() []dao.RunningService {
+	services := []dao.RunningService{}
+	services = append(services, isvcs.InternalServicesIRS)
+	services = append(services, isvcs.ElasticsearchIRS)
+	services = append(services, isvcs.ZookeeperIRS)
+	services = append(services, isvcs.LogstashIRS)
+	services = append(services, isvcs.OpentsdbIRS)
+	services = append(services, isvcs.CeleryIRS)
+	services = append(services, isvcs.DockerRegistryIRS)
 	return services
 }
 
@@ -247,7 +247,7 @@ func restGetAllServices(w *rest.ResponseWriter, r *rest.Request, client *node.Co
 		}
 
 		for _, svc := range result {
-			fillBuiltinMetrics(svc)
+			fillBuiltinMetrics(&svc)
 		}
 		w.WriteJson(&result)
 		return
@@ -261,7 +261,7 @@ func restGetAllServices(w *rest.ResponseWriter, r *rest.Request, client *node.Co
 		}
 
 		for _, svc := range result {
-			fillBuiltinMetrics(svc)
+			fillBuiltinMetrics(&svc)
 		}
 		w.WriteJson(&result)
 		return
@@ -275,7 +275,7 @@ func restGetAllServices(w *rest.ResponseWriter, r *rest.Request, client *node.Co
 	}
 
 	for _, svc := range result {
-		fillBuiltinMetrics(svc)
+		fillBuiltinMetrics(&svc)
 	}
 	w.WriteJson(&result)
 }
@@ -286,7 +286,7 @@ func restGetRunningForHost(w *rest.ResponseWriter, r *rest.Request, client *node
 		restBadRequest(w, err)
 		return
 	}
-	var services []*dao.RunningService
+	var services []dao.RunningService
 	err = client.GetRunningServicesForHost(hostID, &services)
 	if err != nil {
 		glog.Errorf("Could not get services: %v", err)
@@ -295,7 +295,7 @@ func restGetRunningForHost(w *rest.ResponseWriter, r *rest.Request, client *node
 	}
 	if services == nil {
 		glog.V(3).Info("Running services was nil, returning empty list instead")
-		services = []*dao.RunningService{}
+		services = []dao.RunningService{}
 	}
 	glog.V(2).Infof("Returning %d running services for host %s", len(services), hostID)
 	w.WriteJson(&services)
@@ -304,30 +304,30 @@ func restGetRunningForHost(w *rest.ResponseWriter, r *rest.Request, client *node
 func restGetRunningForService(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClient) {
 	serviceID, err := url.QueryUnescape(r.PathParam("serviceId"))
 	if strings.Contains(serviceID, "isvc-") {
-		w.WriteJson([]*dao.RunningService{})
+		w.WriteJson([]dao.RunningService{})
 		return
 	}
 	if err != nil {
 		restBadRequest(w, err)
 		return
 	}
-	var services []*dao.RunningService
+	var services []dao.RunningService
 	err = client.GetRunningServicesForService(serviceID, &services)
 	if err != nil {
-		glog.Errorf("Could not get services: %v", err)
+		glog.Errorf("Could not get running services for %s: %v", serviceID, err)
 		restServerError(w, err)
 		return
 	}
 	if services == nil {
 		glog.V(3).Info("Running services was nil, returning empty list instead")
-		services = []*dao.RunningService{}
+		services = []dao.RunningService{}
 	}
 	glog.V(2).Infof("Returning %d running services for service %s", len(services), serviceID)
 	w.WriteJson(&services)
 }
 
 func restGetAllRunning(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClient) {
-	var services []*dao.RunningService
+	var services []dao.RunningService
 	err := client.GetRunningServices(&empty, &services)
 	if err != nil {
 		glog.Errorf("Could not get services: %v", err)
@@ -336,7 +336,7 @@ func restGetAllRunning(w *rest.ResponseWriter, r *rest.Request, client *node.Con
 	}
 	if services == nil {
 		glog.V(3).Info("Services was nil, returning empty list instead")
-		services = []*dao.RunningService{}
+		services = []dao.RunningService{}
 	}
 
 	for _, rsvc := range services {
@@ -380,8 +380,8 @@ func restKillRunning(w *rest.ResponseWriter, r *rest.Request, client *node.Contr
 }
 
 func restGetTopServices(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClient) {
-	var allServices []*service.Service
-	topServices := []*service.Service{}
+	var allServices []service.Service
+	topServices := []service.Service{}
 
 	err := client.GetServices(&empty, &allServices)
 	if err != nil {
@@ -394,7 +394,7 @@ func restGetTopServices(w *rest.ResponseWriter, r *rest.Request, client *node.Co
 			topServices = append(topServices, service)
 		}
 	}
-	topServices = append(topServices, &isvcs.InternalServicesISVC)
+	topServices = append(topServices, isvcs.InternalServicesISVC)
 	glog.V(2).Infof("Returning %d services as top services", len(topServices))
 	w.WriteJson(&topServices)
 }
@@ -411,7 +411,7 @@ func restGetService(w *rest.ResponseWriter, r *rest.Request, client *node.Contro
 		return
 	}
 
-	var allServices []*service.Service
+	var allServices []service.Service
 
 	if err := client.GetServices(&empty, &allServices); err != nil {
 		glog.Errorf("Could not get services: %v", err)
@@ -419,10 +419,10 @@ func restGetService(w *rest.ResponseWriter, r *rest.Request, client *node.Contro
 		return
 	}
 
-	for _, service := range allServices {
-		if service.ID == sid {
-			fillBuiltinMetrics(service)
-			w.WriteJson(&service)
+	for _, svc := range allServices {
+		if svc.ID == sid {
+			fillBuiltinMetrics(&svc)
+			w.WriteJson(&svc)
 			return
 		}
 	}
@@ -752,7 +752,7 @@ func RestBackupFileList(w *rest.ResponseWriter, r *rest.Request, ctx *requestCon
 	for _, backupFileInfo := range backupFiles {
 		if !backupFileInfo.IsDir() {
 			fullPath := hostIP + ":" + filepath.Join(backupDir, backupFileInfo.Name())
-			fileInfo := JsonizableFileInfo{ fullPath, backupFileInfo.Name(), backupFileInfo.Size(), backupFileInfo.Mode(), backupFileInfo.ModTime()}
+			fileInfo := JsonizableFileInfo{fullPath, backupFileInfo.Name(), backupFileInfo.Size(), backupFileInfo.Mode(), backupFileInfo.ModTime()}
 			fileData = append(fileData, fileInfo)
 		}
 	}

--- a/web/virtualhostresource.go
+++ b/web/virtualhostresource.go
@@ -39,7 +39,7 @@ func restAddVirtualHost(w *rest.ResponseWriter, r *rest.Request, client *node.Co
 		return
 	}
 
-	var services []*service.Service
+	var services []service.Service
 	if err := client.GetServices(&empty, &services); err != nil {
 		glog.Errorf("Could not get services: %v", err)
 		restServerError(w, err)
@@ -49,7 +49,7 @@ func restAddVirtualHost(w *rest.ResponseWriter, r *rest.Request, client *node.Co
 	var service *service.Service
 	for _, _service := range services {
 		if _service.ID == request.ServiceID {
-			service = _service
+			service = &_service
 		}
 	}
 
@@ -153,7 +153,7 @@ type virtualHost struct {
 
 // restGetVirtualHosts gets all services, then extracts all vhost information and returns it.
 func restGetVirtualHosts(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClient) {
-	var services []*service.Service
+	var services []service.Service
 	err := client.GetServices(&empty, &services)
 	if err != nil {
 		glog.Errorf("Unexpected error retrieving virtual hosts: %v", err)
@@ -161,7 +161,7 @@ func restGetVirtualHosts(w *rest.ResponseWriter, r *rest.Request, client *node.C
 		return
 	}
 
-	serviceTree := make(map[string]*service.Service)
+	serviceTree := make(map[string]service.Service)
 	for _, service := range services {
 		serviceTree[service.ID] = service
 	}

--- a/zzk/service/running.go
+++ b/zzk/service/running.go
@@ -72,8 +72,8 @@ func LoadRunningService(conn client.Connection, serviceID, ssID string) (*dao.Ru
 }
 
 // LoadRunningServicesByHost returns a slice of RunningServices given a host(s)
-func LoadRunningServicesByHost(conn client.Connection, hostIDs ...string) ([]*dao.RunningService, error) {
-	var rss []*dao.RunningService
+func LoadRunningServicesByHost(conn client.Connection, hostIDs ...string) ([]dao.RunningService, error) {
+	var rss []dao.RunningService
 	for _, hostID := range hostIDs {
 		if exists, err := zzk.PathExists(conn, hostpath(hostID)); err != nil {
 			return nil, err
@@ -96,15 +96,15 @@ func LoadRunningServicesByHost(conn client.Connection, hostIDs ...string) ([]*da
 				return nil, err
 			}
 
-			rss = append(rss, rs)
+			rss = append(rss, *rs)
 		}
 	}
 	return rss, nil
 }
 
 // LoadRunningServicesByService returns a slice of RunningServices per service id(s)
-func LoadRunningServicesByService(conn client.Connection, serviceIDs ...string) ([]*dao.RunningService, error) {
-	var rss []*dao.RunningService
+func LoadRunningServicesByService(conn client.Connection, serviceIDs ...string) ([]dao.RunningService, error) {
+	var rss []dao.RunningService
 	for _, serviceID := range serviceIDs {
 		if exists, err := zzk.PathExists(conn, servicepath(serviceID)); err != nil {
 			return nil, err
@@ -121,18 +121,18 @@ func LoadRunningServicesByService(conn client.Connection, serviceIDs ...string) 
 			if err != nil {
 				return nil, err
 			}
-			rss = append(rss, rs)
+			rss = append(rss, *rs)
 		}
 	}
 	return rss, nil
 }
 
 // LoadRunningServices gets all RunningServices
-func LoadRunningServices(conn client.Connection) ([]*dao.RunningService, error) {
+func LoadRunningServices(conn client.Connection) ([]dao.RunningService, error) {
 	if exists, err := zzk.PathExists(conn, servicepath()); err != nil {
 		return nil, err
 	} else if !exists {
-		return []*dao.RunningService{}, nil
+		return []dao.RunningService{}, nil
 	}
 
 	serviceIDs, err := conn.Children(servicepath())

--- a/zzk/service/service.go
+++ b/zzk/service/service.go
@@ -37,7 +37,7 @@ func servicepath(nodes ...string) string {
 	return path.Join(p...)
 }
 
-type instances []*dao.RunningService
+type instances []dao.RunningService
 
 func (inst instances) Len() int           { return len(inst) }
 func (inst instances) Less(i, j int) bool { return inst[i].InstanceID < inst[j].InstanceID }
@@ -158,7 +158,7 @@ func (l *ServiceListener) Spawn(shutdown <-chan interface{}, serviceID string) {
 	}
 }
 
-func (l *ServiceListener) sync(svc *service.Service, rss []*dao.RunningService) {
+func (l *ServiceListener) sync(svc *service.Service, rss []dao.RunningService) {
 	// only one service can start and stop service instances at a time
 	l.Lock()
 	defer l.Unlock()
@@ -246,7 +246,7 @@ func (l *ServiceListener) start(svc *service.Service, instanceIDs []int) {
 	}
 }
 
-func (l *ServiceListener) stop(rss []*dao.RunningService) {
+func (l *ServiceListener) stop(rss []dao.RunningService) {
 	for _, state := range rss {
 		if err := StopServiceInstance(l.conn, state.HostID, state.ID); err != nil {
 			glog.Warningf("Service instance %s (%s) from service %s won't die: %s", state.ID, state.Name, state.ServiceID, err)
@@ -256,7 +256,7 @@ func (l *ServiceListener) stop(rss []*dao.RunningService) {
 	}
 }
 
-func (l *ServiceListener) pause(rss []*dao.RunningService) {
+func (l *ServiceListener) pause(rss []dao.RunningService) {
 	for _, state := range rss {
 		// pauseInstance updates the service state ONLY if it has a RUN DesiredState
 		if err := pauseInstance(l.conn, state.HostID, state.ID); err != nil {
@@ -294,10 +294,10 @@ func StopService(conn client.Connection, serviceID string) error {
 }
 
 // SyncServices synchronizes all services into zookeeper
-func SyncServices(conn client.Connection, services []*service.Service) error {
+func SyncServices(conn client.Connection, services []service.Service) error {
 	nodes := make([]zzk.Node, len(services))
 	for i := range services {
-		nodes[i] = &ServiceNode{Service: services[i]}
+		nodes[i] = &ServiceNode{Service: &services[i]}
 	}
 	return zzk.Sync(conn, nodes, servicepath())
 }

--- a/zzk/service/servicestate_test.go
+++ b/zzk/service/servicestate_test.go
@@ -91,12 +91,12 @@ func TestGetServiceStatus(t *testing.T) {
 	}
 
 	// Verify
-	for state, status := range statusmap {
-		expect, ok := expected[state.ID]
+	for _, svcstatus := range statusmap {
+		expect, ok := expected[svcstatus.State.ID]
 		if !ok {
-			t.Fatalf("Missing service state %s", state.ID)
-		} else if expect != status {
-			t.Errorf("MISMATCH: expected %s; actual %s", expect, status)
+			t.Fatalf("Missing service state %s", svcstatus.State.ID)
+		} else if expect != svcstatus.Status {
+			t.Errorf("MISMATCH: expected %s; actual %s", expect, svcstatus.Status)
 		}
 	}
 
@@ -118,12 +118,12 @@ func TestGetServiceStatus(t *testing.T) {
 	}
 
 	// Verify
-	for state, status := range statusmap {
-		expect, ok := expected[state.ID]
+	for _, svcstatus := range statusmap {
+		expect, ok := expected[svcstatus.State.ID]
 		if !ok {
-			t.Fatalf("Missing service state %s", state.ID)
-		} else if expect != status {
-			t.Errorf("MISMATCH: expected %s; actual %s", expect, status)
+			t.Fatalf("Missing service state %s", svcstatus.State.ID)
+		} else if expect != svcstatus.Status {
+			t.Errorf("MISMATCH: expected %s; actual %s", expect, svcstatus.Status)
 		}
 	}
 
@@ -145,12 +145,12 @@ func TestGetServiceStatus(t *testing.T) {
 	}
 
 	// Verify
-	for state, status := range statusmap {
-		expect, ok := expected[state.ID]
+	for _, svcstatus := range statusmap {
+		expect, ok := expected[svcstatus.State.ID]
 		if !ok {
-			t.Fatalf("Missing service state %s", state.ID)
-		} else if expect != status {
-			t.Errorf("MISMATCH: expected %s; actual %s", expect, status)
+			t.Fatalf("Missing service state %s", svcstatus.State.ID)
+		} else if expect != svcstatus.Status {
+			t.Errorf("MISMATCH: expected %s; actual %s", expect, svcstatus.Status)
 		}
 	}
 


### PR DESCRIPTION
history of commits: https://github.com/control-center/serviced/pull/979

DEMO1 - serviced service status doesn't hang:

```
# plu@plu-9: serviced service status
NAME            ID              STATUS      UPTIME          HOST    DOCKER_ID   IN_SYNC
└─Zenoss.core       5oqhbuu2g7734dadb4j1xmdze   Running     5m14.690632782s     plu-9   2ac909878430    Y
  ├─RabbitMQ        1b2g527m5h1qy0lqdyxom8nn0   Running     4m33.680346504s     plu-9   064541ca058f    Y
  ├─MetricConsumer  1ry2dp2af11drttik5ksda561   Running     5m10.340320653s     plu-9   8cd10e6f4cf5    Y
  ├─MetricShipper   1sckrkoyyvf26uir6yb46ugyw   Running     5m10.427868083s     plu-9   68cbfb7a1470    Y
  ├─opentsdb        38vw89uzmz9paell3x394wiy7   Running     5m14.409395421s     plu-9   0459b6d30dfe    Y
  ├─zenjobs     49itsk05ihb1jfmbldxzoz6z4   Running     4m49.568641438s     plu-9   ab94b4f3bb4f    Y
  ├─MySQL       4evjy9vothpketh03siciowyz   Running     4m39.841022501s     plu-9   c0b7c0f0a7de    Y
  ├─CentralQuery    6634ujiheixdnfxusd5hoby5q   Running     5m10.355504057s     plu-9   8096ca7820ae    Y
  ├─redis       6rzqw7zb9sag0xlxq8164m6h2   Running     5m10.35120267s      plu-9   cb53c930eaf6    Y
  ├─zeneventd       8ctr947glgwh0js5we7rusdba   Running     5m10.376967652s     plu-9   4eaacafdb70a    Y
  ├─zeneventserver  9k1jn2ykhhaa8y8gt3vubxts    Running     4m48.661208663s     plu-9   d0b07f846719    Y
  ├─localhost       akwov4pokpc01tl27eqkvsvi6                                   
  │ ├─localhost       130x826p33fwvftf5t15i4ur1                                   
  │ │ ├─zenperfsnmp 18flvv1nzbz75b72ghkklrt4q   Running     5m12.500796656s     plu-9   668a1c155a7a    Y
  │ │ ├─zensyslog   1wy0an8onlrism9wcbz51z0y5   Running     5m9.913284523s      plu-9   38b413515da2    Y
  │ │ ├─zenstatus   2zjfn3h3vgf4xe78e6ddw2097   Running     5m10.181848258s     plu-9   e7584731296b    Y
  │ │ ├─zminion     6rqklzt2fibhmiln54dtddgyc   Running     5m10.219182243s     plu-9   5a2af17eaa0d    Y
  │ │ ├─zencommand  7u3eaba8q11u4m43hnqa6bce7   Running     5m12.509396516s     plu-9   3e1560166af3    Y
  │ │ ├─MetricShipper   82nkz53zxoib6sl9qnlnmdplp   Running     5m10.212899493s     plu-9   f8809de629a6    Y
  │ │ ├─zenmodeler  b44gui15je2ls4f8nfhtkesvg   Running     5m13.4504367s       plu-9   4c0ca129f62c    Y
  │ │ ├─zenjmx      bh5x7cgncrefn3xsqgb7kfxlg   Running     5m12.610698886s     plu-9   82c35d9deec5    Y
  │ │ ├─collectorredis  bvto9k1qgr1ur3s4fkrybrivo   Running     5m12.406867135s     plu-9   5b87f78e3870    Y
  │ │ ├─zenprocess  bxhcan4vz5p4s0p5gomaindne   Running     5m12.556727039s     plu-9   453afc11e7ab    Y
  │ │ ├─zenpython   e4u3okukqikuidqepr52wqrot   Running     5m12.413598723s     plu-9   651c4bed496a    Y
  │ │ ├─zentrap     ew26u0qdgk94jkdyznkmidpe8   Running     5m10.417902595s     plu-9   1b0c4275eca4    Y
  │ │ └─zenping     f0ker8fnkn7vzf7nciiduspum   Running     5m13.433657616s     plu-9   54e284716a48    Y
  │ └─zenhub      67g74qjml4hwc4bf9cgrom0h1   Running     5m10.345948979s     plu-9   79212db60ac1    Y
  ├─HBase       az3db511rh7vf3wasanwtixs9                                   
  │ ├─RegionServer    18cc33mqirxien0p1rlp4h4ml   Running     5m5.19056566s       plu-9   3a67752f78cb    Y
  │ ├─HMaster     745k1v6xdl2qp4lv8du55x46z   Running     4m59.16334598s      plu-9   33726f302c36    Y
  │ └─ZooKeeper       7zir7343thhyonjyoui17dgtw   Running     4m52.727296242s     plu-9   536ebadfdc45    Y
  ├─zenactiond      e3ar7sxsd58jcyrkvdzyybkq    Running     5m10.365700139s     plu-9   33183fa61d6f    Y
  └─Zope        el1h82ddxl6rutah1rd1hkp1w   Running     5m9.733642511s      plu-9   f58803c45d26    Y
```
