### PR TITLE
use commit hash package from zenpip when making deb/rpm

### DIFF
--- a/pkg/makefile
+++ b/pkg/makefile
@@ -33,6 +33,9 @@ VENDOR        = "Zenoss, Inc."
 URL           = http://controlcenter.io/
 DEB_PRIORITY  = extra
 CATEGORY      = admin
+ZENPIPPKGSURL = http://zenpip.zendev.org/packages
+ZENPIP_VERSION ?= "e87b98706480b4965019b24dfde70d8a7e145c44-dirty"
+
 
 ifeq "$(BUILD_NUMBER)" ""
 PKG_VERSION = $(VERSION)$(RELEASE_PHASE)
@@ -124,9 +127,14 @@ stage_tgz: build
 	make clean_dirs clean_dirs=$(PKGROOT)
 	cd ../ && $(MAKE) install DESTDIR=$(abspath $(PKGROOT)) PKG=tgz INSTALL_TEMPLATES=$(INSTALL_TEMPLATES)
 
+stage_serviced:
+	@echo " untarring: $(ZENPIPPKGSURL)/serviced-$(ZENPIP_VERSION).tgz"
+	mkdir -p $(abspath $(PKGROOT))
+	curl -s $(ZENPIPPKGSURL)/serviced-$(ZENPIP_VERSION).tgz | tar -v -C $(abspath $(PKGROOT)) -xz
+
 # Make a DEB
 # net-tools provides ifconfig, needed for VIPs
-deb: stage_deb
+deb: stage_serviced
 	fpm \
 		-n $(FULL_NAME) \
 		-v $(PKG_VERSION)~$$(lsb_release -cs) \
@@ -152,7 +160,7 @@ deb: stage_deb
 		.
 
 # Make an RPM
-rpm: stage_rpm
+rpm: stage_serviced
 	fpm \
 		-n $(FULL_NAME) \
 		-v $(PKG_VERSION) \


### PR DESCRIPTION
DEMO:

```
~/src/europa/src/golang/src/github.com/control-center/serviced
# plu@plu-9: cd pkg
~/src/europa/src/golang/src/github.com/control-center/serviced/pkg
# plu@plu-9: ls
gitstatus.sh  pkgroot  serviced.default  serviced.service      serviced-systemd.sh
makefile      rpm      servicedef.mk     serviced.supervisord  serviced.upstart
~/src/europa/src/golang/src/github.com/control-center/serviced/pkg
# plu@plu-9: make deb
 untarring: http://zenpip.zendev.org/packages/serviced-e87b98706480b4965019b24dfde70d8a7e145c44-dirty.tgz
curl -s http://zenpip.zendev.org/packages/serviced-"e87b98706480b4965019b24dfde70d8a7e145c44-dirty".tgz | tar -v -C /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/pkg/pkgroot -xz
./
./etc/
./etc/bash_completion.d/
./etc/bash_completion.d/serviced
./etc/default/
./etc/default/serviced
./usr/
./usr/bin/
./usr/bin/serviced
./opt/
./opt/serviced/
./opt/serviced/bin/
./opt/serviced/bin/serviced

...

./opt/serviced/isvcs/resources/logstash/logstash.conf.in
./opt/serviced/isvcs/resources/cpcelery.py
fpm \
        -n serviced \
        -v 0.8.0~$(lsb_release -cs) \
        -s dir \
        -d nfs-kernel-server \
        -d net-tools \
        -d nfs-common \
        -d 'lxc-docker >= 1.1.0' \
        -d 'docker-smuggle >= 2.24' \
        -t deb \
        -a x86_64 \
        -C pkgroot \
        -m "Zenoss CM <cm@zenoss.com>" \
        --description "$DESCRIPTION" \
        --deb-user root \
        --deb-group root \
        --deb-priority extra \
        --license Apache-2 \
        --vendor "Zenoss, Inc." \
        --url http://controlcenter.io/ \
        --category admin \
        --config-files /etc/default/serviced \
        .
Created package {:path=>"serviced_0.8.0~trusty_amd64.deb"}
~/src/europa/src/golang/src/github.com/control-center/serviced/pkg
# plu@plu-9: ls
gitstatus.sh  pkgroot  serviced_0.8.0~trusty_amd64.deb  servicedef.mk     serviced.supervisord  serviced.upstart
makefile      rpm      serviced.default                 serviced.service  serviced-systemd.sh
~/src/europa/src/golang/src/github.com/control-center/serviced/pkg
# plu@plu-9: mkdir tmp
~/src/europa/src/golang/src/github.com/control-center/serviced/pkg
# plu@plu-9: cd tmp
~/src/europa/src/golang/src/github.com/control-center/serviced/pkg/tmp
# plu@plu-9: dpkg-deb -R ../serviced_0.8.0~trusty_amd64.deb  .
~/src/europa/src/golang/src/github.com/control-center/serviced/pkg/tmp
# plu@plu-9: ls -al
total 24
drwxr-xr-x 6 plu plu 4096 Oct  6 17:45 .
drwxrwxr-x 5 plu plu 4096 Oct  6 17:44 ..
drwxr-xr-x 2 plu plu 4096 Oct  6 17:44 DEBIAN
drwxr-xr-x 4 plu plu 4096 Oct  6 17:44 etc
drwxr-xr-x 3 plu plu 4096 Oct  6 17:44 opt
drwxr-xr-x 3 plu plu 4096 Oct  6 17:44 usr
~/src/europa/src/golang/src/github.com/control-center/serviced/pkg/tmp
# plu@plu-9: diff -qr ../pkgroot/ .
Only in .: DEBIAN
# plu@plu-9: 
```

DEMO2 - set ZENPIP_VERSION to version wanted on zenpip - should error because that file does not exist yet: 

```
# plu@plu-9: ZENPIP_VERSION=0.8.0-develop make clean deb
rm -f serviced_0.8.0~trusty_amd64.deb
rm -rf pkgroot
 untarring: http://zenpip.zendev.org/packages/serviced-0.8.0-develop.tgz
mkdir -p /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/pkg/pkgroot
curl -s http://zenpip.zendev.org/packages/serviced-0.8.0-develop.tgz | tar -v -C /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/pkg/pkgroot -xz

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
make: *** [stage_serviced] Error 2
```
