### PR TITLE
fixes CC-605: validate host before adding host

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -41,6 +41,7 @@ import (
 	"github.com/control-center/serviced/shell"
 	"github.com/control-center/serviced/stats"
 	"github.com/control-center/serviced/utils"
+	"github.com/control-center/serviced/validation"
 	"github.com/control-center/serviced/volume"
 	"github.com/zenoss/glog"
 	// Need to do btrfs driver initializations
@@ -252,6 +253,8 @@ func (d *daemon) startDockerRegistryProxy() {
 func (d *daemon) run() (err error) {
 	if d.hostID, err = utils.HostID(); err != nil {
 		glog.Fatalf("Could not get host ID: %s", err)
+	} else if err := validation.ValidHostID(d.hostID); err != nil {
+		glog.Errorf("invalid hostid: %s", d.hostID)
 	}
 
 	if currentDockerVersion, err := node.GetDockerVersion(); err != nil {
@@ -502,6 +505,8 @@ func (d *daemon) startAgent() error {
 	myHostID, err := utils.HostID()
 	if err != nil {
 		return fmt.Errorf("HostID failed: %v", err)
+	} else if err := validation.ValidHostID(myHostID); err != nil {
+		glog.Errorf("invalid hostid: %s", myHostID)
 	}
 
 	go func() {

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -45,8 +45,7 @@ import (
 )
 
 const (
-	HOSTID    = "hostID"
-	HOSTIPSID = "HostIPsId"
+	HOSTID = "deadbeef"
 )
 
 var unused int

--- a/domain/host/host_test.go
+++ b/domain/host/host_test.go
@@ -66,7 +66,7 @@ func init() {
 		validateCase{"hostid", 65535, "poolid", "127.0.0.1", []string{"host ip can not be a loopback address"}},
 		validateCase{"hostid", -1, "poolid", ip, []string{"not in valid port range: -1"}},
 		validateCase{"hostid", 65536, "poolid", ip, []string{"not in valid port range: 65536"}},
-		validateCase{"hostid", 65535, "poolid", ip, []string{}},
+		validateCase{"deadb30f", 65535, "poolid", ip, []string{}},
 	}
 
 }
@@ -82,12 +82,12 @@ func Test_ValidateTable(t *testing.T) {
 		err := h.ValidEntity()
 		if len(test.expectedErrors) > 0 {
 			if verr, isVErr := err.(*validation.ValidationError); !isVErr {
-				t.Errorf("expected ValidationError, got %v", err)
+				t.Errorf("expected ValidationError for case %v, got %v", idx, err)
 			} else if !containsAll(verr, test.expectedErrors...) {
 				t.Errorf("Did not find expected errors for case %v, %v", idx, verr)
 			}
 		} else if err != nil {
-			t.Errorf("Unexpected error testig case %v: %v", test, err)
+			t.Errorf("Unexpected error testig case %v %v: %v", idx, test, err)
 		}
 
 	}

--- a/domain/host/hoststore_test.go
+++ b/domain/host/hoststore_test.go
@@ -46,22 +46,23 @@ func (s *S) SetUpTest(c *C) {
 }
 
 func (s *S) Test_HostCRUD(t *C) {
-	defer s.hs.Delete(s.ctx, HostKey("testid"))
+	hostID := "deadb40f"
+	defer s.hs.Delete(s.ctx, HostKey(hostID))
 
 	var host2 Host
 
-	if err := s.hs.Get(s.ctx, HostKey("testid"), &host2); !datastore.IsErrNoSuchEntity(err) {
+	if err := s.hs.Get(s.ctx, HostKey(hostID), &host2); !datastore.IsErrNoSuchEntity(err) {
 		t.Errorf("Expected ErrNoSuchEntity, got: %v", err)
 	}
 
 	host := New()
 
-	err := s.hs.Put(s.ctx, HostKey("testid"), host)
+	err := s.hs.Put(s.ctx, HostKey(hostID), host)
 	if err == nil {
 		t.Errorf("Expected failure to create host %-v", host)
 	}
 
-	host.ID = "testid"
+	host.ID = hostID
 	err = s.hs.Put(s.ctx, HostKey(host.ID), host)
 	if err == nil {
 		t.Errorf("Expected failure to create host %-v", host)
@@ -69,16 +70,16 @@ func (s *S) Test_HostCRUD(t *C) {
 
 	//fill host with required values
 	host, err = Build("", "65535", "pool-id", []string{}...)
-	host.ID = "testid"
+	host.ID = hostID
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)
 	}
-	err = s.hs.Put(s.ctx, HostKey("testid"), host)
+	err = s.hs.Put(s.ctx, HostKey(hostID), host)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	err = s.hs.Get(s.ctx, HostKey("testid"), &host2)
+	err = s.hs.Get(s.ctx, HostKey(hostID), &host2)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -89,7 +90,7 @@ func (s *S) Test_HostCRUD(t *C) {
 	//Test update
 	host.Memory = 1024
 	err = s.hs.Put(s.ctx, HostKey(host.ID), host)
-	err = s.hs.Get(s.ctx, HostKey("testid"), &host2)
+	err = s.hs.Get(s.ctx, HostKey(hostID), &host2)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -98,8 +99,8 @@ func (s *S) Test_HostCRUD(t *C) {
 	}
 
 	//test delete
-	err = s.hs.Delete(s.ctx, HostKey("testid"))
-	err = s.hs.Get(s.ctx, HostKey("testid"), &host2)
+	err = s.hs.Delete(s.ctx, HostKey(hostID))
+	err = s.hs.Get(s.ctx, HostKey(hostID), &host2)
 	if err != nil && !datastore.IsErrNoSuchEntity(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -109,7 +110,7 @@ func (s *S) Test_HostCRUD(t *C) {
 func (s *S) TestDaoGetHostWithIPs(t *C) {
 	//Add host to test scenario where host exists but no IP resource registered
 	h, err := Build("", "65535", "pool-id", []string{}...)
-	h.ID = "TestDaoGetHostWithIPs"
+	h.ID = "deadb41f"
 	h.IPs = []HostIPResource{
 		HostIPResource{h.ID, "testip", "ifname", "address1"},
 		HostIPResource{h.ID, "testip2", "ifname", "address2"},
@@ -140,7 +141,7 @@ func (s *S) Test_GetHosts(t *C) {
 	defer s.hs.Delete(s.ctx, HostKey("Test_GetHosts2"))
 
 	host, err := Build("", "65535", "pool-id", []string{}...)
-	host.ID = "Test_GetHosts1"
+	host.ID = "deadb51f"
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)
 	}
@@ -155,7 +156,7 @@ func (s *S) Test_GetHosts(t *C) {
 		t.Errorf("Expected %v results, got %v :%v", 1, len(hosts), hosts)
 	}
 
-	host.ID = "Test_GetHosts2"
+	host.ID = "deadb52f"
 	err = s.hs.Put(s.ctx, HostKey(host.ID), host)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -171,9 +172,9 @@ func (s *S) Test_GetHosts(t *C) {
 }
 
 func (s *S) Test_FindHostsInPool(t *C) {
-	id1 := "Test_FindHostsInPool1"
-	id2 := "Test_FindHostsInPool2"
-	id3 := "Test_FindHostsInPool3"
+	id1 := "deadb61f"
+	id2 := "deadb62f"
+	id3 := "deadb63f"
 
 	defer s.hs.Delete(s.ctx, HostKey(id1))
 	defer s.hs.Delete(s.ctx, HostKey(id2))
@@ -228,7 +229,7 @@ func (s *S) Test_GetHostByIP(t *C) {
 		t.Fatalf("Unexpected error building host: %v", err)
 	}
 
-	host.ID = "Test_GetHostByIP1"
+	host.ID = "deadb70f"
 	host.IPs = append(host.IPs, HostIPResource{IPAddress: "111.22.333.4"})
 	if err := s.hs.Put(s.ctx, HostKey(host.ID), host); err != nil {
 		t.Errorf("Unexpected error: %v", err)

--- a/domain/host/validation.go
+++ b/domain/host/validation.go
@@ -26,9 +26,14 @@ import (
 func (h *Host) ValidEntity() error {
 	glog.V(4).Info("Validating host")
 
+	//if err := validation.ValidHostID(entity.ID); err != nil {
+	//	return fmt.Errorf("invalid hostid:'%s' for host Name:'%s' IP:%s", entity.ID, entity.Name, entity.IPAddr)
+	//}
+
 	trimmedID := strings.TrimSpace(h.ID)
 	violations := validation.NewValidationError()
 	violations.Add(validation.NotEmpty("Host.ID", h.ID))
+	violations.Add(validation.ValidHostID(h.ID))
 	violations.Add(validation.StringsEqual(h.ID, trimmedID, "leading and trailing spaces not allowed for host id"))
 	violations.Add(validation.ValidPort(h.RPCPort))
 	violations.Add(validation.NotEmpty("Host.PoolID", h.PoolID))

--- a/facade/host_test.go
+++ b/facade/host_test.go
@@ -26,13 +26,13 @@ import (
 )
 
 func (s *FacadeTest) Test_HostCRUD(t *C) {
-	testid := "facadetestid"
+	testid := "deadb10f"
 	poolid := "pool-id"
 	defer s.Facade.RemoveHost(s.CTX, testid)
 
 	//fill host with required values
 	h, err := host.Build("", "65535", poolid, []string{}...)
-	h.ID = "facadetestid"
+	h.ID = testid
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)
 	}
@@ -99,14 +99,14 @@ func (s *FacadeTest) Test_HostRemove(t *C) {
 
 	//add host1
 	h1 := host.Host{
-		ID:      "h1",
+		ID:      "deadb11f",
 		PoolID:  "poolid",
 		Name:    "h1",
 		IPAddr:  "192.168.0.1",
 		RPCPort: 65535,
 		IPs: []host.HostIPResource{
 			host.HostIPResource{
-				HostID:    "h1",
+				HostID:    "deadb11f",
 				IPAddress: "192.168.0.1",
 			},
 		},
@@ -118,14 +118,14 @@ func (s *FacadeTest) Test_HostRemove(t *C) {
 
 	//add host2
 	h2 := host.Host{
-		ID:      "h2",
+		ID:      "deadb12f",
 		PoolID:  "poolid",
 		Name:    "h2",
 		IPAddr:  "192.168.0.2",
 		RPCPort: 65535,
 		IPs: []host.HostIPResource{
 			host.HostIPResource{
-				HostID:    "h2",
+				HostID:    "deadb12f",
 				IPAddress: "192.168.0.2",
 			},
 		},
@@ -146,7 +146,7 @@ func (s *FacadeTest) Test_HostRemove(t *C) {
 	}
 	s1.Endpoints[0].Name = "name"
 	s1.Endpoints[0].AddressConfig = servicedefinition.AddressResourceConfig{Port: 123, Protocol: "tcp"}
-	aa := addressassignment.AddressAssignment{ID: "id", HostID: "h1"}
+	aa := addressassignment.AddressAssignment{ID: "id", HostID: h1.ID}
 	s1.Endpoints[0].SetAssignment(aa)
 	err = s.Facade.AddService(s.CTX, *s1)
 	if err != nil {
@@ -154,7 +154,7 @@ func (s *FacadeTest) Test_HostRemove(t *C) {
 	}
 	defer s.Facade.RemoveService(s.CTX, s1.ID)
 
-	request := dao.AssignmentRequest{ServiceID: s1.ID, IPAddress: "192.168.0.1", AutoAssignment: false}
+	request := dao.AssignmentRequest{ServiceID: s1.ID, IPAddress: h1.IPAddr, AutoAssignment: false}
 	if err = s.Facade.AssignIPs(s.CTX, request); err != nil {
 		t.Fatalf("Failed assigning ip to service: %s", err)
 	}
@@ -168,12 +168,12 @@ func (s *FacadeTest) Test_HostRemove(t *C) {
 		t.Fatalf("Expected service with one endpoint in context")
 	}
 	ep := services[0].Endpoints[0]
-	if ep.AddressAssignment.IPAddr != "192.168.0.1" && ep.AddressAssignment.HostID != "h1" {
+	if ep.AddressAssignment.IPAddr != h1.IPAddr && ep.AddressAssignment.HostID != h1.ID {
 		t.Fatalf("Incorrect IPAddress and HostID before remove host")
 	}
 
 	//remove host1
-	err = s.Facade.RemoveHost(s.CTX, "h1")
+	err = s.Facade.RemoveHost(s.CTX, h1.ID)
 	if err != nil {
 		t.Fatalf("Failed to remove host: %s", err)
 	}
@@ -188,7 +188,7 @@ func (s *FacadeTest) Test_HostRemove(t *C) {
 	}
 
 	ep = services[0].Endpoints[0]
-	if ep.AddressAssignment.IPAddr == "192.168.0.2" || ep.AddressAssignment.HostID == "h2" {
+	if ep.AddressAssignment.IPAddr == h2.IPAddr || ep.AddressAssignment.HostID == h2.ID {
 		t.Fatalf("Incorrect IPAddress and HostID after remove host")
 	}
 }

--- a/facade/pool_test.go
+++ b/facade/pool_test.go
@@ -163,7 +163,7 @@ func (ft *FacadeTest) Test_GetPoolsIPs(t *C) {
 		t.Fail()
 	}
 
-	hostID := "assignIPsHost"
+	hostID := "deadb21f"
 	ipAddress1 := "192.168.100.10"
 	ipAddress2 := "10.50.9.1"
 
@@ -224,7 +224,7 @@ func (ft *FacadeTest) Test_VirtualIPs(t *C) {
 		t.Fail()
 	}
 
-	hostID := "aHost"
+	hostID := "deadb22f"
 	ipAddress1 := "192.168.100.10"
 
 	assignIPsHostIPResources := []host.HostIPResource{}
@@ -326,7 +326,7 @@ func (ft *FacadeTest) Test_InvalidVirtualIPs(t *C) {
 		t.Fail()
 	}
 
-	hostID := "aHost"
+	hostID := "deadb22f"
 	ipAddress1 := "192.168.100.10"
 
 	assignIPsHostIPResources := []host.HostIPResource{}
@@ -408,7 +408,7 @@ func (ft *FacadeTest) Test_InvalidVirtualIPs(t *C) {
 }
 
 func (ft *FacadeTest) Test_PoolCapacity(t *C) {
-	hostid := "host-id"
+	hostid := "deadb23f"
 	poolid := "pool-id"
 
 	//create pool for test

--- a/validation/validators.go
+++ b/validation/validators.go
@@ -16,6 +16,7 @@ package validation
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 )
 
@@ -88,5 +89,17 @@ func IntIn(check int, others ...int) error {
 	if _, ok := set[check]; !ok {
 		return NewViolation(fmt.Sprintf("int %v not in %v", check, others))
 	}
+	return nil
+}
+
+func ValidHostID(hostID string) error {
+	result, err := strconv.ParseUint(hostID, 16, 0)
+	if err != nil {
+		return NewViolation(fmt.Sprintf("unable to convert hostid: %v to uint", hostID))
+	}
+	if result <= 0 {
+		return NewViolation(fmt.Sprintf("not valid hostid: %v", hostID))
+	}
+
 	return nil
 }

--- a/validation/validators_test.go
+++ b/validation/validators_test.go
@@ -64,3 +64,28 @@ func (vs *ValidationSuite) Test_IsSubnet16(c *C) {
 		}
 	}
 }
+
+func (vs *ValidationSuite) Test_IsValidHostID(c *C) {
+	hostIDsValid := []string{
+		"570a276e", // 10.87.110.39
+		"6f0ae003", // 10.111.3.224
+	}
+
+	for _, hostID := range hostIDsValid {
+		if err := ValidHostID(hostID); err != nil {
+			c.Fatalf("Unexpected error validating valid hostid %s: %v", hostID, err)
+		}
+	}
+
+	hostIDsInvalid := []string{
+		"",
+		"0",
+		"00000000",
+	}
+
+	for _, hostID := range hostIDsInvalid {
+		if err := ValidHostID(hostID); err == nil {
+			c.Fatalf("Unexpected non-error validating invalid hostid %s: %v", hostID, err)
+		}
+	}
+}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-605

DEMO0 - unit test for validation:

```
~/src/europa/src/golang/src/github.com/control-center/serviced/validation
# plu@plu-9: go test -v
=== RUN Test
OK: 2 passed
--- PASS: Test (0.00 seconds)
PASS
ok      github.com/control-center/serviced/validation   0.004s
```

DEMO1 - serviced host add with valid hostid succeeds:

```
root@ip-10-111-3-224:~# hostid
6f0ae003
root@ip-10-111-3-224:/opt/serviced/bin# serviced host add 10.111.3.224:4979 default
6f0ae003
```

DEMO2 - serviced host add with invalid hostid fails:

```
root@ip-10-111-3-224:~# hostid
00000000

root@ip-10-111-3-224:/opt/serviced/bin# serviced host add 10.111.3.224:4979 default
ValidationError: 
   0 -  not valid hostid: 00000000
```

DEMO3 - adding invalid hostid fails from UI:
![screen shot 2014-12-17 at 13 11 24](https://cloud.githubusercontent.com/assets/2837923/5477166/823c4c90-85ee-11e4-97c5-899a520a635c.png)
