### PR TITLE
fixes ZEN-11795: post-stop serviced: wait for serviced to stop listening

### DIFF
--- a/pkg/serviced.upstart
+++ b/pkg/serviced.upstart
@@ -9,7 +9,8 @@ limit nofile 1048576 1048576
 
 # this pre-start script is necessary to wait for docker
 pre-start script
-    echo "$(date): waiting for docker"
+    echo ""  # annoying, but this line ensures below echo is in upstart serviced log
+    echo "$(date): starting serviced daemon for $(hostid) - waiting for docker"
     while ! /usr/bin/docker ps; do date ; sleep 1 ; done
     echo "$(date): docker is now ready - done with pre-start"
     sleep 1s
@@ -34,10 +35,25 @@ script
 end script
 
 post-stop script
-    echo "$(date): waiting for serviced to stop"
-    while pgrep -fl 'bin/serviced -agent -master'; do
+    echo "$(date): post-stopping serviced daemon - waiting for serviced to stop"
+
+    # wait for serviced daemon to stop
+    echo "$(date): waiting for serviced daemon to stop"
+    while pgrep -fla "bin/serviced"; do
         sleep 5
     done
+
+    # wait for serviced to stop listening
+    echo "$(date): waiting for serviced to stop listening"
+    while netstat -plant | grep 'LISTEN.*/serviced$'; do
+        sleep 2
+    done
+
+    # stop potentially running isvcs even though serviced stopped (column 2 is IMAGEID)
+    echo "$(date): waiting for serviced isvcs to stop"
+    docker ps --no-trunc | awk '$2 ~ /^zenoss\/serviced-isvcs/{print $1}' | while read c; do docker stop $c; done
+
     echo "$(date): serviced is now stopped - done with post-stop"
+    echo ""  # annoying, but this line ensures above echo is in upstart serviced log
 end script
 


### PR DESCRIPTION
DEMO:

```
root@plu-9:/var/log/upstart# pgrep -fla bin/serviced
20979 ./bin/serviced
root@plu-9:/var/log/upstart# docker ps
CONTAINER ID        IMAGE                       COMMAND                CREATED             STATUS              PORTS                                                                                            NAMES
5cb601623193        zenoss/serviced-isvcs:v16   "/bin/sh -c 'cd /opt   36 seconds ago      Up 35 seconds       0.0.0.0:4242->4242/tcp, 0.0.0.0:8443->8443/tcp, 0.0.0.0:8888->8888/tcp, 0.0.0.0:9090->9090/tcp   opentsdb-3029c044-3459-0a4b-77d9-9662c3359a9e                 
fd65130f78bc        zenoss/serviced-isvcs:v16   "/bin/sh -c 'supervi   36 seconds ago      Up 35 seconds                                                                                                        celery-b5fcf2f4-8d97-86b5-6ede-e85d4d5ddf52                   
5a06b364a069        zenoss/serviced-isvcs:v16   "/bin/sh -c 'DOCKER_   37 seconds ago      Up 36 seconds       0.0.0.0:5000->5000/tcp                                                                           docker-registry-23697b4b-dc29-b645-75f3-bbaf0dac8f16          
cd7ca4ea12be        zenoss/serviced-isvcs:v16   "/bin/sh -c '/opt/lo   37 seconds ago      Up 35 seconds       0.0.0.0:5042->5042/tcp, 0.0.0.0:5043->5043/tcp, 0.0.0.0:9292->9292/tcp                           logstash-acdcb830-8dcd-4a57-6bb7-6d5e0a5758ff                 
8f156309946a        zenoss/serviced-isvcs:v16   "/bin/sh -c '/opt/el   37 seconds ago      Up 36 seconds       0.0.0.0:9200->9200/tcp                                                                           elasticsearch-serviced-1e3ceffa-152b-9829-0219-bee67fc12b87   
f56b0289c080        zenoss/serviced-isvcs:v16   "/bin/sh -c '/opt/el   37 seconds ago      Up 36 seconds       0.0.0.0:9100->9100/tcp                                                                           elasticsearch-logstash-19cfaae4-2ff8-63fb-eb8e-a58cabcfe515   
2f92206b5c1a        zenoss/serviced-isvcs:v16   "/bin/sh -c '/opt/zo   37 seconds ago      Up 36 seconds       0.0.0.0:2181->2181/tcp, 0.0.0.0:12181->12181/tcp                                                 zookeeper-ce551f1b-9d9b-697e-307c-e6ec04699ce9                
root@plu-9:/var/log/upstart# restart serviced


#### excerpt from tail -F /var/log/upstart/serviced.log:
Sat Sep 13 10:50:58 CDT 2014: post-stopping serviced daemon - waiting for serviced to stop
Sat Sep 13 10:50:58 CDT 2014: waiting for serviced daemon to stop
20979 ./bin/serviced
20979 ./bin/serviced
20979 ./bin/serviced
20979 ./bin/serviced
20979 ./bin/serviced
Sat Sep 13 10:51:23 CDT 2014: waiting for serviced to stop listening
Sat Sep 13 10:51:23 CDT 2014: waiting for serviced isvcs to stop
Sat Sep 13 10:51:23 CDT 2014: serviced is now stopped - done with post-stop
Sat Sep 13 10:51:23 CDT 2014: starting serviced daemon for 570a276e - waiting for docker
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
Sat Sep 13 10:51:23 CDT 2014: docker is now ready - done with pre-start
```
