### PR TITLE
updated Godeps to depend on docker 1.3.2

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -37,8 +37,8 @@
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/proxy",
-			"Comment": "v1.3.0-c78088f",
-			"Rev": "c78088fe3d1b90640c637d8c3457de3caa0c7a24"
+			"Comment": "v1.3.2-39fa2fa",
+			"Rev": "39fa2faad2f3d6fa5133de4eb740677202f53ef4"
 		},
 		{
 			"ImportPath": "github.com/syndtr/gocapability/capability",
@@ -98,32 +98,28 @@
 		},
 		{
 			"ImportPath": "github.com/docker/docker/dockerversion",
-			"Comment": "v1.3.0-c78088f",
-			"Rev": "c78088fe3d1b90640c637d8c3457de3caa0c7a24"
+			"Comment": "v1.3.2-39fa2fa",
+			"Rev": "39fa2faad2f3d6fa5133de4eb740677202f53ef4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/term",
-			"Comment": "v1.3.0-c78088f",
-			"Comment": "v1.0.0-1-gd993975",
-			"Rev": "c78088fe3d1b90640c637d8c3457de3caa0c7a24"
+			"Comment": "v1.3.2-39fa2fa",
+			"Rev": "39fa2faad2f3d6fa5133de4eb740677202f53ef4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/units",
-			"Comment": "v1.3.0-c78088f",
-			"Comment": "v1.0.0-1-gd993975",
-			"Rev": "c78088fe3d1b90640c637d8c3457de3caa0c7a24"
+			"Comment": "v1.3.2-39fa2fa",
+			"Rev": "39fa2faad2f3d6fa5133de4eb740677202f53ef4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/utils",
-			"Comment": "v1.3.0-c78088f",
-			"Comment": "v1.0.0-1-gd993975",
-			"Rev": "c78088fe3d1b90640c637d8c3457de3caa0c7a24"
+			"Comment": "v1.3.2-39fa2fa",
+			"Rev": "39fa2faad2f3d6fa5133de4eb740677202f53ef4"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar",
-			"Comment": "v1.3.0-c78088f",
-			"Comment": "v1.0.0-1-gd993975",
-			"Rev": "c78088fe3d1b90640c637d8c3457de3caa0c7a24"
+			"Comment": "v1.3.2-39fa2fa",
+			"Rev": "39fa2faad2f3d6fa5133de4eb740677202f53ef4"
 		},
 		{
 			"ImportPath": "github.com/gorilla/context",


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-509

follow on to:
  https://github.com/control-center/serviced/pull/1337

docker 1.3.2 tag:
  https://github.com/docker/docker/commit/39fa2faad2f3d6fa5133de4eb740677202f53ef4
