### PR TITLE
prefer docker exec over nsenter

### DIFF
--- a/utils/docker_exec.go
+++ b/utils/docker_exec.go
@@ -72,24 +72,45 @@ func generateDockerExecCommand(containerID string, bashcmd []string, prependBash
 	return attachCmd, nil
 }
 
+// hasFeatureDockerExec returns true if docker exec is supported
+func hasFeatureDockerExec() bool {
+	command := []string{"docker", "exec"}
+
+	thecmd := exec.Command(command[0], command[1:]...)
+	output, err := thecmd.CombinedOutput()
+	// when docker exec is supported, we expect above 'docker exec' to fail,
+	// but provide usage
+	glog.V(1).Infof("Successfully ran command:'%s'  err: %s  output: %s\n", command, err, output)
+
+	return strings.Contains(string(output), "Usage: docker exec")
+}
+
 // AttachAndRun attaches to a container and runs the command
 func AttachAndRun(containerID string, bashcmd []string) ([]byte, error) {
+	if hasFeatureDockerExec() {
+		return RunDockerExec(containerID, bashcmd)
+	}
+
 	_, err := exec.LookPath("nsenter")
 	if err == nil {
 		return RunNSEnter(containerID, bashcmd)
 	}
 
-	return RunDockerExec(containerID, bashcmd)
+	return nil, fmt.Errorf("unable to find attach utility to run: %s", bashcmd)
 }
 
 // AttachAndExec attaches to a container and execs the command
 func AttachAndExec(containerID string, bashcmd []string) error {
+	if hasFeatureDockerExec() {
+		return ExecDockerExec(containerID, bashcmd)
+	}
+
 	_, err := exec.LookPath("nsenter")
 	if err == nil {
 		return ExecNSEnter(containerID, bashcmd)
 	}
 
-	return ExecDockerExec(containerID, bashcmd)
+	return fmt.Errorf("unable to find attach utility to exec: %s", bashcmd)
 }
 
 // exePaths returns the full path to the given executables in a map


### PR DESCRIPTION
for https://jira.zenoss.com/browse/CC-197:

DEMO1 - make sure it works for docker 1.2.0 where docker exec is not supported:

```
# plu@plu-9: serviced -v=2 service attach /redis/0 ps -wwef
I0922 13:44:14.015784 05973 service.go:959] ========= rs:8j5ttgm0b48lo2ylq43lrnzxe redis  path[7mxqp7pi247edphyubu1k9min]:zenoss.core/redis/0
I0922 13:44:14.032277 05973 docker_exec.go:85] Successfully ran command:'[docker exec --help]' output: Error: Command not found: exec
Error: Command not found: --help
Usage: docker [OPTIONS] COMMAND [arg...]
 -H=[unix:///var/run/docker.sock]: tcp://host:port to bind/connect to or unix://path/to/socket to use

A self-sufficient runtime for linux containers.

Commands:
    attach    Attach to a running container
    build     Build an image from a Dockerfile
    commit    Create a new image from a container's changes
    cp        Copy files/folders from a container's filesystem to the host path
    diff      Inspect changes on a container's filesystem
    events    Get real time events from the server
    export    Stream the contents of a container as a tar archive
    history   Show the history of an image
    images    List images
    import    Create a new filesystem image from the contents of a tarball
    info      Display system-wide information
    inspect   Return low-level information on a container
    kill      Kill a running container
    load      Load an image from a tar archive
    login     Register or log in to a Docker registry server
    logout    Log out from a Docker registry server
    logs      Fetch the logs of a container
    port      Lookup the public-facing port that is NAT-ed to PRIVATE_PORT
    pause     Pause all processes within a container
    ps        List containers
    pull      Pull an image or a repository from a Docker registry server
    push      Push an image or a repository to a Docker registry server
    restart   Restart a running container
    rm        Remove one or more containers
    rmi       Remove one or more images
    run       Run a command in a new container
    save      Save an image to a tar archive
    search    Search for an image on the Docker Hub
    start     Start a stopped container
    stop      Stop a running container
    tag       Tag an image into a repository
    top       Lookup the running processes of a container
    unpause   Unpause a paused container
    version   Show the Docker version information
    wait      Block until a container stops, then print its exit code


I0922 13:44:14.037001 05973 nsenter.go:108] attach command for container:6daf3a81abadd063eb8a31daeb200f7372b5e7f53bdaace221a2a5589fb357a7 command: [/usr/bin/sudo /usr/bin/nsenter -m -u -i -n -p -t 24871 -- ps -wwef]
I0922 13:44:14.037053 05973 nsenter.go:66] exec command for container:6daf3a81abadd063eb8a31daeb200f7372b5e7f53bdaace221a2a5589fb357a7 command: [/usr/bin/sudo /usr/bin/nsenter -m -u -i -n -p -t 24871 -- ps -wwef]
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 19:27 ?        00:00:01 /serviced/serviced service proxy 8j5ttgm0b48lo2ylq43lrnzxe 0 /usr/bin/redis-server /etc/redis.conf
root        15     1  0 19:27 ?        00:00:00 /usr/local/serviced/resources/logstash/logstash-forwarder -idle-flush-time=5s -old-files-hours=26280 -config /etc/logstash-forwarder.conf
root        19     1  0 19:27 ?        00:00:00 /usr/bin/redis-server *:6379
root       507     0  0 19:44 ?        00:00:00 ps -wwef

```

DEMO2 - use docker exec for docker 1.2.1 where it is supported (cannot test with serviced until docker issues are resolved, but here is the output of docker exec):

```
# plu@plu-9: docker exec

Usage: docker exec [OPTIONS] CONTAINER COMMAND [ARG...]

Run a command in an existing container

  -d, --detach=false         Detached mode: run command in the background
  -i, --interactive=false    Keep STDIN open even if not attached
  -t, --tty=false            Allocate a pseudo-TTY

# plu@plu-9: echo $?
2
```
