### PR TITLE
IPs/Ports are unique to a pool when making address assignments

### DIFF
--- a/domain/addressassignment/addressassignmentstore.go
+++ b/domain/addressassignment/addressassignmentstore.go
@@ -15,6 +15,7 @@ package addressassignment
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/control-center/serviced/datastore"
@@ -42,7 +43,22 @@ func (s *Store) GetServiceAddressAssignments(ctx datastore.Context, serviceID st
 	return convert(results)
 }
 
-func (s *Store) FindAddressAssignment(ctx datastore.Context, serviceID, endpointName string) (*AddressAssignment, error) {
+func (s *Store) GetServiceAddressAssignmentsByPort(ctx datastore.Context, port uint16) ([]AddressAssignment, error) {
+	if port == 0 {
+		return nil, fmt.Errorf("port must be greater than 0")
+	}
+
+	query := search.Query().Term("Port", strconv.FormatUint(uint64(port), 10))
+	search := search.Search("controlplane").Type(kind).Size("50000").Query(query)
+
+	if results, err := datastore.NewQuery(ctx).Execute(search); err != nil {
+		return nil, err
+	} else {
+		return convert(results)
+	}
+}
+
+func (s *Store) FindAssignmentByServiceEndpoint(ctx datastore.Context, serviceID, endpointName string) (*AddressAssignment, error) {
 	if serviceID = strings.TrimSpace(serviceID); serviceID == "" {
 		return nil, fmt.Errorf("service ID cannot be empty")
 	} else if endpointName = strings.TrimSpace(endpointName); endpointName == "" {
@@ -53,6 +69,30 @@ func (s *Store) FindAddressAssignment(ctx datastore.Context, serviceID, endpoint
 		"and",
 		search.Filter().Terms("ServiceID", serviceID),
 		search.Filter().Terms("EndpointName", endpointName),
+	)
+
+	if results, err := datastore.NewQuery(ctx).Execute(search); err != nil {
+		return nil, err
+	} else if output, err := convert(results); err != nil {
+		return nil, err
+	} else if len(output) == 0 {
+		return nil, nil
+	} else {
+		return &output[0], nil
+	}
+}
+
+func (s *Store) FindAssignmentByHostPort(ctx datastore.Context, ipAddr string, port uint16) (*AddressAssignment, error) {
+	if ipAddr = strings.TrimSpace(ipAddr); ipAddr == "" {
+		return nil, fmt.Errorf("hostIP cannot be empty")
+	} else if port == 0 {
+		return nil, fmt.Errorf("port must be greater than 0")
+	}
+
+	search := search.Search("controlplane").Type(kind).Filter(
+		"and",
+		search.Filter().Terms("IPAddr", ipAddr),
+		search.Filter().Terms("Port", strconv.FormatUint(uint64(port), 10)),
 	)
 
 	if results, err := datastore.NewQuery(ctx).Execute(search); err != nil {

--- a/domain/pool/poolstore.go
+++ b/domain/pool/poolstore.go
@@ -55,6 +55,27 @@ func (s *Store) GetResourcePoolsByRealm(ctx datastore.Context, realm string) ([]
 	return convert(results)
 }
 
+// HasVirtualIP returns true if there is a virtual ip found for the given pool
+func (s *Store) HasVirtualIP(ctx datastore.Context, poolID, virtualIP string) (bool, error) {
+	if poolID = strings.TrimSpace(poolID); poolID == "" {
+		return false, errors.New("empty pool id not allowed")
+	} else if virtualIP = strings.TrimSpace(virtualIP); virtualIP == "" {
+		return false, errors.New("empty virtual ip not allowed")
+	}
+
+	search := search.Search("controlplane").Type(kind).Filter(
+		"and",
+		search.Filter().Terms("ID", poolID),
+		search.Filter().Terms("VirtualIPs.IP", virtualIP),
+	)
+
+	results, err := datastore.NewQuery(ctx).Execute(search)
+	if err != nil {
+		return false, err
+	}
+	return results.Len() > 0, nil
+}
+
 //Key creates a Key suitable for getting, putting and deleting ResourcePools
 func Key(id string) datastore.Key {
 	return datastore.NewKey(kind, id)

--- a/domain/pool/poolstore_test.go
+++ b/domain/pool/poolstore_test.go
@@ -148,3 +148,41 @@ func (s *S) Test_GetPools(t *C) {
 		t.Errorf("Expected %v results, got %v: %#v", 2, len(pools), pools)
 	}
 }
+
+func (s *S) Test_HasVirtualIP(t *C) {
+	defer s.ps.Delete(s.ctx, Key("testid"))
+
+	pool := New("testID")
+	pool.Realm = "default"
+	pool.VirtualIPs = []VirtualIP{
+		{IP: "10.20.1.2", Netmask: "255.255.255.255", BindInterface: "test"},
+	}
+
+	if err := s.ps.Put(s.ctx, Key(pool.ID), pool); err != nil {
+		t.Fatalf("Unexpected failure creating pool: %-v", pool)
+	}
+
+	if ok, err := s.ps.HasVirtualIP(s.ctx, "nopool", "10.20.1.2"); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if ok {
+		t.Errorf("Found pool!")
+	}
+
+	if ok, err := s.ps.HasVirtualIP(s.ctx, "testID", "1.2.3.4"); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if ok {
+		t.Errorf("Found pool!")
+	}
+
+	if ok, err := s.ps.HasVirtualIP(s.ctx, "nopool", "1.2.3.4"); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if ok {
+		t.Errorf("Found pool!")
+	}
+
+	if ok, err := s.ps.HasVirtualIP(s.ctx, "testID", "10.20.1.2"); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if !ok {
+		t.Errorf("Did not find pool!")
+	}
+}

--- a/zzk/virtualips/virtualips.go
+++ b/zzk/virtualips/virtualips.go
@@ -180,7 +180,11 @@ func (l *VirtualIPListener) Spawn(shutdown <-chan interface{}, ip string) {
 	for {
 		var vip pool.VirtualIP
 		event, err := l.conn.GetW(l.GetPath(ip), &VirtualIPNode{VirtualIP: &vip})
-		if err != nil {
+		if err == client.ErrEmptyNode {
+			glog.Errorf("Deleting empty node for ip %s", ip)
+			RemoveVirtualIP(l.conn, ip)
+			return
+		} else if err != nil {
 			glog.Errorf("Could not load virtual ip %s: %s", ip, err)
 			return
 		}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-451
https://jira.zenoss.com/browse/CC-468
https://jira.zenoss.com/browse/CC-467
- Added searching for address assignments by port (many), and host/port (unique)
- Added a search to check if a virtual ip exists for a particular pool
- All IPs (virtual and static) must be unique to the pool
- Services can share ports with other services, though those services cannot share the same IP
- Fixed race condition with deleting virtual ips from zookeeper
