### PR TITLE
keep a map of agent mux connection info and added /mux/connections REST ...

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -373,15 +373,6 @@ func createMuxListener() (net.Listener, error) {
 }
 
 func (d *daemon) startAgent() error {
-	muxListener, err := createMuxListener()
-	if err != nil {
-		return err
-	}
-	mux, err := proxy.NewTCPMux(muxListener)
-	if err != nil {
-		return err
-	}
-
 	agentIP := options.OutboundIP
 	if agentIP == "" {
 		var err error
@@ -390,14 +381,23 @@ func (d *daemon) startAgent() error {
 			glog.Fatalf("Failed to acquire ip address: %s", err)
 		}
 	}
-	thisHost, err := host.Build(agentIP, "unknown")
-	if err != nil {
-		panic(err)
-	}
-
 	myHostID, err := utils.HostID()
 	if err != nil {
 		return fmt.Errorf("HostID failed: %v", err)
+	}
+
+	muxListener, err := createMuxListener()
+	if err != nil {
+		return err
+	}
+	mux, err := proxy.NewTCPMux(muxListener, myHostID, agentIP)
+	if err != nil {
+		return err
+	}
+
+	thisHost, err := host.Build(agentIP, "unknown")
+	if err != nil {
+		panic(err)
 	}
 
 	go func() {

--- a/container/controller.go
+++ b/container/controller.go
@@ -97,9 +97,12 @@ type ControllerOptions struct {
 // it creates the managed service instance, logstash forwarding, port forwarding, etc.
 type Controller struct {
 	options                 ControllerOptions
+	serviceName             string
 	hostID                  string
+	hostIP                  string
 	tenantID                string
 	dockerID                string
+	dockerIP                string
 	metricForwarder         *MetricForwarder
 	logforwarder            *subprocess.Instance
 	logforwarderExited      chan error
@@ -286,6 +289,7 @@ func NewController(options ControllerOptions) (*Controller, error) {
 		glog.Errorf("Invalid service from serviceID:%s", options.Service.ID)
 		return c, ErrInvalidService
 	}
+	c.serviceName = service.Name
 
 	c.allowDirectConn = !service.HasEndpointsFor("import_all")
 	glog.Infof("Allow container to container connections: %t", c.allowDirectConn)

--- a/container/proxy.go
+++ b/container/proxy.go
@@ -70,6 +70,7 @@ type addressTuple struct {
 
 type proxy struct {
 	name             string              // Name of the remote service
+	msjson           string              // MuxSource
 	tenantEndpointID string              // Tenant endpoint ID
 	addresses        []addressTuple      // Public/container IP:Port of the remote service
 	tcpMuxPort       uint16              // the port to use for TCP Muxing, 0 is disabled
@@ -81,12 +82,13 @@ type proxy struct {
 }
 
 // Newproxy create a new proxy object. It starts listening on the prxy port asynchronously.
-func newProxy(name, tenantEndpointID string, tcpMuxPort uint16, useTLS bool, listener net.Listener, allowDirectConn bool) (p *proxy, err error) {
+func newProxy(name, msjson, tenantEndpointID string, tcpMuxPort uint16, useTLS bool, listener net.Listener, allowDirectConn bool) (p *proxy, err error) {
 	if len(name) == 0 {
 		return nil, fmt.Errorf("prxy: name can not be empty")
 	}
 	p = &proxy{
 		name:             name,
+		msjson:           msjson,
 		tenantEndpointID: tenantEndpointID,
 		addresses:        make([]addressTuple, 0),
 		tcpMuxPort:       tcpMuxPort,
@@ -239,7 +241,7 @@ func (p *proxy) prxy(local net.Conn, address addressTuple) {
 	}
 
 	if !isLocalContainer {
-		muxHeader := fmt.Sprintf("%s:%s:%s\n", p.tenantEndpointID, p.name, address.containerAddr)
+		muxHeader := fmt.Sprintf("%s:%s:%s:%s\n", p.tenantEndpointID, p.msjson, p.name, address.containerAddr)
 		glog.V(1).Infof("writing socket protocol %s", muxHeader)
 		// Write the container address as the first line, if we use the mux
 		io.WriteString(remote, muxHeader)

--- a/container/proxy_test.go
+++ b/container/proxy_test.go
@@ -55,7 +55,7 @@ func TestNoMux(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not bind to a port for test")
 	}
-	prxy, err := newProxy("foo", "endpointfoo", 0, false, local, false)
+	prxy, err := newProxy("foo", "{ServiceName:srcbaz}", "endpointfoo", 0, false, local, false)
 	if err != nil {
 		t.Fatalf("Could not create a prxy: %s", err)
 	}

--- a/web/cpserver.go
+++ b/web/cpserver.go
@@ -216,7 +216,7 @@ func (sc *ServiceConfig) getClient() (c *node.ControlClient, err error) {
 }
 
 func (sc *ServiceConfig) getMasterClient() (*master.Client, error) {
-	glog.Info("start getMasterClient ... sc.agentPort: %+v", sc.agentPort)
+	glog.Infof("start getMasterClient ... sc.agentPort: %+v", sc.agentPort)
 	c, err := master.NewClient(sc.agentPort)
 	if err != nil {
 		glog.Errorf("Could not create a control center client to %v: %v", sc.agentPort, err)

--- a/web/muxresource.go
+++ b/web/muxresource.go
@@ -1,0 +1,92 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web
+
+import (
+	proxymux "github.com/control-center/serviced/proxy"
+	"github.com/control-center/serviced/utils"
+	"github.com/zenoss/glog"
+	"github.com/zenoss/go-json-rest"
+
+	"sort"
+	"time"
+)
+
+//restGetMuxConnections gets mux connection info from all hosts. Response is map[host-id][src-dst]MuxConnectionInfo
+func restGetMuxConnections(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
+	response := make(map[string]map[string]proxymux.TCPMuxConnectionInfo)
+	client, err := ctx.getMasterClient()
+	if err != nil {
+		restServerError(w, err)
+		return
+	}
+
+	hosts, err := client.GetHosts()
+	if err != nil {
+		glog.Errorf("Could not get hosts: %v", err)
+		restServerError(w, err)
+		return
+	}
+
+	activeHostIDs, err := client.GetActiveHostIDs()
+	if err != nil {
+		glog.Errorf("Could not get active hosts: %v", err)
+		restServerError(w, err)
+		return
+	}
+
+	myHostID, err := utils.HostID()
+	if err != nil {
+		glog.Errorf("Could not get hostid: %v", err)
+		restServerError(w, err)
+		return
+	}
+
+	activeHostIDsMap := make(map[string]string)
+	for _, hostid := range activeHostIDs {
+		activeHostIDsMap[hostid] = hostid
+	}
+
+	glog.V(3).Infof("Returning mux connections for %d active hosts", len(activeHostIDs))
+	for i, host := range hosts {
+		if _, ok := activeHostIDsMap[host.ID]; !ok {
+			continue
+		}
+
+		if myHostID != host.ID {
+			glog.V(3).Infof("TODO: get mux connections for remote hosts: %+v", &hosts[i])
+			continue
+		}
+
+		response[host.ID] = proxymux.GetMuxConnectionInfo()
+		glog.Infof("mux connections (count:%d) for host: %s %s", len(response[host.ID]), host.ID, host.IPAddr)
+
+		sortedkeys := make([]string, len(response[host.ID]))
+		i := 0
+		for k, _ := range response[host.ID] {
+			sortedkeys[i] = k
+			i++
+		}
+		sort.Strings(sortedkeys)
+		for _, k := range sortedkeys {
+			cxn := response[host.ID][k]
+			glog.Infof("  %s  (%s/%d <-- %s/%s) (%s <-- %s) %s", k,
+				cxn.ApplicationEndpoint.Application, cxn.ApplicationEndpoint.InstanceID,
+				cxn.Src.ServiceName, cxn.Src.InstanceID,
+				cxn.ApplicationEndpoint.ServiceID, cxn.Src.ServiceID, time.Since(cxn.CreatedAt))
+		}
+	}
+
+	w.WriteJson(&response)
+}

--- a/web/routes.go
+++ b/web/routes.go
@@ -42,6 +42,9 @@ func (sc *ServiceConfig) getRoutes() []rest.Route {
 		rest.Route{"GET", "/hosts/:hostId/running", sc.authorizedClient(restGetRunningForHost)},
 		rest.Route{"DELETE", "/hosts/:hostId/:serviceStateId", sc.authorizedClient(restKillRunning)},
 
+		// Mux
+		rest.Route{"GET", "/mux/connections", sc.checkAuth(restGetMuxConnections)},
+
 		// Pools
 		rest.Route{"GET", "/pools/:poolId", sc.checkAuth(restGetPool)},
 		rest.Route{"DELETE", "/pools/:poolId", sc.checkAuth(restRemovePool)},


### PR DESCRIPTION
...method

Parts 1 and 2 out of 4 from:
  https://jira.zenoss.com/browse/CC-406

DEMO - serviced.log GET for https://plu-9/mux/connections:

```
I1110 03:42:22.864883 24755 cpserver.go:219] start getMasterClient ... sc.agentPort: 10.87.110.39:4979
I1110 03:42:22.865274 24755 cpserver.go:225] end getMasterClient
I1110 03:42:22.925240 24755 muxresource.go:73] mux connections (count:18) for host: 570a276e 172.17.42.1
I1110 03:42:22.925306 24755 muxresource.go:87]   10.87.110.39    127.0.0.1:5042        <-- 172.17.42.1     172.17.2.122:34669     (controlplane_logstash_tcp/0 <-- HMaster/0) (controlplane_logstash_tcp <-- 3ogmr9ckmz1bd8md4v1e9bm0q) 59.187184116s
I1110 03:42:22.925344 24755 muxresource.go:87]   10.87.110.39    127.0.0.1:5042        <-- 172.17.42.1     172.17.2.124:34379     (controlplane_logstash_tcp/0 <-- RegionServer/0) (controlplane_logstash_tcp <-- a186ztd8o0tf7umnh8dm2kyhs) 53.744595441s
I1110 03:42:22.925368 24755 muxresource.go:87]   10.87.110.39    127.0.0.1:5042        <-- 172.17.42.1     172.17.2.126:32992     (controlplane_logstash_tcp/0 <-- ZooKeeper/0) (controlplane_logstash_tcp <-- 25gv1gky1urcg40t08aeyv8bk) 48.341200924s
I1110 03:42:22.925400 24755 muxresource.go:87]   10.87.110.39    127.0.0.1:5043        <-- 172.17.42.1     172.17.2.122:34666     (controlplane_logstash_lumberjack/0 <-- HMaster/0) (controlplane_logstash_lumberjack <-- 3ogmr9ckmz1bd8md4v1e9bm0q) 59.941005092s
I1110 03:42:22.925435 24755 muxresource.go:87]   10.87.110.39    127.0.0.1:5043        <-- 172.17.42.1     172.17.2.124:34375     (controlplane_logstash_lumberjack/0 <-- RegionServer/0) (controlplane_logstash_lumberjack <-- a186ztd8o0tf7umnh8dm2kyhs) 54.507316953s
I1110 03:42:22.925480 24755 muxresource.go:87]   10.87.110.39    127.0.0.1:5043        <-- 172.17.42.1     172.17.2.126:32988     (controlplane_logstash_lumberjack/0 <-- ZooKeeper/0) (controlplane_logstash_lumberjack <-- 25gv1gky1urcg40t08aeyv8bk) 49.097791805s
I1110 03:42:22.925503 24755 muxresource.go:87]   10.87.110.39    127.0.0.1:8443        <-- 172.17.42.1     172.17.2.122:34744     (controlplane_consumer/0 <-- HMaster/0) (controlplane_consumer <-- 3ogmr9ckmz1bd8md4v1e9bm0q) 45.131206s
I1110 03:42:22.925536 24755 muxresource.go:87]   10.87.110.39    127.0.0.1:8443        <-- 172.17.42.1     172.17.2.124:34459     (controlplane_consumer/0 <-- RegionServer/0) (controlplane_consumer <-- a186ztd8o0tf7umnh8dm2kyhs) 39.699861073s
I1110 03:42:22.925566 24755 muxresource.go:87]   10.87.110.39    127.0.0.1:8443        <-- 172.17.42.1     172.17.2.126:33050     (controlplane_consumer/0 <-- ZooKeeper/0) (controlplane_consumer <-- 25gv1gky1urcg40t08aeyv8bk) 34.297797289s
I1110 03:42:22.925587 24755 muxresource.go:87]   10.87.110.39    172.17.2.122:60000    <-- 172.17.42.1     172.17.2.124:33308     (hbase-master-1/0 <-- RegionServer/0) (3ogmr9ckmz1bd8md4v1e9bm0q <-- a186ztd8o0tf7umnh8dm2kyhs) 29.244616106s
I1110 03:42:22.925617 24755 muxresource.go:87]   10.87.110.39    172.17.2.126:2181     <-- 172.17.42.1     172.17.2.122:36018     (zookeeper-client/0 <-- HMaster/0) (25gv1gky1urcg40t08aeyv8bk <-- 3ogmr9ckmz1bd8md4v1e9bm0q) 45.139280515s
I1110 03:42:22.925649 24755 muxresource.go:87]   10.87.110.39    172.17.2.126:2181     <-- 172.17.42.1     172.17.2.122:36037     (zookeeper-client/0 <-- HMaster/0) (25gv1gky1urcg40t08aeyv8bk <-- 3ogmr9ckmz1bd8md4v1e9bm0q) 43.785697261s
I1110 03:42:22.925671 24755 muxresource.go:87]   10.87.110.39    172.17.2.126:2181     <-- 172.17.42.1     172.17.2.122:36040     (zookeeper-client/0 <-- HMaster/0) (25gv1gky1urcg40t08aeyv8bk <-- 3ogmr9ckmz1bd8md4v1e9bm0q) 43.612520649s
I1110 03:42:22.925697 24755 muxresource.go:87]   10.87.110.39    172.17.2.126:2181     <-- 172.17.42.1     172.17.2.122:36043     (zookeeper-client/0 <-- HMaster/0) (25gv1gky1urcg40t08aeyv8bk <-- 3ogmr9ckmz1bd8md4v1e9bm0q) 43.123374139s
I1110 03:42:22.925719 24755 muxresource.go:87]   10.87.110.39    172.17.2.126:2181     <-- 172.17.42.1     172.17.2.124:33303     (zookeeper-client/0 <-- RegionServer/0) (25gv1gky1urcg40t08aeyv8bk <-- a186ztd8o0tf7umnh8dm2kyhs) 29.629740941s
I1110 03:42:22.925741 24755 muxresource.go:87]   10.87.110.39    172.17.2.126:2181     <-- 172.17.42.1     172.17.2.124:33306     (zookeeper-client/0 <-- RegionServer/0) (25gv1gky1urcg40t08aeyv8bk <-- a186ztd8o0tf7umnh8dm2kyhs) 29.524126431s
I1110 03:42:22.925762 24755 muxresource.go:87]   10.87.110.39    172.17.2.126:2181     <-- 172.17.42.1     172.17.2.124:33313     (zookeeper-client/0 <-- RegionServer/0) (25gv1gky1urcg40t08aeyv8bk <-- a186ztd8o0tf7umnh8dm2kyhs) 29.051177271s
I1110 03:42:22.925788 24755 muxresource.go:87]   10.87.110.39    172.17.2.126:2181     <-- 172.17.42.1     172.17.2.124:33316     (zookeeper-client/0 <-- RegionServer/0) (25gv1gky1urcg40t08aeyv8bk <-- a186ztd8o0tf7umnh8dm2kyhs) 28.974835554s
2014/11/10 03:42:22 200 62.075879ms GET /mux/connections
```

DEMO - https://plu-9/mux/connections:

```
{
  "570a276e": {
    "10.87.110.39    127.0.0.1:5042        \u003c-- 172.17.42.1     172.17.2.122:34669   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "HMaster",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "3ogmr9ckmz1bd8md4v1e9bm0q",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.122",
        "ContainerID": "41b1ecc7dcb3"
      },
      "SrcRemoteAddr": "172.17.2.122:34669",
      "SrcLocalAddr": "10.87.110.39:22250",
      "DstLocalAddr": "127.0.0.1:54129",
      "DstRemoteAddr": "127.0.0.1:5042",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_controlplane_logstash_tcp",
      "ApplicationEndpoint": {
        "ServiceID": "controlplane_logstash_tcp",
        "Application": "controlplane_logstash_tcp",
        "ContainerPort": 5042,
        "HostPort": 5042,
        "HostIP": "10.87.110.39",
        "ContainerIP": "127.0.0.1",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 5042
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:23.738121414Z"
    },
    "10.87.110.39    127.0.0.1:5042        \u003c-- 172.17.42.1     172.17.2.124:34379   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "RegionServer",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "a186ztd8o0tf7umnh8dm2kyhs",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.124",
        "ContainerID": "4c40c95337b6"
      },
      "SrcRemoteAddr": "172.17.2.124:34379",
      "SrcLocalAddr": "10.87.110.39:22250",
      "DstLocalAddr": "127.0.0.1:54153",
      "DstRemoteAddr": "127.0.0.1:5042",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_controlplane_logstash_tcp",
      "ApplicationEndpoint": {
        "ServiceID": "controlplane_logstash_tcp",
        "Application": "controlplane_logstash_tcp",
        "ContainerPort": 5042,
        "HostPort": 5042,
        "HostIP": "10.87.110.39",
        "ContainerIP": "127.0.0.1",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 5042
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:29.180748271Z"
    },
    "10.87.110.39    127.0.0.1:5042        \u003c-- 172.17.42.1     172.17.2.126:32992   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "ZooKeeper",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "25gv1gky1urcg40t08aeyv8bk",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.126",
        "ContainerID": "535d2572b3a7"
      },
      "SrcRemoteAddr": "172.17.2.126:32992",
      "SrcLocalAddr": "10.87.110.39:22250",
      "DstLocalAddr": "127.0.0.1:54185",
      "DstRemoteAddr": "127.0.0.1:5042",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_controlplane_logstash_tcp",
      "ApplicationEndpoint": {
        "ServiceID": "controlplane_logstash_tcp",
        "Application": "controlplane_logstash_tcp",
        "ContainerPort": 5042,
        "HostPort": 5042,
        "HostIP": "10.87.110.39",
        "ContainerIP": "127.0.0.1",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 5042
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:34.584166659Z"
    },
    "10.87.110.39    127.0.0.1:5043        \u003c-- 172.17.42.1     172.17.2.122:34666   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "HMaster",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "3ogmr9ckmz1bd8md4v1e9bm0q",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.122",
        "ContainerID": "41b1ecc7dcb3"
      },
      "SrcRemoteAddr": "172.17.2.122:34666",
      "SrcLocalAddr": "10.87.110.39:22250",
      "DstLocalAddr": "127.0.0.1:41205",
      "DstRemoteAddr": "127.0.0.1:5043",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_controlplane_logstash_lumberjack",
      "ApplicationEndpoint": {
        "ServiceID": "controlplane_logstash_lumberjack",
        "Application": "controlplane_logstash_lumberjack",
        "ContainerPort": 5043,
        "HostPort": 5043,
        "HostIP": "10.87.110.39",
        "ContainerIP": "127.0.0.1",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 5043
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:22.984394821Z"
    },
    "10.87.110.39    127.0.0.1:5043        \u003c-- 172.17.42.1     172.17.2.124:34375   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "RegionServer",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "a186ztd8o0tf7umnh8dm2kyhs",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.124",
        "ContainerID": "4c40c95337b6"
      },
      "SrcRemoteAddr": "172.17.2.124:34375",
      "SrcLocalAddr": "10.87.110.39:22250",
      "DstLocalAddr": "127.0.0.1:41228",
      "DstRemoteAddr": "127.0.0.1:5043",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_controlplane_logstash_lumberjack",
      "ApplicationEndpoint": {
        "ServiceID": "controlplane_logstash_lumberjack",
        "Application": "controlplane_logstash_lumberjack",
        "ContainerPort": 5043,
        "HostPort": 5043,
        "HostIP": "10.87.110.39",
        "ContainerIP": "127.0.0.1",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 5043
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:28.418117965Z"
    },
    "10.87.110.39    127.0.0.1:5043        \u003c-- 172.17.42.1     172.17.2.126:32988   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "ZooKeeper",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "25gv1gky1urcg40t08aeyv8bk",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.126",
        "ContainerID": "535d2572b3a7"
      },
      "SrcRemoteAddr": "172.17.2.126:32988",
      "SrcLocalAddr": "10.87.110.39:22250",
      "DstLocalAddr": "127.0.0.1:41260",
      "DstRemoteAddr": "127.0.0.1:5043",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_controlplane_logstash_lumberjack",
      "ApplicationEndpoint": {
        "ServiceID": "controlplane_logstash_lumberjack",
        "Application": "controlplane_logstash_lumberjack",
        "ContainerPort": 5043,
        "HostPort": 5043,
        "HostIP": "10.87.110.39",
        "ContainerIP": "127.0.0.1",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 5043
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:33.827688113Z"
    },
    "10.87.110.39    127.0.0.1:8443        \u003c-- 172.17.42.1     172.17.2.122:34744   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "HMaster",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "3ogmr9ckmz1bd8md4v1e9bm0q",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.122",
        "ContainerID": "41b1ecc7dcb3"
      },
      "SrcRemoteAddr": "172.17.2.122:34744",
      "SrcLocalAddr": "10.87.110.39:22250",
      "DstLocalAddr": "127.0.0.1:55824",
      "DstRemoteAddr": "127.0.0.1:8443",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_controlplane_consumer",
      "ApplicationEndpoint": {
        "ServiceID": "controlplane_consumer",
        "Application": "controlplane_consumer",
        "ContainerPort": 8443,
        "HostPort": 8443,
        "HostIP": "10.87.110.39",
        "ContainerIP": "127.0.0.1",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 8444
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:37.794296782Z"
    },
    "10.87.110.39    127.0.0.1:8443        \u003c-- 172.17.42.1     172.17.2.124:34459   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "RegionServer",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "a186ztd8o0tf7umnh8dm2kyhs",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.124",
        "ContainerID": "4c40c95337b6"
      },
      "SrcRemoteAddr": "172.17.2.124:34459",
      "SrcLocalAddr": "10.87.110.39:22250",
      "DstLocalAddr": "127.0.0.1:55852",
      "DstRemoteAddr": "127.0.0.1:8443",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_controlplane_consumer",
      "ApplicationEndpoint": {
        "ServiceID": "controlplane_consumer",
        "Application": "controlplane_consumer",
        "ContainerPort": 8443,
        "HostPort": 8443,
        "HostIP": "10.87.110.39",
        "ContainerIP": "127.0.0.1",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 8444
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:43.225674467Z"
    },
    "10.87.110.39    127.0.0.1:8443        \u003c-- 172.17.42.1     172.17.2.126:33050   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "ZooKeeper",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "25gv1gky1urcg40t08aeyv8bk",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.126",
        "ContainerID": "535d2572b3a7"
      },
      "SrcRemoteAddr": "172.17.2.126:33050",
      "SrcLocalAddr": "10.87.110.39:22250",
      "DstLocalAddr": "127.0.0.1:55862",
      "DstRemoteAddr": "127.0.0.1:8443",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_controlplane_consumer",
      "ApplicationEndpoint": {
        "ServiceID": "controlplane_consumer",
        "Application": "controlplane_consumer",
        "ContainerPort": 8443,
        "HostPort": 8443,
        "HostIP": "10.87.110.39",
        "ContainerIP": "127.0.0.1",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 8444
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:48.627768446Z"
    },
    "10.87.110.39    172.17.2.122:60000    \u003c-- 172.17.42.1     172.17.2.124:33308   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "RegionServer",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "a186ztd8o0tf7umnh8dm2kyhs",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.124",
        "ContainerID": "4c40c95337b6"
      },
      "SrcRemoteAddr": "172.17.2.124:33308",
      "SrcLocalAddr": "172.17.42.1:22250",
      "DstLocalAddr": "172.17.42.1:36073",
      "DstRemoteAddr": "172.17.2.122:60000",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_hbase-master-1",
      "ApplicationEndpoint": {
        "ServiceID": "3ogmr9ckmz1bd8md4v1e9bm0q",
        "Application": "hbase-master-1",
        "ContainerPort": 60000,
        "HostPort": 49493,
        "HostIP": "172.17.42.1",
        "ContainerIP": "172.17.2.122",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 60000
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:53.680970786Z"
    },
    "10.87.110.39    172.17.2.126:2181     \u003c-- 172.17.42.1     172.17.2.122:36018   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "HMaster",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "3ogmr9ckmz1bd8md4v1e9bm0q",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.122",
        "ContainerID": "41b1ecc7dcb3"
      },
      "SrcRemoteAddr": "172.17.2.122:36018",
      "SrcLocalAddr": "172.17.42.1:22250",
      "DstLocalAddr": "172.17.42.1:40612",
      "DstRemoteAddr": "172.17.2.126:2181",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_zookeeper-client_0",
      "ApplicationEndpoint": {
        "ServiceID": "25gv1gky1urcg40t08aeyv8bk",
        "Application": "zookeeper-client",
        "ContainerPort": 2181,
        "HostPort": 49499,
        "HostIP": "172.17.42.1",
        "ContainerIP": "172.17.2.126",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 2181
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:37.786336148Z"
    },
    "10.87.110.39    172.17.2.126:2181     \u003c-- 172.17.42.1     172.17.2.122:36037   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "HMaster",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "3ogmr9ckmz1bd8md4v1e9bm0q",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.122",
        "ContainerID": "41b1ecc7dcb3"
      },
      "SrcRemoteAddr": "172.17.2.122:36037",
      "SrcLocalAddr": "172.17.42.1:22250",
      "DstLocalAddr": "172.17.42.1:40628",
      "DstRemoteAddr": "172.17.2.126:2181",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_zookeeper-client_0",
      "ApplicationEndpoint": {
        "ServiceID": "25gv1gky1urcg40t08aeyv8bk",
        "Application": "zookeeper-client",
        "ContainerPort": 2181,
        "HostPort": 49499,
        "HostIP": "172.17.42.1",
        "ContainerIP": "172.17.2.126",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 2181
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:39.139951655Z"
    },
    "10.87.110.39    172.17.2.126:2181     \u003c-- 172.17.42.1     172.17.2.122:36040   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "HMaster",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "3ogmr9ckmz1bd8md4v1e9bm0q",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.122",
        "ContainerID": "41b1ecc7dcb3"
      },
      "SrcRemoteAddr": "172.17.2.122:36040",
      "SrcLocalAddr": "172.17.42.1:22250",
      "DstLocalAddr": "172.17.42.1:40631",
      "DstRemoteAddr": "172.17.2.126:2181",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_zookeeper-client_0",
      "ApplicationEndpoint": {
        "ServiceID": "25gv1gky1urcg40t08aeyv8bk",
        "Application": "zookeeper-client",
        "ContainerPort": 2181,
        "HostPort": 49499,
        "HostIP": "172.17.42.1",
        "ContainerIP": "172.17.2.126",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 2181
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:39.313150013Z"
    },
    "10.87.110.39    172.17.2.126:2181     \u003c-- 172.17.42.1     172.17.2.122:36043   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "HMaster",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "3ogmr9ckmz1bd8md4v1e9bm0q",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.122",
        "ContainerID": "41b1ecc7dcb3"
      },
      "SrcRemoteAddr": "172.17.2.122:36043",
      "SrcLocalAddr": "172.17.42.1:22250",
      "DstLocalAddr": "172.17.42.1:40634",
      "DstRemoteAddr": "172.17.2.126:2181",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_zookeeper-client_0",
      "ApplicationEndpoint": {
        "ServiceID": "25gv1gky1urcg40t08aeyv8bk",
        "Application": "zookeeper-client",
        "ContainerPort": 2181,
        "HostPort": 49499,
        "HostIP": "172.17.42.1",
        "ContainerIP": "172.17.2.126",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 2181
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:39.802322132Z"
    },
    "10.87.110.39    172.17.2.126:2181     \u003c-- 172.17.42.1     172.17.2.124:33303   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "RegionServer",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "a186ztd8o0tf7umnh8dm2kyhs",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.124",
        "ContainerID": "4c40c95337b6"
      },
      "SrcRemoteAddr": "172.17.2.124:33303",
      "SrcLocalAddr": "172.17.42.1:22250",
      "DstLocalAddr": "172.17.42.1:40665",
      "DstRemoteAddr": "172.17.2.126:2181",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_zookeeper-client_0",
      "ApplicationEndpoint": {
        "ServiceID": "25gv1gky1urcg40t08aeyv8bk",
        "Application": "zookeeper-client",
        "ContainerPort": 2181,
        "HostPort": 49499,
        "HostIP": "172.17.42.1",
        "ContainerIP": "172.17.2.126",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 2181
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:53.295978171Z"
    },
    "10.87.110.39    172.17.2.126:2181     \u003c-- 172.17.42.1     172.17.2.124:33306   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "RegionServer",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "a186ztd8o0tf7umnh8dm2kyhs",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.124",
        "ContainerID": "4c40c95337b6"
      },
      "SrcRemoteAddr": "172.17.2.124:33306",
      "SrcLocalAddr": "172.17.42.1:22250",
      "DstLocalAddr": "172.17.42.1:40668",
      "DstRemoteAddr": "172.17.2.126:2181",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_zookeeper-client_0",
      "ApplicationEndpoint": {
        "ServiceID": "25gv1gky1urcg40t08aeyv8bk",
        "Application": "zookeeper-client",
        "ContainerPort": 2181,
        "HostPort": 49499,
        "HostIP": "172.17.42.1",
        "ContainerIP": "172.17.2.126",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 2181
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:53.401613927Z"
    },
    "10.87.110.39    172.17.2.126:2181     \u003c-- 172.17.42.1     172.17.2.124:33313   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "RegionServer",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "a186ztd8o0tf7umnh8dm2kyhs",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.124",
        "ContainerID": "4c40c95337b6"
      },
      "SrcRemoteAddr": "172.17.2.124:33313",
      "SrcLocalAddr": "172.17.42.1:22250",
      "DstLocalAddr": "172.17.42.1:40675",
      "DstRemoteAddr": "172.17.2.126:2181",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_zookeeper-client_0",
      "ApplicationEndpoint": {
        "ServiceID": "25gv1gky1urcg40t08aeyv8bk",
        "Application": "zookeeper-client",
        "ContainerPort": 2181,
        "HostPort": 49499,
        "HostIP": "172.17.42.1",
        "ContainerIP": "172.17.2.126",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 2181
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:53.874584926Z"
    },
    "10.87.110.39    172.17.2.126:2181     \u003c-- 172.17.42.1     172.17.2.124:33316   ": {
      "AgentHostIP": "10.87.110.39",
      "AgentHostID": "570a276e",
      "Src": {
        "AgentHostIP": "172.17.42.1",
        "AgentHostID": "570a276e",
        "ServiceName": "RegionServer",
        "TenantID": "azjzj20363xgoj8gv2bnrr9ho",
        "ServiceID": "a186ztd8o0tf7umnh8dm2kyhs",
        "InstanceID": "0",
        "ContainerIP": "172.17.2.124",
        "ContainerID": "4c40c95337b6"
      },
      "SrcRemoteAddr": "172.17.2.124:33316",
      "SrcLocalAddr": "172.17.42.1:22250",
      "DstLocalAddr": "172.17.42.1:40678",
      "DstRemoteAddr": "172.17.2.126:2181",
      "DstName": "azjzj20363xgoj8gv2bnrr9ho_zookeeper-client_0",
      "ApplicationEndpoint": {
        "ServiceID": "25gv1gky1urcg40t08aeyv8bk",
        "Application": "zookeeper-client",
        "ContainerPort": 2181,
        "HostPort": 49499,
        "HostIP": "172.17.42.1",
        "ContainerIP": "172.17.2.126",
        "Protocol": "tcp",
        "VirtualAddress": "",
        "InstanceID": 0,
        "ProxyPort": 2181
      },
      "ActiveWriters": 2,
      "CreatedAt": "2014-11-10T03:41:53.950952076Z"
    }
  }
}
```
