### PR TITLE
added serviced service logs

### DIFF
--- a/commons/docker/api.go
+++ b/commons/docker/api.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"syscall"
 	"time"
 
 	"github.com/control-center/serviced/commons"
@@ -209,6 +210,22 @@ func FindContainer(id string) (*Container, error) {
 		return nil, err
 	}
 	return &Container{ctr, dockerclient.HostConfig{}}, nil
+}
+
+// Logs calls docker logs for a running service container
+func Logs(dockerID string, args []string) error {
+	if _, err := FindContainer(dockerID); err != nil {
+		return err
+	}
+
+	var command []string = []string{"/usr/bin/docker", "logs"}
+	if len(args) > 0 {
+		command = append(command, args...)
+	}
+	command = append(command, dockerID)
+
+	glog.V(1).Infof("exec logs command for container:%v command: %+v\n", dockerID, command)
+	return syscall.Exec(command[0], command[0:], os.Environ())
 }
 
 // Containers retrieves a list of all the Docker containers.


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-312

DEMO - show usage:

```
# plu@plu-9: serviced service logs
Incorrect Usage.

No help topic for 'logs'
NAME:
   logs - Output the logs of a running service container - calls docker logs

USAGE:
   command logs [command options] [arguments...]

DESCRIPTION:
   serviced service logs { SERVICEID | SERVICENAME | DOCKERID | POOL/...PARENTNAME.../SERVICENAME/INSTANCE }

OPTIONS:
   --endpoint '10.87.110.39:4979'   endpoint for remote serviced (example.com:4979)
```

DEMO1 - serviced logs redis should call docker logs:

```
# plu@plu-9: serviced -v=1 service logs redis/0
I1016 13:15:50.585722 06643 api.go:227] exec logs command for container:48e45209f60db67e8e6cc22925eb3d6cb711749e485d25ff4a58cdd06d6e3bfe command: [/usr/bin/docker logs 48e45209f60db67e8e6cc22925eb3d6cb711749e485d25ff4a58cdd06d6e3bfe]
I1016 18:01:18.024478 00001 vif.go:58] vif subnet is: 10.3
I1016 18:01:18.025074 00001 lbClient.go:79] ControlPlaneAgent.GetServiceInstance()
I1016 18:01:18.064185 00001 controller.go:291] Allow container to container connections: true
I1016 18:01:18.064537 00001 controller.go:226] Wrote config file /etc/redis.conf
I1016 18:01:18.069769 00001 logstash.go:54] Using logstash resourcePath: /usr/local/serviced/resources/logstash
...
```

DEMO2 - pass flags to docker logs:

```
# plu@plu-9: serviced -v=1 service logs redis/0 -- --tail=5 -t
I1016 13:15:26.509331 06623 api.go:227] exec logs command for container:48e45209f60db67e8e6cc22925eb3d6cb711749e485d25ff4a58cdd06d6e3bfe command: [/usr/bin/docker logs --tail=5 -t 48e45209f60db67e8e6cc22925eb3d6cb711749e485d25ff4a58cdd06d6e3bfe]
2014-10-16T18:14:49.531798554Z W1016 18:14:49.531664 00001 controller.go:740] Health check metrics failed.
2014-10-16T18:15:03.080324051Z 2014/10/16 18:15:03 200 7.222782ms POST /api/metrics/store
2014-10-16T18:15:04.539714411Z W1016 18:15:04.539589 00001 controller.go:740] Health check metrics failed.
2014-10-16T18:15:18.080504003Z 2014/10/16 18:15:18 200 7.57002ms POST /api/metrics/store
2014-10-16T18:15:19.547831602Z W1016 18:15:19.547699 00001 controller.go:740] Health check metrics failed.
```
