### PR TITLE
fixes CC-595: save serviced script log to: /var/log/serviced/script-2014-12-18-083236-USERNAME.log

### DIFF
--- a/cli/cmd/script.go
+++ b/cli/cmd/script.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"os/user"
 	"strings"
 	"syscall"
 	"time"
@@ -93,12 +94,11 @@ func (c *ServicedCli) cmdScriptRun(ctx *cli.Context) {
 		os.Setenv("IS_WITHIN_UNIX_SCRIPT", "TRUE") // prevent inception problem
 
 		// DO NOT EXIT ON ANY ERRORS - continue without logging
-		if logdir, err := utils.UserHomeServicedDir(); err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to log output - error getting home serviced dir: %s\n", err)
-		} else if err := os.MkdirAll(logdir, 0755); err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to log output - error creating dir %s: %s", logdir, err)
+		logdir := utils.ServicedLogDir()
+		if userrec, err := user.Current(); err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to retrieve userid to log output: %s", err)
 		} else {
-			logfile := time.Now().Format(fmt.Sprintf("%s/script.log-2006-01-02-150405", logdir))
+			logfile := time.Now().Format(fmt.Sprintf("%s/script-2006-01-02-150405-%s.log", logdir, userrec.Username))
 
 			// unix exec ourselves
 			cmd := []string{"/usr/bin/script", "--append", "--return", "--flush",

--- a/pkg/deb/postinstall
+++ b/pkg/deb/postinstall
@@ -1,0 +1,4 @@
+
+mkdir -p /var/log/serviced
+chmod 1777 /var/log/serviced
+

--- a/pkg/makefile
+++ b/pkg/makefile
@@ -148,6 +148,7 @@ deb: stage_deb
 		--vendor $(VENDOR) \
 		--url $(URL) \
 		--category $(CATEGORY) \
+		--after-install deb/postinstall \
 		--config-files /etc/default/serviced \
 		.
 

--- a/pkg/rpm/postinstall
+++ b/pkg/rpm/postinstall
@@ -3,3 +3,7 @@ if [ $1 -eq 1 ] ; then
         /usr/bin/systemctl preset serviced >/dev/null 2>&1 || :
         /usr/bin/systemctl enable serviced >/dev/null 2>&1 || :
 fi
+
+mkdir -p /var/log/serviced
+chmod 1777 /var/log/serviced
+

--- a/utils/directory.go
+++ b/utils/directory.go
@@ -74,22 +74,7 @@ func TempDir(p string) string {
 	return tmp
 }
 
-// UserHomeDir gets the home directory of the user
-func UserHomeDir() (string, error) {
-	userid, err := user.Current()
-	if err != nil {
-		return "", fmt.Errorf("unable to retrieve userid: %s\n", err)
-	}
-
-	return userid.HomeDir, nil
-}
-
-// UserHomeServicedDir gets the serviced directory in the user home directory
-func UserHomeServicedDir() (string, error) {
-	homedir, err := UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
-	return path.Join(homedir, "serviced"), nil
+// ServicedLogDir gets the serviced log directory
+func ServicedLogDir() string {
+	return "/var/log/serviced"
 }


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-595

DEMO - installing deb should create new dir /var/log/serviced with rwxrwxrwxt perms:

```
# plu@plu-9: sudo dpkg -i 'serviced_1.0.0~trusty_amd64.deb'
Selecting previously unselected package serviced.
(Reading database ... 209085 files and directories currently installed.)
Preparing to unpack serviced_1.0.0~trusty_amd64.deb ...
Unpacking serviced (1.0.0~trusty) ...
Setting up serviced (1.0.0~trusty) ...
Installing new version of config file /etc/default/serviced ...
Processing triggers for ureadahead (0.100.0-16) ...

# plu@plu-9: ls -al /var/log/serviced
total 8
drwxrwxrwt  2 root root   4096 Dec 18 09:58 .
drwxrwxr-x 15 root syslog 4096 Dec 18 09:58 ..
```

DEMO - serviced script captures stdout/stderr to timestamped log file in /var/log/serviced:

```
# plu@plu-9: serviced -v=1 script run -n expected-to-fail.txt
Logging to logfile: /var/log/serviced/script-2014-12-18-101237-plu.log
I1218 10:12:37.582887 29300 script.go:108] syscall.exec unix script with command: [/usr/bin/script --append --return --flush -c serviced -v=1 script run -n expected-to-fail.txt /var/log/serviced/script-2014-12-18-101237-plu.log]
Script started, file is /var/log/serviced/script-2014-12-18-101237-plu.log
I1218 10:12:37.601707 29312 script.go:115] runScript filename:expected-to-fail.txt &{ServiceID: DockerRegistry: NoOp:false TenantLookup:<nil> Snapshot:<nil> Commit:<nil> Restore:<nil> SvcIDFromPath:<nil> SvcStart:<nil> SvcStop:<nil> SvcRestart:<nil> SvcWait:<nil>}
open expected-to-fail.txt: no such file or directory
Script done, file is /var/log/serviced/script-2014-12-18-101237-plu.log

# plu@plu-9: cat /var/log/serviced/script-2014-12-18-101237-plu.log
Script started on Thu 18 Dec 2014 10:12:37 AM CST
I1218 10:12:37.601707 29312 script.go:115] runScript filename:expected-to-fail.txt &{ServiceID: DockerRegistry: NoOp:false TenantLookup:<nil> Snapshot:<nil> Commit:<nil> Restore:<nil> SvcIDFromPath:<nil> SvcStart:<nil> SvcStop:<nil> SvcRestart:<nil> SvcWait:<nil>}
open expected-to-fail.txt: no such file or directory

Script done on Thu 18 Dec 2014 10:12:37 AM CST

# plu@plu-9: id
uid=1000(plu) gid=1000(plu) groups=1000(plu),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),108(lpadmin),124(sambashare),999(docker)
```
