### PR TITLE
fixes CC-634: do not explicitly pull images for SVC_USE

### DIFF
--- a/cli/cmd/script.go
+++ b/cli/cmd/script.go
@@ -63,6 +63,10 @@ func (c *ServicedCli) cmdScriptRun(ctx *cli.Context) {
 	args := ctx.Args()
 	if len(args) != 1 {
 		fmt.Fprintln(os.Stderr, "Incorrect Usage.\n\n")
+		if !ctx.Bool("help") {
+			fmt.Fprintf(os.Stderr, "Incorrect Usage.\n\n")
+		}
+		cli.ShowSubcommandHelp(ctx)
 		return
 	}
 

--- a/script/eval.go
+++ b/script/eval.go
@@ -71,7 +71,7 @@ func evalUSE(r *runner, n node) error {
 	}
 	glog.Infof("pulling image %s, this may take a while...", imageID)
 	if err := r.pullImage(imageID.String()); err != nil {
-		return fmt.Errorf("unable to pull image %s", imageID)
+		glog.Warningf("unable to pull image %s", imageID)
 	}
 
 	//verify image has been pulled
@@ -113,8 +113,8 @@ func evalSvcWait(r *runner, n node) error {
 
 	var svcIDs []string
 	var stateIdx = -1
-	for i, arg := range(n.args) {
-		if arg == "started"  || arg == "stopped" || arg == "paused" {
+	for i, arg := range n.args {
+		if arg == "started" || arg == "stopped" || arg == "paused" {
 			stateIdx = i
 			break
 		}
@@ -132,11 +132,11 @@ func evalSvcWait(r *runner, n node) error {
 	state := ServiceState(n.args[stateIdx])
 
 	timeout := uint32(0)
-	hasTimeout := len(n.args) == stateIdx + 2
+	hasTimeout := len(n.args) == stateIdx+2
 	if hasTimeout {
 		var timeout64 uint64
 		var err error
-		lastArg := n.args[len(n.args) - 1]
+		lastArg := n.args[len(n.args)-1]
 		if timeout64, err = strconv.ParseUint(lastArg, 10, 32); err != nil {
 			return fmt.Errorf("Unable to parse timeout value %s: %s", lastArg, err)
 		}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-634

DEMO - ensure we didn't break anything - for non-existent image locally and dockerhub, it should try to pull and fail if image does not exist locally:

```
zenny@ip-10-111-3-224:~$ docker images
REPOSITORY               TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
zenoss/resmgr-unstable   5.0.0_2073          ed4840e7839a        12 hours ago        2.233 GB
zenoss/serviced-isvcs    v26                 5532425bb01f        47 hours ago        1.304 GB
zenoss/opentsdb          v11                 79d9b32a9fd0        2 weeks ago         1.346 GB
zenoss/hbase             v4                  155bef732a18        7 weeks ago         555.1 MB

zenny@ip-10-111-3-224:~$ cat test-SVC_USE-non-existent-image.txt 
# Run via 'serviced script run test-SVC_USE-non-existent-image.txt --service Zenoss.resmgr'

DESCRIPTION  SVC_USE test for non-existent image
VERSION   CC-634
REQUIRE_SVC
SVC_USE   zenoss/resmgr-unstable:5.0.0_DOES_NOT_EXIST

SVC_EXEC COMMIT Zenoss.resmgr yum clean all

zenny@ip-10-111-3-224:~$ serviced script run test-SVC_USE-non-existent-image.txt --service Zenoss.resmgr
Logging to logfile: /var/log/serviced/script-2014-12-19-203519-zenny.log
script: open failed: /var/log/serviced/script-2014-12-19-203519-zenny.log: Permission denied
Terminated
zenny@ip-10-111-3-224:~$ serviced script run test-SVC_USE-non-existent-image.txt --service Zenoss.resmgr
Logging to logfile: /var/log/serviced/script-2014-12-19-203544-zenny.log
Script started, file is /var/log/serviced/script-2014-12-19-203544-zenny.log
I1219 20:35:45.047142 13097 runner.go:165] executing step 0: DESCRIPTION  SVC_USE test for non-existent image
I1219 20:35:45.047238 13097 runner.go:165] executing step 1: VERSION   CC-634
I1219 20:35:45.047267 13097 runner.go:165] executing step 2: REQUIRE_SVC
I1219 20:35:45.047280 13097 eval.go:358] checking service requirement
I1219 20:35:45.047292 13097 eval.go:362] verifying service 1cpgd7fh7ci45ganlg3vc62zp
I1219 20:35:45.047502 13097 eval.go:368] found 1cpgd7fh7ci45ganlg3vc62zp tenant id for service 1cpgd7fh7ci45ganlg3vc62zp
I1219 20:35:45.047528 13097 runner.go:165] executing step 3: SVC_USE   zenoss/resmgr-unstable:5.0.0_DOES_NOT_EXIST
I1219 20:35:45.047541 13097 eval.go:59] preparing to use image: zenoss/resmgr-unstable:5.0.0_DOES_NOT_EXIST
I1219 20:35:45.047584 13097 api.go:516] ========= looking up image: zenoss/resmgr-unstable:5.0.0_DOES_NOT_EXIST (pull if neccessary false)
E1219 20:35:45.094526 13097 runner.go:167] error executing step 3: SVC_USE: could not look up image zenoss/resmgr-unstable:5.0.0_DOES_NOT_EXIST: docker: no such image. Check your docker login and retry service deployment.
I1219 20:35:45.094569 13097 runner.go:157] Executing exit functions
could not look up image zenoss/resmgr-unstable:5.0.0_DOES_NOT_EXIST: docker: no such image. Check your docker login and retry service deployment.
Script done, file is /var/log/serviced/script-2014-12-19-203544-zenny.log
```

DEMO - for image that exists locally but not on dockerhub, it should try to pull, warn that it couldn't pull, then continue since the image exists locally:

```
zenny@ip-10-111-3-224:~$ docker tag zenoss/resmgr-unstable:5.0.0_2073 zenoss/resmgr-unstable:5.0.0_IMAGE_EXISTS

zenny@ip-10-111-3-224:~$ docker images
REPOSITORY                                                 TAG                  IMAGE ID            CREATED             VIRTUAL SIZE
localhost:5000/1cpgd7fh7ci45ganlg3vc62zp/resmgr-unstable   latest               ed4840e7839a        12 hours ago        2.233 GB
zenoss/resmgr-unstable                                     5.0.0_2073           ed4840e7839a        12 hours ago        2.233 GB
zenoss/resmgr-unstable                                     5.0.0_IMAGE_EXISTS   ed4840e7839a        12 hours ago        2.233 GB
zenoss/serviced-isvcs                                      v26                  5532425bb01f        47 hours ago        1.304 GB
localhost:5000/1cpgd7fh7ci45ganlg3vc62zp/opentsdb          latest               79d9b32a9fd0        2 weeks ago         1.346 GB
zenoss/opentsdb                                            v11                  79d9b32a9fd0        2 weeks ago         1.346 GB
zenoss/hbase                                               v4                   155bef732a18        7 weeks ago         555.1 MB
localhost:5000/1cpgd7fh7ci45ganlg3vc62zp/hbase             latest               155bef732a18        7 weeks ago         555.1 MB

zenny@ip-10-111-3-224:~$ cat test-SVC_USE-image-exists.txt 
# Run via 'serviced script run test-SVC_USE-image-exists.txt --service Zenoss.resmgr'

DESCRIPTION  SVC_USE test for existent image
VERSION   CC-634
REQUIRE_SVC
SVC_USE   zenoss/resmgr-unstable:5.0.0_IMAGE_EXISTS

SVC_EXEC COMMIT Zenoss.resmgr yum clean all
zenny@ip-10-111-3-224:~$ serviced script run test-SVC_USE-image-exists.txt --service Zenoss.resmgr
Logging to logfile: /var/log/serviced/script-2014-12-19-203841-zenny.log
Script started, file is /var/log/serviced/script-2014-12-19-203841-zenny.log
I1219 20:38:41.327386 13424 runner.go:165] executing step 0: DESCRIPTION  SVC_USE test for existent image
I1219 20:38:41.327501 13424 runner.go:165] executing step 1: VERSION   CC-634
I1219 20:38:41.327524 13424 runner.go:165] executing step 2: REQUIRE_SVC
I1219 20:38:41.327544 13424 eval.go:358] checking service requirement
I1219 20:38:41.327563 13424 eval.go:362] verifying service 1cpgd7fh7ci45ganlg3vc62zp
I1219 20:38:41.327843 13424 eval.go:368] found 1cpgd7fh7ci45ganlg3vc62zp tenant id for service 1cpgd7fh7ci45ganlg3vc62zp
I1219 20:38:41.327871 13424 runner.go:165] executing step 3: SVC_USE   zenoss/resmgr-unstable:5.0.0_IMAGE_EXISTS
I1219 20:38:41.327891 13424 eval.go:59] preparing to use image: zenoss/resmgr-unstable:5.0.0_IMAGE_EXISTS
I1219 20:38:41.327931 13424 api.go:516] ========= looking up image: zenoss/resmgr-unstable:5.0.0_IMAGE_EXISTS (pull if neccessary false)
I1219 20:38:41.368876 13424 eval.go:93] tagging image zenoss/resmgr-unstable:5.0.0_IMAGE_EXISTS to localhost:5000/1cpgd7fh7ci45ganlg3vc62zp/resmgr-unstable:latest 
I1219 20:38:41.369812 13424 runner.go:165] executing step 4: SVC_EXEC COMMIT Zenoss.resmgr yum clean all
I1219 20:38:41.657033 13424 eval.go:320] running: serviced service shell -s 203841-20141219_1cpgd7fh7ci45ganlg3vc62zp 1cpgd7fh7ci45ganlg3vc62zp yum clean all
I1219 20:38:41.935830 13434 server.go:341] Connected to the control center at port 10.111.3.224:4979
I1219 20:38:41.941467 13434 api.go:516] ========= looking up image: localhost:5000/1cpgd7fh7ci45ganlg3vc62zp/resmgr-unstable (pull if neccessary false)
I1219 20:38:41.992178 13434 server.go:435] Acquiring image from the dfs...
I1219 20:38:41.993224 13434 server.go:437] Acquired!  Starting shell
Loaded plugins: fastestmirror
Cleaning repos: base extras updates
Cleaning up everything
Cleaning up list of fastest mirrors
I1219 20:38:42.567928 13424 eval.go:330] committing container 203841-20141219_1cpgd7fh7ci45ganlg3vc62zp
I1219 20:38:51.815828 13424 runner.go:157] Executing exit functions
1cpgd7fh7ci45ganlg3vc62zp_20141219-203851
Script done, file is /var/log/serviced/script-2014-12-19-203841-zenny.log
```

DEMO - fixed help for serviced script run:

```
# plu@plu-9: serviced script run -h
NAME:
   run - Run a script

USAGE:
   command run [command options] [arguments...]

DESCRIPTION:
   serviced script run FILE [--service SERVICEID] [-n]

OPTIONS:
   --service    Service to run this script against
   --no-op, -n  Run through script without modifying system
```
