### PR TITLE
fixes CC-591: lock ubuntu docker dependency to 1.3.3

### DIFF
--- a/pkg/makefile
+++ b/pkg/makefile
@@ -134,7 +134,7 @@ deb: stage_deb
 		-d nfs-kernel-server \
 		-d net-tools \
 		-d nfs-common \
-		-d 'lxc-docker >= 1.3.2' \
+		-d 'lxc-docker = 1.3.3' \
 		-d logrotate \
 		-t deb \
 		-a x86_64 \


### PR DESCRIPTION
docker 1.4 pulled in - lock to docker 1.3.3
