### PR TITLE
Feature/cc 742 monitor

### DIFF
--- a/commons/proc/nfsd.go
+++ b/commons/proc/nfsd.go
@@ -19,10 +19,8 @@ import (
 	"bufio"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"reflect"
 	"strings"
-	"time"
 )
 
 var procNFSDExportsFile = "fs/nfs/exports"
@@ -142,69 +140,4 @@ func parseOptions(line string) map[string]string {
 	}
 
 	return options
-}
-
-// ProcessExportedVolumeChangeFunc is called by MonitorExportedVolume when exported volume info state changes are detected
-type ProcessExportedVolumeChangeFunc func(mountpoint string, isExported bool)
-
-// MonitorExportedVolume monitors the exported volume and logs on failure
-func MonitorExportedVolume(mountpoint string, monitorInterval time.Duration, shutdown <-chan interface{}, changedFunc ProcessExportedVolumeChangeFunc) {
-	glog.Infof("monitoring exported volume %s at polling interval: %s", mountpoint, monitorInterval)
-
-	var modtime time.Time
-	for {
-		glog.V(4).Infof("determining export status for DFS NFS volume %s", mountpoint)
-
-		changed, err := hasFileChanged(GetProcNFSDExportsFilePath(), &modtime)
-		if err != nil {
-			glog.Warningf("unable to determine whether mountpoint %s is exported: %s", mountpoint, err)
-		} else if changed {
-			glog.Infof("exported info has changed for mountpoint %s", mountpoint)
-			mountinfo, err := GetProcNFSDExport(mountpoint)
-			if err != nil {
-				if err == ErrMountPointNotExported {
-					glog.Warningf("volume %s is not exported - further action may be required", mountpoint)
-					changedFunc(mountpoint, false)
-				} else {
-					changedFunc(mountpoint, false)
-					glog.Warningf("unable to retrieve volume export info for %s: %s", mountpoint, err)
-				}
-			} else {
-				changedFunc(mountpoint, true)
-				glog.Infof("DFS NFS volume %s (uuid:%+v) is exported", mountpoint, mountinfo.ClientOptions["*"]["uuid"])
-			}
-		}
-
-		select {
-		case <-time.After(monitorInterval):
-
-		case <-shutdown:
-			glog.Infof("no longer monitoring export status for DFS NFS volume %s", mountpoint)
-			return
-		}
-	}
-}
-
-// hasFileChanged determines whether file has been modified and updates modtime
-func hasFileChanged(filename string, modtime *time.Time) (bool, error) {
-	fileinfo, err := os.Stat(filename)
-	if err != nil {
-		glog.V(4).Infof("unable to stat file: %s %s", filename, err)
-		return false, err
-	}
-
-	prevtime := *modtime
-	*modtime = fileinfo.ModTime()
-	if fileinfo.ModTime().After(prevtime) {
-		duration := fileinfo.ModTime().Sub(prevtime)
-		if prevtime.IsZero() {
-			glog.V(4).Infof("first time file %s is checked", filename)
-			return true, nil
-		}
-		glog.V(4).Infof("file %s has been modified since %s", filename, duration)
-		return true, nil
-	}
-
-	glog.V(4).Infof("file %s has not been modified", filename)
-	return false, nil
 }

