### PR TITLE
initialize values passed back via jsonrpc

### DIFF
--- a/dao/elasticsearch/addressassignment.go
+++ b/dao/elasticsearch/addressassignment.go
@@ -20,7 +20,11 @@ import (
 
 // GetServiceAddressAssignments fills in all AddressAssignments for the specified serviced id.
 func (this *ControlPlaneDao) GetServiceAddressAssignments(serviceID string, assignments *[]addressassignment.AddressAssignment) error {
-	return this.facade.GetServiceAddressAssignments(datastore.Get(), serviceID, assignments)
+	err := this.facade.GetServiceAddressAssignments(datastore.Get(), serviceID, assignments)
+	if assignments == nil {
+		*assignments = make([]addressassignment.AddressAssignment, 0)
+	}
+	return err
 }
 
 // RemoveAddressAssignemnt Removes an AddressAssignment by id

--- a/dao/elasticsearch/filesystem.go
+++ b/dao/elasticsearch/filesystem.go
@@ -122,7 +122,10 @@ func (this *ControlPlaneDao) Snapshots(serviceId string, labels *[]string) error
 	}
 	return nil
 }
+
 func (this *ControlPlaneDao) GetVolume(serviceId string, theVolume *volume.Volume) error {
+	*theVolume = volume.Volume{}
+
 	var tenantId string
 	if err := this.GetTenantId(serviceId, &tenantId); err != nil {
 		glog.V(2).Infof("ControlPlaneDao.GetVolume service=%+v err=%s", serviceId, err)

--- a/dao/elasticsearch/runningservice.go
+++ b/dao/elasticsearch/runningservice.go
@@ -113,6 +113,7 @@ func (this *ControlPlaneDao) GetRunningServicesForService(serviceID string, serv
 
 func (this *ControlPlaneDao) GetRunningService(request dao.ServiceStateRequest, running *dao.RunningService) error {
 	glog.V(3).Infof("ControlPlaneDao.GetRunningService: request=%v", request)
+	*running = dao.RunningService{}
 
 	var myService service.Service
 	if err := this.GetService(request.ServiceID, &myService); err != nil {
@@ -130,7 +131,9 @@ func (this *ControlPlaneDao) GetRunningService(request dao.ServiceStateRequest, 
 		glog.Errorf("zkservice.LoadRunningService failed (conn: %+v serviceID: %v): %v", poolBasedConn, request.ServiceID, err)
 		return err
 	} else {
-		*running = *thisRunning
+		if thisRunning != nil {
+			*running = *thisRunning
+		}
 	}
 
 	return nil

--- a/dao/elasticsearch/service.go
+++ b/dao/elasticsearch/service.go
@@ -46,8 +46,11 @@ func (this *ControlPlaneDao) RemoveService(id string, unused *int) error {
 
 //
 func (this *ControlPlaneDao) GetService(id string, myService *service.Service) error {
+	*myService = service.Service{}
 	if svc, err := this.facade.GetService(datastore.Get(), id); err == nil {
-		*myService = *svc
+		if svc != nil {
+			*myService = *svc
+		}
 		return nil
 	} else {
 		return err
@@ -56,8 +59,11 @@ func (this *ControlPlaneDao) GetService(id string, myService *service.Service) e
 
 // TODO FIXME no need for the request argument
 func (this *ControlPlaneDao) GetServices(request dao.EntityRequest, services *[]service.Service) error {
+	*services = make([]service.Service, 0)
 	if svcs, err := this.facade.GetServices(datastore.Get()); err == nil {
-		*services = svcs
+		if svcs != nil {
+			*services = svcs
+		}
 		return nil
 	} else {
 		return err
@@ -65,9 +71,12 @@ func (this *ControlPlaneDao) GetServices(request dao.EntityRequest, services *[]
 }
 
 //
-func (this *ControlPlaneDao) FindChildService(request dao.FindChildRequest, service *service.Service) error {
+func (this *ControlPlaneDao) FindChildService(request dao.FindChildRequest, myService *service.Service) error {
+	*myService = service.Service{}
 	if svc, err := this.facade.FindChildService(datastore.Get(), request.ServiceID, request.ChildName); err == nil {
-		*service = *svc
+		if svc != nil {
+			*myService = *svc
+		}
 		return nil
 	} else {
 		return err
@@ -76,8 +85,11 @@ func (this *ControlPlaneDao) FindChildService(request dao.FindChildRequest, serv
 
 //
 func (this *ControlPlaneDao) GetTaggedServices(request dao.EntityRequest, services *[]service.Service) error {
+	*services = make([]service.Service, 0)
 	if svcs, err := this.facade.GetTaggedServices(datastore.Get(), request); err == nil {
-		*services = svcs
+		if svcs != nil {
+			*services = svcs
+		}
 		return nil
 	} else {
 		return err
@@ -96,8 +108,11 @@ func (this *ControlPlaneDao) GetTenantId(serviceID string, tenantId *string) err
 
 // Get a service endpoint.
 func (this *ControlPlaneDao) GetServiceEndpoints(serviceID string, response *map[string][]dao.ApplicationEndpoint) (err error) {
+	*response = make(map[string][]dao.ApplicationEndpoint, 0)
 	if result, err := this.facade.GetServiceEndpoints(datastore.Get(), serviceID); err == nil {
-		*response = result
+		if response != nil {
+			*response = result
+		}
 		return nil
 	} else {
 		return err

--- a/dao/elasticsearch/servicetemplate.go
+++ b/dao/elasticsearch/servicetemplate.go
@@ -35,7 +35,11 @@ func (this *ControlPlaneDao) RemoveServiceTemplate(id string, unused *int) error
 
 func (this *ControlPlaneDao) GetServiceTemplates(unused int, templates *map[string]servicetemplate.ServiceTemplate) error {
 	templatemap, err := this.facade.GetServiceTemplates(datastore.Get())
-	*templates = templatemap
+	if templatemap != nil {
+		*templates = templatemap
+	} else {
+		*templates = make(map[string]servicetemplate.ServiceTemplate, 0)
+	}
 	return err
 }
 
@@ -54,6 +58,9 @@ func (this *ControlPlaneDao) DeployTemplateStatus(request dao.ServiceTemplateDep
 func (this *ControlPlaneDao) DeployTemplateActive(notUsed string, active *[]map[string]string) error {
 	var err error
 	err = this.facade.DeployTemplateActive(active)
+	if active == nil {
+		*active = make([]map[string]string, 0)
+	}
 	return err
 }
 

--- a/dao/elasticsearch/user.go
+++ b/dao/elasticsearch/user.go
@@ -19,10 +19,10 @@
 package elasticsearch
 
 import (
-	"github.com/zenoss/glog"
 	"github.com/control-center/serviced/datastore"
 	userdomain "github.com/control-center/serviced/domain/user"
 	"github.com/control-center/serviced/utils"
+	"github.com/zenoss/glog"
 
 	"crypto/sha1"
 	"errors"
@@ -80,6 +80,9 @@ func (this *ControlPlaneDao) GetUser(userName string, user *userdomain.User) err
 	store := userdomain.NewStore()
 	err := store.Get(datastore.Get(), userdomain.Key(userName), user)
 	glog.V(2).Infof("ControlPlaneDao.GetUser: userName=%s, user=%+v, err=%s", userName, user, err)
+	if user == nil {
+		*user = userdomain.User{}
+	}
 	return err
 }
 

--- a/node/agent_proxy.go
+++ b/node/agent_proxy.go
@@ -66,6 +66,8 @@ func (a *HostAgent) GetServiceEndpoints(serviceId string, response *map[string][
 }
 
 func (a *HostAgent) GetService(serviceID string, response *service.Service) (err error) {
+	*response = service.Service{}
+
 	controlClient, err := NewControlClient(a.master)
 	if err != nil {
 		glog.Errorf("Could not start ControlPlane client %v", err)
@@ -74,6 +76,9 @@ func (a *HostAgent) GetService(serviceID string, response *service.Service) (err
 	defer controlClient.Close()
 
 	err = controlClient.GetService(serviceID, response)
+	if response == nil {
+		*response = service.Service{}
+	}
 	if err != nil {
 		return err
 	}
@@ -94,6 +99,8 @@ func (a *HostAgent) GetService(serviceID string, response *service.Service) (err
 }
 
 func (a *HostAgent) GetServiceInstance(req ServiceInstanceRequest, response *service.Service) (err error) {
+	*response = service.Service{}
+
 	controlClient, err := NewControlClient(a.master)
 	if err != nil {
 		glog.Errorf("Could not start ControlPlane client %v", err)
@@ -102,6 +109,9 @@ func (a *HostAgent) GetServiceInstance(req ServiceInstanceRequest, response *ser
 	defer controlClient.Close()
 
 	err = controlClient.GetService(req.ServiceID, response)
+	if response == nil {
+		*response = service.Service{}
+	}
 	if err != nil {
 		return err
 	}
@@ -148,6 +158,8 @@ func (a *HostAgent) AckProxySnapshotQuiece(snapshotId string, unused *interface{
 // GetHealthCheck returns the health check configuration for a service, if it exists
 func (a *HostAgent) GetHealthCheck(req HealthCheckRequest, healthChecks *map[string]domain.HealthCheck) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetHealthCheck()")
+	*healthChecks = make(map[string]domain.HealthCheck, 0)
+
 	controlClient, err := NewControlClient(a.master)
 	if err != nil {
 		glog.Errorf("Could not start ControlPlane client %v", err)
@@ -172,7 +184,9 @@ func (a *HostAgent) GetHealthCheck(req HealthCheckRequest, healthChecks *map[str
 		return svc, err
 	}
 	svc.EvaluateHealthCheckTemplate(getSvc, findChild, req.InstanceID)
-	*healthChecks = svc.HealthChecks
+	if svc.HealthChecks != nil {
+		*healthChecks = svc.HealthChecks
+	}
 	return nil
 }
 
@@ -280,6 +294,7 @@ func (a *HostAgent) GetZkInfo(_ string, zkInfo *ZkInfo) error {
 // GetServiceBindMounts returns the service bindmounts
 func (a *HostAgent) GetServiceBindMounts(serviceID string, bindmounts *map[string]string) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetServiceBindMounts(serviceID:%s)", serviceID)
+	*bindmounts = make(map[string]string, 0)
 
 	var tenantID string
 	if err := a.GetTenantId(serviceID, &tenantID); err != nil {

--- a/rpc/agent/agent.go
+++ b/rpc/agent/agent.go
@@ -14,8 +14,8 @@
 package agent
 
 import (
-	"github.com/zenoss/glog"
 	"github.com/control-center/serviced/domain/host"
+	"github.com/zenoss/glog"
 
 	"os/exec"
 )
@@ -45,13 +45,16 @@ type BuildHostRequest struct {
 
 // BuildHost creates a Host object from the current host.
 func (a *AgentServer) BuildHost(request BuildHostRequest, hostResponse *host.Host) error {
+	*hostResponse = host.Host{}
 
 	glog.Infof("local static ips %v [%d]", a.staticIPs, len(a.staticIPs))
 	h, err := host.Build(request.IP, request.PoolID, a.staticIPs...)
 	if err != nil {
 		return err
 	}
-	*hostResponse = *h
+	if h != nil {
+		*hostResponse = *h
+	}
 	return nil
 }
 


### PR DESCRIPTION
looked at all these files:

```
# plu@plu-9: grep -r 'Call("' .
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetServiceEndpoints", serviceId, response)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetServices", request, replyServices)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetTaggedServices", request, replyServices)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetService", serviceId, &service)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.FindChildService", request, &service)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetTenantId", serviceId, tenantId)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.AddService", service, serviceId)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.DeployService", service, serviceId)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.UpdateService", service, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.RemoveService", serviceId, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.AssignIPs", assignmentRequest, nil)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetServiceAddressAssignments", serviceID, addresses)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetServiceLogs", serviceId, logs)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetServiceStateLogs", request, logs)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetRunningServicesForHost", hostId, runningServices)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetRunningServicesForService", serviceId, runningServices)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.StopRunningInstance", request, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetRunningServices", request, runningServices)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetServiceState", request, state)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetRunningService", request, running)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetServiceStates", serviceId, states)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.StartService", serviceId, hostId)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.RestartService", serviceId, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.StopService", serviceId, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.UpdateServiceState", state, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetServiceStatus", serviceID, statusmap)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.DeployTemplate", request, tenantId)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.DeployTemplateStatus", request, status)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.DeployTemplateActive", notUsed, active)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetServiceTemplates", unused, serviceTemplates)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.AddServiceTemplate", serviceTemplate, templateId)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.UpdateServiceTemplate", serviceTemplate, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.RemoveServiceTemplate", serviceTemplateID, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.Commit", containerId, label)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.Rollback", serviceId, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.TakeSnapshot", serviceId, label)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.Snapshot", serviceId, label)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.DeleteSnapshot", snapshotId, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.Snapshots", serviceId, labels)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.DeleteSnapshots", serviceId, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetVolume", serviceId, volume)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.ValidateCredentials", user, result)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.GetSystemUser", unused, user)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.ReadyDFS", unused, unusedint)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.Backup", backupDirectory, backupFilePath)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.AsyncBackup", backupDirectory, backupFilePath)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.BackupStatus", notUsed, backupStatus)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.Restore", backupFilePath, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.Action", req, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.LogHealthCheck", result, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.AsyncRestore", backupFilePath, unused)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.RestoreStatus", notUsed, restoreStatus)
./node/cp_client.go:    return s.rpcClient.Call("ControlPlane.ImageLayerCount", imageUUID, layers)
./node/lbClient.go: return a.rpcClient.Call("ControlPlaneAgent.Ping", waitFor, timestamp)
./node/lbClient.go: return a.rpcClient.Call("ControlPlaneAgent.SendLogMessage", serviceLogInfo, nil)
./node/lbClient.go: return a.rpcClient.Call("ControlPlaneAgent.GetServiceEndpoints", serviceId, endpoints)
./node/lbClient.go: return a.rpcClient.Call("ControlPlaneAgent.GetService", serviceId, service)
./node/lbClient.go: return a.rpcClient.Call("ControlPlaneAgent.GetServiceInstance", req, service)
./node/lbClient.go: return a.rpcClient.Call("ControlPlaneAgent.GetProxySnapshotQuiece", serviceId, snapshotId)
./node/lbClient.go: return a.rpcClient.Call("ControlPlaneAgent.AckProxySnapshotQuiece", snapshotId, unused)
./node/lbClient.go: return a.rpcClient.Call("ControlPlaneAgent.GetTenantId", serviceId, tenantId)
./node/lbClient.go: return a.rpcClient.Call("ControlPlaneAgent.LogHealthCheck", result, unused)
./node/lbClient.go: return a.rpcClient.Call("ControlPlaneAgent.GetHealthCheck", req, healthChecks)
./node/lbClient.go: return a.rpcClient.Call("ControlPlaneAgent.GetHostID", "na", hostID)
./node/lbClient.go: return a.rpcClient.Call("ControlPlaneAgent.GetZkInfo", "na", zkInfo)
./node/lbClient.go: return a.rpcClient.Call("ControlPlaneAgent.GetServiceBindMounts", serviceID, bindmounts)
./rpc/agent/agent_client.go:    if err := c.rpcClient.Call("Agent.BuildHost", request, hostResponse); err != nil {
./rpc/agent/agent_client.go:    err := c.rpcClient.Call("Agent.GetDockerLogs", dockerID, &logs)
./rpc/master/client.go: return c.rpcClient.Call("Master."+name, request, response)

```
