### PR TITLE
prereq lxc-docker >= 1.3.0 instead of =

### DIFF
--- a/pkg/makefile
+++ b/pkg/makefile
@@ -134,7 +134,7 @@ deb: stage_deb
 		-d nfs-kernel-server \
 		-d net-tools \
 		-d nfs-common \
-		-d 'lxc-docker = 1.3.0' \
+		-d 'lxc-docker >= 1.3.0' \
 		-t deb \
 		-a x86_64 \
 		-C $(PKGROOT) \
@@ -160,7 +160,7 @@ rpm: stage_rpm
 		-d net-tools \
 		-d util-linux \
 		-d bash-completion \
-		-d 'docker = 1.3.0' \
+		-d 'docker >= 1.3.0' \
 		-t rpm \
 		-a x86_64 \
 		-C $(PKGROOT) \


### PR DESCRIPTION
revert temporary workaround https://github.com/control-center/serviced/pull/1237
