### PR TITLE
fixes ZEN-16209: initialize health statuses correctly for interval

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -164,7 +164,7 @@ func RegisterHealthCheck(serviceID string, instanceID string, name string, passe
 		for iname, icheck := range healthChecks {
 			_, ok = instanceStatus[iname]
 			if !ok {
-				instanceStatus[name] = &healthStatus{"unknown", 0, icheck.Interval.Seconds(), time.Now().Unix()}
+				instanceStatus[iname] = &healthStatus{"unknown", 0, icheck.Interval.Seconds(), time.Now().Unix()}
 			}
 		}
 	}


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-16209

ISSUE - the service definition for the top level service:
```
# plu@plu-9: serviced service list zenoss.core.full |grep --after=16 HealthChecks
   "HealthChecks": {
     "answering": {
       "Script": "curl -f -s http://localhost:8080/ \u003e /dev/null",
       "Interval": 5,
       "Timeout": 0
     },
     "ready": {
       "Script": "curl http://localhost:8080/zport/dmd | grep zope \u003e /dev/null",
       "Interval": 30,
       "Timeout": 0
     },
     "running": {
       "Script": "pgrep -fu zenoss nginx \u003e/dev/null",
       "Interval": 5,
       "Timeout": 0
     }
   },
```

Notice that all Intervals in the in memory health status are 30 for the top level service do not match.
https://ip-10-111-23-213/servicehealth
```
        "bhxv1vycprew4ozf82lb9jxmw": {
            "0": {
                "answering": {
                    "Status": "failed",
                    "Timestamp": 1421778111,
                    "Interval": 30,
                    "StartedAt": 1421772068
                },
                "ready": {
                    "Status": "failed",
                    "Timestamp": 1421778107,
                    "Interval": 30,
                    "StartedAt": 1421772093
                },
                "running": {
                    "Status": "passed",
                    "Timestamp": 1421778113,
                    "Interval": 30,
                    "StartedAt": 1421772067
                }
            }
        },
```

If the the intervals were all 5, the 'ready' status would be incorrect.


DEMO - notice that the Intervals in the in memory health status correctly match the service definition:
```
        "7rky1c2mwu1oz9nq92xsfcgeq": {
            "0": {
                "answering": {
                    "Status": "failed",
                    "Timestamp": 1421779785,
                    "Interval": 5,
                    "StartedAt": 1421779702
                },
                "ready": {
                    "Status": "failed",
                    "Timestamp": 1421779788,
                    "Interval": 30,
                    "StartedAt": 1421779702
                },
                "running": {
                    "Status": "passed",
                    "Timestamp": 1421779787,
                    "Interval": 5,
                    "StartedAt": 1421779702
                }
            }
        },
```