### PR TITLE
modal forms wait for success or fail before closing

### DIFF
--- a/web/static/css/main.css
+++ b/web/static/css/main.css
@@ -814,6 +814,9 @@ input.startup {
     text-shadow: 1px 1px 2px #c0c0c0;
     color: #1a1a1a;
 }
+.modal-notify {
+    position: relative;
+}
 
 .flow {
     background-color: #F0F3F7;
@@ -1108,6 +1111,12 @@ rect {
   0%   { opacity: 1; }
   10%  { opacity: .5;}
   20% { opacity: 1; }
+}
+
+/* NOTIFICATION OVERRIDES */
+.modal-notify .notification {
+    position: relative;
+    box-shadow: rgba(0,0,0,0.4) 0 0px 4px inset;
 }
 
 

--- a/web/static/js/controllers/DeployWizard.js
+++ b/web/static/js/controllers/DeployWizard.js
@@ -67,16 +67,18 @@ function DeployWizard($scope, $notification, $translate, resourcesService) {
             return false;
         }
 
-        resourcesService.add_host($scope.newHost, function(){
-            step += 1;
-            resetError();
-            $scope.step_page = $scope.steps[step].content;
-        }, function(data){
-            showError(data.Detail);
-        });
+        resourcesService.add_host($scope.newHost)
+            .success(function(){
+                step += 1;
+                resetError();
+                $scope.step_page = $scope.steps[step].content;
+            })
+            .error(function(data){
+                showError(data.Detail);
+            });
 
         return false;
-    }
+    };
 
     var resetStepPage = function() {
         step = 0;

--- a/web/static/js/controllers/DeployedAppsControl.js
+++ b/web/static/js/controllers/DeployedAppsControl.js
@@ -92,15 +92,21 @@ function DeployedAppsControl($scope, $routeParams, $location, $notification, res
                     action: function(){
                         if(this.validate()){
                             var data = new FormData();
+
                             $.each($("#new_template_filename")[0].files, function(key, value){
                                 data.append("tpl", value);
                             });
-                            resourcesService.add_app_template(data, function(data){
-                                resourcesService.get_app_templates(false, refreshTemplates);
-                            });
-                        }
 
-                        this.close();
+                            resourcesService.add_app_template(data)
+                                .success(function(data, status){
+                                    $notification.create("Added template", data.Detail).success();
+                                    resourcesService.get_app_templates(false, refreshTemplates);
+                                    this.close();
+                                }.bind(this))
+                                .error(function(data, status){
+                                    this.createNotification("Adding template failed", data.Detail).error();
+                                }.bind(this));
+                        }
                     }
                 }
             ]
@@ -148,7 +154,6 @@ function DeployedAppsControl($scope, $routeParams, $location, $notification, res
                     action: function(){
                         if(this.validate()){
                             $scope.remove_service();
-                            // NOTE: should wait for success before closing
                             this.close();
                         }
                     }
@@ -237,7 +242,6 @@ function DeployedAppsControl($scope, $routeParams, $location, $notification, res
                     classes: "btn-danger",
                     action: function(){
                         resourcesService.delete_app_template(templateID, refreshTemplates);
-                        // NOTE: should wait for success before closing
                         this.close();
                     }
                 }

--- a/web/static/js/controllers/HostDetailsControl.js
+++ b/web/static/js/controllers/HostDetailsControl.js
@@ -32,32 +32,6 @@ function HostDetailsControl($scope, $routeParams, $location, resourcesService, a
         { id: 'MAC Address', name: 'ip_addresses_mac' }
     ]);
 
