### PR TITLE
fixes ZEN-16206: use reload-or-restart to only restart nfs when it is not running

### DIFF
--- a/dfs/nfs/nfs.go
+++ b/dfs/nfs/nfs.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/zenoss/glog"
 	"github.com/control-center/serviced/utils"
+	"github.com/zenoss/glog"
 )
 
 var nfsServiceName = determineNfsServiceName()
@@ -28,20 +28,20 @@ var start = startImpl
 var reload = reloadImpl
 
 func determineServiceCommand() string {
-    if utils.Platform == utils.Rhel {
-        return "systemctl"
-    } else {
+	if utils.Platform == utils.Rhel {
+		return "systemctl"
+	} else {
 		return "/usr/sbin/service"
-    }
+	}
 }
 
 func determineNfsServiceName() string {
-    // In RHEL-based releases, the 'nfs-server' service is used
-    if utils.Platform == utils.Rhel {
-        return "nfs-server"
-    } else {
-        return "nfs-kernel-server"
-    }
+	// In RHEL-based releases, the 'nfs-server' service is used
+	if utils.Platform == utils.Rhel {
+		return "nfs-server"
+	} else {
+		return "nfs-kernel-server"
+	}
 }
 
 // reload triggers the kernel to reread its NFS exports.
@@ -64,7 +64,7 @@ func startImpl() error {
 	// FIXME: this does not return the proper exit code to see if nfs is running
 	var cmd *exec.Cmd
 	if utils.Platform == utils.Rhel {
-		cmd = exec.Command(usrBinService, "restart", nfsServiceName)
+		cmd = exec.Command(usrBinService, "reload-or-restart", nfsServiceName)
 	} else {
 		cmd = exec.Command(usrBinService, nfsServiceName, "start")
 	}


### PR DESCRIPTION
Part 1 of 2 - do not restart nfs whenever the remote agent is added:
  https://jira.zenoss.com/browse/ZEN-16206

DEMO - logs when running nfs commands:
```
[root@ip-10-111-3-218 ~]# journalctl -u nfs-server -f
...
Jan 21 17:01:13 ip-10-111-3-218.zenoss.loc systemd[1]: Stopping NFS Server...
Jan 21 17:01:13 ip-10-111-3-218.zenoss.loc systemd[1]: Stopped NFS Server.

Jan 21 17:01:44 ip-10-111-3-218.zenoss.loc systemd[1]: Starting NFS Server...
Jan 21 17:01:44 ip-10-111-3-218.zenoss.loc systemd[1]: Started NFS Server.

Jan 21 17:01:51 ip-10-111-3-218.zenoss.loc systemd[1]: Reloading NFS Server.
Jan 21 17:01:51 ip-10-111-3-218.zenoss.loc systemd[1]: Reloaded NFS Server.

Jan 21 17:02:07 ip-10-111-3-218.zenoss.loc systemd[1]: Reloading NFS Server.
Jan 21 17:02:07 ip-10-111-3-218.zenoss.loc systemd[1]: Reloaded NFS Server.

```

DEMO - notice that reload-or-restart will only restart nfs if that's not running
notice that reload occurs with reload-or-restart (start also reloads):
```
[root@ip-10-111-3-218 ~]# systemctl stop nfs-server
[root@ip-10-111-3-218 ~]# date;systemctl status nfs-server
Wed Jan 21 17:01:33 EST 2015
nfs-server.service - NFS Server
   Loaded: loaded (/usr/lib/systemd/system/nfs-server.service; disabled)
   Active: inactive (dead)
...
Jan 21 17:01:13 ip-10-111-3-218.zenoss.loc systemd[1]: Stopping NFS Server...
Jan 21 17:01:13 ip-10-111-3-218.zenoss.loc systemd[1]: Stopped NFS Server.
[root@ip-10-111-3-218 ~]# date;systemctl reload-or-restart nfs-server
Wed Jan 21 17:01:44 EST 2015
[root@ip-10-111-3-218 ~]# date;systemctl reload-or-restart nfs-server
Wed Jan 21 17:01:51 EST 2015
[root@ip-10-111-3-218 ~]# date;systemctl reload-or-restart nfs-server
Wed Jan 21 17:02:07 EST 2015

```

DEMO - adding remote host:
```
[root@ip-10-111-3-218 bin]# serviced host add 10.111.3.193:4979 default
6f0ac103
[root@ip-10-111-3-218 bin]# date; touch /opt/serviced/var/$(uname -n)-111.txt
Wed Jan 21 17:53:59 EST 2015
[root@ip-10-111-3-218 bin]# ls /opt/serviced/var
ip-10-111-3-218.zenoss.loc-111.txt  isvcs
```

DEMO - no latency in initial write on remote host and sees correct volume  based on FSID:
```
[root@ip-10-111-3-193 bin]# date; df -Ha /opt/serviced/var; time touch /opt/serviced/var/$(uname -n)-111.txt
Wed Jan 21 17:53:36 EST 2015
Filesystem                  Size  Used Avail Use% Mounted on
10.111.3.218:/serviced_var  6.5G  1.7G  4.9G  26% /opt/serviced/var

real	0m0.010s
user	0m0.001s
sys	0m0.001s
[root@ip-10-111-3-193 bin]# ls /opt/serviced/var
ip-10-111-3-193.zenoss.loc-111.txt  ip-10-111-3-218.zenoss.loc-111.txt  isvcs

[root@ip-10-111-3-193 bin]# cat /proc/fs/nfsfs/volumes 
NV SERVER   PORT DEV     FSID              FSC
v4 0a6f03da  801 0:115   668dbd02c20144bc  no 
```

DEMO - master sees file created by remote host:
```
[root@ip-10-111-3-218 bin]# date; ls /opt/serviced/var/
Wed Jan 21 17:56:22 EST 2015
ip-10-111-3-193.zenoss.loc-111.txt  ip-10-111-3-218.zenoss.loc-111.txt  isvcs

[root@ip-10-111-3-218 bin]# cat /proc/fs/nfsd/exports 
# Version 1.1
# Path Client(Flags) # IPs
/exports/serviced_var	*(rw,insecure,no_root_squash,async,wdelay,nohide,no_subtree_check,uuid=668dbd02:c20144bc:be76f606:fc9ab8db,sec=1)
/exports	*(rw,insecure,no_root_squash,async,wdelay,no_subtree_check,fsid=0,uuid=668dbd02:c20144bc:be76f606:fc9ab8db,sec=1)
```