### PR TITLE
fixes CC-617: set default for SERVICED_FS_TYPE to btrfs for installation

### DIFF
--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -53,8 +53,8 @@
 # Set the TLS certfile
 # SERVICED_CERT_FILE=/etc/....
 
-# Set the driver type for the underlying file system (rsync/btrfs)
-# SERVICED_FS_TYPE=rsync
+# Set the driver type on the master for the distributed file system (rsync/btrfs)
+SERVICED_FS_TYPE=btrfs
 
 # Set the aliases for this host (use in vhost muxing)
 # SERVICED_VHOST_ALIASES=foobar.com,example.com

--- a/volume/btrfs/btrfs.go
+++ b/volume/btrfs/btrfs.go
@@ -286,6 +286,12 @@ func (c *BtrfsConn) snapshotExists(label string) (exists bool, err error) {
 	return false, nil
 }
 
+// IsBtrfsFilesystem determines whether the path is a btrfs filesystem
+func IsBtrfsFilesystem(thePath string) error {
+	_, err := runcmd(false, "filesystem", "df", thePath)
+	return err
+}
+
 // runcmd runs the btrfs command
 func runcmd(sudoer bool, args ...string) ([]byte, error) {
 	cmd := append([]string{"btrfs"}, args...)


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-617

DEMO:
```
# plu@plu-9: zendev serviced -dx -- --var=/tmp/notbtrfs/ --fstype=btrfs
...
F0115 16:12:18.446098 29957 daemon.go:276] varpath at /tmp/notbtrfs/ is not a btrfs filesystem
...
```