### PR TITLE
fixes CC-662: Increase the number of maximal tracked connections for iptables

### DIFF
--- a/node/agent.go
+++ b/node/agent.go
@@ -790,6 +790,14 @@ func (a *HostAgent) Start(shutdown <-chan interface{}) {
 		wg.Done()
 	}()
 
+	// Increase the number of maximal tracked connections for iptables
+	maxConnections := "655360"
+	if cnxns := strings.TrimSpace(os.Getenv("SERVICED_IPTABLES_MAX_CONNECTIONS")); cnxns != "" {
+		maxConnections = cnxns
+	}
+	glog.Infof("Set sysctl maximum tracked connections for iptables to %s", maxConnections)
+	utils.SetSysctl("net.netfilter.nf_conntrack_max", maxConnections)
+
 	// Clean up any extant iptables chain, just in case
 	a.servicedChain.Remove()
 	// Add our chain for assigned IP rules

--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -106,6 +106,9 @@
 # Max size of Logstash data to keep in gigabytes
 # SERVICED_LOGSTASH_MAX_SIZE=10
 
+# Max number tracked connections for iptables
+# SERVICED_IPTABLES_MAX_CONNECTIONS=655360
+
 # Arbitrary serviced daemon args
 # SERVICED_OPTS=
 

--- a/utils/sysctl.go
+++ b/utils/sysctl.go
@@ -1,0 +1,39 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/zenoss/glog"
+)
+
+// SetSysctl tries to set sysctl settings
+func SetSysctl(key string, value string) ([]byte, error) {
+	command := []string{"/sbin/sysctl", "-w", fmt.Sprintf("%s=%s", key, value)}
+	thecmd := exec.Command(command[0], command[1:]...)
+	output, err := thecmd.CombinedOutput()
+	if err != nil {
+		glog.Errorf("Error running command:'%s' output: %s  error: %s\n", command, output, err)
+		return output, err
+	}
+	if strings.HasPrefix(string(output), "sysctl: ") {
+		glog.Errorf("Error running command:'%s' output: %s\n", command, output)
+		return output, fmt.Errorf(string(output))
+	}
+	glog.V(1).Infof("Successfully ran command:'%s' output: %s\n", command, output)
+	return output, nil
+}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-662

DEMO:
```
# plu@plu-9: sysctl net.netfilter.nf_conntrack_max
net.netfilter.nf_conntrack_max = 65536
# plu@plu-9: sudo start serviced
...
# plu@plu-9: sysctl net.netfilter.nf_conntrack_max
net.netfilter.nf_conntrack_max = 655360
```

dealt with this corner case - sysctl exits 0 even though there are permission errors:
```
# plu@plu-9: sysctl net.netfilter.nf_conntrack_max=655360
sysctl: permission denied on key 'net.netfilter.nf_conntrack_max'
~/src/europa/src/golang/src/github.com/control-center/serviced
# plu@plu-9: echo $?
0
```
