### PR TITLE
cleanup /tmp/serviced-root/var correctly before startup

### DIFF
--- a/smoke.sh
+++ b/smoke.sh
@@ -57,7 +57,8 @@ add_to_etc_hosts() {
 cleanup() {
     sudo pkill -9 serviced
     docker kill $(docker ps -q)
-    sudo rm -rf /tmp/serviced-root/var/isvcs/*
+    sudo rm -rf /tmp/serviced-root/var
+    sudo tree -L 2 /tmp/serviced-root
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
ISSUE - we have no perms to read /tmp/serviced-root/var/isvcs/ so nothing is removed:

```
# plu@plu-9: ls -ld /tmp/serviced-root/
drwxr-x--- 2 root root 4096 Sep 10 08:56 /tmp/serviced-root/

# plu@plu-9: sudo rm -fr /tmp/serviced-root/var/isvcs/*

# plu@plu-9: sudo tree -L 2 /tmp/serviced-root/
/tmp/serviced-root/
└── var
    ├── isvcs
    └── volumes
3 directories, 0 files

# plu@plu-9: sudo rm -rf /tmp/serviced-root/var

# plu@plu-9: sudo tree -L 2 /tmp/serviced-root/
/tmp/serviced-root/
0 directories, 0 files
```

DEMO:

```
# plu@plu-9: make smoketest
cd isvcs && make
...
===== SUCCESS =====
Service shell ran successfully
===================
b77c6bdcafb2
d1a4ce88f175
ef655f76a310
a3b6fad0df98
ce55a2b8a0e2
91ba060dc301
26c71aac14d4
/tmp/serviced-root

0 directories, 0 files

```
