### PR TITLE
be explicit when retrieving findmnt ServerIP

### DIFF
--- a/commons/proc/nfsfs_test.go
+++ b/commons/proc/nfsfs_test.go
@@ -97,7 +97,7 @@ func TestGetMountInfo(t *testing.T) {
 	defer func(s string) {
 		procFindmntCommand = s
 	}(procFindmntCommand)
-	procFindmntCommand = "grep %s tstproc/self/mountinfo | awk '{n=split($NF,fields,\"=\"); print $3, $9, $10, $5, fields[n]}'"
+	procFindmntCommand = "grep %s tstproc/self/mountinfo | awk '{print $3, $9, $10, $5, $NF}'"
 
 	actual, err := GetMountInfo("/tmp/serviced/var")
 	if err != nil {
@@ -128,7 +128,7 @@ func TestGetNFSVolumeInfo(t *testing.T) {
 	defer func(s string) {
 		procFindmntCommand = s
 	}(procFindmntCommand)
-	procFindmntCommand = "grep %s tstproc/self/mountinfo | awk '{n=split($NF,fields,\"=\"); print $3, $9, $10, $5, fields[n]}'"
+	procFindmntCommand = "grep %s tstproc/self/mountinfo | awk '{print $3, $9, $10, $5, $NF}'"
 
 	actual, err := GetNFSVolumeInfo("/tmp/serviced/var")
 	if err != nil {


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-16206

Don't rely on the ServerIP being in the last field of the mount info options

ISSUE:
```
# plu@plu-9: tail -1 tstproc/self/mountinfo
145 37 0:137 / /tmp/serviced/var rw,relatime shared:65 - nfs4 10.87.209.168:/serviced_var rw,vers=4.0,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,port=0,timeo=600,retrans=2,sec=sys,clientaddr=10.87.209.168,addr=10.87.209.168,local_lock=none
~/src/europa/src/golang/src/github.com/control-center/serviced/commons/proc
# plu@plu-9: go test
--- FAIL: TestGetMountInfo (0.00 seconds)
	nfsfs_test.go:115: expected: {DeviceID:0:137 FSType:nfs4 RemotePath:10.87.209.168:/serviced_var LocalPath:/tmp/serviced/var ServerIP:10.87.209.168} != actual: &{DeviceID:0:137 FSType:nfs4 RemotePath:10.87.209.168:/serviced_var LocalPath:/tmp/serviced/var ServerIP:none}
--- FAIL: TestGetNFSVolumeInfo (0.00 seconds)
	nfsfs_test.go:156: expected: {MountInfo:{DeviceID:0:137 FSType:nfs4 RemotePath:10.87.209.168:/serviced_var LocalPath:/tmp/serviced/var ServerIP:10.87.209.168} Version:v4 ServerID:0a57d1a8 Port:801 FSID:45a148e989326106 FSCache:no} != actual: &{MountInfo:{DeviceID:0:137 FSType:nfs4 RemotePath:10.87.209.168:/serviced_var LocalPath:/tmp/serviced/var ServerIP:none} Version:v4 ServerID:0a57d1a8 Port:801 FSID:45a148e989326106 FSCache:no}
FAIL
exit status 1
FAIL	github.com/control-center/serviced/commons/proc	0.011s
```

DEMO:
```
# plu@plu-9: go test
PASS
ok  	github.com/control-center/serviced/commons/proc	0.011s
```