### PR TITLE
CC-668: Change serviced RPM to require zenoss-docker 1.3.3

### DIFF
--- a/pkg/makefile
+++ b/pkg/makefile
@@ -162,7 +162,7 @@ rpm: stage_rpm
 		-d net-tools \
 		-d util-linux \
 		-d bash-completion \
-		-d 'docker >= 1.3.2' \
+		-d 'zenoss-docker = 1.3.3' \
 		-d logrotate \
 		-t rpm \
 		-a x86_64 \


### PR DESCRIPTION
```
[root@dd1f4c4a066a /]# yum --enablerepo=zenoss-unstable install /mnt/pwd/serviced-1.0.0-1.x86_64.rpm
Loaded plugins: fastestmirror
Examining /mnt/pwd/serviced-1.0.0-1.x86_64.rpm: serviced-1.0.0-1.x86_64
Marking /mnt/pwd/serviced-1.0.0-1.x86_64.rpm to be installed
...
==============================================================================================================================================================================================================================================
 Package                                                     Arch                                        Version                                                          Repository                                                     Size
==============================================================================================================================================================================================================================================
Installing:
 serviced                                                    x86_64                                      1.0.0-1                                                          /serviced-1.0.0-1.x86_64                                       56 M
Installing for dependencies:
...
 zenoss-docker                                               x86_64                                      1.3.3-1                                                          zenoss-unstable                                               4.0 M
```