### PR TITLE
reduce unnecessary logging about watching /servicevhosts

### DIFF
--- a/web/cpserver.go
+++ b/web/cpserver.go
@@ -363,10 +363,10 @@ func (sc *ServiceConfig) syncAllVhosts(shutdown <-chan interface{}) error {
 
 	for {
 		zkServiceVhost := "/servicevhosts" // should this use the constant from zzk/service/servicevhost?
-		glog.V(0).Infof("Running registry.WatchChildren for zookeeper path: %s", zkServiceVhost)
+		glog.V(1).Infof("Running registry.WatchChildren for zookeeper path: %s", zkServiceVhost)
 		err := registry.WatchChildren(rootConn, zkServiceVhost, cancelChan, syncVhosts, vhostWatchError)
 		if err != nil {
-			glog.Warningf("will retry in 10 seconds to WatchChildren(%s) due to error: %v", zkServiceVhost, err)
+			glog.V(1).Infof("Will retry in 10 seconds to WatchChildren(%s) due to error: %v", zkServiceVhost, err)
 			<-time.After(time.Second * 10)
 			continue
 		}


### PR DESCRIPTION
ISSUE - before template is deployed, too much unnecessary spam:

```
I1212 15:12:05.576849 04158 cpserver.go:366] Running registry.WatchChildren for zookeeper path: /servicevhosts
W1212 15:12:05.577526 04158 cpserver.go:369] will retry in 10 seconds to WatchChildren(/servicevhosts) due to error: coord-client: node does not exist
```
