### PR TITLE
* fixes CC-384: expose internal services using host networking namespace to avoid docker-proxy for internal services

### DIFF
--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -74,6 +74,7 @@ type ContainerDescription struct {
 	Configuration map[string]interface{}              // A container specific configuration
 	Notify        func(*Container, interface{}) error // A function to run when notified of a data event
 	volumesDir    string                              // directory to store volume data
+	HostNetwork   bool                                // use host network in container, eg docker run ... --net=host
 }
 
 type Container struct {
@@ -320,6 +321,9 @@ func (c *Container) run() (*exec.Cmd, chan error) {
 	exitChan := make(chan error, 1)
 	args := make([]string, 0)
 	args = append(args, "run", "--rm", "--name", containerName)
+	if c.HostNetwork {
+		args = append(args, "--net=host")
+	}
 
 	// attach all exported ports
 	for _, port := range c.Ports {

--- a/isvcs/docker_registry.go
+++ b/isvcs/docker_registry.go
@@ -37,6 +37,7 @@ func init() {
 			Ports:       []int{registryPort},
 			Volumes:     map[string]string{"registry": "/tmp/registry"},
 			HealthCheck: registryHealthCheck,
+			HostNetwork: true,
 		},
 	)
 	if err != nil {

--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -49,6 +49,7 @@ func init() {
 			Volumes:       map[string]string{"data": "/opt/elasticsearch-0.90.9/data"},
 			Configuration: make(map[string]interface{}),
 			HealthCheck:   elasticsearchHealthCheck(9200),
+			HostNetwork:   true,
 		},
 	)
 	if err != nil {

--- a/isvcs/logstash.go
+++ b/isvcs/logstash.go
@@ -29,13 +29,14 @@ func init() {
 	command := "/opt/logstash-1.4.2/bin/logstash agent -f /usr/local/serviced/resources/logstash/logstash.conf"
 	logstash, err = NewContainer(
 		ContainerDescription{
-			Name:    "logstash",
-			Repo:    IMAGE_REPO,
-			Tag:     IMAGE_TAG,
-			Command: func() string { return command },
-			Ports:   []int{5042, 5043, 9292},
-			Volumes: map[string]string{},
-			Notify:  notifyLogstashConfigChange,
+			Name:        "logstash",
+			Repo:        IMAGE_REPO,
+			Tag:         IMAGE_TAG,
+			Command:     func() string { return command },
+			Ports:       []int{5042, 5043, 9292},
+			Volumes:     map[string]string{},
+			Notify:      notifyLogstashConfigChange,
+			HostNetwork: true,
 		})
 	if err != nil {
 		glog.Fatal("Error initializing logstash_master container: %s", err)

--- a/isvcs/opentsdb.go
+++ b/isvcs/opentsdb.go
@@ -32,10 +32,11 @@ func init() {
 			Name:    "opentsdb",
 			Repo:    IMAGE_REPO,
 			Tag:     IMAGE_TAG,
-			Command: func() string {return command},
+			Command: func() string { return command },
 			//only expose 8443 (the consumer port to the host)
-			Ports:   []int{4242, 8443, 8888, 9090},
-			Volumes: map[string]string{"hbase": "/opt/zenoss/var/hbase"},
+			Ports:       []int{4242, 8443, 8888, 9090},
+			Volumes:     map[string]string{"hbase": "/opt/zenoss/var/hbase"},
+			HostNetwork: true,
 		})
 	if err != nil {
 		glog.Fatal("Error initializing opentsdb container: %s", err)

--- a/isvcs/zk.go
+++ b/isvcs/zk.go
@@ -31,16 +31,17 @@ var zookeeper *Container
 func init() {
 
 	var err error
-	command :=  "/opt/zookeeper-3.4.5/bin/zkServer.sh start-foreground"
+	command := "/opt/zookeeper-3.4.5/bin/zkServer.sh start-foreground"
 	zookeeper, err = NewContainer(
 		ContainerDescription{
 			Name:        "zookeeper",
 			Repo:        IMAGE_REPO,
 			Tag:         IMAGE_TAG,
-			Command:     func() string {return command},
+			Command:     func() string { return command },
 			Ports:       []int{2181, 12181},
 			Volumes:     map[string]string{"data": "/tmp"},
 			HealthCheck: zkHealthCheck,
+			HostNetwork: true,
 		})
 	if err != nil {
 		glog.Fatal("Error initializing zookeeper container: %s", err)


### PR DESCRIPTION
```
dgarcia@dgarcia-desktop:~/src/europa/src/golang/src/github.com/control-center/serviced⟫ sudo netstat -pant | grep LISTEN | grep 2181
tcp6       0      0 :::2181                 :::*                    LISTEN      17544/java      
tcp6       0      0 :::12181                :::*                    LISTEN      17564/java      
```
