### PR TITLE
fixes CC-443: return err for RemoveHost if hostid does not exist

### DIFF
--- a/facade/host.go
+++ b/facade/host.go
@@ -131,7 +131,7 @@ func (f *Facade) RemoveHost(ctx datastore.Context, hostID string) (err error) {
 	if _host, err = f.GetHost(ctx, hostID); err != nil {
 		return err
 	} else if _host == nil {
-		return nil
+		return fmt.Errorf("HostID %s does not exist", hostID)
 	}
 
 	//grab all services that are address assigned this HostID


### PR DESCRIPTION
DEMO:

```
# plu@plu-9: serviced host list
ID      POOL        NAME    ADDR        CORES   MEM     NETWORK
570a276e    default     plu-9   172.17.42.1 12  33659494400 172.17.0.0/255.255.0.0

# plu@plu-9: serviced host remove 570a276e
570a276e

# plu@plu-9: serviced host list
no hosts found

# plu@plu-9: serviced host remove 570a276e
I1112 12:13:13.079290 13533 clients.go:94] rpc error, resetting cached client: HostID 570a276e does not exist
570a276e: HostID 570a276e does not exist
```
