### PR TITLE
fixes CC-94

### DIFF
--- a/cli/api/service.go
+++ b/cli/api/service.go
@@ -66,7 +66,8 @@ func (a *api) GetServices() ([]service.Service, error) {
 	}
 
 	var services []service.Service
-	if err := client.GetServices(&empty, &services); err != nil {
+	var serviceRequest dao.ServiceRequest
+	if err := client.GetServices(serviceRequest, &services); err != nil {
 		return nil, err
 	}
 

--- a/dao/elasticsearch/backup.go
+++ b/dao/elasticsearch/backup.go
@@ -510,7 +510,7 @@ func (cp *ControlPlaneDao) Backup(backupsDirectory string, backupFilePath *strin
 	}
 
 	// Retrieve all service definitions
-	var request dao.EntityRequest
+	var request dao.ServiceRequest
 	if e := cp.GetServices(request, &services); e != nil {
 		glog.Errorf("Could not get services: %v", e)
 		backupError <- e.Error()

--- a/dao/elasticsearch/backup_test.go
+++ b/dao/elasticsearch/backup_test.go
@@ -320,7 +320,7 @@ func (dt *DaoTest) TestBackup_IntegrationTest(t *C) {
 	t.Skip("TODO: Fix this broken test. Maybe a race condition?")
 	var (
 		unused         int
-		request        dao.EntityRequest
+		request        dao.ServiceRequest
 		templateId     string
 		serviceId      string
 		backupFilePath string

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -289,7 +289,8 @@ func (dt *DaoTest) TestDao_GetServices(t *C) {
 	t.Assert(err, IsNil)
 
 	var result []service.Service
-	err = dt.Dao.GetServices(new(dao.EntityRequest), &result)
+	var serviceRequest dao.ServiceRequest
+	err = dt.Dao.GetServices(serviceRequest, &result)
 	t.Assert(err, IsNil)
 	t.Assert(len(result), Equals, 1)
 	//XXX the time.Time types fail comparison despite being equal...
@@ -360,15 +361,14 @@ func (dt *DaoTest) TestStoppingParentStopsChildren(t *C) {
 		glog.Fatalf("Unable to stop parent service: %+v, %s", svc, err)
 	}
 	// verify the children have all stopped
-	query := fmt.Sprintf("ParentServiceID:%s AND NOT Launch:manual", id)
 	var services []service.Service
-	err = dt.Dao.GetServices(query, &services)
+	var serviceRequest dao.ServiceRequest
+	err = dt.Dao.GetServices(serviceRequest, &services)
 	for _, subService := range services {
 		if subService.DesiredState == service.SVCRun && subService.ParentServiceID == id {
 			t.Errorf("Was expecting child services to be stopped %v", subService)
 		}
 	}
-
 }
 
 func (dt *DaoTest) TestDao_StartService(t *C) {

--- a/dao/elasticsearch/service.go
+++ b/dao/elasticsearch/service.go
@@ -46,24 +46,18 @@ func (this *ControlPlaneDao) RemoveService(id string, unused *int) error {
 
 //
 func (this *ControlPlaneDao) GetService(id string, myService *service.Service) error {
-	*myService = service.Service{}
 	if svc, err := this.facade.GetService(datastore.Get(), id); err == nil {
-		if svc != nil {
-			*myService = *svc
-		}
+		*myService = *svc
 		return nil
 	} else {
 		return err
 	}
 }
 
-// TODO FIXME no need for the request argument
-func (this *ControlPlaneDao) GetServices(request dao.EntityRequest, services *[]service.Service) error {
-	*services = make([]service.Service, 0)
-	if svcs, err := this.facade.GetServices(datastore.Get()); err == nil {
-		if svcs != nil {
-			*services = svcs
-		}
+// Get the services (can filter by name and/or tenantID)
+func (this *ControlPlaneDao) GetServices(request dao.ServiceRequest, services *[]service.Service) error {
+	if svcs, err := this.facade.GetServices(datastore.Get(), request); err == nil {
+		*services = svcs
 		return nil
 	} else {
 		return err
@@ -71,25 +65,19 @@ func (this *ControlPlaneDao) GetServices(request dao.EntityRequest, services *[]
 }
 
 //
-func (this *ControlPlaneDao) FindChildService(request dao.FindChildRequest, myService *service.Service) error {
-	*myService = service.Service{}
+func (this *ControlPlaneDao) FindChildService(request dao.FindChildRequest, service *service.Service) error {
 	if svc, err := this.facade.FindChildService(datastore.Get(), request.ServiceID, request.ChildName); err == nil {
-		if svc != nil {
-			*myService = *svc
-		}
+		*service = *svc
 		return nil
 	} else {
 		return err
 	}
 }
 
-//
-func (this *ControlPlaneDao) GetTaggedServices(request dao.EntityRequest, services *[]service.Service) error {
-	*services = make([]service.Service, 0)
+// Get tagged services (can also filter by name and/or tenantID)
+func (this *ControlPlaneDao) GetTaggedServices(request dao.ServiceRequest, services *[]service.Service) error {
 	if svcs, err := this.facade.GetTaggedServices(datastore.Get(), request); err == nil {
-		if svcs != nil {
-			*services = svcs
-		}
+		*services = svcs
 		return nil
 	} else {
 		return err
@@ -108,11 +96,8 @@ func (this *ControlPlaneDao) GetTenantId(serviceID string, tenantId *string) err
 
 // Get a service endpoint.
 func (this *ControlPlaneDao) GetServiceEndpoints(serviceID string, response *map[string][]dao.ApplicationEndpoint) (err error) {
-	*response = make(map[string][]dao.ApplicationEndpoint, 0)
 	if result, err := this.facade.GetServiceEndpoints(datastore.Get(), serviceID); err == nil {
-		if response != nil {
-			*response = result
-		}
+		*response = result
 		return nil
 	} else {
 		return err

--- a/dao/interface.go
+++ b/dao/interface.go
@@ -36,6 +36,12 @@ func (s ControlPlaneError) Error() string {
 // An request for a control plane object.
 type EntityRequest interface{}
 
+type ServiceRequest struct {
+	Tags      []string
+	TenantID  string
+	NameRegex string
+}
+
 type ServiceStateRequest struct {
 	ServiceID      string
 	ServiceStateID string
@@ -82,13 +88,13 @@ type ControlPlane interface {
 	GetService(serviceId string, service *service.Service) error
 
 	// Get a list of services from serviced
-	GetServices(request EntityRequest, services *[]service.Service) error
+	GetServices(request ServiceRequest, services *[]service.Service) error
 
 	// Find a child service with the given name
 	FindChildService(request FindChildRequest, service *service.Service) error
 
 	// Get services with the given tag(s)
-	GetTaggedServices(request EntityRequest, services *[]service.Service) error
+	GetTaggedServices(request ServiceRequest, services *[]service.Service) error
 
 	// Find all service endpoint matches
 	GetServiceEndpoints(serviceId string, response *map[string][]ApplicationEndpoint) error

--- a/dfs/dfs.go
+++ b/dfs/dfs.go
@@ -111,7 +111,8 @@ func (d *DistributedFileSystem) Snapshot(tenantId string) (string, error) {
 	}
 
 	var servicesList []service.Service
-	if err := d.client.GetServices(unused, &servicesList); err != nil {
+	var unusedServiceRequest dao.ServiceRequest
+	if err := d.client.GetServices(unusedServiceRequest, &servicesList); err != nil {
 		glog.V(2).Infof("DistributedFileSystem.Snapshot service=%+v err=%s", myService.ID, err)
 		return "", err
 	}
@@ -376,7 +377,8 @@ func (d *DistributedFileSystem) Rollback(snapshotId string) error {
 
 	// Fail if any services have running instances
 	glog.V(3).Infof("DistributedFileSystem.Rollback checking service states")
-	if err := d.client.GetServices(unused, &services); err != nil {
+	var unusedServiceRequest dao.ServiceRequest
+	if err := d.client.GetServices(unusedServiceRequest, &services); err != nil {
 		glog.V(2).Infof("DistributedFileSystem.Rollback tenant=%+v err=%s", tenantId, err)
 		return err
 	}
@@ -456,7 +458,8 @@ func (d *DistributedFileSystem) RollbackServices(restorePath string) error {
 	}
 
 	// Restore the services ...
-	if err := d.client.GetServices(unused, &existingServices); err != nil {
+	var unusedServiceRequest dao.ServiceRequest
+	if err := d.client.GetServices(unusedServiceRequest, &existingServices); err != nil {
 		glog.Errorf("Could not get existing services: %s", err)
 		return err
 	}
@@ -561,7 +564,8 @@ func (d *DistributedFileSystem) tag(id, oldtag, newtag string) error {
 // desynchronize marks all service states using a particular ImageID as out of
 // sync if started before the time of commit
 func (d *DistributedFileSystem) desynchronize(imageID commons.ImageID, commit time.Time) error {
-	svcs, err := d.facade.GetServices(datastore.Get())
+	var serviceRequest dao.ServiceRequest
+	svcs, err := d.facade.GetServices(datastore.Get(), serviceRequest)
 	if err != nil {
 		return err
 	}

--- a/facade/host_test.go
+++ b/facade/host_test.go
@@ -157,7 +157,8 @@ func (s *FacadeTest) Test_HostRemove(t *C) {
 		t.Fatalf("Failed assigning ip to service: %s", err)
 	}
 
-	services, _ := s.Facade.GetServices(s.CTX)
+	var serviceRequest dao.ServiceRequest
+	services, _ := s.Facade.GetServices(s.CTX, serviceRequest)
 	if len(services) <= 0 {
 		t.Fatalf("Expected one service in context")
 	}
@@ -174,7 +175,7 @@ func (s *FacadeTest) Test_HostRemove(t *C) {
 	if err != nil {
 		t.Fatalf("Failed to remove host: %s", err)
 	}
-	services, _ = s.Facade.GetServices(s.CTX)
+	services, _ = s.Facade.GetServices(s.CTX, serviceRequest)
 
 	if len(services) <= 0 {
 		t.Fatalf("Expected one service in context")

--- a/facade/service.go
+++ b/facade/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -138,18 +139,47 @@ func (f *Facade) GetService(ctx datastore.Context, id string) (*service.Service,
 }
 
 //
-func (f *Facade) GetServices(ctx datastore.Context) ([]service.Service, error) {
+func (f *Facade) GetServices(ctx datastore.Context, request dao.EntityRequest) ([]service.Service, error) {
 	glog.V(3).Infof("Facade.GetServices")
 	store := f.serviceStore
-	results, err := store.GetServices(ctx)
+	services, err := store.GetServices(ctx)
 	if err != nil {
 		glog.Error("Facade.GetServices: err=", err)
-		return results, err
+		return nil, err
 	}
-	if err = f.fillOutServices(ctx, results); err != nil {
-		return results, err
+	if err = f.fillOutServices(ctx, services); err != nil {
+		return nil, err
 	}
-	return results, nil
+
+	switch v := request.(type) {
+	case dao.ServiceRequest:
+		glog.V(3).Infof("request: %+v", request)
+
+		// filter by the name provided
+		if request.(dao.ServiceRequest).NameRegex != "" {
+			services, err = filterByNameRegex(request.(dao.ServiceRequest).NameRegex, services)
+			if err != nil {
+				glog.Error("Facade.GetTaggedServices: err=", err)
+				return nil, err
+			}
+		}
+
+		// filter by the tenantID provided
+		if request.(dao.ServiceRequest).TenantID != "" {
+			services, err = f.filterByTenantID(ctx, request.(dao.ServiceRequest).TenantID, services)
+			if err != nil {
+				glog.Error("Facade.GetTaggedServices: err=", err)
+				return nil, err
+			}
+		}
+
+		return services, nil
+	default:
+		err := fmt.Errorf("Bad request type %v: %+v", v, request)
+		glog.V(2).Info("Facade.GetTaggedServices: err=", err)
+		return nil, err
+	}
+	return services, nil
 }
 
 // GetServicesByPool looks up all services in a particular pool
@@ -172,36 +202,55 @@ func (f *Facade) GetTaggedServices(ctx datastore.Context, request dao.EntityRequ
 	glog.V(3).Infof("Facade.GetTaggedServices")
 
 	store := f.serviceStore
-
-	var v []string
-	switch vals := request.(type) {
-	case []interface{}:
-		v = make([]string, len(vals))
-		for i, s := range vals {
-			if sval, ok := s.(string); ok {
-				v[i] = sval
-				continue
-			}
-			glog.Error("Facade.GetTaggedServices: entity request item is not string: %s", reflect.TypeOf(s))
-			return []service.Service{}, fmt.Errorf("entity request item not a string")
-		}
+	switch v := request.(type) {
 	case []string:
-		v = vals
+		results, err := store.GetTaggedServices(ctx, v...)
+		if err != nil {
+			glog.Error("Facade.GetTaggedServices: err=", err)
+			return nil, err
+		}
+		if err = f.fillOutServices(ctx, results); err != nil {
+			return nil, err
+		}
+		glog.V(2).Infof("Facade.GetTaggedServices: services=%v", results)
+		return results, nil
+	case dao.ServiceRequest:
+		glog.V(3).Infof("request: %+v", request)
+
+		// Get the tagged services
+		services, err := store.GetTaggedServices(ctx, request.(dao.ServiceRequest).Tags...)
+		if err != nil {
+			glog.Error("Facade.GetTaggedServices: err=", err)
+			return nil, err
+		}
+		if err = f.fillOutServices(ctx, services); err != nil {
+			return nil, err
+		}
+
+		// filter by the name provided
+		if request.(dao.ServiceRequest).NameRegex != "" {
+			services, err = filterByNameRegex(request.(dao.ServiceRequest).NameRegex, services)
+			if err != nil {
+				glog.Error("Facade.GetTaggedServices: err=", err)
+				return nil, err
+			}
+		}
+
+		// filter by the tenantID provided
+		if request.(dao.ServiceRequest).TenantID != "" {
+			services, err = f.filterByTenantID(ctx, request.(dao.ServiceRequest).TenantID, services)
+			if err != nil {
+				glog.Error("Facade.GetTaggedServices: err=", err)
+				return nil, err
+			}
+		}
+
+		return services, nil
 	default:
-		err := fmt.Errorf("Bad request type: %v", reflect.TypeOf(request))
+		err := fmt.Errorf("Bad request type: %v", v)
 		glog.V(2).Info("Facade.GetTaggedServices: err=", err)
-		return []service.Service{}, err
+		return nil, err
 	}
-	results, err := store.GetTaggedServices(ctx, v...)
-	if err != nil {
-		glog.Error("Facade.GetTaggedServices: err=", err)
-		return results, err
-	}
-	if err = f.fillOutServices(ctx, results); err != nil {
-		return results, err
-	}
-	glog.V(2).Infof("Facade.GetTaggedServices: services=%v", results)
-	return results, nil
 }
 
 // The tenant id is the root service uuid. Walk the service tree to root to find the tenant id.
@@ -454,6 +503,41 @@ func (f *Facade) AssignIPs(ctx datastore.Context, assignmentRequest dao.Assignme
 
 	glog.Infof("All services requiring an explicit IP address (at f moment) from service: %v and down ... have been assigned: %s", assignmentRequest.ServiceID, assignmentRequest.IPAddress)
 	return nil
+}
+
+func (f *Facade) filterByTenantID(ctx datastore.Context, matchTenantID string, services []service.Service) ([]service.Service, error) {
+	matches := []service.Service{}
+	for _, service := range services {
+		localTenantID, err := f.GetTenantID(ctx, service.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		if localTenantID == matchTenantID {
+			glog.V(5).Infof("    Keeping service ID: %v (tenant ID: %v)", service.ID, localTenantID)
+			matches = append(matches, service)
+		}
+	}
+	glog.V(2).Infof("Returning %d services from tenantID: %v", len(matches), matchTenantID)
+	return matches, nil
+}
+
+func filterByNameRegex(nmregex string, services []service.Service) ([]service.Service, error) {
+	r, err := regexp.Compile(nmregex)
+	if err != nil {
+		glog.Errorf("Bad name regexp :%s", nmregex)
+		return nil, err
+	}
+
+	matches := []service.Service{}
+	for _, service := range services {
+		if r.MatchString(service.Name) {
+			glog.V(5).Infof("    Keeping service ID: %v (service name: %v)", service.ID, service.Name)
+			matches = append(matches, service)
+		}
+	}
+	glog.V(2).Infof("Returning %d services from %v", len(matches), nmregex)
+	return matches, nil
 }
 
 //getService is an internal method that returns a Service without filling in all related service data like address assignments
@@ -795,7 +879,7 @@ func updateTenants(tenantID string, svcIDs ...string) {
 	}
 }
 
-// GetTenantID calls its GetService function to get the tenantID
+// getTenantID calls its GetService function to get the tenantID
 func getTenantID(svcID string, gs service.GetService) (string, error) {
 	if tID, found := lookUpTenant(svcID); found {
 		return tID, nil

--- a/node/cp_client.go
+++ b/node/cp_client.go
@@ -65,11 +65,11 @@ func (s *ControlClient) GetServiceEndpoints(serviceId string, response *map[stri
 	return s.rpcClient.Call("ControlPlane.GetServiceEndpoints", serviceId, response)
 }
 
-func (s *ControlClient) GetServices(request dao.EntityRequest, replyServices *[]service.Service) (err error) {
+func (s *ControlClient) GetServices(request dao.ServiceRequest, replyServices *[]service.Service) (err error) {
 	return s.rpcClient.Call("ControlPlane.GetServices", request, replyServices)
 }
 
-func (s *ControlClient) GetTaggedServices(request dao.EntityRequest, replyServices *[]service.Service) (err error) {
+func (s *ControlClient) GetTaggedServices(request dao.ServiceRequest, replyServices *[]service.Service) (err error) {
 	return s.rpcClient.Call("ControlPlane.GetTaggedServices", request, replyServices)
 }
 

--- a/web/virtualhostresource.go
+++ b/web/virtualhostresource.go
@@ -14,10 +14,11 @@
 package web
 
 import (
+	"github.com/control-center/serviced/dao"
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/node"
 	"github.com/zenoss/glog"
 	"github.com/zenoss/go-json-rest"
-	"github.com/control-center/serviced/node"
-	"github.com/control-center/serviced/domain/service"
 
 	"net/url"
 	"strings"
@@ -40,7 +41,8 @@ func restAddVirtualHost(w *rest.ResponseWriter, r *rest.Request, client *node.Co
 	}
 
 	var services []service.Service
-	if err := client.GetServices(&empty, &services); err != nil {
+	var serviceRequest dao.ServiceRequest
+	if err := client.GetServices(serviceRequest, &services); err != nil {
 		glog.Errorf("Could not get services: %v", err)
 		restServerError(w, err)
 		return
@@ -154,7 +156,8 @@ type virtualHost struct {
 // restGetVirtualHosts gets all services, then extracts all vhost information and returns it.
 func restGetVirtualHosts(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClient) {
 	var services []service.Service
-	err := client.GetServices(&empty, &services)
+	var serviceRequest dao.ServiceRequest
+	err := client.GetServices(serviceRequest, &services)
 	if err != nil {
 		glog.Errorf("Unexpected error retrieving virtual hosts: %v", err)
 		restServerError(w, err)


### PR DESCRIPTION
Zenoss calls to get services now can supply a tenantID. Filtering (by name and tenantID) is now down on the server side.
