### PR TITLE
fixes CC-509: prereq docker 1.3.2

### DIFF
--- a/pkg/makefile
+++ b/pkg/makefile
@@ -134,7 +134,7 @@ deb: stage_deb
 		-d nfs-kernel-server \
 		-d net-tools \
 		-d nfs-common \
-		-d 'lxc-docker >= 1.3.0' \
+		-d 'lxc-docker >= 1.3.2' \
 		-d logrotate \
 		-t deb \
 		-a x86_64 \
@@ -161,7 +161,7 @@ rpm: stage_rpm
 		-d net-tools \
 		-d util-linux \
 		-d bash-completion \
-		-d 'docker >= 1.3.0' \
+		-d 'docker >= 1.3.2' \
 		-d logrotate \
 		-t rpm \
 		-a x86_64 \


### PR DESCRIPTION
may need to update Godeps to reference this:
  https://github.com/docker/docker/commit/39fa2faad2f3d6fa5133de4eb740677202f53ef4
