### PR TITLE
Properly handle abrupt exit in serviced 'script'

### DIFF
--- a/cli/api/api.go
+++ b/cli/api/api.go
@@ -165,4 +165,3 @@ func (a *api) connectDAO() (dao.ControlPlane, error) {
 	}
 	return a.dao, nil
 }
-

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -102,6 +102,6 @@ type API interface {
 	// Metric
 	PostMetric(metricName string, metricValue string) (string, error)
 
-	ScriptRun(fileName string, config *script.Config) error
+	ScriptRun(fileName string, config *script.Config, stopChan chan struct{}) error
 	ScriptParse(fileName string, config *script.Config) error
 }

--- a/cli/api/script.go
+++ b/cli/api/script.go
@@ -15,9 +15,9 @@ package api
 
 import (
 	"fmt"
+	"math"
 	"path"
 	"time"
-	"math"
 
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/domain/service"
@@ -25,14 +25,15 @@ import (
 )
 
 // ScriptRun
-func (a *api) ScriptRun(fileName string, config *script.Config) error {
+func (a *api) ScriptRun(fileName string, config *script.Config, stopChan chan struct{}) error {
 
 	initConfig(config, a)
 	r, err := script.NewRunnerFromFile(fileName, config)
 	if err != nil {
 		return err
 	}
-	return r.Run()
+
+	return r.Run(stopChan)
 }
 
 func (a *api) ScriptParse(fileName string, config *script.Config) error {

--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-//	"sort"
+	//	"sort"
 	"strings"
 	"testing"
 

--- a/script/eval.go
+++ b/script/eval.go
@@ -7,9 +7,9 @@ package script
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
 
 	"github.com/control-center/serviced/commons"
 	"github.com/zenoss/glog"

--- a/script/runner_test.go
+++ b/script/runner_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func (vs *ScriptSuite) Test_Run(t *C) {
+	stopChan := make(chan struct{})
 	config := Config{
 		NoOp:          true,
 		ServiceID:     "TEST_SERVICE_ID_12345",
@@ -19,8 +20,16 @@ func (vs *ScriptSuite) Test_Run(t *C) {
 	}
 	runner, err := NewRunnerFromFile("descriptor_test.txt", &config)
 	t.Assert(err, IsNil)
-	err = runner.Run()
+	err = runner.Run(stopChan)
 	t.Assert(err, IsNil)
+
+	// Test sending a stop signal to the runner
+	runner, err = NewRunnerFromFile("descriptor_test.txt", &config)
+	t.Assert(err, IsNil)
+	newStopChan := make(chan struct{})
+	close(newStopChan)
+	err = runner.Run(newStopChan)
+	t.Assert(err, NotNil)
 
 	runner, err = NewRunnerFromFile("bad_descriptor.txt", &config)
 	t.Assert(err, ErrorMatches, "error parsing script")
@@ -33,7 +42,7 @@ func (vs *ScriptSuite) Test_Run(t *C) {
 	}
 	runner, err = NewRunnerFromFile("descriptor_test.txt", &config)
 	t.Assert(err, IsNil)
-	err = runner.Run()
+	err = runner.Run(stopChan)
 	t.Assert(err, ErrorMatches, "test error id from path")
 
 }

--- a/script/utils.go
+++ b/script/utils.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/control-center/serviced/commons"
 	"github.com/control-center/serviced/commons/docker"
-
 )
 
 //Lookup a tenant ID given a service (name, id, or path)


### PR DESCRIPTION
Specifically, a Ctrl+C from the user
