### PR TITLE
fixes CC-603: move fstype log from generic GetSubvolume to Snapshot/Roll...

### DIFF
--- a/dfs/backup.go
+++ b/dfs/backup.go
@@ -172,6 +172,7 @@ func (dfs *DistributedFilesystem) Backup(dirpath string, last int) (string, erro
 	}
 	dfs.log("Backup file created: %s", filename)
 
+	glog.Infof("Backup succeeded with fsType:%s saved to file:%s", dfs.fsType, filename)
 	return filename, nil
 }
 
@@ -339,6 +340,7 @@ func (dfs *DistributedFilesystem) Restore(filename string) error {
 		dfs.log("Successfully loaded %s", f)
 	}
 
+	glog.Infof("Restore succeeded with fsType:%s from file:%s", dfs.fsType, filename)
 	return nil
 }
 

--- a/dfs/snapshot.go
+++ b/dfs/snapshot.go
@@ -101,6 +101,7 @@ func (dfs *DistributedFilesystem) Snapshot(tenantID string) (string, error) {
 		return "", err
 	}
 
+	glog.Infof("Snapshot succeeded for tenantID:%s with fsType:%s using snapshotID:%s", tenantID, dfs.fsType, label)
 	return label, nil
 }
 
@@ -198,6 +199,7 @@ func (dfs *DistributedFilesystem) Rollback(snapshotID string, forceRestart bool)
 		return err
 	}
 
+	glog.Infof("Rollback succeeded for tenantID:%s with fsType:%s using snapshotID:%s", tenant.ID, dfs.fsType, snapshotID)
 	return nil
 }
 

--- a/dfs/volume.go
+++ b/dfs/volume.go
@@ -42,6 +42,6 @@ func GetSubvolume(fsType, varpath, serviceID string) (*volume.Volume, error) {
 	if err != nil {
 		return nil, err
 	}
-	glog.Infof("Mounting fsType: %v; tenantID: %v; baseDir: %v", fsType, serviceID, baseDir)
+	glog.Infof("Mounting tenantID: %v; baseDir: %v", serviceID, baseDir)
 	return volume.Mount(fsType, serviceID, baseDir)
 }


### PR DESCRIPTION
...back/Backup/Restore

https://jira.zenoss.com/browse/CC-603

DEMO - starting service:

```
I1216 17:00:44.502433 21417 volume.go:45] Mounting tenantID: 7ltjfw97d0kdi9lege7xsqz0t; baseDir: /home/plu/src/europa/var/serviced/volumes
```

DEMO - snapshot:

```
I1216 17:02:56.184305 21417 snapshot.go:104] Snapshot succeeded for tenantID:7ltjfw97d0kdi9lege7xsqz0t with fsType:rsync using snapshotID:7ltjfw97d0kdi9lege7xsqz0t_20141216-170252
```
