### PR TITLE
fixes CC-445: log resetting cached client when higher verbosity is requested

### DIFF
--- a/rpc/rpcutils/clients.go
+++ b/rpc/rpcutils/clients.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
-	"reflect"
 	"sync"
 
 	"github.com/zenoss/glog"
@@ -90,10 +89,8 @@ func (rc *reconnectingClient) Call(serviceMethod string, args interface{}, reply
 	}
 	err = rpcClient.Call(serviceMethod, args, reply)
 	if err != nil {
-		if err == rpc.ErrShutdown || reflect.TypeOf(err) == reflect.TypeOf((*rpc.ServerError)(nil)).Elem() {
-			glog.Infof("rpc error, resetting cached client: %v", err)
-			rc.reset()
-		}
+		glog.V(3).Infof("rpc error, resetting cached client: %v", err)
+		rc.reset()
 	}
 	return err
 }


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-445

DEMO:

```
# plu@plu-9: serviced pool list
ID      PARENT  PRI
default         0

# plu@plu-9: serviced pool remove junk
junk: pool not found

# plu@plu-9: serviced pool list
ID      PARENT  PRI
default         0
```
