### PR TITLE
adds GOBUILD_FLAGS option to makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -157,7 +157,7 @@ $(GOSRC)/$(godep_SRC):
 
 .PHONY: go
 go: 
-	go build ${LDFLAGS}
+	go build $(GOBUILD_FLAGS) ${LDFLAGS}
 
 # As a dev convenience, we call both 'go build' and 'go install'
 # so the current directory and $GOPATH/bin are updated
@@ -176,14 +176,14 @@ FORCE:
 
 serviced: $(Godeps_restored)
 serviced: FORCE
-	go build ${LDFLAGS}
-	go install ${LDFLAGS}
+	go build $(GOBUILD_FLAGS) ${LDFLAGS}
+	go install $(GOBUILD_FLAGS) ${LDFLAGS}
 
 serviced = $(GOBIN)/serviced
 $(serviced): $(Godeps_restored)
 $(serviced): FORCE
-	go build ${LDFLAGS}
-	go install ${LDFLAGS}
+	go build $(GOBUILD_FLAGS) ${LDFLAGS}
+	go install $(GOBUILD_FLAGS) ${LDFLAGS}
 
 .PHONY: docker_build
 pkg_build_tmp = pkg/build/tmp


### PR DESCRIPTION
So if you want to build with race checking, for example, you can:

`control-center/serviced$ GOBUILD_FLAGS=-race make`