### PR TITLE
allow INSTALL_TEMPLATES to be overridden

### DIFF
--- a/makefile
+++ b/makefile
@@ -37,7 +37,7 @@ sysconfdir        = /etc
 # Specify if we want service definition templates (picked up from
 # pkg/templates) to be included as part of the serviced packaging.
 #
-INSTALL_TEMPLATES      = 1
+INSTALL_TEMPLATES      ?= 1
 
 #
 # When packaging just the templates, throw this option.


### PR DESCRIPTION
About to change
http://jenkins.zendev.org/job/europa_develop_serviced_svcdefs_build/configure

FROM:

```
BUILD_NUMBER=$EUROPA_BUILD_NUMBER DOCKER_PUSH_ENABLE=1 zendev -n build svcpkg --clean --output $WORKSPACE/output -t build-$EUROPA_BUILD_NUMBER
```

TO:

```
BUILD_NUMBER=$BUILD_NUMBER DOCKER_PUSH_ENABLE=1 INSTALL_TEMPLATES=0 zendev -n build serviced --clean --output $WORKSPACE/output -t build-$EUROPA_BUILD_NUMBER
BUILD_NUMBER=$EUROPA_BUILD_NUMBER DOCKER_PUSH_ENABLE=1 zendev -n build svcdefpkg-core svcdefpkg-resmgr --clean --output $WORKSPACE/output -t build-$EUROPA_BUILD_NUMBER
```

DEMO:

```
# plu@plu-9:  BUILD_NUMBER=85 DOCKER_PUSH_ENABLE=0 INSTALL_TEMPLATES=0 zendev build serviced --clean --output /home/plu/workspace/europa_develop_serviced_svcdefs_build/output -t build-642
...

# plu@plu-9:  ls -l 
-rw-r--r-- 1 root root 16648622 Sep 16 16:32 serviced_0.8.0-85~trusty_amd64.deb
-rw-r--r-- 1 root root 16556828 Sep 16 16:32 serviced-0.8.0_85-1.x86_64.rpm

# plu@plu-9: wget http://artifacts.zenoss.loc/europa/642/serviced_0.8.0-642~trusty_amd64.deb
--2014-09-16 16:38:55--  http://artifacts.zenoss.loc/europa/642/serviced_0.8.0-642~trusty_amd64.deb

2014-09-16 16:38:58 (7.41 MB/s) - ‘serviced_0.8.0-642~trusty_amd64.deb’ saved [16652342/16652342]

# plu@plu-9: dpkg-deb -R serviced_0.8.0-642~trusty_amd64.deb 642

# plu@plu-9: dpkg-deb -R serviced_0.8.0-85~trusty_amd64.deb 85

# plu@plu-9: diff -qr 642 85
Files 642/DEBIAN/control and 85/DEBIAN/control differ
Files 642/DEBIAN/md5sums and 85/DEBIAN/md5sums differ
Files 642/opt/serviced/bin/serviced and 85/opt/serviced/bin/serviced differ
Files 642/opt/serviced/isvcs/resources/logstash/logstash.conf and 85/opt/serviced/isvcs/resources/logstash/logstash.conf differ
...
```