-    $scope.viewConfig = function(running) {
-        $scope.editService = $.extend({}, running);
-        $scope.editService.config = 'TODO: Implement';
-        $modalService.create({
-            templateUrl: "edit-config.html",
-            model: $scope,
-            title: $translate.instant("title_edit_config") +" - "+ $scope.editService.config,
-            bigModal: true,
-            actions: [
-                {
-                    role: "cancel"
-                },{
-                    role: "ok",
-                    label: "save",
-                    action: function(){
-                        if(this.validate()){
-                            $scope.updateService();
-                            // NOTE: should wait for response before closing
-                            this.close();
-                        }
-                    }
-                }
-            ]
-        });
-    };
-
     $scope.viewLog = function(running) {
         $scope.editService = $.extend({}, running);
         resourcesService.get_service_state_logs(running.ServiceID, running.ID, function(log) {

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -782,6 +782,25 @@ function isInstanceOfService(service){
     return "InstanceID" in service;
 }
 
+// accepts a preferred  and decorates it with success 
+// and error functions to simulate $http promise
+function httpifyDeferred(defer){
+    // TODO - move this to a utils function where we 
+    // can access $q and make our own defer
+
+    // simulate an angular $http promise
+    defer.promise.success = function(callback){
+        defer.promise.then(callback);
+        return defer.promise;
+    };
+    defer.promise.error = function(callback){
+        defer.promise.then(null, callback);
+        return defer.promise;
+    };
+
+    return defer;
+}
+
 // keep notifications stuck to bottom of nav, or top of window
 // if nav is out ovf view.
 var $window = $(window);

--- a/web/static/js/modules/modalService.js
+++ b/web/static/js/modules/modalService.js
@@ -5,8 +5,8 @@
 
     angular.module('modalService', []).
     factory("$modalService", [
-        "$rootScope", "$templateCache", "$http", "$interpolate", "$compile", "$translate",
-        function($rootScope, $templateCache, $http, $interpolate, $compile, $translate){
+        "$rootScope", "$templateCache", "$http", "$interpolate", "$compile", "$translate", "$notification",
+        function($rootScope, $templateCache, $http, $interpolate, $compile, $translate, $notification){
 
             var defaultModalTemplate = '<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">\
                 <div class="modal-dialog {{bigModal}}">\
@@ -15,10 +15,11 @@
                             <button type="button" class="close glyphicon glyphicon-remove-circle" data-dismiss="modal" aria-hidden="true"></button>\
                             <span class="modal-title">{{title}}</span>\
                         </div>\
+                        <div class="modal-notify"></div>\
                         <div class="modal-body">{{template}}</div>\
                         <div class="modal-footer"></div>\
                     </div>\
-                </div>>\
+                </div>\
             </div>';
 
             var actionButtonTemplate = '<button type="button" class="btn {{classes}}">{{label}}</button>';
@@ -47,6 +48,7 @@
              */
             function Modal(template, model, config){
                 var $modalFooter;
+
                 // inject user provided template into modal template
                 var modalTemplate = $interpolate(defaultModalTemplate)({
                     template: template,
@@ -58,6 +60,8 @@
                 this.$el = $($compile(modalTemplate)(model)).modal();
 
                 $modalFooter = this.$el.find(".modal-footer");
+                // cache a reference to the notification holder
+                this.$notificationEl = this.$el.find(".modal-notify");
 
                 // create action buttons
                 config.actions.forEach(function(action){
@@ -96,7 +100,6 @@
                 constructor: Modal,
                 close: function(){
                     this.$el.modal("hide");
-                    
                 },
                 show: function(){
                     this.$el.modal("show");
@@ -106,6 +109,10 @@
                 },
                 destroy: function(){
                     this.$el.remove();
+                },
+                // convenience method for attaching notifications to the modal
+                createNotification: function(title, message){
+                    return $notification.create(title, message, this.$notificationEl);
                 }
             };
             

--- a/web/static/js/modules/resourcesService.js
+++ b/web/static/js/modules/resourcesService.js
@@ -65,9 +65,7 @@
               error(function(data, status) {
                   // TODO error screen
                   if(DEBUG) console.log('Unable to retrieve services');
-                  if (status === 401) {
-                      unauthorized($location);
-                  }
+                  redirectIfUnauthorized(status);
               });
       };
 
@@ -81,9 +79,7 @@
               error(function(data, status) {
                   // TODO error screen
                   if(DEBUG) console.log('Unable to retrieve application templates');
-                  if (status === 401) {
-                      unauthorized($location);
-                  }
+                  redirectIfUnauthorized(status);
               });
       };
 
@@ -98,9 +94,7 @@
               error(function(data, status) {
                   // TODO error screen
                   if(DEBUG) console.log('Unable to retrieve list of pools');
-                  if (status === 401) {
-                      unauthorized($location);
-                  }
+                  redirectIfUnauthorized(status);
               });
       };
 
@@ -114,9 +108,7 @@
               error(function(data, status) {
                   // TODO error screen
                   if(DEBUG) console.log('Unable to retrieve hosts for pool ' + poolID);
-                  if (status === 401) {
-                      unauthorized($location);
-                  }
+                  redirectIfUnauthorized(status);
               });
       };
 
@@ -130,10 +122,14 @@
               error(function(data, status) {
                   // TODO error screen
                   if(DEBUG) console.log('Unable to retrieve host details');
-                  if (status === 401) {
-                      unauthorized($location);
-                  }
+                  redirectIfUnauthorized(status);
               });
+      };
+
+      var redirectIfUnauthorized = function(status){
+          if (status === 401) {
+              unauthorized($location);
+          }
       };
 
       return {
@@ -146,24 +142,14 @@
            * @param {ip} string ip address to assign to service, set as null for automatic assignment
            * @param {function} callback data is passed to a callback on success.
            */
-          assign_ip: function(serviceID, ip, callback) {
+          assign_ip: function(serviceID, ip) {
             var url = '/services/' + serviceID + "/ip";
             if (ip !== null) {
               url = url + "/" + ip;
             }
-            $http.put(url).
-                success(function(data, status) {
-                    $notification.create("Assigned IP", ip).success();
-                    if (callback) {
-                      callback(data);
-                    }
-                }).
+            return $http.put(url).
                 error(function(data, status) {
-                    // TODO error screen
-                    $notification.create("Unable to assign ip", ip).error();
-                    if (status === 401) {
-                        unauthorized($location);
-                    }
+                    redirectIfUnauthorized(status);
                 });
           },
 
@@ -198,9 +184,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       if(DEBUG) console.log("Unable to acquire pool", data.Detail);
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -219,9 +203,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       if(DEBUG) console.log("Unable to acquire pool", data.Detail);
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -243,9 +225,7 @@
                 error(function(data, status) {
                     // TODO error screen
                     if(DEBUG) console.log("Unable to acquire running services", data.Detail);
-                    if (status === 401) {
-                        unauthorized($location);
-                    }
+                    redirectIfUnauthorized(status);
                 });
           },
 
@@ -264,30 +244,21 @@
                   error(function(data, status) {
                       // TODO error screen
                       if(DEBUG) console.log("Unable to acquire virtual hosts", data.Detail);
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
           /*
            * add a virtual host,
            */
-          add_vhost: function(serviceId, application, virtualhost, callback) {
+          add_vhost: function(serviceId, application, virtualhost) {
               var ep = '/services/' + serviceId + '/endpoint/' + application + '/vhosts/' + virtualhost;
               var object = {'ServiceID':serviceId, 'Application':application, 'VirtualHostName':virtualhost};
-              var payload = JSON.stringify( object);
-              $http.put(ep, payload).
-                  success(function(data, status) {
-                      $notification.create("Added virtual host", ep + data.Detail).success();
-                      callback(data);
-                  }).
-                  error(function(data, status) {
-                      // TODO error screen
-                      $notification.create("Unable to add virtual hosts", ep + data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+              var payload = JSON.stringify(object);
+
+              return $http.put(ep, payload)
+                  .error(function(data, status) {
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -304,9 +275,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("Unable to remove virtual hosts", ep + data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -325,9 +294,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       if(DEBUG) console.log("Unable to acquire running services", data.Detail);
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -345,9 +312,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       if(DEBUG) console.log("Unable to acquire running services", data.Detail);
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -357,19 +322,12 @@
            * @param {object} pool New pool details to be added.
            * @param {function} callback Add result passed to callback on success.
            */
-          add_pool: function(pool, callback) {
+          add_pool: function(pool) {
               if(DEBUG) console.log('Adding detail: %s', JSON.stringify(pool));
-              $http.post('/pools/add', pool).
-                  success(function(data, status) {
-                      $notification.create("", "Added new pool").success();
-                      callback(data);
-                  }).
+
+              return $http.post('/pools/add', pool).
                   error(function(data, status) {
-                      // TODO error screen
-                      $notification.create("Adding pool failed", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -389,9 +347,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("Updating pool failed", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -410,9 +366,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("Removing pool failed", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
           /*
@@ -422,20 +376,13 @@
            * @param {string} ip virtual ip to add to pool
            * @param {function} callback Add result passed to callback on success.
            */
-          add_pool_virtual_ip: function(pool, ip, netmask, _interface, callback) {
+          add_pool_virtual_ip: function(pool, ip, netmask, _interface) {
               var payload = JSON.stringify( {'PoolID':pool, 'IP':ip, 'Netmask':netmask, 'BindInterface':_interface});
               if(DEBUG) console.log('Adding pool virtual ip: %s', payload);
-              $http.put('/pools/' + pool + '/virtualip', payload).
-                  success(function(data, status) {
-                      $notification.create("Added new pool virtual ip", ip).success();
-                      callback(data);
-                  }).
-                  error(function(data, status) {
-                      // TODO error screen
-                      $notification.create("Adding pool virtual ip failed", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+
+              return $http.put('/pools/' + pool + '/virtualip', payload)
+                  .error(function(data, status) {
+                      redirectIfUnauthorized(status);
                   });
           },
           /*
@@ -455,9 +402,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("Remove pool virtual ip failed", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -476,9 +421,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("Terminating instance failed", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -513,9 +456,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("Unable to acquire host", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -526,21 +467,9 @@
            * @param {function} callback Add result passed to callback on success.
            */
           add_host: function(host, callback, errorCallback) {
-              $http.post('/hosts/add', host).
-                  success(function(data, status) {
-                      $notification.create("", data.Detail).success();
-                      callback(data);
-                  }).
-                  error(function(data, status) {
-                      // TODO error screen
-                      $notification.create("", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
-
-                      if(errorCallback){
-                          errorCallback(data);
-                      }
+              return $http.post('/hosts/add', host)
+                  .error(function(data, status){
+                     redirectIfUnauthorized(status);
                   });
           },
 
@@ -560,10 +489,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("Updating host failed", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
-
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -574,17 +500,9 @@
            * @param {function} callback Delete result passed to callback on success.
            */
           remove_host: function(hostId, callback) {
-              $http.delete('/hosts/' + hostId).
-                  success(function(data, status) {
-                      $notification.create("Removed host", hostId).success();
-                      callback(data);
-                  }).
-                  error(function(data, status) {
-                      // TODO error screen
-                      $notification.create("Removing host failed", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+              return $http.delete('/hosts/' + hostId)
+                  .error(function(data, status){
+                     redirectIfUnauthorized(status);
                   });
           },
 
@@ -593,9 +511,7 @@
                     callback(data);
                 }).error(function(data, status){
                   if(DEBUG) console.log('Unable to retrieve running hosts');
-                  if (status === 401) {
-                      unauthorized($location);
-                  }
+                  redirectIfUnauthorized(status);
                 });
           },
 
@@ -693,9 +609,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       if(DEBUG) console.log("Unable to retrieve service logs", data.Detail);
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -713,9 +627,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       if(DEBUG) console.log("Unable to retrieve service logs", data.Detail);
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -750,21 +662,20 @@
           },
 
           add_app_template: function(fileData, callback){
-              $.ajax( {
+              return $http({
                   url: "/templates/add",
-                  type: "POST",
+                  method: "POST",
                   data: fileData,
-                  processData: false,
-                  contentType: false,
-                  success: function(data, status){
-                      $notification.create("Added template", data.Detail).success();
-                      callback(data);
-                  },
-                  error: function(data, status){
-                      console.log(data);
-                      $notification.create("Adding template failed", data.responseJSON.Detail).error();
-                  }
+                  // content-type undefined forces the browser to fill in the
+                  // boundary parameter of the request
+                  headers: {"Content-Type": undefined},
+                  // identity returns the value it receives, which prevents
+                  // transform from modifying the request in any way
+                  transformRequest: angular.identity,
+              }).error(function(data, status){
+                  redirectIfUnauthorized(status);
               });
+
           },
 
           delete_app_template: function(templateID, callback){
@@ -794,9 +705,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("Adding service failed", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -805,23 +714,11 @@
            *
            * @param {string} serviceId The ID of the service to update.
            * @param {object} editedService The modified service.
-           * @param {function} callback Response passed to callback on success.
            */
-          update_service: function(serviceId, editedService, success, fail) {
-              fail = fail || angular.noop;
-
-              $http.put('/services/' + serviceId, editedService).
-                  success(function(data, status) {
-                      $notification.create("Updated service", serviceId).success();
-                      success(data);
-                  }).
+          update_service: function(serviceId, editedService) {
+              return $http.put('/services/' + serviceId, editedService).
                   error(function(data, status) {
-                      // TODO error screen
-                      $notification.create("Updating service failed", data.Detail).error();
-                      fail(data, status);
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -841,9 +738,7 @@
                       // TODO error screen
                       $notification.create("Deploying application template failed", data.Detail).error();
                       failCallback(data);
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -861,9 +756,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("Snapshot service failed", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -882,9 +775,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("Removing service failed", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -911,9 +802,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("Was unable to start service", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
           /*
@@ -938,9 +827,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("Was unable to stop service", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
           /*
@@ -965,9 +852,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("Was unable to restart service", data.Detail).error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
           /**
@@ -981,9 +866,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("", "Could not retrieve Serviced version from server.").warning();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -998,9 +881,7 @@
                       success(data);
                   }).
                   error(function(data, status) {
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                       fail(data, status);
                   });
           },
@@ -1016,9 +897,7 @@
                       success(data);
                   }).
                   error(function(data, status) {
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                       fail(data, status);
                   });
           },
@@ -1032,9 +911,7 @@
                   error(function(data, status) {
                       // TODO error screen
                       $notification.create("", "Failed retrieving list of backup files.").error();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                   });
           },
 
@@ -1047,9 +924,7 @@
                       successCallback(data);
                   }).
                   error(function(data, status) {
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                       failCallback(data, status);
                   });
           },
@@ -1064,9 +939,7 @@
                   }).
                   error(function(data, status) {
                       $notification.create("", 'Failed retrieving status of restore.').warning();
-                      if (status === 401) {
-                          unauthorized($location);
-                      }
+                      redirectIfUnauthorized(status);
                       failCallback(data, status);
                   });
           },
@@ -1082,9 +955,7 @@
               }).
               error(function(data, status) {
                   if(DEBUG) console.log('Failed retrieving health checks.');
-                  if (status === 401) {
-                      unauthorized($location);
-                  }
+                  redirectIfUnauthorized(status);
               });
 
             
@@ -1115,9 +986,7 @@
               error(function(data, status) {
                   // TODO error screen
                   $notification.create("", 'serviced is not collecting stats.').error();
-                  if (status === 401) {
-                      unauthorized($location);
-                  }
+                  redirectIfUnauthorized(status);
                   callback(status);
               });
           },

--- a/web/static/js/modules/zenNotify.js
+++ b/web/static/js/modules/zenNotify.js
@@ -164,6 +164,11 @@ var lastMessage;
                     lastMessage.hide();
                 }
 
+                // if $attachPoint is no longer in the document
+                // use the default attachPoint
+                if(!$.contains(document, this.$attachPoint[0])){
+                    this.$attachPoint = $("#notifications"); 
+                }
                 this.$attachPoint.append(this.$el);
 
                 autoclose = typeof autoclose !== 'undefined' ? autoclose : true;


### PR DESCRIPTION
Modal forms used to close as soon as the submit button was pressed and the success/fail notification appear in the usual place. If there was a failure, the user was forced to reopen the modal and re-enter the info.

This PR enables modals to use promises to wait for success or error and take the appropriate action. If success, the modal will close. If there is an error, the error message appears inside the modal.

Many of the resoucesService methods were changed to return promises instead of using callbacks. Additionally those methods no longer trigger notifications as that is not their responsibility. The responsibility lies with the code that kicks off the request, not the code responsible for making async requests.
