### PR TITLE
fixes CC-447: store the RPCPort when host is added

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -299,7 +299,13 @@ func (d *daemon) startMaster() error {
 	}
 
 	// This is storage related
-	thisHost, err := host.Build(agentIP, d.masterPoolID)
+	rpcPort := "0"
+	parts := strings.Split(options.Listen, ":")
+	if len(parts) > 1 {
+		rpcPort = parts[1]
+	}
+
+	thisHost, err := host.Build(agentIP, rpcPort, d.masterPoolID)
 	if err != nil {
 		glog.Errorf("could not build host for agent IP %s: %v", agentIP, err)
 		return err
@@ -390,7 +396,14 @@ func (d *daemon) startAgent() error {
 			glog.Fatalf("Failed to acquire ip address: %s", err)
 		}
 	}
-	thisHost, err := host.Build(agentIP, "unknown")
+
+	rpcPort := "0"
+	parts := strings.Split(options.Listen, ":")
+	if len(parts) > 1 {
+		rpcPort = parts[1]
+	}
+
+	thisHost, err := host.Build(agentIP, rpcPort, "unknown")
 	if err != nil {
 		panic(err)
 	}

--- a/cli/cmd/host.go
+++ b/cli/cmd/host.go
@@ -148,9 +148,9 @@ func (c *ServicedCli) cmdHostList(ctx *cli.Context) {
 		}
 	} else {
 		tableHost := newtable(0, 8, 2)
-		tableHost.printrow("ID", "POOL", "NAME", "ADDR", "CORES", "MEM", "NETWORK")
+		tableHost.printrow("ID", "POOL", "NAME", "ADDR", "RPCPORT", "CORES", "MEM", "NETWORK")
 		for _, h := range hosts {
-			tableHost.printrow(h.ID, h.PoolID, h.Name, h.IPAddr, h.Cores, h.Memory, h.PrivateNetwork)
+			tableHost.printrow(h.ID, h.PoolID, h.Name, h.IPAddr, h.RPCPort, h.Cores, h.Memory, h.PrivateNetwork)
 		}
 		tableHost.flush()
 	}

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -525,7 +525,7 @@ func (dt *DaoTest) TestDaoAutoAssignIPs(t *C) {
 	oneHostIPResource.InterfaceName = "eth1"
 	assignIPsHostIPResources = append(assignIPsHostIPResources, oneHostIPResource)
 
-	assignIPsHost, err := host.Build("", assignIPsPool.ID, []string{}...)
+	assignIPsHost, err := host.Build("", "65535", assignIPsPool.ID, []string{}...)
 	if err != nil {
 		t.Fatalf("Error creating host: %v", err)
 	}
@@ -599,7 +599,7 @@ func (dt *DaoTest) TestAssignAddress(t *C) {
 	ip := "10.0.1.5"
 	endpoint := "default"
 	serviceId := ""
-	h, err := host.Build("", "default", []string{}...)
+	h, err := host.Build("", "65535", "default", []string{}...)
 	t.Assert(err, IsNil)
 	h.ID = hostid
 	h.IPs = []host.HostIPResource{host.HostIPResource{hostid, ip, "ifname", "macaddress"}}

--- a/domain/host/hoststore_test.go
+++ b/domain/host/hoststore_test.go
@@ -68,7 +68,7 @@ func (s *S) Test_HostCRUD(t *C) {
 	}
 
 	//fill host with required values
-	host, err = Build("", "pool-id", []string{}...)
+	host, err = Build("", "65535", "pool-id", []string{}...)
 	host.ID = "testid"
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)
@@ -108,7 +108,7 @@ func (s *S) Test_HostCRUD(t *C) {
 
 func (s *S) TestDaoGetHostWithIPs(t *C) {
 	//Add host to test scenario where host exists but no IP resource registered
-	h, err := Build("", "pool-id", []string{}...)
+	h, err := Build("", "65535", "pool-id", []string{}...)
 	h.ID = "TestDaoGetHostWithIPs"
 	h.IPs = []HostIPResource{
 		HostIPResource{h.ID, "testip", "ifname", "address1"},
@@ -139,7 +139,7 @@ func (s *S) Test_GetHosts(t *C) {
 	defer s.hs.Delete(s.ctx, HostKey("Test_GetHosts1"))
 	defer s.hs.Delete(s.ctx, HostKey("Test_GetHosts2"))
 
-	host, err := Build("", "pool-id", []string{}...)
+	host, err := Build("", "65535", "pool-id", []string{}...)
 	host.ID = "Test_GetHosts1"
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)
@@ -179,7 +179,7 @@ func (s *S) Test_FindHostsInPool(t *C) {
 	defer s.hs.Delete(s.ctx, HostKey(id2))
 	defer s.hs.Delete(s.ctx, HostKey(id3))
 
-	host, err := Build("", "pool1", []string{}...)
+	host, err := Build("", "65535", "pool1", []string{}...)
 	host.ID = id1
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)

--- a/domain/host/utils.go
+++ b/domain/host/utils.go
@@ -29,7 +29,7 @@ import (
 
 // currentHost creates a Host object of the reprsenting the host where this method is invoked. The passed in poolID is
 // used as the resource pool in the result.
-func currentHost(ip string, poolID string) (host *Host, err error) {
+func currentHost(ip string, rpcPort int, poolID string) (host *Host, err error) {
 	cpus := runtime.NumCPU()
 	memory, err := utils.GetMemorySize()
 	if err != nil {
@@ -61,6 +61,7 @@ func currentHost(ip string, poolID string) (host *Host, err error) {
 			return host, err
 		}
 	}
+	host.RPCPort = rpcPort
 
 	host.ID = hostidStr
 	host.Cores = cpus

--- a/domain/host/validation.go
+++ b/domain/host/validation.go
@@ -14,8 +14,8 @@
 package host
 
 import (
-	"github.com/zenoss/glog"
 	"github.com/control-center/serviced/validation"
+	"github.com/zenoss/glog"
 
 	"errors"
 	"net"
@@ -30,6 +30,7 @@ func (h *Host) ValidEntity() error {
 	violations := validation.NewValidationError()
 	violations.Add(validation.NotEmpty("Host.ID", h.ID))
 	violations.Add(validation.StringsEqual(h.ID, trimmedID, "leading and trailing spaces not allowed for host id"))
+	violations.Add(validation.ValidPort(h.RPCPort))
 	violations.Add(validation.NotEmpty("Host.PoolID", h.PoolID))
 	violations.Add(validation.IsIP(h.IPAddr))
 

--- a/facade/host_test.go
+++ b/facade/host_test.go
@@ -31,7 +31,7 @@ func (s *FacadeTest) Test_HostCRUD(t *C) {
 	defer s.Facade.RemoveHost(s.CTX, testid)
 
 	//fill host with required values
-	h, err := host.Build("", poolid, []string{}...)
+	h, err := host.Build("", "65535", poolid, []string{}...)
 	h.ID = "facadetestid"
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)
@@ -99,10 +99,11 @@ func (s *FacadeTest) Test_HostRemove(t *C) {
 
 	//add host1
 	h1 := host.Host{
-		ID:     "h1",
-		PoolID: "poolid",
-		Name:   "h1",
-		IPAddr: "192.168.0.1",
+		ID:      "h1",
+		PoolID:  "poolid",
+		Name:    "h1",
+		IPAddr:  "192.168.0.1",
+		RPCPort: 65535,
 		IPs: []host.HostIPResource{
 			host.HostIPResource{
 				HostID:    "h1",
@@ -117,10 +118,11 @@ func (s *FacadeTest) Test_HostRemove(t *C) {
 
 	//add host2
 	h2 := host.Host{
-		ID:     "h2",
-		PoolID: "poolid",
-		Name:   "h2",
-		IPAddr: "192.168.0.2",
+		ID:      "h2",
+		PoolID:  "poolid",
+		Name:    "h2",
+		IPAddr:  "192.168.0.2",
+		RPCPort: 65535,
 		IPs: []host.HostIPResource{
 			host.HostIPResource{
 				HostID:    "h2",

--- a/facade/pool_test.go
+++ b/facade/pool_test.go
@@ -181,7 +181,7 @@ func (ft *FacadeTest) Test_GetPoolsIPs(t *C) {
 	oneHostIPResource.InterfaceName = "eth1"
 	assignIPsHostIPResources = append(assignIPsHostIPResources, oneHostIPResource)
 
-	assignIPsHost, err := host.Build("", assignIPsPool.ID, []string{}...)
+	assignIPsHost, err := host.Build("", "65535", assignIPsPool.ID, []string{}...)
 	if err != nil {
 		t.Fatalf("could not build host for test: %v", err)
 	}
@@ -238,7 +238,7 @@ func (ft *FacadeTest) Test_VirtualIPs(t *C) {
 	oneHostIPResource.InterfaceName = myInterfaceName
 	assignIPsHostIPResources = append(assignIPsHostIPResources, oneHostIPResource)
 
-	assignIPsHost, err := host.Build("", assignIPsPool.ID, []string{}...)
+	assignIPsHost, err := host.Build("", "65535", assignIPsPool.ID, []string{}...)
 	if err != nil {
 		t.Fatalf("could not build host for test: %v", err)
 	}
@@ -340,7 +340,7 @@ func (ft *FacadeTest) Test_InvalidVirtualIPs(t *C) {
 	oneHostIPResource.InterfaceName = myInterfaceName
 	assignIPsHostIPResources = append(assignIPsHostIPResources, oneHostIPResource)
 
-	assignIPsHost, err := host.Build("", assignIPsPool.ID, []string{}...)
+	assignIPsHost, err := host.Build("", "65535", assignIPsPool.ID, []string{}...)
 	if err != nil {
 		t.Fatalf("could not build host for test: %v", err)
 	}
@@ -421,7 +421,7 @@ func (ft *FacadeTest) Test_PoolCapacity(t *C) {
 	}
 
 	//fill host with required values
-	h, err := host.Build("", poolid, []string{}...)
+	h, err := host.Build("", "65535", poolid, []string{}...)
 	h.ID = hostid
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)

--- a/rpc/agent/agent.go
+++ b/rpc/agent/agent.go
@@ -17,6 +17,7 @@ import (
 	"github.com/control-center/serviced/domain/host"
 	"github.com/zenoss/glog"
 
+	"fmt"
 	"os/exec"
 )
 
@@ -48,7 +49,7 @@ func (a *AgentServer) BuildHost(request BuildHostRequest, hostResponse *host.Hos
 	*hostResponse = host.Host{}
 
 	glog.Infof("local static ips %v [%d]", a.staticIPs, len(a.staticIPs))
-	h, err := host.Build(request.IP, request.PoolID, a.staticIPs...)
+	h, err := host.Build(request.IP, fmt.Sprintf("%d", request.Port), request.PoolID, a.staticIPs...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-447

DEMO1:

```
# plu@plu-9: serviced host add plu-9:4979 default
570a276e
```

DEMO2:

```
# plu@plu-9: serviced host list
ID      POOL        NAME    ADDR        RPCPORT     CORES   MEM     NETWORK
570a276e    default     plu-9   10.87.110.39    4979        12  33659494400 172.17.0.0/255.255.0.0
```

DEMO3:

```
# plu@plu-9: serviced host list --verbose
[
   {
     "ID": "570a276e",
     "Name": "plu-9",
     "PoolID": "default",
     "IPAddr": "10.87.110.39",
     "RPCPort": 4979,
     "Cores": 12,
     "Memory": 33659494400,
     "PrivateNetwork": "172.17.0.0/255.255.0.0",
     "CreatedAt": "2014-11-12T20:50:36.37781999Z",
     "UpdatedAt": "2014-11-12T20:50:36.37781999Z",
     "IPs": [
       {
         "HostID": "570a276e",
         "IPAddress": "10.87.110.39",
         "InterfaceName": "eth0",
         "MACAddress": "18:03:73:3f:b5:d8"
       }
     ],
     "KernelVersion": "#47-Ubuntu",
     "KernelRelease": "3.13.0-24-generic",
     "ServiceD": {
       "Version": "0.10.0-dev",
       "Date": "Wed Nov 12 20:22:49 UTC 2014",
       "Gitcommit": "22ce1bf-dirty",
       "Gitbranch": "develop",
       "Giturl": "",
       "Buildtag": "0"
     },
     "MonitoringProfile": {
       "MetricConfigs": null,
       "GraphConfigs": null,
       "ThresholdConfigs": null
     },
     "DatabaseVersion": 4
   }
 ]
```