--- a/commons/proc/nfsd_test.go
+++ b/commons/proc/nfsd_test.go
@@ -14,13 +14,7 @@
 package proc
 
 import (
-	"io/ioutil"
-	"os"
-	"path"
 	"testing"
-	"time"
-
-	"github.com/zenoss/glog"
 )
 
 func setProcDir(dir string) {
@@ -107,84 +101,4 @@ func TestGetProcNFSDExports(t *testing.T) {
 	if expectedUUID != actualUUID {
 		t.Fatalf("expectedUUID: %+v != actualUUID: %+v", expectedUUID, actualUUID)
 	}
-}
-
-func TestMonitorExportedVolume(t *testing.T) {
-	// create temporary proc dir
-	tmpVar, err := ioutil.TempDir("", "tstproc")
-	if err != nil {
-		t.Fatalf("could not create tempdir %+v: %s", tmpVar, err)
-	}
-	defer os.RemoveAll(tmpVar)
-
-	// mock up our proc dir
-	defer setProcDir(procDir)
-	procDir = tmpVar + "/"
-
-	nfsdDir := path.Join(procDir, path.Dir(procNFSDExportsFile))
-	if err := os.MkdirAll(nfsdDir, 0755); err != nil {
-		t.Fatalf("unable to mkdir %+v: %s", nfsdDir, err)
-	}
-
-	// populate the mocked up export file
-	exportsLine := "#\n/exports/serviced_var   *(rw,insecure,no_root_squash,async,wdelay,nohide,no_subtree_check,uuid=45a148e9:89326106:00000000:00000000,sec=1)\n"
-	exportsFile := path.Join(nfsdDir, path.Base(procNFSDExportsFile))
-	glog.Infof("==== writing to exports %s: %s", exportsFile, exportsLine)
-	if err := ioutil.WriteFile(exportsFile, []byte(exportsLine), 0600); err != nil {
-		t.Fatalf("unable to write file %+v: %s", exportsFile, err)
-	}
-
-	expectedMountPoint := "/exports/serviced_var"
-	actual, err := GetProcNFSDExport(expectedMountPoint)
-	if err != nil {
-		t.Fatalf("could not find expected mountpoint %s from file %s: %s", expectedMountPoint, exportsFile, err)
-	}
-
-	actualUUID := actual.ClientOptions["*"]["uuid"]
-	expectedUUID := "45a148e9:89326106:00000000:00000000"
-	if expectedUUID != actualUUID {
-		t.Fatalf("expectedUUID: %+v != actualUUID: %+v", expectedUUID, actualUUID)
-	}
-
-	// monitor
-	expectedIsExported := true
-	processExportedVolumeChangeFunc := func(mountpoint string, actualIsExported bool) {
-		glog.Infof("==== received exported volume info changed message - isExported:%+v", actualIsExported)
-		if expectedIsExported != actualIsExported {
-			t.Fatalf("expectedIsExported: %+v != actualIsExported: %+v", expectedIsExported, actualIsExported)
-		}
-	}
-
-	shutdown := make(chan interface{})
-	defer close(shutdown)
-	go MonitorExportedVolume(expectedMountPoint, time.Duration(2*time.Second), shutdown, processExportedVolumeChangeFunc)
-
-	// wait some time
-	waitTime := time.Second * 6
-	time.Sleep(waitTime)
-
-	// update the file
-	glog.Infof("==== writing to exports %s: %s", exportsFile, exportsLine)
-	if err := ioutil.WriteFile(exportsFile, []byte(exportsLine), 0600); err != nil {
-		t.Fatalf("unable to write file %+v: %s", exportsFile, err)
-	}
-
-	// wait some time
-	time.Sleep(waitTime)
-
-	// remove the export
-	expectedIsExported = false
-	noEntries := "#\n"
-	glog.Infof("==== clearing exports %s: %s", exportsFile, noEntries)
-	if err := ioutil.WriteFile(exportsFile, []byte(noEntries), 0600); err != nil {
-		t.Fatalf("unable to write file %+v: %s", exportsFile, err)
-	}
-
-	actual, err = GetProcNFSDExport(expectedMountPoint)
-	if err != ErrMountPointNotExported {
-		t.Fatalf("should not have found mountpoint %s from cleared file %s: %s", expectedMountPoint, exportsFile, err)
-	}
-
-	// wait some time
-	time.Sleep(waitTime)
 }

--- a/coordinator/storage/client.go
+++ b/coordinator/storage/client.go
@@ -16,6 +16,7 @@ package storage
 import (
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/control-center/serviced/coordinator/client"
@@ -36,6 +37,8 @@ type Client struct {
 	localPath string
 	closing   chan struct{}
 	mounted   chan chan<- string
+	conn      client.Connection
+	setLock   sync.Mutex
 }
 
 // NewClient returns a Client that manages remote mounts
@@ -48,6 +51,7 @@ func NewClient(host *host.Host, localPath string) (*Client, error) {
 		localPath: localPath,
 		mounted:   make(chan chan<- string),
 		closing:   make(chan struct{}),
+		// conn:      nil,   // commented out on purpose - no need to initialize
 	}
 	go c.loop()
 	return c, nil
@@ -89,10 +93,15 @@ func (c *Client) loop() {
 		version: nil,
 	}
 
+	remoteShutdown := make(chan interface{})
+	defer close(remoteShutdown)
+
 	var doneC chan<- string
 	var leader client.Leader
-	var conn client.Connection
 	nodePath := fmt.Sprintf("/storage/clients/%s", node.IPAddr)
+	updateMonitorInterval := getDefaultDFSMonitorRemoteInterval()
+	go UpdateRemoteMonitorFile(c.localPath, updateMonitorInterval, c.host.IPAddr, remoteShutdown)
+	go c.UpdateUpdatedAt(updateMonitorInterval, c.conn, nodePath, node)
 	for {
 		if doneC == nil {
 			select {
@@ -113,33 +122,33 @@ func (c *Client) loop() {
 		err = nil
 		if leader == nil {
 			// /storage/leader needs to be at the root
-			conn, err = zzk.GetLocalConnection("/")
+			c.conn, err = zzk.GetLocalConnection("/")
 
 			if err != nil {
 				continue
 			}
-			leader = conn.NewLeader("/storage/leader", leaderNode)
+			leader = c.conn.NewLeader("/storage/leader", leaderNode)
 		}
 
 		glog.Infof("creating %s", nodePath)
-		if err = conn.Create(nodePath, node); err != nil && err != client.ErrNodeExists {
+		if err = c.conn.Create(nodePath, node); err != nil && err != client.ErrNodeExists {
 			glog.Errorf("could not create %s: %s", nodePath, err)
 			continue
 		}
 		if err == client.ErrNodeExists {
-			err = conn.Get(nodePath, node)
+			err = c.conn.Get(nodePath, node)
 			if err != nil && err != client.ErrEmptyNode {
 				glog.Errorf("could not get %s: %s", nodePath, err)
 				continue
 			}
 		}
 		node.Host = *c.host
-		if err := conn.Set(nodePath, node); err != nil {
+		if err := c.setNode(nodePath, node, false); err != nil {
 			glog.Errorf("problem updating %s: %s", nodePath, err)
 			continue
 		}
 
-		e, err = conn.GetW(nodePath, node)
+		e, err = c.conn.GetW(nodePath, node)
 		if err != nil {
 			glog.Errorf("err getting node %s: %s", nodePath, err)
 			continue
@@ -155,9 +164,10 @@ func (c *Client) loop() {
 				if err == nfs.ErrNfsMountingUnsupported {
 					glog.Errorf("install the nfs-common package: %s", err)
 				}
-				glog.Errorf("problem mouting %s: %s", leaderNode.ExportPath, err)
+				glog.Errorf("problem mounting %s: %s", leaderNode.ExportPath, err)
 				continue
 			}
+
 		} else {
 			glog.Info("skipping nfs mounting, server is localhost")
 		}
@@ -167,10 +177,57 @@ func (c *Client) loop() {
 			// notifying someone who cares
 			doneC = nil
 		case <-c.closing:
+			remoteShutdown <- true
 			return
 		case evt := <-e:
 			glog.Errorf("got zk event: %s", evt)
 			continue
 		}
 	}
+}
+
+func (c *Client) setNode(nodePath string, node *Node, doGetBeforeSet bool) error {
+	glog.V(4).Infof("waiting on lock for node %s: %+v", nodePath, node)
+	c.setLock.Lock()
+	defer c.setLock.Unlock()
+	glog.V(4).Infof("got lock for node %s: %+v", nodePath, node)
+
+	if doGetBeforeSet {
+		err := c.conn.Get(nodePath, node)
+		if err != nil && err != client.ErrEmptyNode {
+			glog.Warningf("could not get %s: %s", nodePath, err)
+			return err
+		}
+	}
+
+	node.Host.UpdatedAt = time.Now()
+	if err := c.conn.Set(nodePath, node); err != nil {
+		return err
+	}
+
+	glog.V(4).Infof("updated node %s: %+v", nodePath, node)
+	return nil
+}
+
+func (c *Client) UpdateUpdatedAt(updaterInterval time.Duration, conn client.Connection, nodePath string, node *Node) error {
+	glog.Infof("updating UpdatedAt for node %s at interval %s", nodePath, updaterInterval)
+	for {
+		if node.version == nil {
+			// prevents that this go routine from starting before the initial c.setNode in client.loop()
+			glog.Infof("version is nil for node %s", nodePath)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		glog.V(4).Infof("updating node %s: %+v", nodePath, node)
+		if err := c.setNode(nodePath, node, true); err != nil {
+			glog.Warningf("problem updating UpdatedAt for node %s: %s", nodePath, err)
+		}
+
+		select {
+		case <-time.After(updaterInterval):
+		}
+	}
+
+	return nil
 }

--- a/coordinator/storage/client.go
+++ b/coordinator/storage/client.go
@@ -210,7 +210,7 @@ func (c *Client) setNode(nodePath string, node *Node, doGetBeforeSet bool) error
 }
 
 func (c *Client) UpdateUpdatedAt(updaterInterval time.Duration, conn client.Connection, nodePath string, node *Node) error {
-	glog.Infof("updating UpdatedAt for node %s at interval %s", nodePath, updaterInterval)
+	glog.Infof("updating DFS remote client UpdatedAt for node %s at interval %s", nodePath, updaterInterval)
 	for {
 		if node.version == nil {
 			// prevents that this go routine from starting before the initial c.setNode in client.loop()

--- a/coordinator/storage/monitor.go
+++ b/coordinator/storage/monitor.go
@@ -90,7 +90,7 @@ func (m *Monitor) SetMonitorRemoteHosts(ipAddrs ...string) {
 	if len(ipAddrs) == 0 {
 		glog.Warningf("disabled DFS volume monitoring - no remote IPs to monitor")
 	} else {
-		glog.V(0).Infof("enabled DFS volume monitoring for remote IPs: %+v", ipAddrs)
+		glog.V(2).Infof("enabled DFS volume monitoring for remote IPs: %+v", ipAddrs)
 	}
 	m.monitoredHostsLock.Lock()
 	defer m.monitoredHostsLock.Unlock()

--- a/coordinator/storage/monitor.go
+++ b/coordinator/storage/monitor.go
@@ -17,6 +17,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -167,7 +169,11 @@ func (m *Monitor) MonitorDFSVolume(mountpoint string, shutdown <-chan interface{
 		activeRemotes := remoteIPs
 		if m.conn != nil && len(m.storageClientsPath) != 0 {
 			activeRemotes = getActiveRemoteHosts(m.conn, m.storageClientsPath, m.monitorInterval)
-			glog.V(2).Infof("DFS active remotes: %s", activeRemotes)
+			sort.Sort(sort.StringSlice(activeRemotes))
+			sort.Sort(sort.StringSlice(remoteIPs))
+			if !reflect.DeepEqual(activeRemotes, remoteIPs) {
+				glog.Infof("DFS active remotes to be monitored has changed to: %+v", activeRemotes)
+			}
 			m.SetMonitorRemoteHosts(activeRemotes...)
 		}
 

--- a/coordinator/storage/monitor.go
+++ b/coordinator/storage/monitor.go
@@ -1,0 +1,293 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/control-center/serviced/coordinator/client"
+	"github.com/control-center/serviced/domain/host"
+	"github.com/zenoss/glog"
+)
+
+const monitorSubDir string = "/monitor"
+
+// Monitor monitors the exporting of a file system to clients.
+type Monitor struct {
+	driver StorageDriver
+
+	monitoredHosts     map[string]bool
+	monitoredHostsLock sync.RWMutex
+
+	shouldRestart   bool
+	monitorInterval time.Duration
+	previousRestart time.Time
+
+	conn               client.Connection
+	storageClientsPath string
+}
+
+// NewMonitor returns a Monitor object to monitor the exported file system
+func NewMonitor(driver StorageDriver, monitorInterval time.Duration) (*Monitor, error) {
+	m := &Monitor{
+		driver:          driver,
+		monitoredHosts:  make(map[string]bool),
+		shouldRestart:   getShouldRestartDFSOnFailure(),
+		monitorInterval: monitorInterval,
+	}
+
+	return m, nil
+}
+
+// UpdateRemoteMonitorFile is used by remote clients to write a tiny file to the DFS volume at the given cycle
+func UpdateRemoteMonitorFile(localPath string, writeInterval time.Duration, ipAddr string, shutdown <-chan interface{}) {
+	remoteFile := path.Join(localPath, monitorSubDir, ipAddr)
+	glog.Infof("updating DFS volume monitor file %s at write interval: %s", remoteFile, writeInterval)
+
+	for {
+		glog.V(2).Infof("writing DFS file %s", remoteFile)
+		if err := ioutil.WriteFile(remoteFile, []byte(ipAddr), 0600); err != nil {
+			glog.Warningf("unable to write DFS file %s: %s", remoteFile, err)
+		}
+
+		// wait for next cycle or shutdown
+		select {
+		case <-time.After(writeInterval):
+
+		case <-shutdown:
+			glog.Infof("no longer writing remote monitor status for DFS volume %s to %s", localPath, remoteFile)
+			return
+		}
+	}
+}
+
+// SetMonitorStorageClients sets the monitored remote IPs that are active
+func (m *Monitor) SetMonitorStorageClients(conn client.Connection, storageClientsPath string, clients ...string) {
+	m.conn = conn
+	m.storageClientsPath = storageClientsPath
+	m.SetMonitorRemoteHosts(getActiveRemoteHosts(conn, storageClientsPath, m.monitorInterval, clients...)...)
+}
+
+// SetMonitorRemoteHosts sets the remote hosts to monitor
+func (m *Monitor) SetMonitorRemoteHosts(ipAddrs ...string) {
+	m.monitoredHostsLock.Lock()
+	defer m.monitoredHostsLock.Unlock()
+	for _, ipAddr := range ipAddrs {
+		m.monitoredHosts[ipAddr] = true
+	}
+}
+
+// setMonitorRemoteHost updates the status of the monitored remote
+func (m *Monitor) setMonitorRemoteHost(ipAddr string, hasUpdated bool) {
+	m.monitoredHostsLock.Lock()
+	defer m.monitoredHostsLock.Unlock()
+	m.monitoredHosts[ipAddr] = hasUpdated
+}
+
+// getMonitorRemoteHosts returns the statuses of the monitored remotes
+func (m *Monitor) getMonitorRemoteHosts() map[string]bool {
+	m.monitoredHostsLock.RLock()
+	defer m.monitoredHostsLock.RUnlock()
+	return m.monitoredHosts
+}
+
+// ProcessDFSVolumePollUpdateFunc is called by MonitorDFSVolume when updates are detected
+type DFSVolumeMonitorPollUpdateFunc func(mountpoint, remoteIP string, isUpdated bool)
+
+// DFSVolumeMonitorPollUpdateFunc restarts nfs based on status of monitored remotes
+func (m *Monitor) DFSVolumeMonitorPollUpdateFunc(mountpoint, remoteIP string, hasUpdatedFile bool) {
+	// monitor dfs; log warnings each cycle; restart dfs if needed
+
+	if hasUpdatedFile {
+		return
+	} else if len(m.getMonitorRemoteHosts()) == 0 {
+		return
+	}
+
+	glog.Warningf("DFS NFS volume %s is not seen by remoteIP:%s - further action may be needed i.e: restart nfs", mountpoint, remoteIP)
+	now := time.Now()
+	since := now.Sub(m.previousRestart)
+	if !m.shouldRestart {
+		glog.Warningf("Not restarting DFS NFS service due to configuration setting: SERVICED_MONITOR_DFS_MASTER_RESTART=0")
+		return
+	} else if since < m.monitorInterval {
+		glog.Warningf("Not restarting DFS NFS service - have not surpassed interval: %s since last restart", m.monitorInterval)
+		return
+	}
+
+	m.previousRestart = now
+	if err := m.driver.Restart(); err != nil {
+		glog.Errorf("Error restarting DFS NFS service: %s", err)
+	}
+}
+
+// MonitorVolume monitors the DFS volume - logs on failure and calls pollUpdateFunc
+func (m *Monitor) MonitorDFSVolume(mountpoint string, shutdown <-chan interface{}, pollUpdateFunc DFSVolumeMonitorPollUpdateFunc) {
+	glog.Infof("monitoring DFS export info for DFS volume %s at polling interval: %s", mountpoint, m.monitorInterval)
+
+	m.previousRestart = time.Now()
+
+	monitorPath := path.Join(mountpoint, monitorSubDir)
+	os.RemoveAll(monitorPath)
+	if err := os.MkdirAll(monitorPath, 0755); err != nil {
+		glog.Errorf("no longer monitoring status for DFS volume %s - unable to mkdir %+v: %s", mountpoint, monitorPath, err)
+		return
+	}
+
+	for {
+		// check all active remotes
+		remotes := m.getMonitorRemoteHosts()
+		remoteIPs := make([]string, 0, len(remotes))
+		for k := range remotes {
+			remoteIPs = append(remoteIPs, k)
+		}
+
+		activeRemotes := remoteIPs
+		if m.conn != nil && len(m.storageClientsPath) != 0 {
+			activeRemotes = getActiveRemoteHosts(m.conn, m.storageClientsPath, m.monitorInterval, remoteIPs...)
+			glog.V(0).Infof("==== active remotes: %s checked from list of remotes: %s", activeRemotes, remoteIPs) // V(2)
+		}
+		// TODO: remoteIPs = getAllRemoteHostsFromZookeeper()
+		for _, remoteIP := range activeRemotes {
+			remoteFile := path.Join(monitorPath, remoteIP)
+			sinceModified, err := fileSinceModified(remoteFile)
+			hasUpdatedFile := false
+			if err != nil {
+				glog.Warningf("remote agent %s is not synced on DFS volume %s for file %s: %s", remoteIP, mountpoint, remoteFile, err)
+			} else if sinceModified > m.monitorInterval {
+				glog.Warningf("remote agent %s is not synced DFS volume %s for file %s (since modified: %s)", remoteIP, mountpoint, remoteFile, sinceModified)
+			} else {
+				glog.V(4).Infof("remote agent %s is synced on DFS volume %s for file %s (since modified: %s)", remoteIP, mountpoint, remoteFile, sinceModified)
+				hasUpdatedFile = true
+			}
+
+			m.setMonitorRemoteHost(remoteIP, hasUpdatedFile)
+			pollUpdateFunc(mountpoint, remoteIP, hasUpdatedFile)
+		}
+
+		// wait for next cycle or shutdown
+		select {
+		case <-time.After(m.monitorInterval):
+
+		case <-shutdown:
+			glog.Infof("no longer monitoring status for DFS volume %s", mountpoint)
+			return
+		}
+	}
+}
+
+// fileSinceModified returns the duration of the file since last modified
+func fileSinceModified(filename string) (time.Duration, error) {
+	fileinfo, err := os.Stat(filename)
+	if err != nil {
+		glog.V(2).Infof("unable to stat file: %s %s", filename, err)
+		return 0, err
+	}
+
+	timeSince := time.Now().Sub(fileinfo.ModTime())
+	glog.V(4).Infof("file %s was modified %s ago", filename, timeSince)
+	return timeSince, nil
+}
+
+// Get the variable determining if we will restart NFS when we detect a failure
+func getShouldRestartDFSOnFailure() bool {
+	shouldRestart := os.Getenv("SERVICED_MONITOR_DFS_MASTER_RESTART")
+	if len(shouldRestart) == 0 {
+		glog.Infof("defaulting SERVICED_MONITOR_DFS_MASTER_RESTART to true")
+		return true
+	} else if shouldRestart == "1" {
+		return true
+	} else {
+		return false
+	}
+}
+
+// getDefaultDFSMonitorRemoteInterval returns the duration specified in seconds for the env var SERVICED_DFS_MONITOR_REMOTE_UPDATE_INTERVAL
+func getDefaultDFSMonitorRemoteInterval() time.Duration {
+	return getEnvMinDuration("SERVICED_MONITOR_DFS_REMOTE_UPDATE_INTERVAL", 60, 60)
+}
+
+func getDefaultNFSMonitorMasterInterval() time.Duration {
+	min := getDefaultDFSMonitorRemoteInterval()
+	return getEnvMinDuration("SERVICED_MONITOR_DFS_MASTER_INTERVAL", 900, int32(min.Seconds())*2)
+}
+
+// getEnvMinDuration returns the time.Duration env var meeting minimum and default duration
+func getEnvMinDuration(envvar string, def, min int32) time.Duration {
+	duration := def
+	envval := os.Getenv(envvar)
+	if len(strings.TrimSpace(envval)) == 0 {
+		// ignore unset envvar
+	} else if intVal, intErr := strconv.ParseInt(envval, 0, 32); intErr != nil {
+		glog.Warningf("ignoring invalid %s of '%s': %s", envvar, envval, intErr)
+		duration = min
+	} else if int32(intVal) < min {
+		glog.Warningf("ignoring invalid %s of '%s' < minimum:%v seconds", envvar, envval, min)
+	} else {
+		duration = int32(intVal)
+	}
+
+	return time.Duration(duration) * time.Second
+}
+
+// StorageClientHostNode is the zookeeper node for a host
+type StorageClientHostNode struct {
+	host.Host
+	version interface{}
+}
+
+// Version is an implementation of client.Node
+func (v *StorageClientHostNode) Version() interface{} { return v.version }
+
+// SetVersion is an implementation of client.Node
+func (v *StorageClientHostNode) SetVersion(version interface{}) { v.version = version }
+
+// getActiveRemoteHosts returns a slice of activeClientIPs
+func getActiveRemoteHosts(conn client.Connection, zpath string, monitorInterval time.Duration, clients ...string) []string {
+	var activeClientIPs []string
+	now := time.Now()
+	for _, clnt := range clients {
+		cp := path.Join(zpath, clnt)
+		glog.V(0).Infof("retrieving info for DFS for remoteIP %s at zookeeper node %s", clnt, cp) // V2
+
+		hnode := StorageClientHostNode{}
+		err := conn.Get(cp, &hnode)
+		if err != nil && err != client.ErrEmptyNode {
+			glog.Errorf("DFS could not get zookeeper hostnode %s: %s", cp, err)
+			continue
+		}
+		if hnode.Host.UpdatedAt.IsZero() {
+			glog.Infof("DFS not monitoring non-active host %+v:  HostID:%v  UpdatedAt:%+v", clnt, hnode.ID, hnode.UpdatedAt)
+			continue
+		}
+
+		elapsed := now.Sub(hnode.Host.UpdatedAt)
+		glog.V(0).Infof("retrieved info for DFS for remoteIP %s  UpdatedAt:%s  elapsed:%s  monitorInterval:%s", clnt, hnode.Host.UpdatedAt, elapsed, monitorInterval) // V2
+		if elapsed > monitorInterval {
+			glog.Infof("DFS not monitoring non-active host %+v:  HostID:%v  UpdatedAt:%+v  lastseen:%s ago", clnt, hnode.ID, hnode.UpdatedAt, elapsed)
+			continue
+		}
+
+		activeClientIPs = append(activeClientIPs, clnt)
+	}
+
+	glog.V(0).Infof("DFS remote active IPs: %+v", activeClientIPs) // V2
+	return activeClientIPs
+}

--- a/coordinator/storage/monitor.go
+++ b/coordinator/storage/monitor.go
@@ -161,10 +161,11 @@ func (m *Monitor) MonitorDFSVolume(mountpoint string, shutdown <-chan interface{
 
 		activeRemotes := remoteIPs
 		if m.conn != nil && len(m.storageClientsPath) != 0 {
+			// TODO: remoteIPs = getAllRemoteHostsFromZookeeper() when deletion of zookeeper nodes are implemented in server.go
 			activeRemotes = getActiveRemoteHosts(m.conn, m.storageClientsPath, m.monitorInterval, remoteIPs...)
-			glog.V(0).Infof("==== active remotes: %s checked from list of remotes: %s", activeRemotes, remoteIPs) // V(2)
+			glog.V(2).Infof("==== active remotes: %s checked from list of remotes: %s", activeRemotes, remoteIPs)
 		}
-		// TODO: remoteIPs = getAllRemoteHostsFromZookeeper()
+
 		for _, remoteIP := range activeRemotes {
 			remoteFile := path.Join(monitorPath, remoteIP)
 			sinceModified, err := fileSinceModified(remoteFile)
@@ -265,7 +266,7 @@ func getActiveRemoteHosts(conn client.Connection, zpath string, monitorInterval 
 	now := time.Now()
 	for _, clnt := range clients {
 		cp := path.Join(zpath, clnt)
-		glog.V(0).Infof("retrieving info for DFS for remoteIP %s at zookeeper node %s", clnt, cp) // V2
+		glog.V(2).Infof("retrieving info for DFS for remoteIP %s at zookeeper node %s", clnt, cp)
 
 		hnode := StorageClientHostNode{}
 		err := conn.Get(cp, &hnode)
@@ -279,7 +280,7 @@ func getActiveRemoteHosts(conn client.Connection, zpath string, monitorInterval 
 		}
 
 		elapsed := now.Sub(hnode.Host.UpdatedAt)
-		glog.V(0).Infof("retrieved info for DFS for remoteIP %s  UpdatedAt:%s  elapsed:%s  monitorInterval:%s", clnt, hnode.Host.UpdatedAt, elapsed, monitorInterval) // V2
+		glog.V(2).Infof("retrieved info for DFS for remoteIP %s  UpdatedAt:%s  elapsed:%s  monitorInterval:%s", clnt, hnode.Host.UpdatedAt, elapsed, monitorInterval)
 		if elapsed > monitorInterval {
 			glog.Infof("DFS not monitoring non-active host %+v:  HostID:%v  UpdatedAt:%+v  lastseen:%s ago", clnt, hnode.ID, hnode.UpdatedAt, elapsed)
 			continue
@@ -288,6 +289,6 @@ func getActiveRemoteHosts(conn client.Connection, zpath string, monitorInterval 
 		activeClientIPs = append(activeClientIPs, clnt)
 	}
 
-	glog.V(0).Infof("DFS remote active IPs: %+v", activeClientIPs) // V2
+	glog.V(2).Infof("DFS remote active IPs: %+v", activeClientIPs)
 	return activeClientIPs
 }

--- a/coordinator/storage/monitor_test.go
+++ b/coordinator/storage/monitor_test.go
@@ -1,0 +1,120 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"github.com/zenoss/glog"
+
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+	"time"
+)
+
+// MockStorageDriver is an interface that mock the storage subsystem
+type MockStorageDriver struct {
+	exportPath string
+}
+
+func (m *MockStorageDriver) ExportPath() string {
+	return m.exportPath
+}
+
+func (m *MockStorageDriver) SetClients(clients ...string) {
+}
+
+func (m *MockStorageDriver) Sync() error {
+	return nil
+}
+
+func (m *MockStorageDriver) Restart() error {
+	return nil
+}
+
+func TestMonitorVolume(t *testing.T) {
+	// create temporary proc dir
+	tmpPath, err := ioutil.TempDir("", "storage")
+	if err != nil {
+		t.Fatalf("could not create tempdir %+v: %s", tmpPath, err)
+	}
+	defer os.RemoveAll(tmpPath)
+
+	if err := os.MkdirAll(tmpPath, 0755); err != nil {
+		t.Fatalf("unable to mkdir %+v: %s", tmpPath, err)
+	}
+
+	// make shutdown channel
+	shutdown := make(chan interface{})
+	defer close(shutdown)
+
+	// ---- create mock driver
+	driver := &MockStorageDriver{
+		exportPath: tmpPath,
+	}
+
+	// ---- start monitor
+	monitor, err := NewMonitor(driver, time.Duration(3*time.Second))
+	if err != nil {
+		t.Fatalf("unable to create new monitor %s", err)
+	}
+
+	updatedCount := 0
+	pDFSVolumeMonitorPollUpdateFunc := func(mountpoint, remoteIP string, isUpdated bool) {
+		glog.Infof("==== received remoteIP:%v isUpdated:%+v", remoteIP, isUpdated)
+		if isUpdated {
+			updatedCount++
+		}
+	}
+
+	go monitor.MonitorDFSVolume(tmpPath, shutdown, pDFSVolumeMonitorPollUpdateFunc)
+
+	time.Sleep(time.Second * 2)
+
+	// ---- start writer; wait some time; check that the update count increased
+	glog.Infof("==== starting writer")
+	remoteIP := "127.0.0.1"
+	monitor.SetMonitorRemoteHosts(remoteIP)
+
+	remoteShutdown := make(chan interface{})
+	defer close(remoteShutdown)
+	writeInterval := time.Duration(1 * time.Second)
+	go UpdateRemoteMonitorFile(tmpPath, writeInterval, remoteIP, remoteShutdown)
+
+	// wait some time
+	waitTime := time.Second * 12
+	time.Sleep(waitTime)
+
+	monitorPath := path.Join(tmpPath, monitorSubDir)
+	if updatedCount < 3 {
+		t.Fatalf("have not seen any updates to dir %s", monitorPath)
+	}
+
+	// ---- stop writing; wait some time; check count has not increased
+	glog.Infof("==== stopping writer")
+	remoteShutdown <- true
+
+	// wait some time for shutdown
+	time.Sleep(2 * writeInterval)
+	updatedCount = 0
+
+	// wait some time
+	time.Sleep(waitTime)
+
+	if updatedCount != 0 {
+		t.Fatalf("updates (updatedCount: %d) should not have occurred to dir %s", updatedCount, monitorPath)
+	}
+
+	glog.Infof("==== current updatedCount:%+v", updatedCount)
+}

--- a/coordinator/storage/server.go
+++ b/coordinator/storage/server.go
@@ -96,7 +96,7 @@ func (s *Server) Run(shutdown <-chan interface{}, conn client.Connection) error 
 			return err
 		}
 
-		s.monitor.SetMonitorStorageClients(conn, storageClientsPath, clients...)
+		s.monitor.SetMonitorStorageClients(conn, storageClientsPath)
 		s.driver.SetClients(clients...)
 		if err := s.driver.Sync(); err != nil {
 			glog.Errorf("Error syncing driver: %s", err)
@@ -114,4 +114,3 @@ func (s *Server) Run(shutdown <-chan interface{}, conn client.Connection) error 
 		}
 	}
 }
-

--- a/coordinator/storage/server.go
+++ b/coordinator/storage/server.go
@@ -15,13 +15,8 @@ package storage
 
 import (
 	"fmt"
-	"os"
 	"path"
-	"strconv"
-	"strings"
-	"time"
 
-	"github.com/control-center/serviced/commons/proc"
 	"github.com/control-center/serviced/coordinator/client"
 	"github.com/control-center/serviced/coordinator/client/zookeeper"
 	"github.com/control-center/serviced/domain/host"
@@ -30,8 +25,9 @@ import (
 
 // Server manages the exporting of a file system to clients.
 type Server struct {
-	host   *host.Host
-	driver StorageDriver
+	host    *host.Host
+	driver  StorageDriver
+	monitor *Monitor
 }
 
 // StorageDriver is an interface that storage subsystem must implement to be used
@@ -49,9 +45,15 @@ func NewServer(driver StorageDriver, host *host.Host) (*Server, error) {
 		return nil, fmt.Errorf("export path can not be empty")
 	}
 
+	monitor, err := NewMonitor(driver, getDefaultNFSMonitorMasterInterval())
+	if err != nil {
+		return nil, fmt.Errorf("unable to create new monitor %s", err)
+	}
+
 	s := &Server{
-		host:   host,
-		driver: driver,
+		host:    host,
+		driver:  driver,
+		monitor: monitor,
 	}
 
 	return s, nil
@@ -68,8 +70,10 @@ func (s *Server) Run(shutdown <-chan interface{}, conn client.Connection) error 
 		conn.CreateDir("/storage/leader")
 	}
 
-	if exists, _ := conn.Exists("/storage/clients"); !exists {
-		conn.CreateDir("/storage/clients")
+	storageClientsPath := "/storage/clients"
+
+	if exists, _ := conn.Exists(storageClientsPath); !exists {
+		conn.CreateDir(storageClientsPath)
 	}
 
 	leader := conn.NewLeader("/storage/leader", node)
@@ -79,31 +83,20 @@ func (s *Server) Run(shutdown <-chan interface{}, conn client.Connection) error 
 		return err
 	}
 
-	processExportedVolumeChangeFunc := func(mountpoint string, isExported bool) {
-		if !isExported {
-			glog.Warningf("DFS NFS volume %s is not exported - take further action i.e: restart nfs", mountpoint)
-			/*
-				// TODO: restart nfs when active num remotes > 0
-				// race condition with restarting nfs on master and mounting on
-				// remote is seen if nfs is prematurely started before any remotes
-				// check in
-				if err := s.driver.Restart(); err != nil {
-					glog.Errorf("Error restarting driver: %s", err)
-				}
-			*/
-		}
-	}
-	go proc.MonitorExportedVolume(path.Join("/exports", s.driver.ExportPath()), getDefaultNFSMonitorInterval(), shutdown, processExportedVolumeChangeFunc)
+	// monitor dfs; log warnings each cycle; restart dfs if needed
+	go s.monitor.MonitorDFSVolume(path.Join("/exports", s.driver.ExportPath()), shutdown, s.monitor.DFSVolumeMonitorPollUpdateFunc)
 
+	// loop until shutdown event
 	defer leader.ReleaseLead()
 
 	for {
-		clients, clientW, err := conn.ChildrenW("/storage/clients")
+		clients, clientW, err := conn.ChildrenW(storageClientsPath)
 		if err != nil {
 			glog.Errorf("Could not set up watch for storage clients: %s", err)
 			return err
 		}
 
+		s.monitor.SetMonitorStorageClients(conn, storageClientsPath, clients...)
 		s.driver.SetClients(clients...)
 		if err := s.driver.Sync(); err != nil {
 			glog.Errorf("Error syncing driver: %s", err)
@@ -120,17 +113,4 @@ func (s *Server) Run(shutdown <-chan interface{}, conn client.Connection) error 
 			return nil
 		}
 	}
-}
-
-func getDefaultNFSMonitorInterval() time.Duration {
-	var monitorInterval int32 = 60 // default is 60 seconds
-	monitorIntervalString := os.Getenv("SERVICED_NFS_MONITOR_INTERVAL")
-	if len(strings.TrimSpace(monitorIntervalString)) == 0 {
-	} else if intVal, intErr := strconv.ParseInt(monitorIntervalString, 0, 32); intErr != nil {
-		glog.Warningf("ignoring invalid SERVICED_NFS_MONITOR_INTERVAL of '%s': %s", monitorIntervalString, intErr)
-	} else {
-		monitorInterval = int32(intVal)
-	}
-
-	return time.Duration(monitorInterval) * time.Second
 }

--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -109,6 +109,23 @@
 # Max number tracked connections for iptables
 # SERVICED_IPTABLES_MAX_CONNECTIONS=655360
 
+# The interval, in seconds, at which a serviced instance configured as agent
+# modifies its /opt/serviced/var/monitor/<IP-Address> file.
+# Default: 60     (1 minute)
+# SERVICED_MONITOR_DFS_REMOTE_UPDATE_INTERVAL=60
+
+# The interval, in seconds, at which a serviced instance configured as master
+# checks the modification times of the /opt/serviced/var/monitor/<IP-Address>
+# files of active serviced instances configured as agents. The value of this
+# variable must be a minimum of twice the value of the
+# SERVICED_MONITOR_DFS_REMOTE_UPDATE_INTERVAL variable.
+# Default: 900    (15 minutes)
+# SERVICED_MONITOR_DFS_MASTER_INTERVAL=900
+
+# Set to 0 in order to disable restarting nfs upon out of sync detection
+# Default: 1    (enable)
+# SERVICED_MONITOR_DFS_MASTER_RESTART=1
+
 # Arbitrary serviced daemon args
 # SERVICED_OPTS=
 


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-742

DEMO:
```
~/src/europa/src/golang/src/github.com/control-center/serviced/coordinator/storage
# plu@plu-9: go test -v
=== RUN TestClient
--- SKIP: TestClient (0.00 seconds)
	client_test.go:34: Test cluster is not set up properly
=== RUN TestMonitorVolume
I0124 11:18:21.416346 17580 monitor.go:96] monitoring DFS export info for DFS volume /tmp/storage199463140 at polling interval: 3s
I0124 11:18:23.416319 17580 monitor_test.go:56] ==== starting writer
I0124 11:18:23.416379 17580 monitor.go:41] writing remote monitor file to DFS volume /tmp/storage199463140 at interval: 1s
I0124 11:18:23.416404 17580 monitor.go:45] writing DFS file /tmp/storage199463140/monitor/127.0.0.1
I0124 11:18:24.416664 17580 monitor.go:45] writing DFS file /tmp/storage199463140/monitor/127.0.0.1
I0124 11:18:24.416893 17580 monitor.go:145] file /tmp/storage199463140/monitor/127.0.0.1 was modified 6.667821ms ago
I0124 11:18:24.416911 17580 monitor.go:117] remote agent 127.0.0.1 is synced on DFS volume /tmp/storage199463140 for file /tmp/storage199463140/monitor/127.0.0.1 (since modified: 6.667821ms)
I0124 11:18:24.416925 17580 monitor_test.go:45] ==== received remoteIP:127.0.0.1 isUpdated:true
I0124 11:18:25.416987 17580 monitor.go:45] writing DFS file /tmp/storage199463140/monitor/127.0.0.1
I0124 11:18:26.417365 17580 monitor.go:45] writing DFS file /tmp/storage199463140/monitor/127.0.0.1
I0124 11:18:27.417135 17580 monitor.go:145] file /tmp/storage199463140/monitor/127.0.0.1 was modified 1.002913479s ago
I0124 11:18:27.417180 17580 monitor.go:117] remote agent 127.0.0.1 is synced on DFS volume /tmp/storage199463140 for file /tmp/storage199463140/monitor/127.0.0.1 (since modified: 1.002913479s)
I0124 11:18:27.417206 17580 monitor_test.go:45] ==== received remoteIP:127.0.0.1 isUpdated:true
I0124 11:18:27.417840 17580 monitor.go:45] writing DFS file /tmp/storage199463140/monitor/127.0.0.1
I0124 11:18:28.418122 17580 monitor.go:45] writing DFS file /tmp/storage199463140/monitor/127.0.0.1
I0124 11:18:29.418456 17580 monitor.go:45] writing DFS file /tmp/storage199463140/monitor/127.0.0.1
I0124 11:18:30.417380 17580 monitor.go:145] file /tmp/storage199463140/monitor/127.0.0.1 was modified 1.00315692s ago
I0124 11:18:30.417426 17580 monitor.go:117] remote agent 127.0.0.1 is synced on DFS volume /tmp/storage199463140 for file /tmp/storage199463140/monitor/127.0.0.1 (since modified: 1.00315692s)
I0124 11:18:30.417440 17580 monitor_test.go:45] ==== received remoteIP:127.0.0.1 isUpdated:true
I0124 11:18:30.418768 17580 monitor.go:45] writing DFS file /tmp/storage199463140/monitor/127.0.0.1
I0124 11:18:31.419084 17580 monitor.go:45] writing DFS file /tmp/storage199463140/monitor/127.0.0.1
I0124 11:18:32.419441 17580 monitor.go:45] writing DFS file /tmp/storage199463140/monitor/127.0.0.1
I0124 11:18:33.416525 17580 monitor_test.go:75] ==== stopping writer
I0124 11:18:33.416573 17580 monitor.go:55] no longer writing remote monitor status for DFS volume /tmp/storage199463140 to /tmp/storage199463140/monitor/127.0.0.1
I0124 11:18:33.417602 17580 monitor.go:145] file /tmp/storage199463140/monitor/127.0.0.1 was modified 1.003377201s ago
I0124 11:18:33.417631 17580 monitor.go:117] remote agent 127.0.0.1 is synced on DFS volume /tmp/storage199463140 for file /tmp/storage199463140/monitor/127.0.0.1 (since modified: 1.003377201s)
I0124 11:18:33.417644 17580 monitor_test.go:45] ==== received remoteIP:127.0.0.1 isUpdated:true
I0124 11:18:36.417823 17580 monitor.go:145] file /tmp/storage199463140/monitor/127.0.0.1 was modified 4.003597666s ago
W0124 11:18:36.417887 17580 monitor.go:115] remote agent 127.0.0.1 is not synced DFS volume /tmp/storage199463140 for file /tmp/storage199463140/monitor/127.0.0.1 (since modified: 4.003597666s)
I0124 11:18:36.417921 17580 monitor_test.go:45] ==== received remoteIP:127.0.0.1 isUpdated:false
I0124 11:18:39.418101 17580 monitor.go:145] file /tmp/storage199463140/monitor/127.0.0.1 was modified 7.003875619s ago
W0124 11:18:39.418145 17580 monitor.go:115] remote agent 127.0.0.1 is not synced DFS volume /tmp/storage199463140 for file /tmp/storage199463140/monitor/127.0.0.1 (since modified: 7.003875619s)
I0124 11:18:39.418160 17580 monitor_test.go:45] ==== received remoteIP:127.0.0.1 isUpdated:false
I0124 11:18:42.418304 17580 monitor.go:145] file /tmp/storage199463140/monitor/127.0.0.1 was modified 10.004078255s ago
W0124 11:18:42.418346 17580 monitor.go:115] remote agent 127.0.0.1 is not synced DFS volume /tmp/storage199463140 for file /tmp/storage199463140/monitor/127.0.0.1 (since modified: 10.004078255s)
I0124 11:18:42.418360 17580 monitor_test.go:45] ==== received remoteIP:127.0.0.1 isUpdated:false
I0124 11:18:45.416935 17580 monitor_test.go:89] ==== current updatedCount:0
I0124 11:18:45.416995 17580 monitor.go:130] no longer monitoring status for DFS volume /tmp/storage199463140
--- PASS: TestMonitorVolume (24.00 seconds)
=== RUN TestServer
--- SKIP: TestServer (0.00 seconds)
	server_test.go:60: 
PASS
ok  	github.com/control-center/serviced/coordinator/storage	24.010s
```