### PR TITLE
fixes CC-649: replace hardcoded 4979 with SERVICED_RPC_PORT and SERVICED_ENDPOINT

### DIFF
--- a/cli/api/api.go
+++ b/cli/api/api.go
@@ -32,6 +32,7 @@ var options Options
 type Options struct {
 	Endpoint             string // the endpoint address to make RPC requests to
 	UIPort               string
+	RPCPort              string
 	Listen               string
 	OutboundIP           string // outbound ip to listen on
 	Master               bool
@@ -85,6 +86,16 @@ func LoadOptions(ops Options) {
 		glog.V(0).Infof("overriding elastic search startup timeout with minimum %d", minTimeout)
 		options.ESStartupTimeout = minTimeout
 	}
+}
+
+// GetOptionsEndpoint returns the serviced RPC endpoint from options
+func GetOptionsRPCEndpoint() string {
+	return options.Endpoint
+}
+
+// GetOptionsRPCPort returns the serviced RPC port from options
+func GetOptionsRPCPort() string {
+	return options.RPCPort
 }
 
 type api struct {

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -602,6 +602,7 @@ func (d *daemon) startAgent() error {
 			PoolID:               thisHost.PoolID,
 			Master:               options.Endpoint,
 			UIPort:               options.UIPort,
+			RPCPort:              options.RPCPort,
 			DockerDNS:            options.DockerDNS,
 			VarPath:              options.VarPath,
 			Mount:                options.Mount,

--- a/cli/api/utils.go
+++ b/cli/api/utils.go
@@ -37,7 +37,7 @@ var (
 )
 
 // GetAgentIP returns the agent ip address
-func GetAgentIP() string {
+func GetAgentIP(defaultRPCPort int) string {
 	if options.Endpoint != "" {
 		return options.Endpoint
 	}
@@ -45,7 +45,7 @@ func GetAgentIP() string {
 	if err != nil {
 		panic(err)
 	}
-	return agentIP + ":4979"
+	return agentIP + fmt.Sprintf(":%d", defaultRPCPort)
 }
 
 // GetDockerDNS returns the docker dns address

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -89,21 +89,20 @@ func configBool(key string, defaultVal bool) bool {
 
 const defaultRPCPort = 4979
 
-// New instantiates a new command-line client
-
-func getLocalAgentIP() string {
+func getLocalAgentEndpoint(port int) string {
 	ip := configEnv("OUTBOUND_IP", "")
 	if ip != "" {
-		ip = ip + ":4979"
+		return fmt.Sprintf("%s:%d", ip, port)
 	} else {
-		ip = api.GetAgentIP()
+		return api.GetAgentIP(port)
 	}
-	return ip
 }
 
+// New instantiates a new command-line client
 func New(driver api.API) *ServicedCli {
 	var (
-		agentIP          = getLocalAgentIP()
+		rpcPort          = configInt("RPC_PORT", defaultRPCPort)
+		agentEndpoint    = getLocalAgentEndpoint(rpcPort)
 		varPath          = api.GetVarPath()
 		esStartupTimeout = api.GetESStartupTimeout()
 		dockerDNS        = cli.StringSlice(api.GetDockerDNS())
@@ -166,10 +165,10 @@ func New(driver api.API) *ServicedCli {
 	c.app.Flags = []cli.Flag{
 		cli.StringFlag{"docker-registry", configEnv("DOCKER_REGISTRY", defaultDockerRegistry), "local docker registry to use"},
 		cli.StringSliceFlag{"static-ip", &staticIps, "static ips for this agent to advertise"},
-		cli.StringFlag{"endpoint", configEnv("ENDPOINT", agentIP), "endpoint for remote serviced (example.com:8080)"},
+		cli.StringFlag{"endpoint", configEnv("ENDPOINT", agentEndpoint), fmt.Sprintf("endpoint for remote serviced (example.com:%d)", defaultRPCPort)},
 		cli.StringFlag{"outbound", configEnv("OUTBOUND_IP", ""), "outbound ip address"},
 		cli.StringFlag{"uiport", configEnv("UI_PORT", ":443"), "port for ui"},
-		cli.StringFlag{"listen", configEnv("RPC_PORT", fmt.Sprintf(":%d", defaultRPCPort)), "port for local serviced (example.com:8080)"},
+		cli.IntFlag{"listen", rpcPort, fmt.Sprintf("rpc port for serviced (%d)", defaultRPCPort)},
 		cli.StringSliceFlag{"docker-dns", &dockerDNS, "docker dns configuration used for running containers"},
 		cli.BoolFlag{"master", "run in master mode, i.e., the control center service"},
 		cli.BoolFlag{"agent", "run in agent mode, i.e., a host in a resource pool"},
@@ -245,7 +244,8 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 		Endpoint:             ctx.GlobalString("endpoint"),
 		StaticIPs:            ctx.GlobalStringSlice("static-ip"),
 		UIPort:               ctx.GlobalString("uiport"),
-		Listen:               ctx.GlobalString("listen"),
+		RPCPort:              fmt.Sprintf("%d", ctx.GlobalInt("listen")),
+		Listen:               fmt.Sprintf(":%d", ctx.GlobalInt("listen")),
 		DockerDNS:            ctx.GlobalStringSlice("docker-dns"),
 		Master:               ctx.GlobalBool("master"),
 		Agent:                ctx.GlobalBool("agent"),

--- a/dao/elasticsearch/logs.go
+++ b/dao/elasticsearch/logs.go
@@ -14,6 +14,8 @@
 package elasticsearch
 
 import (
+	"fmt"
+
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/domain/servicestate"
 	"github.com/control-center/serviced/rpc/agent"
@@ -34,8 +36,7 @@ func (this *ControlPlaneDao) GetServiceLogs(serviceID string, logs *string) erro
 	}
 
 	serviceState := serviceStates[0]
-	// FIXME: don't assume port is 4979
-	endpoint := serviceState.HostIP + ":4979"
+	endpoint := fmt.Sprintf("%s:%d", serviceState.HostIP, this.port)
 	agentClient, err := agent.NewClient(endpoint)
 	if err != nil {
 		glog.Errorf("could not create client to %s", endpoint)
@@ -58,8 +59,7 @@ func (this *ControlPlaneDao) GetServiceStateLogs(request dao.ServiceStateRequest
 		return err
 	}
 
-	// FIXME: don't assume port is 4979
-	endpoint := serviceState.HostIP + ":4979"
+	endpoint := fmt.Sprintf("%s:%d", serviceState.HostIP, this.port)
 	agentClient, err := agent.NewClient(endpoint)
 	if err != nil {
 		glog.Errorf("could not create client to %s", endpoint)

--- a/node/agent.go
+++ b/node/agent.go
@@ -76,6 +76,7 @@ type HostAgent struct {
 	poolID               string
 	master               string               // the connection string to the master agent
 	uiport               string               // the port to the ui (legacy was port 8787, now default 443)
+	rpcport              string               // the rpc port to serviced (default is 4979)
 	hostID               string               // the hostID of the current host
 	dockerDNS            []string             // docker dns addresses
 	varPath              string               // directory to store serviced	 data
@@ -114,6 +115,7 @@ type AgentOptions struct {
 	PoolID               string
 	Master               string
 	UIPort               string
+	RPCPort              string
 	DockerDNS            []string
 	VarPath              string
 	Mount                []string
@@ -134,6 +136,7 @@ func NewHostAgent(options AgentOptions) (*HostAgent, error) {
 	agent.poolID = options.PoolID
 	agent.master = options.Master
 	agent.uiport = options.UIPort
+	agent.rpcport = options.RPCPort
 	agent.dockerDNS = options.DockerDNS
 	agent.varPath = options.VarPath
 	agent.mount = options.Mount
@@ -714,6 +717,7 @@ func configureContainer(a *HostAgent, client *ControlClient,
 		fmt.Sprintf("SERVICED_NOREGISTRY=%s", os.Getenv("SERVICED_NOREGISTRY")),
 		fmt.Sprintf("SERVICED_SERVICE_IMAGE=%s", svc.ImageID),
 		fmt.Sprintf("SERVICED_MAX_RPC_CLIENTS=1"),
+		fmt.Sprintf("SERVICED_RPC_PORT=%s", a.rpcport),
 		fmt.Sprintf("TZ=%s", os.Getenv("TZ")))
 
 	// add dns values to setup

--- a/web/cpserver.go
+++ b/web/cpserver.go
@@ -60,9 +60,6 @@ func NewServiceConfig(bindPort string, agentPort string, stats bool, hostaliases
 		muxPort:     muxPort,
 	}
 	adminGroup = aGroup
-	if len(cfg.agentPort) == 0 {
-		cfg.agentPort = "127.0.0.1:4979"
-	}
 	return &cfg
 }
 


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-649

DEMO - serviced starts with ENDPOINT and RPC_PORT different from 4979:
```
root@plu-9:/etc/default# grep 4979 /etc/default/serviced
SERVICED_ENDPOINT=10.87.110.39:54979
SERVICED_RPC_PORT=54979
root@plu-9:/etc/default# start serviced
serviced start/running, process 11690
root@plu-9:/etc/default# export SERVICED_ENDPOINT=10.87.110.39:54979
root@plu-9:/etc/default# export SERVICED_RPC_PORT=54979
root@plu-9:/etc/default# serviced host add $(hostname -i):54979 default
570a276e
root@plu-9:/etc/default# serviced host list
ID		POOL		NAME	ADDR		RPCPORT		CORES	MEM		NETWORK			RELEASE
570a276e	default		plu-9	10.87.110.39	54979		12	33659494400	172.17.0.0/255.255.0.0	1.0.0~trusty-0.1.CR11
root@plu-9:/etc/default# id=$(serviced template add /opt/serviced/templates/*.json); echo $id
c740db1d0ea26dc698294e94266b344a
root@plu-9:/etc/default# time serviced template deploy $id default zenoss
Deploying template - please wait...
6ehhhmdvb59x7um5rhybalc27

real	0m18.532s
user	0m0.066s
sys	0m0.025s
root@plu-9:/etc/default# serviced service start zenoss.core
Scheduled 33 service(s) to start
```

DEMO - all services started:
```
root@plu-9:/etc/default# serviced service status
NAME			ID				STATUS		UPTIME			HOST	IN_SYNC		DOCKER_ID
└─Zenoss.core		6ehhhmdvb59x7um5rhybalc27	Running		17m37.799379354s	plu-9	Y		5e868ab9ef11
  ├─MariaDB		3lv8w625tntxi195pnb3lnrqu	Running		17m37.67357102s		plu-9	Y		c715b949ef78
  ├─zenactiond		463ok06mqtbe1j2d0yl9itdi9	Running		17m39.589227757s	plu-9	Y		9c2e06fa874f
  ├─zenjobs		7juhd52qvc5z7vkd5aai4corj	Running		17m37.731407934s	plu-9	Y		03c870e9da72
  ├─MetricShipper	8oslbm8z8rwmyexzd6ce7a2x4	Running		17m41.939275964s	plu-9	Y		82119866c407
  ├─MetricConsumer	9qopj7qpi1vio0e7s8umswien	Running		17m46.73145576s		plu-9	Y		b64d58150cae
  ├─Zope		b715vrupd6c4zx5j6s0rt92c2	Running		17m37.644069796s	plu-9	Y		424187422f59
  ├─RabbitMQ		br4k5k3e5duxkj2jzwahfmg4t	Running		17m44.513301072s	plu-9	Y		94229645ddd9
  ├─zeneventd		cetrtg8b15p1lqxu26x1mbm73	Running		17m40.021457898s	plu-9	Y		8cc1edae91a6
  ├─zeneventserver	cp5il9sg1kbk7g96ltjab7tum	Running		17m46.861272766s	plu-9	Y		07a240207ae3
  ├─localhost		ct4j8eh7hyf9690ft7my1mma									
  │ ├─zenhub		91w4hcatudg4919nkzmutcfnl	Running		17m37.818280392s	plu-9	Y		46a11cb20372
  │ └─localhost		bbpq0wvdgp0zw0fja314twf5h									
  │   ├─zenmodeler	1fup9tesmtrzfbdx1n8qmmt18	Running		17m37.736378127s	plu-9	Y		0aa4028739db
  │   ├─MetricShipper	2yu9llwqagwg6vv4inrn18ma7	Running		17m38.448919569s	plu-9	Y		45df5173dd11
  │   ├─zenperfsnmp	7ztuqhb3u88s5xjho6cscviav	Running		17m37.749236139s	plu-9	Y		0967a2035d88
  │   ├─zenstatus	8cjyq3d9jafi2f8psb5nwacql	Running		17m41.093142022s	plu-9	Y		4a2507cdaa44
  │   ├─zminion		978vs27yyao5ulsvt5mpx62s6	Running		17m38.517907626s	plu-9	Y		8fc52c0bf629
  │   ├─zenprocess	9e2y1usyzhtan456a7hqggbvr	Running		17m37.780106283s	plu-9	Y		78d0f544acff
  │   ├─zenping		atl1gsdcbrfxt4pwfhdhk3nlu	Running		17m37.908889817s	plu-9	Y		f95e02afb7cd
  │   ├─zensyslog	b4zo678jhzhi1kog9g074ua2e	Running		17m37.812764227s	plu-9	Y		9730357acdac
  │   ├─zenjmx		b7csu1vpskq466wtn9ux8b0y9	Running		17m42.26620943s		plu-9	Y		f5707850fed8
  │   ├─zenpython	b9t1027ovseimuye281fjd1qg	Running		17m38.527760492s	plu-9	Y		22f53bef9f9f
  │   ├─zencommand	d05ojmg1267zec57se56brryn	Running		17m37.706143763s	plu-9	Y		f93804639685
  │   ├─collectorredis	f31yyc7tgsngezy48957lx8na	Running		17m37.750734733s	plu-9	Y		dd8bb8b9fbe9
  │   └─zentrap		h8lcmnottpzeiuzg7p58qg6d	Running		17m39.326105239s	plu-9	Y		46c425018e49
  ├─CentralQuery	e71pyngr4aby2dzgmgu1jl12d	Running		17m39.888350354s	plu-9	Y		ae4a593e694f
  ├─opentsdb		e9zkuwnnrkx3z3fkdj37jjm3z	Running		17m37.613396136s	plu-9	Y		938b997241cf
  ├─HBase		ek5c7oc5jwpy1t814nlb99mdi									
  │ ├─HMaster		4wpotcrxit38nspqzm9l09lok	Running		17m39.260334733s	plu-9	Y		15848ae41352
  │ ├─RegionServer	6bblnh4hrd7hbo4ga57ha7369	Running		17m37.660090421s	plu-9	Y		4be07615478d
  │ └─ZooKeeper		bl2si6y14w0el2aaxq747dppt	Running		17m37.78122801s		plu-9	Y		574496b3d8a1
  └─redis		emkc4szpc9ryxuymphn213fgv	Running		17m37.667979794s	plu-9	Y		21a6fb6611c6
```

DEMO - containers use RPC_PORT:
```
root@plu-9:/etc/default# serviced service attach /redis/0
[root@21a6fb6611c6 /]# ps -wwef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 20:12 ?        00:00:01 /serviced/serviced service proxy emkc4szpc9ryxuymphn213fgv 0 /usr/bin/redis-server /etc/redis.conf
root        16     1  0 20:12 ?        00:00:00 /usr/local/serviced/resources/logstash/logstash-forwarder -idle-flush-time=5s -old-files-hours=26280 -config /etc/logstash-forwarder.conf
root        20     1  0 20:12 ?        00:00:02 /usr/bin/redis-server *:6379
root       623     0  0 20:30 ?        00:00:00 /bin/bash
root       639   623  0 20:30 ?        00:00:00 ps -wwef
[root@21a6fb6611c6 /]# env|grep RPC
SERVICED_MAX_RPC_CLIENTS=1
SERVICED_RPC_PORT=54979
[root@21a6fb6611c6 /]# env|grep END
[root@21a6fb6611c6 /]# exit
```

![screen shot 2015-03-09 at 15 33 30](https://cloud.githubusercontent.com/assets/2837923/6563797/f8631552-c671-11e4-880e-121860d3875a.png)
