### PR TITLE
ZEN-16236: Make pacakge versioning more sane

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,8 +10,13 @@
 # # Mount your source in an interactive container for quick testing:
 # docker run -v `pwd`:/go/src/github.com/zenoss/serviced -privileged -lxc-conf=lxc.aa_profile=unconfined -i -t serviced bash
 #
-#
+
+# Please be careful when changing the 'FROM' line below - the packaging code
+# uses the output of 'lsb_release' to determine the version string of the
+# .deb pacakge, and if the base image changes here, then that string will
+# change accordingly.
 FROM ubuntu:trusty
+
 MAINTAINER Zenoss, Inc <dev@zenoss.com>	
 
 RUN	apt-get update -qq

--- a/makefile
+++ b/makefile
@@ -390,8 +390,15 @@ PKGS = deb rpm tgz
 pkgs:
 	cd pkg && $(MAKE) IN_DOCKER=$(IN_DOCKER) INSTALL_TEMPLATES=$(INSTALL_TEMPLATES) $(PKGS)
 
+# Both BUILD_NUMBER and RELEASE_PHASE cannot be empty.
+# If not providing a BUILD_NUMBER, then it is assumed that this is not a nightly build,
+# and a RELEASE_PHASE must be provided (ALPHA1, BETA1, RC1, etc)
+
 .PHONY: docker_buildandpackage
 docker_buildandpackage: docker_ok
+	if [ -z "$$RELEASE_PHASE" -a -z "$$BUILD_NUMBER" ]; then \
+        exit 1 ;\
+    fi
 	docker build -t zenoss/serviced-build build
 	docker run --rm \
 	-v `pwd`:/go/src/github.com/control-center/serviced \

--- a/pkg/makefile
+++ b/pkg/makefile
@@ -17,7 +17,7 @@
 
 NAME          ?= serviced
 VERSION       ?= $(shell cat ../VERSION)
-RELEASE_PHASE ?=
+RELEASE_PHASE ?= # ALPHA1, BETA1, BETA2, CR1, GA
 GIT_COMMIT   ?= $(shell ./gitstatus.sh)
 SUBPRODUCT    ?=
 MAINTAINER    ="Zenoss CM <cm@zenoss.com>"
@@ -34,10 +34,31 @@ URL           = http://controlcenter.io/
 DEB_PRIORITY  = extra
 CATEGORY      = admin
 
-ifeq "$(BUILD_NUMBER)" ""
-PKG_VERSION = $(VERSION)$(RELEASE_PHASE)
+# Package versions will follow the following idiom:
+#   
+#   BUILD_NUMBER=1234
+#   RELEASE_PHASE=#ignored
+#   NIGHTLY: serviced-1.0.0-0.0.1234.unstable (where 1234 is the build number)
+#
+#   RELEASE_PHASE=ALPHA1
+#   BUILD_NUMBER=#ignored
+#   TESTING: serviced-1.0.0-0.1.ALPHA1 (where ALPHA1 is the release phase.  Could be any of
+#                                       ALPHA#, BETA#, CR#, or GA)
+#
+#   RELEASE_PHASE=GA
+#   BUILD_NUMBER=#ignored
+#   STABLE:  serviced-1.0.0-1 (this is special, and will result in a '1' REVISION)
+
+PKG_VERSION = $(VERSION)
+ifeq "$(RELEASE_PHASE)" ""
+    ITERATION = 0.0.$(BUILD_NUMBER).unstable
 else
-PKG_VERSION = $(VERSION)$(RELEASE_PHASE)-$(BUILD_NUMBER)
+    # Included a RELEASE_PHASE - assume NOT a nightly build
+    ifeq "$(RELEASE_PHASE)" "GA"
+        ITERATION = 1
+    else
+        ITERATION = 0.1.$(RELEASE_PHASE)
+    endif
 endif
 
 ifeq "$(SUBPRODUCT)" ""
@@ -130,6 +151,7 @@ deb: stage_deb
 	fpm \
 		-n $(FULL_NAME) \
 		-v $(PKG_VERSION)~$$(lsb_release -cs) \
+		--iteration $(ITERATION) \
 		-s dir \
 		-d nfs-kernel-server \
 		-d net-tools \
@@ -157,6 +179,7 @@ rpm: stage_rpm
 	fpm \
 		-n $(FULL_NAME) \
 		-v $(PKG_VERSION) \
+		--iteration $(ITERATION) \
 		-s dir \
 		-d nfs-utils \
 		-d net-tools \


### PR DESCRIPTION
```
# UNSTABLE
(feature/packageVersions) alapidas@alap-dev:~/src/europa/src/golang/src/github.com/control-center/serviced$ make INSTALL_TEMPLATES=0 BUILD_NUMBER=1234 docker_buildandpackage
...
(feature/packageVersions) alapidas@alap-dev:~/src/europa/src/golang/src/github.com/control-center/serviced$ ll pkg/*.{deb,rpm}
-rw-r--r-- 1 root root 18933139 Jan 20 16:54 pkg/serviced-1.0.0-0.0.1234.unstable.x86_64.rpm
-rw-r--r-- 1 root root 19016904 Jan 20 16:53 pkg/serviced_1.0.0~trusty-0.0.1234.unstable_amd64.deb

# TESTING
(feature/packageVersions) alapidas@alap-dev:~/src/europa/src/golang/src/github.com/control-center/serviced$ make INSTALL_TEMPLATES=0 BUILD_NUMBER=1234 RELEASE_PHASE=BETA3 docker_buildandpackage
...
(feature/packageVersions) alapidas@alap-dev:~/src/europa/src/golang/src/github.com/control-center/serviced$ ll pkg/*.{deb,rpm}
-rw-r--r-- 1 root root 18933027 Jan 20 16:59 pkg/serviced-1.0.0-0.1.BETA3.x86_64.rpm
-rw-r--r-- 1 root root 19014958 Jan 20 16:58 pkg/serviced_1.0.0~trusty-0.1.BETA3_amd64.deb

# STABLE
(feature/packageVersions) alapidas@alap-dev:~/src/europa/src/golang/src/github.com/control-center/serviced$ make INSTALL_TEMPLATES=0 BUILD_NUMBER=1234 RELEASE_PHASE=GA docker_buildandpackage
...
(feature/packageVersions) alapidas@alap-dev:~/src/europa/src/golang/src/github.com/control-center/serviced$ ll pkg/*.{deb,rpm}
-rw-r--r-- 1 root root 18933016 Jan 20 17:00 pkg/serviced-1.0.0-1.x86_64.rpm
-rw-r--r-- 1 root root 19013948 Jan 20 17:00 pkg/serviced_1.0.0~trusty-1_amd64.deb
```