### PR TITLE
Performance Improvements

### DIFF
--- a/commons/cache.go
+++ b/commons/cache.go
@@ -1,0 +1,60 @@
+package commons
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+type CopyCache struct {
+	data map[string]interface{}
+	sync.Mutex
+}
+
+func NewCache() *CopyCache {
+	return &CopyCache{data: make(map[string]interface{})}
+}
+
+func (c *CopyCache) Invalidate(key string) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.data, key)
+}
+
+func (c *CopyCache) Add(key string, val interface{}) {
+	c.Lock()
+	defer c.Unlock()
+	c.data[key] = val
+	//// Make sure that we make a copy
+	//obj := reflect.ValueOf(val)
+	//cp := reflect.New(obj.Type())
+	//cp.Elem().Set(obj)
+	//c.data[key] = cp.Elem().Interface()
+}
+
+func (c *CopyCache) Get(key string) (interface{}, bool) {
+	val, ok := c.data[key]
+	return val, ok
+}
+
+// GetInto() gets a cached value at the specified target address.
+func (c *CopyCache) GetInto(key string, target interface{}) (bool, error) {
+	// Retrieve a cached value, if there is one
+	val, ok := c.Get(key)
+	if !ok {
+		return false, nil
+	}
+	// Verify that the target address is in fact a pointer
+	t := reflect.ValueOf(target)
+	if t.Kind() != reflect.Ptr {
+		return false, fmt.Errorf("GetInto() requires a pointer")
+	}
+	// Make sure that the value we retrieve from the cache is the object itself
+	v := reflect.ValueOf(val)
+	if v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	// Write a copy of the cached value to the address passed in
+	t.Elem().Set(v)
+	return true, nil
+}

--- a/commons/cache_test.go
+++ b/commons/cache_test.go
@@ -1,0 +1,78 @@
+package commons
+
+import (
+	"fmt"
+	"testing"
+)
+
+type testObject struct {
+	i int
+}
+
+func TestInvalidateCache(t *testing.T) {
+	c := NewCache()
+	orig := testObject{}
+
+	c.data["abc"] = orig
+	c.Invalidate("abc")
+
+	if _, ok := c.data["abc"]; ok {
+		t.Fatalf("Invalidate() didn't invalidate")
+	}
+}
+
+func TestAddToCache(t *testing.T) {
+	c := NewCache()
+	var (
+		orig interface{}
+	)
+	obj := testObject{4}
+	orig = obj
+
+	c.Add("abc", orig)
+	val, ok := c.data["abc"]
+	if !ok {
+		t.Fatalf("Add() didn't add to the cache")
+	}
+	if &val == &orig {
+		t.Fatalf("Add() didn't keep a copy")
+	}
+}
+
+func TestGetFromCache(t *testing.T) {
+	c := NewCache()
+	var orig interface{}
+	orig = testObject{}
+
+	c.data["abc"] = orig
+	val, ok := c.Get("abc")
+	if !ok {
+		t.Fatalf("Couldn't Get() from the cache")
+	}
+	if &val == &orig {
+		t.Fatalf("Get() didn't return a copy")
+	}
+	val, ok = c.Get("cde")
+	if ok {
+		t.Fatalf("Get()ting an invalid cache item was ok")
+	}
+}
+
+func TestGetInto(t *testing.T) {
+	c := NewCache()
+	var source, target interface{}
+
+	source = testObject{5}
+	target = testObject{}
+
+	c.Add("abc", source)
+	ok, _ := c.GetInto("abc", &target)
+	if !ok {
+		t.Fatalf("Couldn't GetInto() a valid cache item")
+	}
+	isto, ok := target.(testObject)
+	if isto.i != 5 {
+		fmt.Printf("%+v %+v", isto, source)
+		t.Fatalf("GetInto() target doesn't match original")
+	}
+}

--- a/dao/elasticsearch/health.go
+++ b/dao/elasticsearch/health.go
@@ -19,6 +19,6 @@ import (
 )
 
 func (this *ControlPlaneDao) LogHealthCheck(result domain.HealthCheckResult, unused *int) error {
-	health.RegisterHealthCheck(result.ServiceID, result.Name, result.Passed, this)
+	health.RegisterHealthCheck(result.ServiceID, result.Name, result.Passed, this, this.facade)
 	return nil
 }

