### PR TITLE
fixes CC-591: temporarily lock down docker version to 1.3.3

### DIFF
--- a/pkg/makefile
+++ b/pkg/makefile
@@ -135,6 +135,7 @@ deb: stage_deb
 		-d net-tools \
 		-d nfs-common \
 		-d 'lxc-docker >= 1.3.2' \
+		-d 'lxc-docker << 1.4' \
 		-d logrotate \
 		-t deb \
 		-a x86_64 \


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-591

valid fpm dependency operators:
  https://www.debian.org/doc/debian-policy/ch-relationships.html

history:
  https://github.com/control-center/serviced/pull/1237
  https://github.com/control-center/serviced/pull/1240

CAVEAT: RPMs can't have multiple '-d'
