### PR TITLE
replace deprecated base:latest with ubuntu:latest

### DIFF
--- a/commons/docker/container_test.go
+++ b/commons/docker/container_test.go
@@ -27,7 +27,7 @@ func TestContainerCommit(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -72,7 +72,7 @@ func TestOnContainerStart(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -119,7 +119,7 @@ func TestOnContainerCreated(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -145,7 +145,7 @@ func TestOnContainerStop(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -182,7 +182,7 @@ func TestCancelOnEvent(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -223,7 +223,7 @@ func TestRestartContainer(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -268,7 +268,7 @@ func TestListContainers(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -322,7 +322,7 @@ func TestWaitForContainer(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -364,7 +364,7 @@ func TestInspectContainer(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -416,7 +416,7 @@ func TestRepeatedStart(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -457,7 +457,7 @@ func TestNewContainerOnCreatedAndStartedActions(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -516,7 +516,7 @@ func TestNewContainerOnCreatedAction(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -562,7 +562,7 @@ func TestNewContainerOnStartedAction(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -609,7 +609,7 @@ func TestFindContainer(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},
@@ -651,7 +651,7 @@ func TestContainerExport(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{
 			Config: &dockerclient.Config{
-				Image: "base:latest",
+				Image: "ubuntu:latest",
 				Cmd:   []string{"watch", "ls"},
 			},
 		},


### PR DESCRIPTION
docker 1.3.3 and later no longer support base:latest image.

ISSUE:

```
# plu@plu-9: docker version
Client version: 1.3.3
Client API version: 1.15
Go version (client): go1.3.3
Git commit (client): d344625
OS/Arch (client): linux/amd64
Server version: 1.3.3
Server API version: 1.15
Go version (server): go1.3.3
Git commit (server): d344625

~/src/europa/src/golang/src/github.com/control-center/serviced/commons/docker
# plu@plu-9: go test -v
=== RUN TestContainerCommit
--- FAIL: TestContainerCommit (0.00 seconds)
    container_test.go:39: can't create container:  API error (500): image ID '27cf784147099545' is invalid

=== RUN TestOnContainerStart
--- FAIL: TestOnContainerStart (0.00 seconds)
    container_test.go:84: can't create container:  API error (500): image ID '27cf784147099545' is invalid
```

DEMO:

```
~/src/europa/src/golang/src/github.com/control-center/serviced/commons/docker
# plu@plu-9: go test -v
=== RUN TestContainerCommit
--- PASS: TestContainerCommit (0.40 seconds)
=== RUN TestOnContainerStart
--- PASS: TestOnContainerStart (0.27 seconds)
=== RUN TestOnContainerCreated
--- PASS: TestOnContainerCreated (0.04 seconds)
=== RUN TestOnContainerStop
--- PASS: TestOnContainerStop (0.42 seconds)
    container_test.go:175: Receieved exit code: 1
=== RUN TestCancelOnEvent
--- PASS: TestCancelOnEvent (2.39 seconds)
=== RUN TestRestartContainer
--- PASS: TestRestartContainer (0.66 seconds)
=== RUN TestListContainers
--- PASS: TestListContainers (1.48 seconds)
=== RUN TestWaitForContainer
--- PASS: TestWaitForContainer (10.26 seconds)
=== RUN TestInspectContainer
--- PASS: TestInspectContainer (0.18 seconds)
=== RUN TestRepeatedStart
--- SKIP: TestRepeatedStart (0.00 seconds)
    container_test.go:415: skip this until the build box issues get sorted out
=== RUN TestNewContainerOnCreatedAndStartedActions
--- PASS: TestNewContainerOnCreatedAndStartedActions (0.45 seconds)
=== RUN TestNewContainerOnCreatedAction
--- PASS: TestNewContainerOnCreatedAction (0.03 seconds)
=== RUN TestNewContainerOnStartedAction
--- PASS: TestNewContainerOnStartedAction (0.44 seconds)
=== RUN TestFindContainer
--- PASS: TestFindContainer (0.08 seconds)
=== RUN TestContainerExport
--- PASS: TestContainerExport (1.12 seconds)
=== RUN TestImageAPI
I1217 12:14:30.794379 00996 api.go:729] pushing image from repo: localhost:5000/testimageapi/busyb to registry: localhost:5000 with tag: 
I1217 12:14:33.460941 00996 api.go:743] finished pushing image from repo: localhost:5000/testimageapi/busyb to registry: localhost:5000 with tag: 
I1217 12:14:33.890418 00996 api.go:729] pushing image from repo: localhost:5000/testimageapi/busybox to registry: localhost:5000 with tag: victim
I1217 12:14:35.942231 00996 api.go:743] finished pushing image from repo: localhost:5000/testimageapi/busybox to registry: localhost:5000 with tag: victim
I1217 12:14:36.413307 00996 api.go:729] pushing image from repo: localhost:5000/testimageapi/busybox to registry: localhost:5000 with tag: latest
I1217 12:14:38.463287 00996 api.go:743] finished pushing image from repo: localhost:5000/testimageapi/busybox to registry: localhost:5000 with tag: latest
I1217 12:14:38.465604 00996 api.go:729] pushing image from repo: localhost:5000/testimageapi/busybox to registry: localhost:5000 with tag: snapshot
I1217 12:14:40.513293 00996 api.go:743] finished pushing image from repo: localhost:5000/testimageapi/busybox to registry: localhost:5000 with tag: snapshot
I1217 12:14:44.073311 00996 api.go:729] pushing image from repo: localhost:5000/testimageapi/busybox to registry: localhost:5000 with tag: latest
I1217 12:14:46.119918 00996 api.go:743] finished pushing image from repo: localhost:5000/testimageapi/busybox to registry: localhost:5000 with tag: latest
OK: 8 passed
--- PASS: TestImageAPI (21.80 seconds)
PASS
ok      github.com/control-center/serviced/commons/docker   40.030s
```

![screen shot 2014-12-17 at 12 04 35](https://cloud.githubusercontent.com/assets/2837923/5476313/8031a83a-85e6-11e4-8c9f-cc13d2e0d89b.png)
