### PR TITLE
fixes CC-595: log output of serviced script using unix script

### DIFF
--- a/utils/directory.go
+++ b/utils/directory.go
@@ -73,3 +73,23 @@ func TempDir(p string) string {
 
 	return tmp
 }
+
+// UserHomeDir gets the home directory of the user
+func UserHomeDir() (string, error) {
+	userid, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve userid: %s\n", err)
+	}
+
+	return userid.HomeDir, nil
+}
+
+// UserHomeServicedDir gets the serviced directory in the user home directory
+func UserHomeServicedDir() (string, error) {
+	homedir, err := UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return path.Join(homedir, "serviced"), nil
+}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-595

DEMO - capture output to logfile then show the contents of the logfile:

```
# plu@plu-9: serviced -v=1 script run -n abc.txt
Logging to logfile: /home/plu/serviced/script.log-2014-12-17-231520
I1217 23:15:20.044094 21598 script.go:108] syscall.exec unix script with command: [/usr/bin/script --append --return --flush -c serviced -v=1 script run -n abc.txt /home/plu/serviced/script.log-2014-12-17-231520]
Script started, file is /home/plu/serviced/script.log-2014-12-17-231520
I1217 23:15:20.078107 21611 script.go:115] runScript filename:abc.txt &{ServiceID: DockerRegistry: NoOp:false TenantLookup:<nil> Snapshot:<nil> Commit:<nil> Restore:<nil> SvcIDFromPath:<nil> SvcStart:<nil> SvcStop:<nil> SvcRestart:<nil> SvcWait:<nil>}
open abc.txt: no such file or directory
Script done, file is /home/plu/serviced/script.log-2014-12-17-231520

# plu@plu-9: cat /home/plu/serviced/script.log-2014-12-17-231520
Script started on Wed 17 Dec 2014 11:15:20 PM CST
I1217 23:15:20.078107 21611 script.go:115] runScript filename:abc.txt &{ServiceID: DockerRegistry: NoOp:false TenantLookup:<nil> Snapshot:<nil> Commit:<nil> Restore:<nil> SvcIDFromPath:<nil> SvcStart:<nil> SvcStop:<nil> SvcRestart:<nil> SvcWait:<nil>}
open abc.txt: no such file or directory

Script done on Wed 17 Dec 2014 11:15:20 PM CST
```

DEMO - /usr/bin/script is available on normal centos install:

```
# plu@plu-9: docker run -it centos:centos7 rpm -qf /usr/bin/script
util-linux-2.23.2-16.el7.x86_64
# plu@plu-9: docker run -it centos:centos7 rpm -qf /usr/bin/su
util-linux-2.23.2-16.el7.x86_64
```
