### PR TITLE
fixed dynamic endpoints port calculation

### DIFF
--- a/container/endpoint.go
+++ b/container/endpoint.go
@@ -519,7 +519,7 @@ func (c *Controller) setProxyAddresses(tenantEndpointID string, endpoints []dao.
 	} else if purpose == "import_all" {
 		// Need to create a proxy per instance of the service whose endpoint is
 		// being imported
-		for _, instance := range endpoints {
+		for ii, instance := range endpoints {
 			// Port for this instance is base port + instanceID
 			containerPort := instance.ContainerPort + uint16(instance.InstanceID)
 			if _, conflict := exported[containerPort]; conflict {
@@ -527,7 +527,7 @@ func (c *Controller) setProxyAddresses(tenantEndpointID string, endpoints []dao.
 				continue
 			}
 			proxyKeys[instance.InstanceID] = fmt.Sprintf("%s_%d", tenantEndpointID, instance.InstanceID)
-			instance.ContainerPort = containerPort
+			endpoints[ii].ContainerPort = containerPort
 		}
 	}
 


### PR DESCRIPTION
Due to:
https://github.com/control-center/serviced/pull/984

DEMO:

```
# plu@plu-9: docker logs -f $(serviced service status | awk '/HMaster/{print $(NF-1)}') 2>&1 | grep zookeeper-client
I0910 05:29:21.745367 00001 endpoint.go:305]   cached imported endpoint[5jvx1zcjddcv7wc92ooxu382j_zookeeper-client]: {endpointID:zookeeper-client instanceID:0 virtualAddress:zk{{ plus 1 .InstanceID }}:2181 purpose:import_all port:2181}
I0910 05:29:21.758032 00001 endpoint.go:471] starting setProxyAddresses(tenantEndpointID: 5jvx1zcjddcv7wc92ooxu382j_zookeeper-client, purpose: import_all)
I0910 05:29:21.758060 00001 endpoint.go:474] starting setProxyAddresses(tenantEndpointID: 5jvx1zcjddcv7wc92ooxu382j_zookeeper-client) locked
I0910 05:29:21.758087 00001 endpoint.go:578] Attempting port map for: 5jvx1zcjddcv7wc92ooxu382j_zookeeper-client_1 -> {ServiceID:ezglehne4mu2mm92ha8n7yyoy Application:zookeeper-client ContainerPort:2182 HostPort:49610 HostIP:172.17.42.1 ContainerIP:172.17.3.92 Protocol:tcp VirtualAddress: InstanceID:1}
I0910 05:29:21.758169 00001 endpoint.go:596] Success binding port: 5jvx1zcjddcv7wc92ooxu382j_zookeeper-client_1 -> proxy[{ezglehne4mu2mm92ha8n7yyoy zookeeper-client 2182 49610 172.17.42.1 172.17.3.92 tcp  1}; &{%!s(*net.netFD=&{{0 0 0} 13 2 1 false tcp4 0xc2080beb40 ?reflect.Value? {140622279039992}})}]=>[]
I0910 05:29:21.805366 00001 endpoint.go:578] Attempting port map for: 5jvx1zcjddcv7wc92ooxu382j_zookeeper-client_2 -> {ServiceID:ezglehne4mu2mm92ha8n7yyoy Application:zookeeper-client ContainerPort:2183 HostPort:49611 HostIP:172.17.42.1 ContainerIP:172.17.3.95 Protocol:tcp VirtualAddress: InstanceID:2}
I0910 05:29:21.805492 00001 endpoint.go:596] Success binding port: 5jvx1zcjddcv7wc92ooxu382j_zookeeper-client_2 -> proxy[{ezglehne4mu2mm92ha8n7yyoy zookeeper-client 2183 49611 172.17.42.1 172.17.3.95 tcp  2}; &{%!s(*net.netFD=&{{0 0 0} 12 2 1 false tcp4 0xc2080b21b0 ?reflect.Value? {140622279041400}})}]=>[]
I0910 05:29:21.823854 00001 endpoint.go:578] Attempting port map for: 5jvx1zcjddcv7wc92ooxu382j_zookeeper-client_0 -> {ServiceID:ezglehne4mu2mm92ha8n7yyoy Application:zookeeper-client ContainerPort:2181 HostPort:49605 HostIP:172.17.42.1 ContainerIP:172.17.3.90 Protocol:tcp VirtualAddress: InstanceID:0}
I0910 05:29:21.823984 00001 endpoint.go:596] Success binding port: 5jvx1zcjddcv7wc92ooxu382j_zookeeper-client_0 -> proxy[{ezglehne4mu2mm92ha8n7yyoy zookeeper-client 2181 49605 172.17.42.1 172.17.3.90 tcp  0}; &{%!s(*net.netFD=&{{0 0 0} 14 2 1 false tcp4 0xc20809a630 ?reflect.Value? {140622279039640}})}]=>[]

```
