### PR TITLE
fixes CC-605: disallow start of agent or master for invalid hostid

### DIFF
--- a/node/agent.go
+++ b/node/agent.go
@@ -154,7 +154,7 @@ func NewHostAgent(options AgentOptions) (*HostAgent, error) {
 
 	hostID, err := utils.HostID()
 	if err != nil {
-		panic("Could not get hostid")
+		glog.Fatalf("unable to get valid hostid: %s", err)
 	}
 	agent.hostID = hostID
 	agent.currentServices = make(map[string]*exec.Cmd)

--- a/validation/validators.go
+++ b/validation/validators.go
@@ -16,6 +16,7 @@ package validation
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 )
 
@@ -88,5 +89,17 @@ func IntIn(check int, others ...int) error {
 	if _, ok := set[check]; !ok {
 		return NewViolation(fmt.Sprintf("int %v not in %v", check, others))
 	}
+	return nil
+}
+
+func ValidHostID(hostID string) error {
+	result, err := strconv.ParseUint(hostID, 16, 0)
+	if err != nil {
+		return NewViolation(fmt.Sprintf("unable to convert hostid: %v to uint", hostID))
+	}
+	if result <= 0 {
+		return NewViolation(fmt.Sprintf("not valid hostid: %v", hostID))
+	}
+
 	return nil
 }

--- a/validation/validators_test.go
+++ b/validation/validators_test.go
@@ -64,3 +64,28 @@ func (vs *ValidationSuite) Test_IsSubnet16(c *C) {
 		}
 	}
 }
+
+func (vs *ValidationSuite) Test_IsValidHostID(c *C) {
+	hostIDsValid := []string{
+		"570a276e", // 10.87.110.39
+		"6f0ae003", // 10.111.3.224
+	}
+
+	for _, hostID := range hostIDsValid {
+		if err := ValidHostID(hostID); err != nil {
+			c.Fatalf("Unexpected error validating valid hostid %s: %v", hostID, err)
+		}
+	}
+
+	hostIDsInvalid := []string{
+		"",
+		"0",
+		"00000000",
+	}
+
+	for _, hostID := range hostIDsInvalid {
+		if err := ValidHostID(hostID); err == nil {
+			c.Fatalf("Unexpected non-error validating invalid hostid %s: %v", hostID, err)
+		}
+	}
+}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-605

DEMO - unit test for validation:

```
~/src/europa/src/golang/src/github.com/control-center/serviced/validation
# plu@plu-9: go test -v
=== RUN Test
OK: 2 passed
--- PASS: Test (0.00 seconds)
PASS
ok      github.com/control-center/serviced/validation   0.004s
```

DEMO - serviced started on valid hostid:

```
root@ip-10-111-3-224:~# hostid
6f0ae003

root@ip-10-111-3-224:~# tail -F /var/log/upstart/serviced.log
I1216 22:49:13.937212 07106 daemon.go:511] Trying to discover my pool...
W1216 22:49:13.940514 07106 daemon.go:521] masterClient.GetHost 6f0ae003 failed: hosts_server.go host not found (has this host been added?)
```

DEMO - serviced will not start with invalid hostid:

```
root@ip-10-111-3-224:~# hostid
00000000

root@ip-10-111-3-224:~# tail -F /var/log/upstart/serviced.log
This master has been configured to be in pool: default
I1216 22:52:38.303329 08898 api.go:103] StartServer: [] (0)
F1216 22:52:38.388871 08898 daemon.go:254] Could not get host ID: invalid hostid:'00000000'
Tue Dec 16 22:52:38 UTC 2014: post-stopping serviced daemon - waiting for serviced to stop
Tue Dec 16 22:52:38 UTC 2014: waiting for serviced daemon to stop
Tue Dec 16 22:52:38 UTC 2014: waiting for serviced to stop listening
Tue Dec 16 22:52:38 UTC 2014: waiting for serviced isvcs to stop
Tue Dec 16 22:52:38 UTC 2014: serviced is now stopped - done with post-stop
```
