### PR TITLE
serviced snapshot commit will allow the short form of the container ID

### DIFF
--- a/cli/api/snapshot.go
+++ b/cli/api/snapshot.go
@@ -86,6 +86,20 @@ func (a *api) RemoveSnapshot(snapshotID string) error {
 	return nil
 }
 
+// getLongContainerID returns the full container id of a docker container
+func (a *api) getLongContainerID(containerID string) (string, error) {
+	dockerClient, err := a.connectDocker()
+	if err != nil {
+		return "", err
+	}
+	container, err := dockerClient.InspectContainer(containerID)
+	if err != nil {
+		return "", err
+	}
+
+	return container.ID, nil
+}
+
 // Commit creates a snapshot and commits it as the service's image
 func (a *api) Commit(dockerID string) (string, error) {
 	client, err := a.connectDAO()
@@ -93,8 +107,13 @@ func (a *api) Commit(dockerID string) (string, error) {
 		return "", err
 	}
 
+	containerID, err := a.getLongContainerID(dockerID)
+	if err != nil {
+		return "", err
+	}
+
 	var snapshotID string
-	if err := client.Commit(dockerID, &snapshotID); err != nil {
+	if err := client.Commit(containerID, &snapshotID); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
DEMO1 - do no harm, it should work like it used to:

```
zenny@ip-10-111-3-51:~$ ./serviced service shell -i -s baz zope bash
I0927 05:30:34.707779 08243 server.go:341] Connected to the control center at port 10.111.3.51:4979
I0927 05:30:34.935757 08243 server.go:435] Acquiring image from the dfs...
I0927 05:30:34.936040 08243 server.go:437] Acquired!  Starting shell
Trying to connect to logstash server... 127.0.0.1:5042
Connected to logstash server.
bash-4.2# uname -n
c31cdc06ef34
bash-4.2# exit

zenny@ip-10-111-3-51:~$ docker ps --no-trunc -a |grep c31cdc06ef34
c31cdc06ef34795b867561d884c37588a2ca2c709dc9db8304511a984fa48a6e   ip-10-111-3-51:5000/2vlacjlun05czwlm1y8tqlcbk/resmgr-unstable:20140927-052815   "/serviced/serviced --logtostderr=false service proxy --autorestart=false --disable-metric-forwarding --logstash=false --logstash-idle-flush-time=0 --logstash-settle-time=0 esr59hlrvromn9cxtdu408hw4 0 bash"   26 seconds ago      Exited (0) 9 seconds ago                                                                                                    baz                                                           
zenny@ip-10-111-3-51:~$ ./serviced snapshot commit c31cdc06ef34795b867561d884c37588a2ca2c709dc9db8304511a984fa48a6e
2vlacjlun05czwlm1y8tqlcbk_20140927-053137
zenny@ip-10-111-3-51:~$ 
```

DEMO2 - allow short docker id:

```
zenny@ip-10-111-3-51:~$ ./serviced service shell -i -s foo zope bash
I0927 05:26:51.706751 09329 server.go:341] Connected to the control center at port 10.111.3.51:4979
I0927 05:26:51.932956 09329 server.go:435] Acquiring image from the dfs...
I0927 05:26:51.933217 09329 server.go:437] Acquired!  Starting shell
Trying to connect to logstash server... 127.0.0.1:5042
Connected to logstash server.
bash-4.2# uname -n
f7950f9adbd0
bash-4.2# exit

zenny@ip-10-111-3-51:~$ ./serviced snapshot commit f7950f9adbd0
2vlacjlun05czwlm1y8tqlcbk_20140927-052815
zenny@ip-10-111-3-51:~$ 
```
