### PR TITLE
remove extraneous -- from docker exec command

### DIFF
--- a/utils/docker_exec.go
+++ b/utils/docker_exec.go
@@ -62,7 +62,7 @@ func generateDockerExecCommand(containerID string, bashcmd []string, prependBash
 
 	// TODO: add '-h' hostname to specify the container hostname when that
 	// feature becomes available
-	attachCmd := []string{exeMap["docker"], "exec", "-i", "-t", containerID, "--"}
+	attachCmd := []string{exeMap["docker"], "exec", "-i", "-t", containerID}
 	if prependBash {
 		attachCmd = append(attachCmd, "/bin/bash", "-c", fmt.Sprintf("%s", strings.Join(bashcmd, " ")))
 	} else {


### PR DESCRIPTION
ISSUE - serviced attach with docker exec fails:

```
# plu@plu-9: serviced service attach /redis/0
2014/10/10 21:05:32 docker-exec: failed to exec: exec: "--": executable file not found in $PATH
```

DEMO1 - show that attach works:

```
# plu@plu-9: serviced service attach /redis/0 ps -wwef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 21:05 ?        00:00:00 /serviced/serviced service proxy 4jc6qgrfj71nx9jki3oe1n8d5 0 /usr/bin/redis-server /etc/redis.conf
root        14     1  0 21:05 ?        00:00:00 /usr/local/serviced/resources/logstash/logstash-forwarder -idle-flush-time=5s -old-files-hours=26280 -config /etc/logstash-forwarder.conf
root        15     1  0 21:05 ?        00:00:00 /usr/bin/redis-server *:6379
root       368     0  0 21:15 ?        00:00:00 ps -wwef
# plu@plu-9: 
```

DEMO2 - show that docker exec is being used:

```
# plu@plu-9: serviced -v=1 service attach /redis/0 ps -wwef
I1010 16:15:21.913400 32242 docker_exec.go:83] Successfully ran command:'[docker exec]'  err: exit status 2  output: 
Usage: docker exec [OPTIONS] CONTAINER COMMAND [ARG...]

Run a command in an existing container

  -d, --detach=false         Detached mode: run command in the background
  -i, --interactive=false    Keep STDIN open even if not attached
  -t, --tty=false            Allocate a pseudo-TTY

I1010 16:15:21.913629 32242 docker_exec.go:71] attach command for container:95133001e19fed6496f361ffc3be30dad5300be6c72c7b0b25ae5ac4159e4335 command: [/usr/bin/docker exec -i -t 95133001e19fed6496f361ffc3be30dad5300be6c72c7b0b25ae5ac4159e4335 ps -wwef]
I1010 16:15:21.913665 32242 docker_exec.go:32] exec command for container:95133001e19fed6496f361ffc3be30dad5300be6c72c7b0b25ae5ac4159e4335 command: [/usr/bin/docker exec -i -t 95133001e19fed6496f361ffc3be30dad5300be6c72c7b0b25ae5ac4159e4335 ps -wwef]
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 21:05 ?        00:00:00 /serviced/serviced service proxy 4jc6qgrfj71nx9jki3oe1n8d5 0 /usr/bin/redis-server /etc/redis.conf
root        14     1  0 21:05 ?        00:00:00 /usr/local/serviced/resources/logstash/logstash-forwarder -idle-flush-time=5s -old-files-hours=26280 -config /etc/logstash-forwarder.conf
root        15     1  0 21:05 ?        00:00:00 /usr/bin/redis-server *:6379
root       355     0  0 21:15 ?        00:00:00 ps -wwef
```

DEMO3 - attach without command to run:

```
# plu@plu-9: serviced service attach /redis/0 
bash-4.2# ps -wwef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 21:05 ?        00:00:00 /serviced/serviced service proxy 4jc6qgrfj71nx9jki3oe1n8d5 0 /usr/bin/redis-server /etc/redis.conf
root        14     1  0 21:05 ?        00:00:00 /usr/local/serviced/resources/logstash/logstash-forwarder -idle-flush-time=5s -old-files-hours=26280 -config /etc/logstash-forwarder.conf
root        15     1  0 21:05 ?        00:00:00 /usr/bin/redis-server *:6379
root       444     0  0 21:17 ?        00:00:00 /bin/bash
root       450   444  0 21:17 ?        00:00:00 ps -wwef
```
