### PR TITLE
Remove redundant action from recipe

### DIFF
--- a/makefile
+++ b/makefile
@@ -176,7 +176,6 @@ FORCE:
 
 serviced: $(Godeps_restored)
 serviced: FORCE
-	go build ${LDFLAGS}
 	go install ${LDFLAGS}
 
 serviced = $(GOBIN)/serviced


### PR DESCRIPTION
'go install' performs 'go build'; why do them both?

This speeds up dev builds by almost 50%
