### PR TITLE
do not dereference nil pointer when FindChildService returns nil child

### DIFF
--- a/dao/elasticsearch/service.go
+++ b/dao/elasticsearch/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain/service"
+	"github.com/zenoss/glog"
 )
 
 // AddService add a service. Return error if service already exists
@@ -66,12 +67,17 @@ func (this *ControlPlaneDao) GetServices(request dao.ServiceRequest, services *[
 
 //
 func (this *ControlPlaneDao) FindChildService(request dao.FindChildRequest, service *service.Service) error {
-	if svc, err := this.facade.FindChildService(datastore.Get(), request.ServiceID, request.ChildName); err == nil {
-		*service = *svc
-		return nil
-	} else {
+	svc, err := this.facade.FindChildService(datastore.Get(), request.ServiceID, request.ChildName)
+	if err == nil {
 		return err
 	}
+
+	if svc != nil {
+		*service = *svc
+	} else {
+		glog.Warningf("unable to find child of service: %+v", service)
+	}
+	return nil
 }
 
 // Get tagged services (can also filter by name and/or tenantID)


### PR DESCRIPTION
ISSUE - occurring when starting services:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x50c583]

goroutine 4800 [running]:
runtime.panic(0x9d0140, 0x14b8ae8)
        /usr/local/go/src/pkg/runtime/panic.c:266 +0xb6
github.com/control-center/serviced/dao/elasticsearch.(*ControlPlaneDao).FindChildService(0xc210176990, 0xc2123a21c0, 0x19, 0xc212095138, 0x5, ...)
        /go/src/github.com/control-center/serviced/dao/elasticsearch/service.go:70 +0xc3
reflect.Value.call(0x975060, 0xa84560, 0x130, 0xa8d270, 0x4, ...)
        /usr/local/go/src/pkg/reflect/value.go:474 +0xe0b
reflect.Value.Call(0x975060, 0xa84560, 0x130, 0x7f50685cbee8, 0x3, ...)
        /usr/local/go/src/pkg/reflect/value.go:345 +0x9d
net/rpc.(*service).call(0xc210166440, 0xc2100a5100, 0xc212c0d958, 0xc2102bd580, 0xc2128bb240, ...)
        /usr/local/go/src/pkg/net/rpc/server.go:381 +0x159
created by net/rpc.(*Server).ServeCodec
        /usr/local/go/src/pkg/net/rpc/server.go:452 +0x3bb
```

DEMO:

```
W0917 15:36:37.918653 14137 service.go:78] unable to find child of service: &{ID: Name: Title: Version: Context:map[] Startup: Description: Tags:[] OriginalConfigs:map[] ConfigFiles:map[] Instances:0 InstanceLimits:{Min:0 Max:0 Default:0} ChangeOptions:[] ImageID: PoolID: DesiredState:0 HostPolicy: Hostname: Privileged:false Launch: Endpoints:[] Tasks:[] ParentServiceID: Volumes:[] CreatedAt:0001-01-01 00:00:00 +0000 UTC UpdatedAt:0001-01-01 00:00:00 +0000 UTC DeploymentID: DisableImage:false LogConfigs:[] Snapshot:{Pause: Resume:} Runs:map[] RAMCommitment:0 CPUCommitment:0 Actions:map[] HealthChecks:map[] Prereqs:[] MonitoringProfile:{MetricConfigs:[] GraphConfigs:[] ThresholdConfigs:[]} MemoryLimit:0 CPUShares:0 PIDFile: VersionedEntity:{DatabaseVersion:0}}
```

DEMO2 - services started:

```
root@ip-10-111-2-211:/var/log/upstart# serviced service status
NAME            ID              STATUS      UPTIME          HOST            IN_SYNC     DOCKER_ID
└─Zenoss.resmgr     5bxjeiep5clvb7wy0mm24bg1k   Running     8m46.286608124s     ip-10-111-2-128     Y       632ae05788a6
  ├─zeneventserver  16jq6rcq8snlke7tgke9abuje   Running     8m38.892081708s     ip-10-111-2-128     Y       af63e59b8b2f
  ├─Zauth       1ikh0bt5ycwu52ipamecka6ce   Running     9m28.022283633s     ip-10-111-2-211     Y       31503219748c
  ├─localhost       23w6jp9b0hpplnqpuq78x2vqs                                           
  │ ├─localhost       au47a6whlsk3p7gfmzbi3jw82   Running     8m46.425168317s     ip-10-111-2-128     Y       2ce4842a6ce3
  │ │ ├─zenwebtx    15lnilpohrygogtodzfk95p95   Running     9m30.725255901s     ip-10-111-2-33      Y       e7c0a6e24eaa
  │ │ ├─zenprocess  2fopfowfw4bo9bxriqtldhagb   Running     9m30.58164172s      ip-10-111-2-33      Y       e47f6cb073cd
  │ │ ├─zenstatus   2pey88p7d4vpiweq87uluyfpv   Running     8m46.772923078s     ip-10-111-2-211     Y       ed9ba5389597
  │ │ ├─MetricShipper   3lva9rgfjh8lybfb2rbp2yovn   Running     7m27.019378667s     ip-10-111-2-33      Y       c65bbd82d799
  │ │ ├─zenucsevents    494sc6yw0pj8pfzwfkvhqd7ai   Running     8m46.565686123s     ip-10-111-2-128     Y       a8d6e02671ef
  │ │ ├─zencommand  4aqrttqsabckwcvsrdadikfyt   Running     8m42.233992361s     ip-10-111-2-128     Y       d1123ef7e665
  │ │ ├─zenjmx      6lzpgfy08besa8roz1dx2qydu   Running     8m46.502314254s     ip-10-111-2-128     Y       a0b8eb1d7983
  │ │ ├─zminion     77vgf3d0mmiga8g0fj0rua54u   Running     8m57.043509498s     ip-10-111-2-33      Y       d5b247c493d1
  │ │ ├─zenperfsnmp 7ko60s5yonfn4cco7qr4ox6m5   Running     7m26.984277845s     ip-10-111-2-33      Y       118c7120ac5a
  │ │ ├─zentrap     8uewnb8jegahf0euszrmv28e6   Running     8m59.133921547s     ip-10-111-2-211     Y       825500d06dd3
  │ │ ├─collectorredis  a7t1c40g60z0od6uexljhisx0   Running     9m30.582536756s     ip-10-111-2-33      Y       838f5385eefd
  │ │ ├─zensyslog   afc6odp6d9lub6ch1qlrumnt9   Running     8m46.99602865s      ip-10-111-2-211     Y       fa436d7056ee
  │ │ ├─zenping     c5as4yb2mjz0i9lc5gb5vkm93   Running     9m35.468582196s     ip-10-111-2-211     Y       4b050b43d7a5
  │ │ ├─zenmailtx   cimd6cf1xq659dvg0p57chkbx   Running     9m35.691310531s     ip-10-111-2-211     Y       9fe835abbb30
  │ │ ├─zenvsphere  cqbkcmpb4ols0ms2x12cfc6xo   Running     8m46.514537305s     ip-10-111-2-128     Y       712bd664dcae
  │ │ ├─zenmodeler  mih70k01iaw3yrhxn8ghdzr     Running     8m46.43832487s      ip-10-111-2-128     Y       9540cd7092f9
  │ │ └─zenpython   ytzcastpx98897lmpgpji74r    Running     8m46.484406716s     ip-10-111-2-128     Y       408d497d3f4c
  │ └─zenhub      k3f4sakqvvosw6ygr7enan0c    Running     9m30.750470774s     ip-10-111-2-33      Y       077e13b927c7
  ├─opentsdb        2acgip4soq3gntucferu6sbas                                           
  │ ├─writer      8v3c4a3vckck8ukx2cbpaii3v   Running     5m21.078625212s     ip-10-111-2-33      Y       28bda7d03803
  │ └─reader      cxruejf3x0wnf2dc8t0vrcggc   Running     9m22.004051346s     ip-10-111-2-211     Y       fe2dfa58225a
  ├─MetricConsumer  3du4sbkj80ykli1qxfacbqjr8   Running     9m31.144746987s     ip-10-111-2-33      Y       3e4a10872f99
  ├─zenjserver      5l4tpw0yie1wwnecmcs050y7w   Running     8m46.945122366s     ip-10-111-2-128     Y       6ed91b135f8f
  ├─MetricShipper   5nb3uyk9eao8lodap0apij2ai   Running     9m31.012644829s     ip-10-111-2-33      Y       07f05cc6e21f
  ├─CentralQuery    5ppqo725s4923x5jyzgey4owb   Running     9m23.180265497s     ip-10-111-2-33      Y       181a5296a928
  ├─zenactiond      6cedyyoiq47ipnhd3y7ygm0yr   Running     9m35.342702506s     ip-10-111-2-211     Y       17c5cf3cf2aa
  ├─RabbitMQ        82oar1jt7qu9ygs4adcc24sr3   Running     9m9.450578255s      ip-10-111-2-33      Y       649c49511ee5
  ├─zencatalogservice   85jupiirhkdgolqr862pv5xq0   Running     8m49.777134605s     ip-10-111-2-211     Y       9003799e3c9b
  ├─HBase       8g83256hm773k08bqyvnslt9p                                           
  │ ├─RegionServer/0  32gpcgkr0rgsqkuytdzgxkegr/0 Running     9m11.813842851s     ip-10-111-2-211     Y       ae1e27778a4d
  │ ├─RegionServer/1  32gpcgkr0rgsqkuytdzgxkegr/1 Running     6m47.44273142s      ip-10-111-2-128     Y       dc4cba5e3f92
  │ ├─RegionServer/2  32gpcgkr0rgsqkuytdzgxkegr/2 Running     7m9.907925317s      ip-10-111-2-33      Y       73fc46ab9e66
  │ ├─HMaster     6azljvji312owrbgdk1p0zlwc   Running     7m21.645170278s     ip-10-111-2-33      Y       63cc7b59c0e9
  │ ├─ZooKeeper/0 dqu15zb0oldkt1zn4q61x8ht4/0 Running     7m15.328778228s     ip-10-111-2-33      Y       daa690f7b1f9
  │ ├─ZooKeeper/1 dqu15zb0oldkt1zn4q61x8ht4/1 Running     9m21.858657285s     ip-10-111-2-211     Y       eacc7990d245
  │ └─ZooKeeper/2 dqu15zb0oldkt1zn4q61x8ht4/2 Running     6m53.078947315s     ip-10-111-2-128     Y       3b6b21dc66bb
  ├─redis       8vdnbx4uujlncz5djvcl54z1t   Running     8m46.347353182s     ip-10-111-2-128     Y       8e5df13ce825
  ├─MySQL       b823q39la019onnnseirk3mz9   Running     9m27.574487904s     ip-10-111-2-211     Y       2a49e1d06fd4
  ├─zenjobs     cl8y6st0uxchveqwl9ahd1ic9   Running     8m4.941223868s      ip-10-111-2-128     Y       5424e645362d
  ├─memcached       cmfdvna9ldduxih8x5d3ltt3l   Running     8m46.356166382s     ip-10-111-2-128     Y       a0b72142f78d
  ├─Zope/0      e4qdux5tuji46i1rcrrew39wk/0 Running     6m29.380297912s     ip-10-111-2-33      Y       7d22aad09692
  ├─Zope/1      e4qdux5tuji46i1rcrrew39wk/1 Running     7m31.120394256s     ip-10-111-2-33      Y       4e28613b26e7
  ├─Zope/2      e4qdux5tuji46i1rcrrew39wk/2 Running     7m40.292449693s     ip-10-111-2-211     Y       4e29fb5c2d81
  ├─Zope/3      e4qdux5tuji46i1rcrrew39wk/3 Running     7m44.787472581s     ip-10-111-2-128     Y       fbf4b568b711
  ├─Zope/4      e4qdux5tuji46i1rcrrew39wk/4 Running     7m30.999586797s     ip-10-111-2-33      Y       91d28116334e
  ├─Zope/5      e4qdux5tuji46i1rcrrew39wk/5 Running     7m51.747193793s     ip-10-111-2-211     Y       77992d7258c8
  └─zeneventd       gtvfl3pfemlxbdfranwft9du    Running     9m33.797065929s     ip-10-111-2-211     Y       6b124eee2fdd
root@ip-10-111-2-211:/var/log/upstart# 
```
