### PR TITLE
fixes CC-605: disallow start of agent or master for invalid hostid

### DIFF
--- a/node/agent.go
+++ b/node/agent.go
@@ -154,7 +154,7 @@ func NewHostAgent(options AgentOptions) (*HostAgent, error) {
 
 	hostID, err := utils.HostID()
 	if err != nil {
-		panic("Could not get hostid")
+		glog.Fatalf("unable to get valid hostid: %s", err)
 	}
 	agent.hostID = hostID
 	agent.currentServices = make(map[string]*exec.Cmd)

--- a/validation/validators.go
+++ b/validation/validators.go
@@ -16,6 +16,7 @@ package validation
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 )
 
@@ -88,5 +89,17 @@ func IntIn(check int, others ...int) error {
 	if _, ok := set[check]; !ok {
 		return NewViolation(fmt.Sprintf("int %v not in %v", check, others))
 	}
+	return nil
+}
+
+func ValidHostID(hostID string) error {
+	result, err := strconv.ParseUint(hostID, 16, 0)
+	if err != nil {
+		return NewViolation(fmt.Sprintf("unable to convert hostid: %v to uint", hostID))
+	}
+	if result <= 0 {
+		return NewViolation(fmt.Sprintf("not valid hostid: %v", hostID))
+	}
+
 	return nil
 }

--- a/validation/validators_test.go
+++ b/validation/validators_test.go
@@ -64,3 +64,28 @@ func (vs *ValidationSuite) Test_IsSubnet16(c *C) {
 		}
 	}
 }
+
+func (vs *ValidationSuite) Test_IsValidHostID(c *C) {
+	hostIDsValid := []string{
+		"570a276e", // 10.87.110.39
+		"6f0ae003", // 10.111.3.224
+	}
+
+	for _, hostID := range hostIDsValid {
+		if err := ValidHostID(hostID); err != nil {
+			c.Fatalf("Unexpected error validating valid hostid %s: %v", hostID, err)
+		}
+	}
+
+	hostIDsInvalid := []string{
+		"",
+		"0",
+		"00000000",
+	}
+
+	for _, hostID := range hostIDsInvalid {
+		if err := ValidHostID(hostID); err == nil {
+			c.Fatalf("Unexpected non-error validating invalid hostid %s: %v", hostID, err)
+		}
+	}
+}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-605

DEMO - unit test for validation:

```
~/src/europa/src/golang/src/github.com/control-center/serviced/validation
# plu@plu-9: go test -v
=== RUN Test
OK: 2 passed
--- PASS: Test (0.00 seconds)
PASS
ok      github.com/control-center/serviced/validation   0.004s
```

DEMO - serviced started on valid hostid:

```
root@ip-10-111-3-224:~# hostid
6f0ae003

root@ip-10-111-3-224:~# tail -F /var/log/upstart/serviced.log
I1217 00:36:58.861746 12889 daemon.go:516] Trying to discover my pool...
W1217 00:36:58.864192 12889 daemon.go:526] masterClient.GetHost 6f0ae003 failed: hosts_server.go host not found (has this host been added?)

root@ip-10-111-3-224:/opt/serviced/bin# serviced host add 10.111.3.224:4979 default
6f0ae003
```

DEMO - serviced will not start with invalid hostid:

```
root@ip-10-111-3-224:~# hostid
00000000

root@ip-10-111-3-224:~# tail -F /var/log/upstart/serviced.log
...
I1217 00:29:02.967209 09395 host.go:144] building with ipsAddrs: [10.111.3.224] [1]
I1217 00:29:02.967700 09395 utils.go:133] looking for '10.111.3.224'
E1217 00:29:03.050558 09395 daemon.go:509] invalid hostid: 00000000
...
W1217 00:29:03.052897 09395 daemon.go:526] masterClient.GetHost 00000000 failed: hosts_server.go host not found (has this host been added?)

root@ip-10-111-3-224:/opt/serviced/bin# serviced host add 10.111.3.224:4979 default
invalid hostid for host: &{ID:00000000 Name:ip-10-111-3-224 PoolID:default IPAddr:10.111.3.224 RPCPort:4979 Cores:8 Memory:64426311680 PrivateNetwork:172.17.0.0/255.255.0.0 CreatedAt:0001-01-01 00:00:00 +0000 UTC UpdatedAt:0001-01-01 00:00:00 +0000 UTC IPs:[{HostID:00000000 IPAddress:10.111.3.224 InterfaceName:eth0 MACAddress:12:a9:d1:36:53:3e}] KernelVersion:#63-Ubuntu KernelRelease:3.13.0-36-generic ServiceD:{Version:1.0.0 Date:Wed Dec 17 00:27:07 UTC 2014 Gitcommit:2e995c9 Gitbranch:feature/CC-605 Giturl: Buildtag:0} MonitoringProfile:{MetricConfigs:[] GraphConfigs:[] ThresholdConfigs:[]} VersionedEntity:{DatabaseVersion:0}}

```
