### PR TITLE
CC-650: SVC_USE now works correctly on mulithost environments

### DIFF
--- a/cli/api/script.go
+++ b/cli/api/script.go
@@ -51,6 +51,21 @@ func initConfig(config *script.Config, a *api) {
 	config.SvcRestart = cliServiceControl(a.RestartService)
 	config.SvcWait = cliServiceWait(a)
 	config.Commit = a.Commit
+	config.SvcUse = cliServiceUse(a)
+}
+
+func cliServiceUse(a *api) script.ServiceUse {
+	return func(serviceID string, imageID string, registry string, noOp bool) (string, error) {
+		client, err := a.connectMaster()
+		if err != nil {
+			return "", err
+		}
+		image, err := client.ServiceUse(serviceID, imageID, registry, noOp)
+		if err != nil {
+			return "", err
+		}
+		return image, nil
+	}
 }
 
 func cliServiceControl(svcControlMethod ServiceStateController) script.ServiceControl {

--- a/commons/docker/api.go
+++ b/commons/docker/api.go
@@ -571,6 +571,10 @@ func (img *Image) Tag(tag string) (*Image, error) {
 	return &Image{args.uuid, *iid}, nil
 }
 
+func TagImage(img *Image, tag string) (*Image, error) {
+	return img.Tag(tag)
+}
+
 func InspectImage(uuid string) (*dockerclient.Image, error) {
 	dc, err := dockerclient.NewClient(dockerep)
 	if err != nil {

--- a/commons/docker/utils.go
+++ b/commons/docker/utils.go
@@ -23,6 +23,8 @@ import (
 // ServiceUse will tag a new image (imageName) in a given registry for a given tenant
 // to latest, making sure to push changes to the registry
 func ServiceUse(serviceID string, imageName string, registry string, noOp bool) (string, error) {
+	// If noOp is True, then replace the 'real' functions that talk to Docker with
+	// no-op functions (for dry run purposes)
 	pullImage := PullImage
 	findImage := FindImage
 	tagImage := TagImage

--- a/commons/docker/utils.go
+++ b/commons/docker/utils.go
@@ -34,6 +34,7 @@ func ServiceUse(serviceID string, imageName string, registry string, noOp bool) 
 		tagImage = noOpTagImage
 	}
 
+	// imageName is the new image to pull, eg. "zenoss/resmgr-unstable:1.2.3.4"
 	glog.V(0).Infof("preparing to use image: %s", imageName)
 	imageID, err := commons.ParseImageID(imageName)
 	if err != nil {

--- a/commons/docker/utils.go
+++ b/commons/docker/utils.go
@@ -1,0 +1,80 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	"fmt"
+
+	"github.com/control-center/serviced/commons"
+	"github.com/zenoss/glog"
+)
+
+// ServiceUse will tag a new image (imageName) in a given registry for a given tenant
+// to latest, making sure to push changes to the registry
+func ServiceUse(serviceID string, imageName string, registry string, noOp bool) (string, error) {
+	pullImage := PullImage
+	findImage := FindImage
+	tagImage := TagImage
+	if noOp {
+		pullImage = noOpPullImage
+		findImage = noOpFindImage
+		tagImage = noOpTagImage
+	}
+
+	glog.V(0).Infof("preparing to use image: %s", imageName)
+	imageID, err := commons.ParseImageID(imageName)
+	if err != nil {
+		return "", err
+	}
+	if imageID.Tag == "" {
+		imageID.Tag = "latest"
+	}
+	glog.Infof("pulling image %s, this may take a while...", imageID)
+	if err := pullImage(imageID.String()); err != nil {
+		glog.Warningf("unable to pull image %s", imageID)
+	}
+
+	//verify image has been pulled
+	img, err := findImage(imageID.String(), false)
+	if err != nil {
+		err = fmt.Errorf("could not look up image %s: %s. Check your docker login and retry service deployment.", imageID, err)
+		return "", err
+	}
+
+	//Tag images to latest all images
+	var newTag *commons.ImageID
+
+	newTag, err = commons.RenameImageID(registry, serviceID, imageID.String(), "latest")
+	if err != nil {
+		return "", err
+	}
+	glog.Infof("tagging image %s to %s ", imageName, newTag)
+	if _, err = tagImage(img, newTag.String()); err != nil {
+		glog.Errorf("could not tag image: %s (%v)", imageName, err)
+		return "", err
+	}
+	return newTag.String(), nil
+}
+
+func noOpTagImage(img *Image, tag string) (*Image, error) {
+	return nil, nil
+}
+
+func noOpFindImage(repotag string, pull bool) (*Image, error) {
+	return nil, nil
+}
+
+func noOpPullImage(repotag string) error {
+	return nil
+}

--- a/commons/imageid.go
+++ b/commons/imageid.go
@@ -15,12 +15,16 @@ package commons
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/docker/docker/pkg/parsers"
 )
 
 // states that the parser can be in as it scans
@@ -60,6 +64,18 @@ func init() {
 	period, _ = utf8.DecodeRune([]byte("."))
 	slash, _ = utf8.DecodeRune([]byte("/"))
 	underscore, _ = utf8.DecodeRune([]byte("_"))
+}
+
+func RenameImageID(dockerRegistry, tenantId string, imgID string, tag string) (*ImageID, error) {
+	repo, _ := parsers.ParseRepositoryTag(imgID)
+	re := regexp.MustCompile("/?([^/]+)\\z")
+	matches := re.FindStringSubmatch(repo)
+	if matches == nil {
+		return nil, errors.New("malformed imageid")
+	}
+	name := matches[1]
+	newImageID := fmt.Sprintf("%s/%s/%s:%s", dockerRegistry, tenantId, name, tag)
+	return ParseImageID(newImageID)
 }
 
 // ParseImageID parses the string representation of a Docker image ID into an ImageID structure.

--- a/commons/imageid.go
+++ b/commons/imageid.go
@@ -66,6 +66,8 @@ func init() {
 	underscore, _ = utf8.DecodeRune([]byte("_"))
 }
 
+// Return an Image object from all the normal parts of a serviced-managed
+// image name (registry, tenant ID, image, and tag)
 func RenameImageID(dockerRegistry, tenantId string, imgID string, tag string) (*ImageID, error) {
 	repo, _ := parsers.ParseRepositoryTag(imgID)
 	re := regexp.MustCompile("/?([^/]+)\\z")

--- a/facade/service.go
+++ b/facade/service.go
@@ -26,6 +26,8 @@ import (
 	"github.com/control-center/serviced/domain/serviceconfigfile"
 	"github.com/control-center/serviced/domain/servicedefinition"
 	"github.com/control-center/serviced/domain/servicestate"
+
+	"github.com/control-center/serviced/commons/docker"
 )
 
 // AddService adds a service; return error if service already exists
@@ -629,6 +631,14 @@ func (f *Facade) AssignIPs(ctx datastore.Context, request dao.AssignmentRequest)
 
 	// traverse all the services
 	return f.walkServices(ctx, request.ServiceID, true, visitor)
+}
+
+func (f *Facade) ServiceUse(ctx datastore.Context, serviceID string, imageName string, registry string, noOp bool) (string, error) {
+	result, err := docker.ServiceUse(serviceID, imageName, registry, noOp)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
 }
 
 func (f *Facade) getAutoAssignment(ctx datastore.Context, poolID string, ports ...uint16) (ipinfo, error) {

--- a/rpc/master/service_client.go
+++ b/rpc/master/service_client.go
@@ -1,0 +1,37 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package master
+
+import (
+	"github.com/zenoss/glog"
+)
+
+type ServiceUseRequest struct {
+	ServiceID string
+	ImageID   string
+	Registry  string
+	NoOp      bool
+}
+
+//GetHost gets the host for the given hostID or nil
+func (c *Client) ServiceUse(serviceID string, imageID string, registry string, noOp bool) (string, error) {
+	svcUseRequest := &ServiceUseRequest{ServiceID: serviceID, ImageID: imageID, Registry: registry, NoOp: noOp}
+	imageResult := ""
+	glog.Infof("Pulling %s, tagging to latest, and pushing to registry %s - this may take a while", imageID, registry)
+	err := c.call("ServiceUse", svcUseRequest, &imageResult)
+	if err != nil {
+		return "", err
+	}
+	return imageResult, nil
+}

--- a/rpc/master/service_server.go
+++ b/rpc/master/service_server.go
@@ -1,0 +1,26 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package master
+
+import ()
+
+// Use a new image for a given service - this will pull the image and tag it
+func (s *Server) ServiceUse(request *ServiceUseRequest, returnImage *string) error {
+	image, err := s.f.ServiceUse(s.context(), request.ServiceID, request.ImageID, request.Registry, request.NoOp)
+	if err != nil {
+		return err
+	}
+	*returnImage = image
+	return nil
+}

--- a/script/runner.go
+++ b/script/runner.go
@@ -50,6 +50,7 @@ type Config struct {
 	SvcStop        ServiceControl    // function to stop a service
 	SvcRestart     ServiceControl    // function to restart a service
 	SvcWait        ServiceWait       // function to wait for a service to be in a desired state
+	SvcUse         ServiceUse
 }
 
 type Runner interface {
@@ -75,6 +76,7 @@ type runner struct {
 	pullImage       pullImage
 	execCommand     execCmd
 	tagImage        tagImage
+	svcUse          ServiceUse
 }
 
 func NewRunnerFromFile(fileName string, config *Config) (Runner, error) {
@@ -123,6 +125,7 @@ func newRunner(config *Config, pctx *parseContext) *runner {
 		pullImage:       docker.PullImage,
 		execCommand:     defaultExec,
 		tagImage:        defaultTagImage,
+		svcUse:          config.SvcUse,
 	}
 	if config.NoOp {
 		glog.Infof("creatng no op runner")
@@ -137,6 +140,7 @@ func newRunner(config *Config, pctx *parseContext) *runner {
 		r.svcStop = noOpServiceStop
 		r.svcRestart = noOpServiceRestart
 		r.svcWait = noOpServiceWait
+		r.svcUse = docker.ServiceUse
 	}
 
 	return r

--- a/script/runner.go
+++ b/script/runner.go
@@ -72,10 +72,7 @@ type runner struct {
 	svcStop         ServiceControl    // function to stop a service
 	svcRestart      ServiceControl    // function to restart a service
 	svcWait         ServiceWait
-	findImage       findImage
-	pullImage       pullImage
 	execCommand     execCmd
-	tagImage        tagImage
 	svcUse          ServiceUse
 }
 
@@ -121,21 +118,15 @@ func newRunner(config *Config, pctx *parseContext) *runner {
 		svcStop:         config.SvcStop,
 		svcWait:         config.SvcWait,
 		svcRestart:      config.SvcRestart,
-		findImage:       docker.FindImage,
-		pullImage:       docker.PullImage,
 		execCommand:     defaultExec,
-		tagImage:        defaultTagImage,
 		svcUse:          config.SvcUse,
 	}
 	if config.NoOp {
 		glog.Infof("creatng no op runner")
 		r.execCommand = noOpExec
-		r.tagImage = noOpTagImage
 		r.restore = noOpRestore
 		r.snapshot = noOpSnapshot
 		r.commitContainer = noOpCommit
-		r.pullImage = noOpPull
-		r.findImage = noOpFindImage
 		r.svcStart = noOpServiceStart
 		r.svcStop = noOpServiceStop
 		r.svcRestart = noOpServiceRestart

--- a/script/utils.go
+++ b/script/utils.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/control-center/serviced/commons"
 	"github.com/control-center/serviced/commons/docker"
 )
 
@@ -39,12 +38,6 @@ type ServiceState string
 type ServiceWait func(serviceID []string, serviceState ServiceState, timeout uint32) error
 
 type execCmd func(string, ...string) error
-
-type findImage func(string, bool) (*docker.Image, error)
-
-type pullImage func(string) error
-
-type tagImage func(*docker.Image, string) (*docker.Image, error)
 
 type findTenant func(string) (string, error)
 
@@ -79,10 +72,6 @@ func noOpServiceWait(serviceID []string, serviceState ServiceState, timeout uint
 	return nil
 }
 
-func noOpTagImage(image *docker.Image, newTag string) (*docker.Image, error) {
-	return image, nil
-}
-
 func noOpRestore(snapshotID string, forceRestart bool) error {
 	return nil
 }
@@ -93,16 +82,4 @@ func noOpSnapshot(serviceID string) (string, error) {
 
 func noOpCommit(containerID string) (string, error) {
 	return "no_op_commit", nil
-}
-
-func noOpPull(image string) error {
-	return nil
-}
-
-func noOpFindImage(image string, pull bool) (*docker.Image, error) {
-	id, err := commons.ParseImageID(image)
-	if err != nil {
-		return nil, err
-	}
-	return &docker.Image{"123456789", *id}, nil
 }

--- a/script/utils.go
+++ b/script/utils.go
@@ -5,13 +5,8 @@
 package script
 
 import (
-	"errors"
-	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
-
-	"github.com/docker/docker/pkg/parsers"
 
 	"github.com/control-center/serviced/commons"
 	"github.com/control-center/serviced/commons/docker"
@@ -34,6 +29,9 @@ type ServiceIDFromPath func(tenantID string, path string) (string, error)
 
 // ServiceControl is a func used to control the state of a service
 type ServiceControl func(serviceID string, recursive bool) error
+
+// ServiceUse is a func used to control the state of a service
+type ServiceUse func(serviceID string, imageID string, registry string, noOp bool) (string, error)
 
 type ServiceState string
 
@@ -59,18 +57,6 @@ func defaultExec(name string, args ...string) error {
 
 func defaultTagImage(image *docker.Image, newTag string) (*docker.Image, error) {
 	return image.Tag(newTag)
-}
-
-func renameImageID(dockerRegistry, tenantId string, imgID string, tag string) (*commons.ImageID, error) {
-	repo, _ := parsers.ParseRepositoryTag(imgID)
-	re := regexp.MustCompile("/?([^/]+)\\z")
-	matches := re.FindStringSubmatch(repo)
-	if matches == nil {
-		return nil, errors.New("malformed imageid")
-	}
-	name := matches[1]
-	newImageID := fmt.Sprintf("%s/%s/%s:%s", dockerRegistry, tenantId, name, tag)
-	return commons.ParseImageID(newImageID)
 }
 
 func noOpExec(name string, args ...string) error {


### PR DESCRIPTION
This was originally broken on multihost because SVC_USE would re-tag, but would not push to the registry (because the code was running on the client where SERVICED_REGISTRY was set to False, not the server where it is True). 

https://github.com/control-center/serviced/blob/develop/commons/docker/api.go#L563

This change makes the code do an RPC call to the server, so the tagging gets pushed into the registry.  This requires that the operation be physically performed on the master, but we already have this requirement due to snapshotting.