### PR TITLE
fix ISSUE-1142: fix compile instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ start serviced
    for user requests. You can track the output of serviced at 
    /var/log/upstart/serviced.log.
 
-4. Browse the UI at http://localhost:8787
+4. Browse the UI at https://localhost
 
 Usage
 -----
@@ -33,18 +33,12 @@ Serviced is a platform for running services. Serviced is composed of a master
 serviced process and agent processes running on each host. Each host must be registered
 with the master process. To register a agent process:
 ```bash
-serviced add-host [HOSTNAME:PORT]
-```
-
-After the hosts are registered they must be placed in to a resource pool. This is done
-by first creating a pool:
-```bash
-serviced add-pool NAME CORE_LIMIT MEMORY_LIMIT PRIORITY
+serviced host add HOST:PORT RESOURCE_POOL
 ```
 
 Dev Environment
 ---------------
-Serviced is written in go. To install go, download go v1.2 from http://golang.org.
+Serviced is written in go. To install go, download go v1.3 from http://golang.org.
 Untar the distribution to /usr/local/go. If you use a different location for go, you
 must set GOROOT. See the http://www.golang.org for more information. Ensure that 
 $GOROOT/bin is in you path.
@@ -63,12 +57,13 @@ With $GOROOT set and $GOROOT/bin in your $PATH, create a development workspace.
 ```bash
 export GOPATH=~/mygo
 export PATH="$PATH:$GOPATH/bin"
-mkdir $GOPATH/{bin,pkg,src} -p
-mkdir $GOPATH/src/github.com/zenoss -p
-cd $GOPATH/src/github.com/zenoss 
-git clone git@github.com:control-center/serviced.git
+mkdir -p $GOPATH/{bin,pkg,src}
+mkdir -p $GOPATH/src/github.com/control-center
+cd $GOPATH/src/github.com/control-center 
+git clone git@github.com:control-center/serviced
+    # alternatively: git clone https://github.com/control-center/serviced
 cd serviced
-make install
+make
 ```
 
 After this, a binary should exist at $GOPATH/bin/serviced & 


### PR DESCRIPTION
FIX:
  https://github.com/control-center/serviced/issues/1142

DEMO:

```
# plu@plu-9: ls ~/mygo
ls: cannot access /home/plu/mygo: No such file or directory
# plu@plu-9: export GOPATH=~/mygo
# plu@plu-9: export PATH="$PATH:$GOPATH/bin"
# plu@plu-9: mkdir -p $GOPATH/{bin,pkg,src}
# plu@plu-9: mkdir -p $GOPATH/src/github.com/control-center
# plu@plu-9: cd $GOPATH/src/github.com/control-center
# plu@plu-9: git clone git@github.com:control-center/serviced
Cloning into 'serviced'...
remote: Counting objects: 32711, done.
remote: Compressing objects: 100% (149/149), done.
remote: Total 32711 (delta 68), reused 0 (delta 0)
Receiving objects: 100% (32711/32711), 22.29 MiB | 5.91 MiB/s, done.
Resolving deltas: 100% (21379/21379), done.
Checking connectivity... done.
# plu@plu-9: cd serviced
# plu@plu-9: make
go get github.com/tools/godep
go install github.com/tools/godep
/home/plu/mygo/bin/godep restore
touch .Godeps_restored
cd isvcs && make
make[1]: Entering directory `/home/plu/mygo/src/github.com/control-center/serviced/isvcs'
cp resources/logstash/logstash.conf.in resources/logstash/logstash.conf
make[1]: Leaving directory `/home/plu/mygo/src/github.com/control-center/serviced/isvcs'
cd web && make build_js
make[1]: Entering directory `/home/plu/mygo/src/github.com/control-center/serviced/web'
cat static/js/main.js static/js/controllers/BackupRestoreControl.js static/js/controllers/CeleryLogicControl.js static/js/controllers/DeployedAppsControl.js static/js/controllers/DeployWizard.js static/js/controllers/DevControl.js static/js/controllers/HostDetailsControl.js static/js/controllers/HostsControl.js static/js/controllers/HostsMapControl.js static/js/controllers/IsvcsControl.js static/js/controllers/LanguageControl.js static/js/controllers/LogControl.js static/js/controllers/LoginControl.js static/js/controllers/NavbarControl.js static/js/controllers/PoolsControl.js static/js/controllers/PoolsDetailsControl.js static/js/controllers/ServicesMapControl.js static/js/controllers/SubServiceControl.js > static/js/controlplane.js || rm -rf static/js/controlplane.js
makefile:46: WARNING: This is a scurrilous lie. We are not minifying anything.
cp static/js/controlplane.js static/js/controlplane.min.js
make[1]: Leaving directory `/home/plu/mygo/src/github.com/control-center/serviced/web'
go build -ldflags "-X main.Version 0.8.0 -X main.Giturl '' -X main.Gitcommit 5905a4c -X main.Gitbranch develop -X main.Date 'Mon Oct  6 20:12:13 UTC 2014' -X main.Buildtag 0"
go install -ldflags "-X main.Version 0.8.0 -X main.Giturl '' -X main.Gitcommit 5905a4c -X main.Gitbranch develop -X main.Date 'Mon Oct  6 20:12:13 UTC 2014' -X main.Buildtag 0"
# plu@plu-9: ls -l ~/mygo/bin/
total 25200
-rwxr-xr-x 1 plu plu  8820568 Oct  6 15:12 godep
-rwxr-xr-x 1 plu plu 16980757 Oct  6 15:13 serviced
```
