### PR TITLE
fixes ZEN-15583: Bump to isvcs v23

### DIFF
--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -30,7 +30,7 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO = "zenoss/serviced-isvcs"
-	IMAGE_TAG  = "v22"
+	IMAGE_TAG  = "v23"
 )
 
 func Init() {


### PR DESCRIPTION
depends on https://github.com/control-center/serviced-isvcs/pull/12

![screen shot 2014-12-03 at 18 17 47](https://cloud.githubusercontent.com/assets/2837923/5291490/0abf2f3c-7b19-11e4-9b5e-e319ad4cdd8f.png)
![screen shot 2014-12-03 at 18 18 11](https://cloud.githubusercontent.com/assets/2837923/5291491/0ac5d90e-7b19-11e4-88c1-23da58185f03.png)
