### PR TITLE
Allow multiple services per SVC_WAIT line

### DIFF
--- a/cli/api/script.go
+++ b/cli/api/script.go
@@ -64,7 +64,7 @@ func cliServiceControl(svcControlMethod ServiceStateController) script.ServiceCo
 }
 
 func cliServiceWait(a *api) script.ServiceWait {
-	return func(svcID string, state script.ServiceState, timeout uint32) error {
+	return func(svcIDs []string, state script.ServiceState, timeout uint32) error {
 		client, err := a.connectDAO()
 		if err != nil {
 			return err
@@ -84,7 +84,7 @@ func cliServiceWait(a *api) script.ServiceWait {
 		if timeout == 0 {
 			timeout = math.MaxUint32
 		}
-		wsr := dao.WaitServiceRequest{ServiceIDs: []string{svcID},
+		wsr := dao.WaitServiceRequest{ServiceIDs: svcIDs,
 			DesiredState: desiredState,
 			Timeout:      time.Duration(timeout) * time.Second}
 		if err = client.WaitService(wsr, nil); err != nil {

--- a/script/nodes_test.go
+++ b/script/nodes_test.go
@@ -7,6 +7,7 @@ package script
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	. "gopkg.in/check.v1"
 )
@@ -169,6 +170,22 @@ func (vs *ScriptSuite) Test_svcWait(t *C) {
 	cmd, err = nodeFactories[SVC_WAIT](ctx, SVC_WAIT, []string{"zope", "started", "4", "extra"})
 	t.Assert(err, NotNil)
 
+	line = "SVC_WAIT zope mariadb started 0"
+	ctx.line = line
+	cmd, err = nodeFactories[SVC_WAIT](ctx, SVC_WAIT, strings.Split(line, " "))
+	t.Assert(err, IsNil)
+	t.Assert(cmd, DeepEquals, node{cmd: SVC_WAIT, line: line, args: strings.Split(line, " ")})
+
+	line = "SVC_WAIT zope mariadb started"
+	ctx.line = line
+	cmd, err = nodeFactories[SVC_WAIT](ctx, SVC_WAIT, strings.Split(line, " "))
+	t.Assert(err, IsNil)
+	t.Assert(cmd, DeepEquals, node{cmd: SVC_WAIT, line: line, args: strings.Split(line, " ")})
+
+	line = "SVC_WAIT zope mariadb started extra"
+	ctx.line = line
+	cmd, err = nodeFactories[SVC_WAIT](ctx, SVC_WAIT, strings.Split(line, " "))
+	t.Assert(err, NotNil)
 }
 
 func (vs *ScriptSuite) Test_svcexec(t *C) {

--- a/script/utils.go
+++ b/script/utils.go
@@ -38,7 +38,7 @@ type ServiceControl func(serviceID string, recursive bool) error
 type ServiceState string
 
 // Wait for a service to be in a particular state
-type ServiceWait func(serviceID string, serviceState ServiceState, timeout uint32) error
+type ServiceWait func(serviceID []string, serviceState ServiceState, timeout uint32) error
 
 type execCmd func(string, ...string) error
 
@@ -89,7 +89,7 @@ func noOpServiceRestart(serviceID string, recursive bool) error {
 	return nil
 }
 
-func noOpServiceWait(serviceID string, serviceState ServiceState, timeout uint32) error {
+func noOpServiceWait(serviceID []string, serviceState ServiceState, timeout uint32) error {
 	return nil
 }
 


### PR DESCRIPTION
Change made due to feedback from iteration demo: it would be nice to wait on multiple services in parallel.
The syntax of the SVC_WAIT script command is modified to allow multiple services.
