### PR TITLE
fix panic in RegisterHealthCheck when stopping serviced

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -95,8 +95,9 @@ func RegisterHealthCheck(serviceID string, name string, passed string, d dao.Con
 	thisStatus.Status = passed
 	thisStatus.Timestamp = time.Now().UTC().Unix()
 
-
 	var runningServices []dao.RunningService
-	d.GetRunningServicesForService(serviceID, &runningServices)
-	thisStatus.StartedAt = runningServices[0].StartedAt.Unix()
+	err := d.GetRunningServicesForService(serviceID, &runningServices)
+	if err == nil && len(runningServices) > 0 {
+		thisStatus.StartedAt = runningServices[0].StartedAt.Unix()
+	}
 }


### PR DESCRIPTION
ISSUE - seen when stopping serviced with services started:

```
E0912 03:37:29.519999 09683 runningservice.go:91] Unable to get service 75n1qbru6n7scp94yyr5y1xt8: Get http://localhost:9200/controlplane/service/9wfvgqylgygmxojur0r6d063: EOF
panic: runtime error: index out of range

goroutine 12637 [running]:
runtime.panic(0xab83c0, 0x111fe7c)
    /usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
github.com/control-center/serviced/health.RegisterHealthCheck(0xc209376f20, 0x19, 0xc209abc730, 0xf, 0xc209abc740, 0x6, 0x7f190f9335d0, 0xc208212630)
    /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/health/health.go:101 +0x807
github.com/control-center/serviced/dao/elasticsearch.(*ControlPlaneDao).LogHealthCheck(0xc208212630, 0xc209376f20, 0x19, 0xc209abc730, 0xf, 0xc209c86840, 0x27, 0xc209abc740, 0x6, 0xc209abc748, ...)
    /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/dao/elasticsearch/health.go:26 +0xe5
```
