### PR TITLE
fixes CC-346: removed SERVICED_MUX_TLS and --tls flag

### DIFF
--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -143,7 +143,6 @@ func (c *ServicedCli) initService() {
 					cli.StringFlag{"forwarder-config", "/etc/logstash-forwarder.conf", "path to the logstash-forwarder config file"},
 					cli.IntFlag{"muxport", 22250, "multiplexing port to use"},
 					cli.BoolTFlag{"mux", "enable port multiplexing"},
-					cli.BoolTFlag{"tls", "enable tls"},
 					cli.StringFlag{"keyfile", "", "path to private key file (defaults to compiled in private keys"},
 					cli.StringFlag{"certfile", "", "path to public certificate file (defaults to compiled in public cert)"},
 					cli.StringFlag{"endpoint", api.GetGateway(defaultRPCPort), "serviced endpoint address"},
@@ -855,7 +854,7 @@ func (c *ServicedCli) cmdServiceProxy(ctx *cli.Context) error {
 	options := api.ControllerOptions{
 		MuxPort:                 ctx.GlobalInt("muxport"),
 		Mux:                     ctx.GlobalBool("mux"),
-		TLS:                     ctx.GlobalBool("tls"),
+		TLS:                     true,
 		KeyPEMFile:              ctx.GlobalString("keyfile"),
 		CertPEMFile:             ctx.GlobalString("certfile"),
 		ServicedEndpoint:        ctx.GlobalString("endpoint"),

--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -692,7 +692,6 @@ func ExampleServicedCLI_CmdServiceProxy_usage() {
 	// OPTIONS:
 	//    --muxport '22250'			multiplexing port to use
 	//    --mux				enable port multiplexing
-	//    --tls				enable tls
 	//    --keyfile 				path to private key file (defaults to compiled in private keys
 	//    --certfile 				path to public certificate file (defaults to compiled in public cert)
 	//    --endpoint '10.87.103.1:4979'	serviced endpoint address

--- a/container/proxy.go
+++ b/container/proxy.go
@@ -61,7 +61,7 @@ prxy [OPTIONS] SERVICE_ID
   -keyfile="": path to private key file (defaults to compiled in private key)
   -mux=true: enable port multiplexing
   -muxport=22250: multiplexing port to use
-  -tls=true: enable TLS
+  tls is always enabled
 
 To terminate the prxy service connect to it via port 4321 and it will exit.
 The netcat (nc) command is particularly useful for this:

--- a/node/agent.go
+++ b/node/agent.go
@@ -701,7 +701,6 @@ func configureContainer(a *HostAgent, client *ControlClient,
 		fmt.Sprintf("/serviced/%s", binary),
 		"service",
 		"proxy",
-		fmt.Sprintf("--tls=%v", a.useTLS),
 		svc.ID,
 		strconv.Itoa(serviceState.InstanceID),
 		svc.Startup)

--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -53,9 +53,6 @@
 # Set the TLS certfile
 # SERVICED_CERT_FILE=/etc/....
 
-# Set to 0 to disable TLS for the mux port
-# SERVICED_MUX_TLS=1
-
 # Set the driver type for the underlying file system (rsync/btrfs)
 # SERVICED_FS_TYPE=rsync
 


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-346

revert https://github.com/control-center/serviced/pull/1216

DEMO:

```
# plu@plu-9: serviced service status
NAME            ID              STATUS      UPTIME          HOST    IN_SYNC     DOCKER_ID
└─Zenoss.core       5xhx1xsz529rsem0ong887230   Running     6m30.321244002s     plu-9   Y       2553d29a65b1
  ├─redis       1lor6rm4tnebq47wztjkjr09e   Running     6m31.379743676s     plu-9   Y       52582ccd0e2a
  ├─MetricConsumer  30onkrhm58rb0lu6apcbyf1wr   Running     6m36.795583411s     plu-9   Y       b19a53c1a82f
  ├─zeneventd       3z491qn9dnpmmdjewzpm7gpmq   Running     5m2.632742153s      plu-9   Y       8b81a2e261b5
  ├─Zope        51q5b07cxwxnaudw4qn5z7a76   Running     6m16.059523103s     plu-9   Y       05a318e986f9
  ├─opentsdb        5rjtla7cj0h8jfju6pqhku1mw   Running     6m30.938879141s     plu-9   Y       ce07da6d470a
  ├─HBase       61tow3o3xhvhfwvxuf1ty5rt5                                   
  │ ├─HMaster     2s8d1kvae3khjkcaxfjvp06iq   Running     5m59.452069794s     plu-9   Y       b543eff3680f
  │ ├─RegionServer    3n6aqioxcbopj3ln6ohjq4cr3   Running     6m5.012976833s      plu-9   Y       81ad22c9ab12
  │ └─ZooKeeper       9tjwi38c8olaace11rh8u45ew   Running     5m53.858306196s     plu-9   Y       42c1a2dd86ce
  ├─MariaDB     6fw6tbpixjs7hxa62uo90ye1a   Running     4m19.024474758s     plu-9   Y       cdc8a0344336
  ├─CentralQuery    91gmdlbcesfr95nje4ctx9omr   Running     6m36.702388879s     plu-9   Y       664c658f0712
  ├─zenactiond      9gk0o4fe0y389wdwggkhwgo2v   Running     4m13.497738924s     plu-9   Y       281160fc0442
  ├─zeneventserver  b5qhx3kuf4mavqt5m2p5ymenl   Running     4m33.237880302s     plu-9   Y       62d6d08f2e67
  ├─MetricShipper   bbynzhk0no4uqqgk70roa6u2e   Running     6m37.020763126s     plu-9   Y       df449aa2b5cc
  ├─zenjobs     cd2adiar62u486w1zielycn8p   Running     4m25.091895977s     plu-9   Y       9c9432ef632d
  ├─RabbitMQ        dr3vm8ohfbuf1rrkhs6r7wsty   Running     6m10.559333679s     plu-9   Y       63e7e51d9559
  └─localhost       m71rrebb6siel3kktoz1wrng                                    
    ├─localhost     7hyrj716qhhnv1uvlp267zs4t                                   
    │ ├─zensyslog 1x2k4g3rkxmedmvm0f3axt169   Running     5m8.188279442s      plu-9   Y       47cdac5771f8
    │ ├─zencommand    2l93u7exz7f1ceo7ddbyazc2h   Running     4m51.478683491s     plu-9   Y       5a86a1c8bf03
    │ ├─zminion       2xx9fko1wybvyxxxff2m54jcx   Running     5m13.924406548s     plu-9   Y       3d20f6880f96
    │ ├─zentrap       4ffmwuu18vqvc6s7zv3l76z4h   Running     5m37.000567607s     plu-9   Y       187b77c33f41
    │ ├─zenmodeler    7dczxrhd7wmzsojgeqxl1z1y6   Running     5m42.611931454s     plu-9   Y       fb7e9aac7a14
    │ ├─collectorredis    9v3iifgrc70ralkbvj8wk8n45   Running     6m33.200385122s     plu-9   Y       b92bb085c28d
    │ ├─zenstatus 9zmoijt6dwjlhecnbp3xyuohq   Running     4m40.238052456s     plu-9   Y       1161597b0724
    │ ├─zenpython anfaxm8t6jn91s8ugibz3gcpm   Running     4m57.067212295s     plu-9   Y       fff0d7d6476b
    │ ├─MetricShipper ckakupihhsqpbvmcwmkutrefw   Running     6m31.824065079s     plu-9   Y       ffc21c02a4f7
    │ ├─zenping       dazwcs52jrz5q2wfe4t8pw7en   Running     5m30.795363923s     plu-9   Y       ca7b6ff92cac
    │ ├─zenperfsnmp   dm8hiqnvxhuftrt16xpxjcq7r   Running     5m25.197978333s     plu-9   Y       a3db22a350cf
    │ ├─zenprocess    euggo4hgtu2ahegjgtdihnyvr   Running     5m19.549202647s     plu-9   Y       fe91065e4328
    │ └─zenjmx        j5x4yl2l2kc8if7a30m9bwhu    Running     4m45.88234546s      plu-9   Y       1e6aef128c1e
    └─zenhub        9457unmhymyrtz9a18pbjx4xk   Running     5m48.223273288s     plu-9   Y       f18917e232c0
```

![screen shot 2014-11-21 at 13 41 02](https://cloud.githubusercontent.com/assets/2837923/5148391/39025caa-7184-11e4-81eb-688668c6f2bb.png)
![screen shot 2014-11-21 at 13 41 11](https://cloud.githubusercontent.com/assets/2837923/5148396/3ea246e8-7184-11e4-8a07-a65e484157d5.png)
