### PR TITLE
fixes CC-302: replaced SERVICED_VFS with SERVICED_FS_TYPE, vfs with fsType, VFS with F...

### DIFF
--- a/cli/api/api.go
+++ b/cli/api/api.go
@@ -52,7 +52,7 @@ type Options struct {
 	MCPasswd             string
 	Mount                []string
 	ResourcePeriod       int
-	VFS                  string
+	FSType               string
 	ESStartupTimeout     int
 	HostAliases          []string
 	Verbosity            int

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -169,8 +169,8 @@ func (d *daemon) run() error {
 	}
 
 	//TODO: is this needed for both agent and master?
-	if _, ok := volume.Registered(options.VFS); !ok {
-		glog.Fatalf("no driver registered for %s", options.VFS)
+	if _, ok := volume.Registered(options.FSType); !ok {
+		glog.Fatalf("no driver registered for %s", options.FSType)
 	}
 
 	if options.Master {
@@ -498,7 +498,7 @@ func (d *daemon) startAgent() error {
 			DockerDNS:            options.DockerDNS,
 			VarPath:              options.VarPath,
 			Mount:                options.Mount,
-			VFS:                  options.VFS,
+			FSType:               options.FSType,
 			Zookeepers:           options.Zookeepers,
 			Mux:                  mux,
 			UseTLS:               options.TLS,
@@ -636,7 +636,7 @@ func (d *daemon) initISVCS() error {
 
 func (d *daemon) initDAO() (dao.ControlPlane, error) {
 	dfsTimeout := time.Duration(options.MaxDFSTimeout) * time.Second
-	return elasticsearch.NewControlSvc("localhost", 9200, d.facade, options.VarPath, options.VFS, dfsTimeout, options.DockerRegistry)
+	return elasticsearch.NewControlSvc("localhost", 9200, d.facade, options.VarPath, options.FSType, dfsTimeout, options.DockerRegistry)
 }
 
 func (d *daemon) initWeb() {

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -166,7 +166,7 @@ func New(driver api.API) *ServicedCli {
 		// TODO: 1.1
 		// cli.StringSliceFlag{"remote-zk", &remotezks, "Specify a zookeeper instance to connect to (e.g. -remote-zk remote:2181)"},
 		cli.StringSliceFlag{"mount", &cli.StringSlice{}, "bind mount: DOCKER_IMAGE,HOST_PATH[,CONTAINER_PATH]"},
-		cli.StringFlag{"vfs", configEnv("VFS", "rsync"), "filesystem for container volumes"},
+		cli.StringFlag{"fstype", configEnv("FS_TYPE", "rsync"), "driver for underlying file system"},
 		cli.StringSliceFlag{"alias", &aliases, "list of aliases for this host, e.g., localhost"},
 		cli.IntFlag{"es-startup-timeout", esStartupTimeout, "time to wait on elasticsearch startup before bailing"},
 		cli.IntFlag{"max-container-age", configInt("MAX_CONTAINER_AGE", 60*60*24), "maximum age (seconds) of a stopped container before removing"},
@@ -234,7 +234,7 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 		Zookeepers:           ctx.GlobalStringSlice("zk"),
 		RemoteZookeepers:     ctx.GlobalStringSlice("remote-zk"),
 		Mount:                ctx.GlobalStringSlice("mount"),
-		VFS:                  ctx.GlobalString("vfs"),
+		FSType:               ctx.GlobalString("fstype"),
 		HostAliases:          ctx.GlobalStringSlice("alias"),
 		ESStartupTimeout:     ctx.GlobalInt("es-startup-timeout"),
 		ReportStats:          ctx.GlobalBool("report-stats"),

--- a/dao/elasticsearch/controlplanedao.go
+++ b/dao/elasticsearch/controlplanedao.go
@@ -46,7 +46,7 @@ type ControlPlaneDao struct {
 	hostName       string
 	port           int
 	varpath        string
-	vfs            string
+	fsType         string
 	dfs            *dfs.DistributedFilesystem
 	facade         *facade.Facade
 	dockerRegistry string
@@ -127,7 +127,7 @@ func NewControlPlaneDao(hostName string, port int) (*ControlPlaneDao, error) {
 	return dao, nil
 }
 
-func NewControlSvc(hostName string, port int, facade *facade.Facade, varpath, vfs string, maxdfstimeout time.Duration, dockerRegistry string) (*ControlPlaneDao, error) {
+func NewControlSvc(hostName string, port int, facade *facade.Facade, varpath, fsType string, maxdfstimeout time.Duration, dockerRegistry string) (*ControlPlaneDao, error) {
 	glog.V(2).Info("calling NewControlSvc()")
 	defer glog.V(2).Info("leaving NewControlSvc()")
 
@@ -140,14 +140,14 @@ func NewControlSvc(hostName string, port int, facade *facade.Facade, varpath, vf
 	s.facade = facade
 
 	s.varpath = varpath
-	s.vfs = vfs
+	s.fsType = fsType
 
 	// create the account credentials
 	if err = createSystemUser(s); err != nil {
 		return nil, err
 	}
 
-	dfs, err := dfs.NewDistributedFilesystem(vfs, varpath, dockerRegistry, facade, maxdfstimeout)
+	dfs, err := dfs.NewDistributedFilesystem(fsType, varpath, dockerRegistry, facade, maxdfstimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/dfs/backup_test.go
+++ b/dfs/backup_test.go
@@ -414,7 +414,7 @@ func TestBackup_IntegrationTest(t *testing.T) {
 				}
 
 				// Write some data to the DFS
-				volume, e := getSubvolume(dt.Dao.vfs, "default", serviceId)
+				volume, e := getSubvolume(dt.Dao.fsType, "default", serviceId)
 				if e != nil {
 					t.Fatalf("Failed to get subvolume: %s", e)
 				}

--- a/dfs/dfs.go
+++ b/dfs/dfs.go
@@ -28,7 +28,7 @@ import (
 )
 
 type DistributedFilesystem struct {
-	vfs        string
+	fsType     string
 	varpath    string
 	dockerHost string
 	dockerPort int
@@ -43,7 +43,7 @@ type DistributedFilesystem struct {
 	logger *logger
 }
 
-func NewDistributedFilesystem(vfs, varpath, dockerRegistry string, facade *facade.Facade, timeout time.Duration) (*DistributedFilesystem, error) {
+func NewDistributedFilesystem(fsType, varpath, dockerRegistry string, facade *facade.Facade, timeout time.Duration) (*DistributedFilesystem, error) {
 	host, port, err := parseRegistry(dockerRegistry)
 	if err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func NewDistributedFilesystem(vfs, varpath, dockerRegistry string, facade *facad
 	}
 	lock := zkservice.ServiceLock(conn)
 
-	return &DistributedFilesystem{vfs: vfs, varpath: varpath, dockerHost: host, dockerPort: port, facade: facade, timeout: timeout, lock: lock}, nil
+	return &DistributedFilesystem{fsType: fsType, varpath: varpath, dockerHost: host, dockerPort: port, facade: facade, timeout: timeout, lock: lock}, nil
 }
 
 func (dfs *DistributedFilesystem) Lock() error {

--- a/dfs/volume.go
+++ b/dfs/volume.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (dfs *DistributedFilesystem) GetVolume(serviceID string) (*volume.Volume, error) {
-	v, err := GetSubvolume(dfs.vfs, dfs.varpath, serviceID)
+	v, err := GetSubvolume(dfs.fsType, dfs.varpath, serviceID)
 	if err != nil {
 		glog.Errorf("Could not acquire subvolume for service %s: %s", serviceID, err)
 		return nil, err
@@ -41,13 +41,13 @@ func (dfs *DistributedFilesystem) GetVolume(serviceID string) (*volume.Volume, e
 }
 
 // GetSubvolume gets the path of the *local* volume on the host
-func GetSubvolume(vfs, varpath, serviceID string) (*volume.Volume, error) {
+func GetSubvolume(fsType, varpath, serviceID string) (*volume.Volume, error) {
 	baseDir, err := filepath.Abs(path.Join(varpath, "volumes"))
 	if err != nil {
 		return nil, err
 	}
-	glog.Infof("Mounting vfs: %v; tenantID: %v; baseDir: %v", vfs, serviceID, baseDir)
-	return volume.Mount(vfs, serviceID, baseDir)
+	glog.Infof("Mounting fsType: %v; tenantID: %v; baseDir: %v", fsType, serviceID, baseDir)
+	return volume.Mount(fsType, serviceID, baseDir)
 }
 
 func getHome() string {

--- a/dita/topics/config-defaults.dita
+++ b/dita/topics/config-defaults.dita
@@ -132,9 +132,9 @@ SERVICED_MASTER=1</codeblock></li>
           <dd>The path of a TLS certificate file. By default, no certificate file is installed.</dd>
         </dlentry>
         <dlentry>
-          <dt><codeph>SERVICED_VFS</codeph></dt>
+          <dt><codeph>SERVICED_FS_TYPE</codeph></dt>
           <dd>Default: <codeph>rsync</codeph></dd> 
-          <dd>The driver for virtual file system volumes. The supported drivers are 
+          <dd>The driver for the underlying file system. The supported drivers are 
             <codeph>rsync</codeph> and <codeph>btrfs</codeph>.</dd>
         </dlentry>
         <dlentry>

--- a/node/agent.go
+++ b/node/agent.go
@@ -80,7 +80,7 @@ type HostAgent struct {
 	dockerDNS            []string             // docker dns addresses
 	varPath              string               // directory to store serviced	 data
 	mount                []string             // each element is in the form: dockerImage,hostPath,containerPath
-	vfs                  string               // driver for container volumes
+	fsType               string               // driver for container volumes
 	currentServices      map[string]*exec.Cmd // the current running services
 	mux                  *proxy.TCPMux
 	useTLS               bool // Whether the mux uses TLS
@@ -116,7 +116,7 @@ type AgentOptions struct {
 	DockerDNS            []string
 	VarPath              string
 	Mount                []string
-	VFS                  string
+	FSType               string
 	Zookeepers           []string
 	Mux                  *proxy.TCPMux
 	UseTLS               bool
@@ -136,7 +136,7 @@ func NewHostAgent(options AgentOptions) (*HostAgent, error) {
 	agent.dockerDNS = options.DockerDNS
 	agent.varPath = options.VarPath
 	agent.mount = options.Mount
-	agent.vfs = "rsync"
+	agent.fsType = "rsync"
 	agent.mux = options.Mux
 	agent.useTLS = options.UseTLS
 	agent.maxContainerAge = options.MaxContainerAge
@@ -728,7 +728,7 @@ func configureContainer(a *HostAgent, client *ControlClient,
 // setupVolume
 func (a *HostAgent) setupVolume(tenantID string, service *service.Service, volume servicedefinition.Volume) (string, error) {
 	glog.V(4).Infof("setupVolume for service Name:%s ID:%s", service.Name, service.ID)
-	sv, err := dfs.GetSubvolume(a.vfs, a.varPath, tenantID)
+	sv, err := dfs.GetSubvolume(a.fsType, a.varPath, tenantID)
 	if err != nil {
 		return "", fmt.Errorf("Could not create subvolume: %s", err)
 	}

--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -53,8 +53,8 @@
 # Set to 0 to disable TLS for the mux port
 # SERVICED_MUX_TLS=1
 
-# Set the driver type for the volumes (rsync/btrfs)
-# SERVICED_VFS=rsync
+# Set the driver type for the underlying file system (rsync/btrfs)
+# SERVICED_FS_TYPE=rsync
 
 # Set the aliases for this host (use in vhost muxing)
 # SERVICED_VHOST_ALIASES=foobar.com,example.com


### PR DESCRIPTION
...SType

https://jira.zenoss.com/browse/CC-302

DEMO - snapshot still works:

```
# plu@plu-9: docker images |grep 5000
plu-9:5000/e1vkqe94ppx2450z6v7simbil/devimg     latest              94a4b48b3c4d        7 days ago          2.192 GB
plu-9:5000/e1vkqe94ppx2450z6v7simbil/opentsdb   latest              f55af1da2e5f        8 days ago          1.347 GB
plu-9:5000/e1vkqe94ppx2450z6v7simbil/hbase      latest              155bef732a18        11 days ago         595.9 MB

# plu@plu-9: serviced service snapshot mysql
e1vkqe94ppx2450z6v7simbil_20141107-163123

# plu@plu-9: docker images |grep 5000
plu-9:5000/e1vkqe94ppx2450z6v7simbil/devimg     20141107-163123     94a4b48b3c4d        7 days ago          2.192 GB
plu-9:5000/e1vkqe94ppx2450z6v7simbil/devimg     latest              94a4b48b3c4d        7 days ago          2.192 GB
plu-9:5000/e1vkqe94ppx2450z6v7simbil/opentsdb   20141107-163123     f55af1da2e5f        8 days ago          1.347 GB
plu-9:5000/e1vkqe94ppx2450z6v7simbil/opentsdb   latest              f55af1da2e5f        8 days ago          1.347 GB
plu-9:5000/e1vkqe94ppx2450z6v7simbil/hbase      20141107-163123     155bef732a18        11 days ago         595.9 MB
plu-9:5000/e1vkqe94ppx2450z6v7simbil/hbase      latest              155bef732a18        11 days ago         595.9 MB

```

Zenoss still works:

![screen shot 2014-11-07 at 10 32 18](https://cloud.githubusercontent.com/assets/2837923/4956385/b054dfb0-669b-11e4-8b66-6443ede2c90a.png)
