### PR TITLE
log messages for web/pam authentication failures for support troubleshoo...

### DIFF
--- a/web/cauth.c
+++ b/web/cauth.c
@@ -37,16 +37,19 @@ int authenticate(const char *pam_file, const char *username, const char* pass, c
         struct pam_conv pam_conversation = { conv, (void*)pw_reply };
         if ((retval = pam_start(pam_file, username, &pam_conversation, &pamh)) != PAM_SUCCESS) {
                 free(group_list);
+                fprintf(stderr, "cauth: pam_start returned %d: %s\n", retval, pam_strerror(pamh, retval));
                 return _CP_FAIL_START;
         }
         if ((retval = pam_authenticate(pamh, PAM_DISALLOW_NULL_AUTHTOK)) != PAM_SUCCESS) {
                 free(group_list);
                 pam_end(pamh, PAM_DATA_SILENT);
+                fprintf(stderr, "cauth: pam_authenticate returned %d: %s\n", retval, pam_strerror(pamh, retval));
                 return _CP_FAIL_AUTH;
         }
         if ((retval = pam_acct_mgmt(pamh, PAM_SILENT)) != PAM_SUCCESS) {
                 free(group_list);
                 pam_end(pamh, PAM_DATA_SILENT);
+                fprintf(stderr, "cauth: pam_acct_mgmt returned %d: %s\n", retval, pam_strerror(pamh, retval));
                 return _CP_FAIL_ACCT;
         }
         pw = getpwnam(username);


### PR DESCRIPTION
...ting

DEMO - failure when user is not part of admin group:

```
E1023 18:57:56.317454 12075 auth.go:70] PAM result for user:huey group:sudo was 4: pam: invalid admin group
I1023 18:57:56.317510 12075 session.go:161] Attempting to validate user huey against the control center api
E1023 18:57:56.319371 12075 session.go:172] Unable to validate credentials No such entity {kind:user, id:huey}
2014/10/23 18:57:56 401 20.488801ms POST /login
```

DEMO2 - failure when user supplies wrong password:

```
cauth: pam_authenticate returned 7: Authentication failure
E1023 19:04:22.655161 12075 auth.go:70] PAM result for user:plu group:sudo was 2: pam: authentication failed
I1023 19:04:22.655215 12075 session.go:161] Attempting to validate user plu against the control center api
E1023 19:04:22.657198 12075 session.go:172] Unable to validate credentials No such entity {kind:user, id:plu}
```
