### PR TITLE
fixes CC-460: pass rpcport to master.AddHost

### DIFF
--- a/web/cpserver.go
+++ b/web/cpserver.go
@@ -229,7 +229,7 @@ func (sc *ServiceConfig) getClient() (c *node.ControlClient, err error) {
 }
 
 func (sc *ServiceConfig) getMasterClient() (*master.Client, error) {
-	glog.Info("start getMasterClient ... sc.agentPort: %+v", sc.agentPort)
+	glog.Infof("start getMasterClient ... sc.agentPort: %+v", sc.agentPort)
 	c, err := master.NewClient(sc.agentPort)
 	if err != nil {
 		glog.Errorf("Could not create a control center client to %v: %v", sc.agentPort, err)

--- a/web/hostresource.go
+++ b/web/hostresource.go
@@ -22,6 +22,7 @@ import (
 
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -125,6 +126,19 @@ func restAddHost(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
 	}
 	hostIP := hostIPAddr.IP.String()
 
+	if len(parts) < 2 {
+		glog.Errorf("rpcport needs to be specified")
+		restBadRequest(w, err)
+		return
+	}
+
+	rpcPort, err := strconv.Atoi(parts[1])
+	if err != nil {
+		glog.Errorf("could not convert rpcport %s to int", parts[1])
+		restBadRequest(w, err)
+		return
+	}
+
 	agentClient, err := agent.NewClient(payload.IPAddr)
 	//	remoteClient, err := serviced.NewAgentClient(payload.IPAddr)
 	if err != nil {
@@ -139,6 +153,7 @@ func restAddHost(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
 	}
 	buildRequest := agent.BuildHostRequest{
 		IP:     hostIP,
+		Port:   rpcPort,
 		PoolID: payload.PoolID,
 	}
 	host, err := agentClient.BuildHost(buildRequest)


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-460

DEMO:

```
I1113 19:51:02.394987 26890 agent.go:51] local static ips [] [0]
I1113 19:51:02.410187 26890 host.go:144] building with ipsAddrs: [10.87.110.39] [1]
I1113 19:51:02.412188 26890 utils.go:133] looking for '10.87.110.39'
I1113 19:51:02.412645 26890 cpserver.go:232] start getMasterClient ... sc.agentPort: 10.87.110.39:4979
I1113 19:51:02.412711 26890 cpserver.go:238] end getMasterClient
I1113 19:51:02.449701 26890 hostresource.go:177] Added host 570a276e
2014/11/13 19:51:02 200 56.296216ms POST /hosts/add
```
