### PR TITLE
Purge logstash data older than a configurable number of days; use isvcs:v17

### DIFF
--- a/cli/api/api.go
+++ b/cli/api/api.go
@@ -64,6 +64,7 @@ type Options struct {
 	VirtualAddressSubnet string
 	MasterPoolID         string
 	LogstashES           string //logstatsh elasticsearch host:port
+	LogstashMaxDays      int    // Days to keep logstash indices
 }
 
 // LoadOptions overwrites the existing server options

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -164,6 +164,7 @@ func New(driver api.API) *ServicedCli {
 		cli.BoolFlag{"alsologtostderr", "log to standard error as well as files"},
 		cli.StringFlag{"logstashurl", configEnv("LOG_ADDRESS", "127.0.0.1:5042"), "logstash url and port"},
 		cli.StringFlag{"logstash-es", configEnv("LOGSTASH_ES", "127.0.0.1:9100"), "host and port for logstash elastic search"},
+		cli.IntFlag{"logstash-max-days", configInt("LOGSTASH_MAX_DAYS", 14), "days to keep Logstash data"},
 		cli.IntFlag{"v", configInt("LOG_LEVEL", 0), "log level for V logs"},
 		cli.StringFlag{"stderrthreshold", "", "logs at or above this threshold go to stderr"},
 		cli.StringFlag{"vmodule", "", "comma-separated list of pattern=N settings for file-filtered logging"},
@@ -223,6 +224,7 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 		MasterPoolID:         ctx.GlobalString("master-pool-id"),
 		OutboundIP:           ctx.GlobalString("outbound"),
 		LogstashES:           ctx.GlobalString("logstash-es"),
+		LogstashMaxDays:      ctx.GlobalInt("logstash-max-days"),
 	}
 	if os.Getenv("SERVICED_MASTER") == "1" {
 		options.Master = true

--- a/container/stats.go
+++ b/container/stats.go
@@ -61,7 +61,7 @@ func collect(ts time.Time, statsUrl string) {
 		}
 		i++
 	}
-	glog.Info("posting samples: %+v", samples)
+	glog.V(4).Infof("posting samples: %+v", samples)
 	if err := stats.Post(statsUrl, samples); err != nil {
 		glog.Errorf("could not post stats: %s", err)
 	}

--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -408,3 +408,23 @@ func (c *Container) Stop() error {
 	c.ops <- req
 	return <-req.response
 }
+
+// RunCommand runs a command inside the container.
+func (c *Container) RunCommand(command []string) error {
+	var id string
+	ids, err := c.getMatchingContainersIds()
+	if err != nil {
+		glog.Warningf("Error collecting isvc container IDs.")
+	}
+	if len(*ids) == 0 {
+		// Container hasn't started yet
+		return fmt.Errorf("No docker container found for %s", c.Name)
+	}
+	id = (*ids)[0]
+	output, err := utils.AttachAndRun(id, command)
+	if err != nil {
+		return err
+	}
+	os.Stdout.Write(output)
+	return nil
+}

--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -137,3 +137,12 @@ func elasticsearchHealthCheck(port int) func() error {
 		return nil
 	}
 }
+
+func PurgeLogstashIndices(days int) error {
+	container := elasticsearch_logstash
+	port := container.Ports[0]
+	glog.Infof("Purging logstash entries older than %d days", days)
+	return container.RunCommand([]string{
+		"/usr/local/bin/curator", "--port", fmt.Sprintf("%d", port),
+		"delete", "--older-than", fmt.Sprintf("%d", days)})
+}

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -30,7 +30,7 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO = "zenoss/serviced-isvcs"
-	IMAGE_TAG  = "v16"
+	IMAGE_TAG  = "v17"
 )
 
 func Init() {

--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -71,6 +71,9 @@
 # Set the address for the logstash elastic search
 # export SERVICED_LOGSTASH_ES=$SERVICED_MASTER_IP:9100
 
+# Set the age (in days) of logstash data to keep
+# export SERVICED_LOGSTASH_MAX_DAYS=14
+
 # Set the default serviced stats endpoint to use
 # export SERVICED_STATS_PORT=$SERVICED_MASTER_IP:8443
 


### PR DESCRIPTION
DEMO:

```
$ zendev serviced -dx
...
I0917 13:56:59.433386 02985 es.go:144] Purging logstash entries older than 14 days
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
2014-09-17 13:57:00,027 INFO      Job starting...
2014-09-17 13:57:00,031 INFO      Beginning DELETE operations...
2014-09-17 13:57:00,036 INFO      logstash-2014.09.17 is within the threshold period (14 days).
2014-09-17 13:57:00,036 INFO      DELETE index operations completed.
2014-09-17 13:57:00,036 INFO      Done in 0:00:00.018674.

$ zendev serviced -dx -- --logstash-max-days=2
...
I0917 13:58:46.368207 05401 es.go:144] Purging logstash entries older than 2 days
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
2014-09-17 13:58:47,000 INFO      Job starting...
2014-09-17 13:58:47,004 INFO      Beginning DELETE operations...
2014-09-17 13:58:47,010 INFO      logstash-2014.09.17 is within the threshold period (2 days).
2014-09-17 13:58:47,010 INFO      DELETE index operations completed.
2014-09-17 13:58:47,011 INFO      Done in 0:00:00.022001.

$ SERVICED_LOGSTASH_MAX_DAYS=4 zendev serviced -dx
...
I0917 14:00:42.464749 07846 es.go:144] Purging logstash entries older than 4 days
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
2014-09-17 14:00:42,912 INFO      Job starting...
2014-09-17 14:00:42,916 INFO      Beginning DELETE operations...
2014-09-17 14:00:42,922 INFO      logstash-2014.09.17 is within the threshold period (4 days).
2014-09-17 14:00:42,922 INFO      DELETE index operations completed.
2014-09-17 14:00:42,923 INFO      Done in 0:00:00.021805.
```
