### PR TITLE
Proxy wait-for-prereqs behavior polish

### DIFF
--- a/shell/server.go
+++ b/shell/server.go
@@ -413,9 +413,8 @@ func StartDocker(cfg *ProcessConfig, port string) (*exec.Cmd, error) {
 
 	if cfg.IsTTY {
 		argv = append(argv, "-i", "-t")
-	} else {
-		argv = append(argv, "-t")
 	}
+
 	// set the systemuser and password
 	unused := 0
 	systemUser := user.User{}


### PR DESCRIPTION
Fixes ZEN-13076
Log "prereq failed" message directly to stderr
Handle interrupt signal before service started
Do not 'leak' serviced-proxy process
