### PR TITLE
shell command defaults to /bin/bash when no command is specified

### DIFF
--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -140,7 +140,7 @@ func (c *ServicedCli) initService() {
 			}, {
 				Name:         "shell",
 				Usage:        "Starts a service instance",
-				Description:  "serviced service shell SERVICEID COMMAND",
+				Description:  "serviced service shell SERVICEID [COMMAND]",
 				BashComplete: c.printServicesFirst,
 				Before:       c.cmdServiceShell,
 				Flags: []cli.Flag{
@@ -811,10 +811,10 @@ func (c *ServicedCli) cmdServiceProxy(ctx *cli.Context) error {
 	return fmt.Errorf("serviced service proxy")
 }
 
-// serviced service shell [--saveas SAVEAS]  [--interactive, -i] SERVICEID COMMAND
+// serviced service shell [--saveas SAVEAS]  [--interactive, -i] SERVICEID [COMMAND]
 func (c *ServicedCli) cmdServiceShell(ctx *cli.Context) error {
 	args := ctx.Args()
-	if len(args) < 2 {
+	if len(args) < 1 {
 		fmt.Printf("Incorrect Usage.\n\n")
 		return nil
 	}
@@ -822,6 +822,7 @@ func (c *ServicedCli) cmdServiceShell(ctx *cli.Context) error {
 	var (
 		command string
 		argv    []string
+		isTTY   bool
 	)
 
 	svc, err := c.searchForService(args[0])
@@ -830,7 +831,14 @@ func (c *ServicedCli) cmdServiceShell(ctx *cli.Context) error {
 		return err
 	}
 
-	command = args[1]
+	if len(args) < 2 {
+		command = "/bin/bash"
+		isTTY = true
+	} else {
+		command = args[1]
+		isTTY = ctx.GlobalBool("interactive")
+	}
+
 	if len(args) > 2 {
 		argv = args[2:]
 	}
@@ -841,7 +849,7 @@ func (c *ServicedCli) cmdServiceShell(ctx *cli.Context) error {
 		Command:          command,
 		Args:             argv,
 		SaveAs:           ctx.GlobalString("saveas"),
-		IsTTY:            ctx.GlobalBool("interactive"),
+		IsTTY:            isTTY,
 		Mounts:           ctx.GlobalStringSlice("mount"),
 		ServicedEndpoint: "localhost" + agentPort,
 	}

--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -670,7 +670,7 @@ func ExampleServicedCLI_CmdServiceShell_usage() {
 	//    command shell [command options] [arguments...]
 	//
 	// DESCRIPTION:
-	//    serviced service shell SERVICEID COMMAND
+	//    serviced service shell SERVICEID [COMMAND]
 	//
 	// OPTIONS:
 	//    --saveas, -s 				saves the service instance with the given name


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-309

Demo:

``` bash
 {develop} [...]/control-center/serviced$ serviced service shell 9dlm0bhm061714it9e8thqocg
I1016 12:13:12.066151 29379 server.go:341] Connected to the control center at port 10.87.111.175:4979
I1016 12:13:12.178677 29379 server.go:435] Acquiring image from the dfs...
I1016 12:13:12.179391 29379 server.go:437] Acquired!  Starting shell
bash-4.2# Trying to connect to logstash server... 127.0.0.1:5042
Connected to logstash server.

bash-4.2# exit
```
