### PR TITLE
fixes CC-732: allow case-insensitive suffix match for service paths

### DIFF
--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -381,7 +381,7 @@ func (c *ServicedCli) searchForService(keyword string) (*service.Service, error)
 		default:
 			if keyword == "" {
 				services = append(services, svc)
-			} else if strings.HasSuffix(pathmap[svc.ID], keyword) {
+			} else if strings.HasSuffix(pathmap[svc.ID], strings.ToLower(keyword)) {
 				services = append(services, svc)
 			}
 		}
@@ -1092,7 +1092,7 @@ func (c *ServicedCli) searchForRunningService(keyword string) (*dao.RunningServi
 		default:
 			if keyword == "" {
 				states = append(states, rs)
-			} else if strings.HasSuffix(pathmap[rs.ID], keyword) {
+			} else if strings.HasSuffix(pathmap[rs.ID], strings.ToLower(keyword)) {
 				states = append(states, rs)
 			}
 		}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-732

ISSUE 1 - does not allow case insensitive suffix match of service paths for attach/action:
```
# plu@plu-9: serviced service status zope
NAME			ID				STATUS		UPTIME			HOST	IN_SYNC		DOCKER_ID
└─Zenoss.core.full	9fqtd07yj8cl31712exbqmeeb	Running		3m24.613209206s		plu-9	Y		98efe8373e7d
  ├─Zope/0		476qqtgbnzxtjcgbsdjg3lff6/0	Running		14.644660333s		plu-9	Y		359c2ed7ff50
  └─Zope/1		476qqtgbnzxtjcgbsdjg3lff6/1	Running		1m12.701140852s		plu-9	Y		b789521ff0b6

# plu@plu-9: serviced service attach zope/1 uname -n
b789521ff0b6

# plu@plu-9: serviced service attach Zope/1 uname -n
no matches found
no matches found
```

DEMO 1 - allow case insensitive suffix match of service paths for attach/action:
```
# plu@plu-9: serviced service attach zope/1 uname -n
b789521ff0b6

# plu@plu-9: serviced service attach Zope/1 uname -n
b789521ff0b6
```


ISSUE 2 - does not allow case insensitive suffix match of service paths for start:
```
# plu@plu-9: serviced -v=2 service start Zope
Service already started

# plu@plu-9: serviced -v=2 service start core.full/Zope
...
I0120 08:29:47.622900 05809 service.go:357] service: Zope              476qqtgbnzxtjcgbsdjg3lff6  path: zenoss.core.full/zope
...
service not found
```

DEMO 2 - allow case insensitive suffix match of service paths for start:
```
# plu@plu-9: serviced -v=2 service start core.full/Zope
...
I0120 08:29:47.622900 05809 service.go:357] service: Zope              476qqtgbnzxtjcgbsdjg3lff6  path: zenoss.core.full/zope
...
Service already started
```