--- a/dao/elasticsearch/runningservice.go
+++ b/dao/elasticsearch/runningservice.go
@@ -16,7 +16,6 @@ package elasticsearch
 import (
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/datastore"
-	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/zzk"
 	zkservice "github.com/control-center/serviced/zzk/service"
 	"github.com/zenoss/glog"
@@ -86,15 +85,16 @@ func (this *ControlPlaneDao) GetRunningServicesForHost(hostID string, services *
 func (this *ControlPlaneDao) GetRunningServicesForService(serviceID string, services *[]dao.RunningService) error {
 	// we initialize the data container to something here in case it has not been initialized yet
 	*services = make([]dao.RunningService, 0)
-	myService, err := this.facade.GetService(datastore.Get(), serviceID)
+
+	poolID, err := this.facade.GetPoolForService(datastore.Get(), serviceID)
 	if err != nil {
 		glog.Errorf("Unable to get service %v: %v", serviceID, err)
 		return err
 	}
 
-	poolBasedConn, err := zzk.GetLocalConnection(zzk.GeneratePoolPath(myService.PoolID))
+	poolBasedConn, err := zzk.GetLocalConnection(zzk.GeneratePoolPath(poolID))
 	if err != nil {
-		glog.Errorf("Error in getting a connection based on pool %v: %v", myService.PoolID, err)
+		glog.Errorf("Error in getting a connection based on pool %v: %v", poolID, err)
 		return err
 	}
 
@@ -115,15 +115,16 @@ func (this *ControlPlaneDao) GetRunningService(request dao.ServiceStateRequest, 
 	glog.V(3).Infof("ControlPlaneDao.GetRunningService: request=%v", request)
 	*running = dao.RunningService{}
 
-	var myService service.Service
-	if err := this.GetService(request.ServiceID, &myService); err != nil {
-		glog.V(2).Infof("ControlPlaneDao.GetServiceLogs service=%+v err=%s", request.ServiceID, err)
+	serviceID := request.ServiceID
+	poolID, err := this.facade.GetPoolForService(datastore.Get(), serviceID)
+	if err != nil {
+		glog.Errorf("Unable to get service %v: %v", request, err)
 		return err
 	}
 
-	poolBasedConn, err := zzk.GetLocalConnection(zzk.GeneratePoolPath(myService.PoolID))
+	poolBasedConn, err := zzk.GetLocalConnection(zzk.GeneratePoolPath(poolID))
 	if err != nil {
-		glog.Errorf("Error in getting a connection based on pool %v: %v", myService.PoolID, err)
+		glog.Errorf("Error in getting a connection based on pool %v: %v", poolID, err)
 		return err
 	}
 

--- a/facade/service.go
+++ b/facade/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/control-center/serviced/commons"
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain"
 	"github.com/control-center/serviced/domain/addressassignment"
 
 	"github.com/control-center/serviced/domain/service"
@@ -122,6 +123,26 @@ func (f *Facade) RemoveService(ctx datastore.Context, id string) error {
 	}
 	//TODO: remove AddressAssignments with f Service
 	return nil
+}
+
+func (f *Facade) GetPoolForService(ctx datastore.Context, id string) (string, error) {
+	glog.V(3).Infof("Facade.GetPoolForService: id=%s", id)
+	store := f.serviceStore
+	svc, err := store.Get(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	return svc.PoolID, nil
+}
+
+func (f *Facade) GetHealthChecksForService(ctx datastore.Context, serviceID string) (map[string]domain.HealthCheck, error) {
+	glog.V(3).Infof("Facade.GetHealthChecksForService: id=%s", serviceID)
+	store := f.serviceStore
+	svc, err := store.Get(ctx, serviceID)
+	if err != nil {
+		return nil, err
+	}
+	return svc.HealthChecks, nil
 }
 
 func (f *Facade) GetService(ctx datastore.Context, id string) (*service.Service, error) {

--- a/health/health.go
+++ b/health/health.go
@@ -14,13 +14,15 @@
 package health
 
 import (
+	"sync"
+	"time"
+
 	"github.com/control-center/serviced/dao"
-	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/facade"
 	"github.com/control-center/serviced/node"
 	"github.com/zenoss/glog"
 	"github.com/zenoss/go-json-rest"
-	"sync"
-	"time"
 )
 
 type healthStatus struct {
@@ -62,7 +64,7 @@ func RestGetHealthStatus(w *rest.ResponseWriter, r *rest.Request, client *node.C
 }
 
 // RegisterHealthCheck updates the healthStatus and healthTime structures with a health check result.
-func RegisterHealthCheck(serviceID string, name string, passed string, d dao.ControlPlane) {
+func RegisterHealthCheck(serviceID string, name string, passed string, d dao.ControlPlane, f *facade.Facade) {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -74,14 +76,12 @@ func RegisterHealthCheck(serviceID string, name string, passed string, d dao.Con
 	}
 	thisStatus, ok := serviceStatus[name]
 	if !ok {
-		var service service.Service
-
-		err := d.GetService(serviceID, &service)
+		healthChecks, err := f.GetHealthChecksForService(datastore.Get(), serviceID)
 		if err != nil {
-			glog.Errorf("Unable to acquire services.")
+			glog.Errorf("Unable to acquire health checks: %+v", err)
 			return
 		}
-		for iname, icheck := range service.HealthChecks {
+		for iname, icheck := range healthChecks {
 			_, ok = serviceStatus[iname]
 			if !ok {
 				serviceStatus[name] = &healthStatus{"unknown", 0, icheck.Interval.Seconds(), time.Now().Unix()}
@@ -96,9 +96,11 @@ func RegisterHealthCheck(serviceID string, name string, passed string, d dao.Con
 	thisStatus.Status = passed
 	thisStatus.Timestamp = time.Now().UTC().Unix()
 
-	var runningServices []dao.RunningService
-	err := d.GetRunningServicesForService(serviceID, &runningServices)
-	if err == nil && len(runningServices) > 0 {
-		thisStatus.StartedAt = runningServices[0].StartedAt.Unix()
+	if thisStatus.StartedAt == 0 {
+		var runningServices []dao.RunningService
+		err := d.GetRunningServicesForService(serviceID, &runningServices)
+		if err == nil && len(runningServices) > 0 {
+			thisStatus.StartedAt = runningServices[0].StartedAt.Unix()
+		}
 	}
 }


### PR DESCRIPTION
Several were added here. They are:

1) Added specific calls to retrieve HealthChecks and PoolID from services, rather than deserializing the entire service tree every time
2) Added a simple caching layer for Elasticsearch to avoid deserializing constantly
3) Limited calls to ZooKeeper to get running services while processing health check results

This removes the UI as a major contributor to serviced's CPU usage. In addition, it drops "resting state" CPU usage from 80-90% (for a started, but not populated, Core system) to around 20%.

The bulk of that remaining 20% is in TLS handshakes. Another pull request is coming to deal with that to the extent possible.
