### PR TITLE
Clean up container shutdown

### DIFF
--- a/container/controller.go
+++ b/container/controller.go
@@ -473,8 +473,6 @@ func (c *Controller) shutdown() {
 	//defers run in LIFO order
 	defer os.Exit(c.exitStatus)
 	defer zzk.ShutdownConnections()
-	defer c.unregisterVhosts()
-	defer c.unregisterEndpoints()
 }
 
 // Run executes the controller's main loop and block until the service exits
@@ -534,7 +532,9 @@ func (c *Controller) Run() (err error) {
 	}
 	c.watchRemotePorts()
 	go c.checkPrereqs(prereqsPassed, rpcDead)
-	healthExits := c.kickOffHealthChecks()
+	healthExit := make (chan struct{})
+	defer close(healthExit)
+	c.kickOffHealthChecks(healthExit)
 	doRegisterEndpoints := true
 	exited := false
 
@@ -546,6 +546,7 @@ func (c *Controller) Run() (err error) {
 			startAfter = nil
 			rpcDead = nil
 			exitAfter = time.After(time.Second * 30)
+			close(healthExit)
 		} else {
 			c.exitStatus = 1
 			exited = true
@@ -600,9 +601,6 @@ func (c *Controller) Run() (err error) {
 			shutdownService(service, syscall.SIGTERM)
 		}
 	}
-	for _, exitChannel := range healthExits {
-		exitChannel <- true
-	}
 	return
 }
 
@@ -643,12 +641,11 @@ func (c *Controller) checkPrereqs(prereqsPassed chan bool, rpcDead chan struct{}
 	return nil
 }
 
-func (c *Controller) kickOffHealthChecks() map[string]chan bool {
-	exitChannels := make(map[string]chan bool)
+func (c *Controller) kickOffHealthChecks(healthExit chan struct{}) {
 	client, err := node.NewLBClient(c.options.ServicedEndpoint)
 	if err != nil {
 		glog.Errorf("Could not create a client to endpoint: %s, %s", c.options.ServicedEndpoint, err)
-		return nil
+		return
 	}
 	defer client.Close()
 	var healthChecks map[string]domain.HealthCheck
@@ -656,24 +653,23 @@ func (c *Controller) kickOffHealthChecks() map[string]chan bool {
 	instanceID, err := strconv.Atoi(c.options.Service.InstanceID)
 	if err != nil {
 		glog.Errorf("Invalid instance from instanceID:%s", c.options.Service.InstanceID)
-		return nil
+		return
 	}
 	err = client.GetHealthCheck(node.HealthCheckRequest{
 		c.options.Service.ID, instanceID}, &healthChecks)
 	if err != nil {
 		glog.Errorf("Error getting health checks: %s", err)
-		return nil
+		return
 	}
 	for key, mapping := range healthChecks {
 		glog.Infof("Kicking off health check %s.", key)
-		exitChannels[key] = make(chan bool)
 		glog.Infof("Setting up health check: %s", mapping.Script)
-		go c.handleHealthCheck(key, mapping.Script, mapping.Interval, exitChannels[key])
+		go c.handleHealthCheck(key, mapping.Script, mapping.Interval, healthExit)
 	}
-	return exitChannels
+	return
 }
 
-func (c *Controller) handleHealthCheck(name string, script string, interval time.Duration, exitChannel chan bool) {
+func (c *Controller) handleHealthCheck(name string, script string, interval time.Duration, exitChannel chan struct{}) {
 	client, err := node.NewLBClient(c.options.ServicedEndpoint)
 	if err != nil {
 		glog.Errorf("Could not create a client to endpoint: %s, %s", c.options.ServicedEndpoint, err)


### PR DESCRIPTION
1) Don't explicitly clean up ephemeral ZK nodes.  These will go away when
shutdown the ZK connection, and if we lost zk server these function will not
complete.
2) Sanify (as in make sane) healthcheck exit channel handling.
3) Stop performing health checks after container exit has been requested.
