### PR TITLE
set default for SERVICED_ADMIN_GROUP depending on Ubuntu or RHEL7

### DIFF
--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -93,6 +93,7 @@
 # SERVICED_ISVCS_ENV_0=elasticsearch-logstash:ES_JAVA_OPTS=-Xmx4g
 
 # Set the user group that can log in to control center
+#   wheel is the default on RHEL and sudo is the default on Ubuntu
 # SERVICED_ADMIN_GROUP=wheel
 
 # Arbitrary serviced daemon args


### PR DESCRIPTION
DEMO on Ubuntu:

```
~/src/europa/src/golang/src/github.com/control-center/serviced/pkg
# plu@plu-9: uname -a
Linux plu-9 3.13.0-24-generic #47-Ubuntu SMP Fri May 2 23:30:00 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
~/src/europa/src/golang/src/github.com/control-center/serviced/pkg
# plu@plu-9: SERVICED_ADMIN_GROUP=$(grep -q DISTRIB_ID=Ubuntu /etc/*-release && echo sudo || echo wheel)
~/src/europa/src/golang/src/github.com/control-center/serviced/pkg
# plu@plu-9: echo $SERVICED_ADMIN_GROUP
sudo
```
