### PR TITLE
changed Service.Context to natural representation (map[string]interface{}) from current json encoded string

### DIFF
--- a/container/logstash_test.go
+++ b/container/logstash_test.go
@@ -18,10 +18,10 @@
 package container
 
 import (
-	"github.com/zenoss/glog"
 	"github.com/control-center/serviced/domain"
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/domain/servicedefinition"
+	"github.com/zenoss/glog"
 
 	"encoding/json"
 	"io/ioutil"
@@ -35,7 +35,7 @@ func getTestService() service.Service {
 	return service.Service{
 		ID:              "0",
 		Name:            "Zenoss",
-		Context:         "",
+		Context:         nil,
 		Startup:         "",
 		Description:     "Zenoss 5.x",
 		Instances:       0,
@@ -149,7 +149,7 @@ func TestDontWriteToNilMap(t *testing.T) {
 	service := service.Service{
 		ID:              "0",
 		Name:            "Zenoss",
-		Context:         "",
+		Context:         nil,
 		Startup:         "",
 		Description:     "Zenoss 5.x",
 		Instances:       0,

--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -14,9 +14,9 @@
 package service
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -40,7 +40,7 @@ type Service struct {
 	ID                string
 	Name              string
 	Version           string
-	Context           string
+	Context           map[string]interface{}
 	Startup           string
 	Description       string
 	Tags              []string
@@ -118,18 +118,13 @@ func BuildService(sd servicedefinition.ServiceDefinition, parentServiceID string
 		return nil, err
 	}
 
-	ctx, err := json.Marshal(sd.Context)
-	if err != nil {
-		return nil, err
-	}
-
 	now := time.Now()
 
 	svc := Service{}
 	svc.ID = svcuuid
 	svc.Name = sd.Name
 	svc.Version = sd.Version
-	svc.Context = string(ctx)
+	svc.Context = sd.Context
 	svc.Startup = sd.Command
 	svc.Description = sd.Description
 	svc.Tags = sd.Tags
@@ -345,7 +340,7 @@ func (s *Service) Equals(b *Service) bool {
 	if s.Version != b.Version {
 		return false
 	}
-	if s.Context != b.Context {
+	if !reflect.DeepEqual(s.Context, b.Context) {
 		return false
 	}
 	if s.Startup != b.Startup {

--- a/domain/service/serviceeval_test.go
+++ b/domain/service/serviceeval_test.go
@@ -38,7 +38,7 @@ var startup_testcases = []struct {
 	{Service{
 		ID:              "0",
 		Name:            "Zenoss",
-		Context:         "",
+		Context:         nil,
 		Startup:         "",
 		Description:     "Zenoss 5.x",
 		Instances:       0,
@@ -80,7 +80,7 @@ var startup_testcases = []struct {
 	{Service{
 		ID:              "1",
 		Name:            "Collector",
-		Context:         "{\"RemoteHost\":\"a_hostname\"}",
+		Context:         map[string]interface{}{"RemoteHost": "a_hostname"},
 		Startup:         "",
 		Description:     "",
 		Instances:       0,
@@ -100,7 +100,7 @@ var startup_testcases = []struct {
 	{Service{
 		ID:              "2",
 		Name:            "pinger",
-		Context:         "{\"Count\": 32}",
+		Context:         map[string]interface{}{"Count": 32},
 		Startup:         "/usr/bin/ping -c {{(context .).Count}} {{(context (parent .)).RemoteHost}}",
 		Description:     "Ping a remote host a fixed number of times",
 		Instances:       1,
@@ -119,7 +119,7 @@ var startup_testcases = []struct {
 	{Service{
 		ID:              "3",
 		Name:            "/bin/sh",
-		Context:         "",
+		Context:         nil,
 		Startup:         "{{.Name}} ls -l .",
 		Description:     "Execute ls -l on .",
 		Instances:       1,
@@ -144,7 +144,7 @@ var endpoint_testcases = []struct {
 	{Service{
 		ID:              "100",
 		Name:            "Zenoss",
-		Context:         "{\"RemoteHost\":\"hostname\"}",
+		Context:         map[string]interface{}{"RemoteHost": "hostname"},
 		Startup:         "",
 		Description:     "Zenoss 5.x",
 		Instances:       0,
@@ -161,7 +161,7 @@ var endpoint_testcases = []struct {
 	{Service{
 		ID:             "101",
 		Name:           "Collector",
-		Context:        "",
+		Context:        nil,
 		Startup:        "",
 		Description:    "",
 		Instances:      0,
@@ -186,58 +186,58 @@ var endpoint_testcases = []struct {
 	}, "hostname_collector"},
 }
 
-var context_testcases = []Service {
+var context_testcases = []Service{
 	{
-		ID: "200",
-		Name: "200",
-		PoolID: "default",
-		Launch: "manual",
-		Context: `{"A": "a_200", "B": "b_200", "g.w":"W"}`,
+		ID:      "200",
+		Name:    "200",
+		PoolID:  "default",
+		Launch:  "manual",
+		Context: map[string]interface{}{"A": "a_200", "B": "b_200", "g.w": "W"},
 	},
 	{
-		ID: "201",
-		Name: "201",
-		PoolID: "default",
-		Launch: "manual",
-		Context: `{"A": "a_201", "C": "c_201"}`,
+		ID:              "201",
+		Name:            "201",
+		PoolID:          "default",
+		Launch:          "manual",
+		Context:         map[string]interface{}{"A": "a_201", "C": "c_201"},
 		ParentServiceID: "200",
 		ConfigFiles: map[string]servicedefinition.ConfigFile{
 			"inherited": servicedefinition.ConfigFile{
 				// We store the expected value in the Owner field
 				// Note that B comes from the parent context
-				Owner: `a_201, b_200, c_201`,
-				Content:`{{(context .).A}}, {{(context .).B}}, {{(context .).C}}`,
+				Owner:   `a_201, b_200, c_201`,
+				Content: `{{(context .).A}}, {{(context .).B}}, {{(context .).C}}`,
 			},
 		},
 	},
 	{
-		ID: "202",
-		Name: "202",
-		PoolID: "default",
-		Launch: "manual",
-		Context: `{"g.y": "Y", "g.x": "X", "g.z": "Z", "foo": "bar"}`,
+		ID:              "202",
+		Name:            "202",
+		PoolID:          "default",
+		Launch:          "manual",
+		Context:         map[string]interface{}{"g.y": "Y", "g.x": "X", "g.z": "Z", "foo": "bar"},
 		ParentServiceID: "200",
 		ConfigFiles: map[string]servicedefinition.ConfigFile{
-			"range": servicedefinition.ConfigFile {
+			"range": servicedefinition.ConfigFile{
 				// We store the expected value in the Owner field
 				// Note the keys are filtered, trimmed and sorted
-				Owner: `w:W, x:X, y:Y, z:Z, `,
-				Content:`{{range $key,$val:=contextFilter . "g."}}{{$key}}:{{$val}}, {{end}}`,
+				Owner:   `w:W, x:X, y:Y, z:Z, `,
+				Content: `{{range $key,$val:=contextFilter . "g."}}{{$key}}:{{$val}}, {{end}}`,
 			},
 		},
 	},
 	{
-		ID: "203",
-		Name: "203",
-		PoolID: "default",
-		Launch: "manual",
-		Context: `{"foo.bar-baz": "qux"}`,
+		ID:              "203",
+		Name:            "203",
+		PoolID:          "default",
+		Launch:          "manual",
+		Context:         map[string]interface{}{"foo.bar-baz": "qux"},
 		ParentServiceID: "200",
 		ConfigFiles: map[string]servicedefinition.ConfigFile{
-			"range": servicedefinition.ConfigFile {
+			"range": servicedefinition.ConfigFile{
 				// We store the expected value in the Owner field
-				Owner: `qux!`,
-				Content:`{{(contextFilter . "foo.bar-").baz}}!`,
+				Owner:   `qux!`,
+				Content: `{{(contextFilter . "foo.bar-").baz}}!`,
 			},
 		},
 	},
@@ -259,10 +259,10 @@ func createSvcs(store *Store, ctx datastore.Context) error {
 	return nil
 }
 
-func createContextSvcs (store *Store, ctx datastore.Context) error {
+func createContextSvcs(store *Store, ctx datastore.Context) error {
 	for _, testcase := range context_testcases {
 		if err := store.Put(ctx, &testcase); err != nil {
-				return err
+			return err
 		}
 	}
 	return nil
@@ -423,7 +423,7 @@ func (s *S) TestIncompleteStartupInjection(t *C) {
 	svc := Service{
 		ID:              "1000",
 		Name:            "pinger",
-		Context:         "{\"RemoteHost\": \"zenoss.com\"}",
+		Context:         map[string]interface{}{"RemoteHost": "zenoss.com"},
 		Startup:         "/usr/bin/ping -c {{(context .).Count}} {{(context .).RemoteHost}}",
 		Description:     "Ping a remote host a fixed number of times",
 		Instances:       1,

--- a/domain/service/servicemapping.go
+++ b/domain/service/servicemapping.go
@@ -14,8 +14,8 @@
 package service
 
 import (
-	"github.com/zenoss/glog"
 	"github.com/control-center/serviced/datastore/elastic"
+	"github.com/zenoss/glog"
 )
 
 var (
@@ -26,7 +26,7 @@ var (
 		"ID" :             {"type": "string", "index":"not_analyzed"},
 		"Name":            {"type": "string", "index":"not_analyzed"},
 		"Startup":         {"type": "string", "index":"not_analyzed"},
-		"Context":         {"type": "string", "index":"not_analyzed"},
+		"Context":         {"type": "object", "index":"not_analyzed"},
 		"Description":     {"type": "string", "index":"not_analyzed"},
 		"DeploymentID":    {"type": "string", "index":"not_analyzed"},
 		"Tags":            {"type": "string", "index_name": "tag"},

--- a/isvcs/resources/controlplane.json
+++ b/isvcs/resources/controlplane.json
@@ -33,7 +33,7 @@
         "Id" :             {"type": "string", "index":"not_analyzed"},
         "Name":            {"type": "string", "index":"not_analyzed"},
         "Startup":         {"type": "string", "index":"not_analyzed"},
-        "Context":         {"type": "string", "index":"not_analyzed"},
+        "Context":         {"type": "object", "index":"not_analyzed"},
         "Description":     {"type": "string", "index":"not_analyzed"},
         "Tags":            {"type": "string", "index_name": "tag"},
         "Instances":       {"type": "long", "index":"not_analyzed"},


### PR DESCRIPTION
DEMO:

```
# plu@plu-9: serviced service list
NAME            SERVICEID           INST    IMAGEID             POOL        DSTATE  LAUNCH  DEPID
└─Zenoss.core       km1s0tlq14przd0fv313w8eh    1   .../km1s0tl.../devimg       default     0   auto    HBase
  ├─opentsdb        1jiuf7m2yax4gut4cqppdm60f   1   .../km1s0tl.../opentsdb     default     0   auto    HBase
  ├─HBase       290dkqdoby2bbu2zitfn35o3o   0                   default     0   auto    HBase
  │ ├─RegionServer    1i3qodf20alqc7e8nf13bump4   1   .../km1s0tl.../hbase        default     0   auto    HBase
  │ ├─HMaster     bhup7eagafb0cw2st4hs6cklx   1   .../km1s0tl.../hbase        default     0   auto    HBase
  │ └─ZooKeeper       d6xxx4586zrb7nsfrcglv2bfv   1   .../km1s0tl.../hbase        default     0   auto    HBase
  ├─zeneventd       2ndrw69x431nk41tccon48dbk   1   .../km1s0tl.../devimg       default     0   auto    HBase
  ├─RabbitMQ        2rdg4ud9jeieslwxbz09a0kc1   1   .../km1s0tl.../devimg       default     0   auto    HBase
  ├─localhost       3ujh0nds5njxgqc5yg48dpugr   0                   default     0   auto    HBase
  │ ├─zenhub      4rj8x7lvzujr5pletv15anc3g   1   .../km1s0tl.../devimg       default     0   auto    HBase
  │ └─localhost       asb9mktaz21iegqgb4e4ecna7   0                   default     0   auto    HBase
  │   ├─zenpython 1zjz48p0va95hcv33fr2m6mth   1   .../km1s0tl.../devimg       default     0   auto    HBase
  │   ├─zencommand    245jbp6hpift1t5hk8pq92mji   1   .../km1s0tl.../devimg       default     0   auto    HBase
  │   ├─zenjmx        3ytpwiyv8hf6mzr4brpzv1f7h   1   .../km1s0tl.../devimg       default     0   auto    HBase
  │   ├─zenping       4gi08e28vv08fqrshm611d2eq   1   .../km1s0tl.../devimg       default     0   auto    HBase
  │   ├─zenperfsnmp   4np1j0zvnz7slz8e5cecuylh4   1   .../km1s0tl.../devimg       default     0   auto    HBase
  │   ├─zentrap       56yg11tqacn53gfl9iqo1cvmz   1   .../km1s0tl.../devimg       default     0   auto    HBase
  │   ├─zensyslog 6ukrysgm02295akrc7ggps6xp   1   .../km1s0tl.../devimg       default     0   auto    HBase
  │   ├─collectorredis    777jgw2j4jaf2kzc73yv4psjy   1   .../km1s0tl.../devimg       default     0   auto    HBase
  │   ├─MetricShipper 9d1wg4ynx091xsz28a56yve3i   1   .../km1s0tl.../devimg       default     0   auto    HBase
  │   ├─zenstatus agqu1vg87bw787fhn6ratlu5n   1   .../km1s0tl.../devimg       default     0   auto    HBase
  │   ├─zenprocess    b4fkeju9d81p1kxtnaxkcywnd   1   .../km1s0tl.../devimg       default     0   auto    HBase
  │   ├─zminion       c9p7zoz43lbxxgxx9729v9us9   1   .../km1s0tl.../devimg       default     0   auto    HBase
  │   └─zenmodeler    cpa7nuoiupsdoubjaziibsmo5   1   .../km1s0tl.../devimg       default     0   auto    HBase
  ├─MetricConsumer  8fziji25znbpcxl9uz3ardx9    1   .../km1s0tl.../devimg       default     0   auto    HBase
  ├─MySQL       8lvfdqx0q1kgibtmj5va5mr9    1   .../km1s0tl.../devimg       default     0   auto    HBase
  ├─zenactiond      9kk17nu6saddf1igf28vbjzgh   1   .../km1s0tl.../devimg       default     0   auto    HBase
  ├─Zope        9q0ip1vmdk63e12ur4biw4aum   1   .../km1s0tl.../devimg       default     0   auto    HBase
  ├─redis       9rn717b6wtezay5af252cwibv   1   .../km1s0tl.../devimg       default     0   auto    HBase
  ├─zeneventserver  9y8wky3cn4incc9uo2b3h0e2y   1   .../km1s0tl.../devimg       default     0   auto    HBase
  ├─zenjobs     dq7aozjlo4uhnubzfcdbsoz7u   1   .../km1s0tl.../devimg       default     0   auto    HBase
  ├─MetricShipper   eimy5hxxovzrbneup0siz0wn8   1   .../km1s0tl.../devimg       default     0   auto    HBase

```
