### PR TITLE
avoid dockerclient leak on container.Wait() by blocking a long time, the...

### DIFF
--- a/commons/docker/api.go
+++ b/commons/docker/api.go
@@ -402,7 +402,7 @@ func (c *Container) Wait(timeout time.Duration) (int, error) {
 		rc  int
 		err error
 	}
-	errc := make(chan waitResult)
+	errc := make(chan waitResult, 1)
 	go func() {
 		rc, err := dc.WaitContainer(c.ID)
 		errc <- waitResult{rc, err}

--- a/node/agent.go
+++ b/node/agent.go
@@ -450,10 +450,7 @@ func (a *HostAgent) setProxy(svc *service.Service, ctr *docker.Container) {
 			defer a.proxyRegistry.RemoveProxy(proxyID)
 		}
 	}
-
-	for ctr.IsRunning() {
-		ctr.Wait(time.Minute)
-	}
+	ctr.Wait(time.Hour * 24 * 365)
 }
 
 func (a *HostAgent) removeInstance(stateID string, ctr *docker.Container) {


### PR DESCRIPTION
... http client does not have a timeout
