### PR TITLE
fixed typo for elasticsearch url

### DIFF
--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -78,7 +78,7 @@ func init() {
 	if err != nil {
 		glog.Fatal("Error initializing elasticsearch container: %s", err)
 	}
-	envPerService[serviceName]["ES_JAVA_OPTS"]="-Xmx4g"
+	envPerService[serviceName]["ES_JAVA_OPTS"] = "-Xmx4g"
 	elasticsearch_logstash.Command = func() string {
 		clusterArg := ""
 		if clusterName, ok := elasticsearch_logstash.Configuration["cluster"]; ok {
@@ -134,7 +134,7 @@ func elasticsearchHealthCheck(port int) func() error {
 			}
 			time.Sleep(time.Millisecond * 1000)
 		}
-		glog.Info("elasticsearch container started, browser at %s/_plugin/head/", baseUrl)
+		glog.Infof("elasticsearch container started, browser at %s/_plugin/head/", baseUrl)
 		return nil
 	}
 }


### PR DESCRIPTION
ISSUE:

```
I1014 19:40:51.128684 16130 es.go:137] elasticsearch container started, browser at %s/_plugin/head/http://localhost:9200
```

DEMO:

```
I1014 20:09:47.607432 26308 es.go:137] elasticsearch container started, browser at http://localhost:9200/_plugin/head/
```
