### PR TITLE
fixes CC-464: reload by not starting isvcs and restarting self with exec

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -302,10 +302,16 @@ func (d *daemon) run() (err error) {
 		defer glog.Infof("Timeout waiting for shutdown")
 	}
 
-	if options.Master && sig != syscall.SIGHUP {
-		d.stopISVCS()
-	} else {
-		glog.Infof("Not shutting down isvcs")
+	if options.Master {
+		switch sig {
+		case syscall.SIGHUP:
+			glog.Infof("Not shutting down isvcs")
+			command := os.Args
+			glog.Infof("Reloading by calling syscall.exec for command: %+v\n", command)
+			syscall.Exec(command[0], command[0:], os.Environ())
+		default:
+			d.stopISVCS()
+		}
 	}
 
 	return nil


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-464

DEMO:

```
# plu@plu-9: pgrep -fla bin/serviced
25926 sudo -E ZD_ORIGPATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/sbin:/sbin:/usr/local/bin GOPATH=/home/plu/src/europa/src/golang SERVICED_MASTER=1 TZ=UTC ZENHOME=/home/plu/src/europa/zenhome GOBIN=/home/plu/src/europa/src/golang/bin SRCROOT=/home/plu/src/europa/src SERVICED_VARPATH=/home/plu/src/europa/var/serviced SERVICED_AGENT=1 PATH=/home/plu/src/europa/src/golang/bin:/home/plu/src/europa/zenhome/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/sbin:/sbin:/usr/local/bin /home/plu/src/europa/src/golang/bin/serviced --mount zendev/devimg,/home/plu/.m2,/home/zenoss/.m2 --mount zendev/devimg,/home/plu/src/europa/zenhome,/opt/zenoss --mount zendev/devimg,/home/plu/src/europa/src,/mnt/src --mount /zenoss/impact-unstable:latest,/home/plu/src/europa/src,/mnt/src --uiport :443
25929 /home/plu/src/europa/src/golang/bin/serviced --mount zendev/devimg,/home/plu/.m2,/home/zenoss/.m2 --mount zendev/devimg,/home/plu/src/europa/zenhome,/opt/zenoss --mount zendev/devimg,/home/plu/src/europa/src,/mnt/src --mount /zenoss/impact-unstable:latest,/home/plu/src/europa/src,/mnt/src --uiport :443

# plu@plu-9: docker ps 
CONTAINER ID        IMAGE                       COMMAND                CREATED             STATUS              PORTS                    NAMES
15415a328e98        zenoss/serviced-isvcs:v21   "/bin/sh -c '/opt/el   34 seconds ago      Up 33 seconds       0.0.0.0:9100->9100/tcp   serviced-isvcs_elasticsearch-logstash   
43fc407fdeff        zenoss/serviced-isvcs:v21   "/bin/sh -c '/opt/el   34 seconds ago      Up 33 seconds                                serviced-isvcs_elasticsearch-serviced   
e0ff2565dc4e        zenoss/serviced-isvcs:v21   "/bin/sh -c '/opt/zo   34 seconds ago      Up 33 seconds                                serviced-isvcs_zookeeper                
07230052a7c2        zenoss/serviced-isvcs:v21   "/bin/sh -c 'DOCKER_   34 seconds ago      Up 33 seconds       0.0.0.0:5000->5000/tcp   serviced-isvcs_docker-registry          
906be2b54766        zenoss/serviced-isvcs:v21   "/bin/sh -c 'supervi   34 seconds ago      Up 33 seconds                                serviced-isvcs_celery                   
78afdbff681d        zenoss/serviced-isvcs:v21   "/bin/sh -c 'cd /opt   34 seconds ago      Up 33 seconds                                serviced-isvcs_opentsdb                 
6484c994a92c        zenoss/serviced-isvcs:v21   "/bin/sh -c '/opt/lo   34 seconds ago      Up 33 seconds                                serviced-isvcs_logstash                 

# plu@plu-9: sudo kill -HUP 25926

# plu@plu-9: pgrep -fla bin/serviced
25926 sudo -E ZD_ORIGPATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/sbin:/sbin:/usr/local/bin GOPATH=/home/plu/src/europa/src/golang SERVICED_MASTER=1 TZ=UTC ZENHOME=/home/plu/src/europa/zenhome GOBIN=/home/plu/src/europa/src/golang/bin SRCROOT=/home/plu/src/europa/src SERVICED_VARPATH=/home/plu/src/europa/var/serviced SERVICED_AGENT=1 PATH=/home/plu/src/europa/src/golang/bin:/home/plu/src/europa/zenhome/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/sbin:/sbin:/usr/local/bin /home/plu/src/europa/src/golang/bin/serviced --mount zendev/devimg,/home/plu/.m2,/home/zenoss/.m2 --mount zendev/devimg,/home/plu/src/europa/zenhome,/opt/zenoss --mount zendev/devimg,/home/plu/src/europa/src,/mnt/src --mount /zenoss/impact-unstable:latest,/home/plu/src/europa/src,/mnt/src --uiport :443
25929 /home/plu/src/europa/src/golang/bin/serviced --mount zendev/devimg,/home/plu/.m2,/home/zenoss/.m2 --mount zendev/devimg,/home/plu/src/europa/zenhome,/opt/zenoss --mount zendev/devimg,/home/plu/src/europa/src,/mnt/src --mount /zenoss/impact-unstable:latest,/home/plu/src/europa/src,/mnt/src --uiport :443

# plu@plu-9: docker ps 
CONTAINER ID        IMAGE                       COMMAND                CREATED             STATUS              PORTS                    NAMES
4ab3a33c38ff        zenoss/serviced-isvcs:v21   "/bin/sh -c '/opt/lo   20 minutes ago      Up 20 minutes                                serviced-isvcs_logstash                 
15415a328e98        zenoss/serviced-isvcs:v21   "/bin/sh -c '/opt/el   21 minutes ago      Up 21 minutes       0.0.0.0:9100->9100/tcp   serviced-isvcs_elasticsearch-logstash   
43fc407fdeff        zenoss/serviced-isvcs:v21   "/bin/sh -c '/opt/el   21 minutes ago      Up 21 minutes                                serviced-isvcs_elasticsearch-serviced   
e0ff2565dc4e        zenoss/serviced-isvcs:v21   "/bin/sh -c '/opt/zo   21 minutes ago      Up 21 minutes                                serviced-isvcs_zookeeper                
07230052a7c2        zenoss/serviced-isvcs:v21   "/bin/sh -c 'DOCKER_   21 minutes ago      Up 21 minutes       0.0.0.0:5000->5000/tcp   serviced-isvcs_docker-registry          
906be2b54766        zenoss/serviced-isvcs:v21   "/bin/sh -c 'supervi   21 minutes ago      Up 21 minutes                                serviced-isvcs_celery                   
78afdbff681d        zenoss/serviced-isvcs:v21   "/bin/sh -c 'cd /opt   21 minutes ago      Up 21 minutes                                serviced-isvcs_opentsdb                 

```

LOG: 

```
I1202 15:29:34.717015 25929 service.go:442] Created address assignment for endpoint rabbitmq of service a6hrp29lknx4jypkdvodr7pxr at 172.17.42.1:5672
bvgj3t8wj32hr5esxl33qyzda
I1202 15:29:55.755027 25929 daemon.go:287] Shutting down due to interrupt
...
I1202 15:29:55.762086 25929 daemon.go:308] Not shutting down isvcs
I1202 15:29:55.762133 25929 daemon.go:310] Reloading by calling syscall.exec for command: [/home/plu/src/europa/src/golang/bin/serviced --mount zendev/devimg,/home/plu/.m2,/home/zenoss/.m2 --mount zendev/devimg,/home/plu/src/europa/zenhome,/opt/zenoss --mount zendev/devimg,/home/plu/src/europa/src,/mnt/src --mount /zenoss/impact-unstable:latest,/home/plu/src/europa/src,/mnt/src --uiport :443]
This master has been configured to be in pool: default
I1202 15:29:55.785837 25929 api.go:103] StartServer: [] (0)
I1202 15:29:55.812022 25929 daemon.go:172] Listening on [::]:4979
```
