### PR TITLE
Run 'npm install' in the serviced-build container to precache NPM packag...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ isvcs/build/*.tar.gz
 *.iml
 *.test
 
+build/package.json
+build/npmLink.sh
+
 web/node_modules/
 web/static/js/controlplane.js
 web/static/js/controlplane.js.map

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -51,4 +51,10 @@ RUN	apt-get install -y -q rpm
 RUN	apt-get install -y -q mercurial bzr
 RUN apt-get install -y -q libdevmapper-dev libsqlite3-dev
 
+# Cache the NPM packages within the docker image
+RUN mkdir -p /npm-cache/serviced/node_modules
+ADD package.json /npm-cache/serviced/package.json
+WORKDIR /npm-cache/serviced
+RUN npm install
+
 WORKDIR	/go/src/github.com/control-center/serviced

--- a/web/README.md
+++ b/web/README.md
@@ -50,8 +50,9 @@ If you want to install them locally, refer to the commands in [`serviced/build/D
 
 Once the pre-requisite build tools are installed, all other components of the JS tool chain are downloaded by NPM based on the definitions in [`serviced/web/package.json`](./package.json).  If you build with make, this download happens automatically. If you are not building with make, you will need to run the command `npm install` once to download the rest of the tool chain.
 
-**NOTE:** NPM will cache everything it downloads in `serviced/web/node_modules`.  In the unlikely event, you encoutner a problem with
-incompatible tool versions, you may have to delete this directory and download a fresh set of dependencies by rerunning the make (or running `npm install` if you have installed npm on your local).
+**NOTE:** NPM will cache everything it downloads in `serviced/web/node_modules`.  When building with the `serviced-build` docker image, the make process will create a soft-link from `serviced/web/node_modules` to a location on the image where the packages are pre-cached. However, when building with a local copy of node, npm, etc, the build system expects `serviced/web/node_modules` to be a local directory
+  * If you switch from building with the docker build image to building locally, you must first delete `serviced/web/node_modules`
+  * In the unlikely event, you encounter a problem with incompatible tool versions, you may have to delete this directory and download a fresh set of dependencies by rerunning the make (or running `npm install` if you have installed npm on your local).  If you
 
 ### Updating dev tool versions
 To change a version of one of the prerequisite tools (node.js, npm, gulp or 6to5), you must edit [`serviced/build/Dockerfile`](../build/Dockerfile) to include the necessary changes.  Be sure to test with a clean build, removing `serviced/web/node_modules` just to be safe.

--- a/web/makefile
+++ b/web/makefile
@@ -43,34 +43,48 @@ test: build test_js
 	go test -i ;\
 	go test $(GOTEST_FLAGS)
 
-.PHONY: test_js
-test_js:
+# This task installs the necessary NPM packages.
+#	If the user has node installed locally, then run npm install locally.
+# 	Otherwise, rebuild the the serviced-build container which will execute 'npm install'
+#	 as part of the image, thereby caching the npm packages inside the docker image.
+npmInstall: ../build/package.json ../build/npmLink.sh
 	if [ -x "$(NODEJS)" ]; then \
+		./npmLink.sh; \
 		npm install; \
-		gulp test; \
 	else \
 		docker build -t zenoss/serviced-build ../build; \
+	fi
+
+../build/package.json: package.json
+	cp package.json ../build
+
+../build/npmLink.sh: npmLink.sh
+	cp npmLink.sh ../build
+
+.PHONY: test_js
+test_js: npmInstall
+	if [ -x "$(NODEJS)" ]; then \
+		gulp test; \
+	else \
 		docker run --rm \
 		-v $(PWD):$(docker_working_DIR) \
 		-e UID_X=$(shell id -u) \
 		-e GID_X=$(shell id -g) \
 		zenoss/serviced-build \
-		/bin/bash -c "source /root/userdo.sh \"cd $(docker_working_DIR) && npm install && gulp test\""; \
+		/bin/bash -c "source /root/userdo.sh \"cd $(docker_working_DIR) && ./npmLink.sh && gulp test\""; \
 	fi
 
 .PHONY: build_js build-js
-build_js build-js:
+build_js build-js: npmInstall
 	if [ -x "$(NODEJS)" ]; then \
-		npm install; \
 		gulp release; \
 	else \
-		docker build -t zenoss/serviced-build ../build; \
 		docker run --rm \
 		-v $(PWD):$(docker_working_DIR) \
 		-e UID_X=$(shell id -u) \
 		-e GID_X=$(shell id -g) \
 		zenoss/serviced-build \
-		/bin/bash -c "source /root/userdo.sh \"cd $(docker_working_DIR) && npm install && gulp release\""; \
+		/bin/bash -c "source /root/userdo.sh \"cd $(docker_working_DIR) && ./npmLink.sh && gulp release\""; \
 	fi
 
 .PHONY: clean

--- a/web/npmLink.sh
+++ b/web/npmLink.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# This script encapsulates the logic to link the local './node_modules' to a
+#	predefined NPM cache.
+#
+
+if [ -h ./node_modules ]
+then
+	LINK_TARGET=`readlink ./node_modules`
+	if [ ! -d ${LINK_TARGET} ]
+	then
+		echo "ERROR: target=${LINK_TARGET} for soft link ./node_modules does not exist"
+		exit 1
+	fi
+fi
+
+if [ ! -d ./node_modules -a ! -h ./node_modules ]
+then
+	if [ -d /npm-cache/serviced/node_modules ]
+	then
+		# This case should only happen when running inside the serviced-build
+		#     docker container where the root user populates the cache, but
+		#	  build user needs to link to it.
+		NODE_MODULES_DIR=/npm-cache/serviced/node_modules
+		echo "Making node_modules link to $NODE_MODULES_DIR"
+		ln -s ${NODE_MODULES_DIR} ./node_modules
+	fi
+fi


### PR DESCRIPTION
@jplouis - the intent is to speed up builds for developers who haven't taken extra steps to install node. I can explain the problem and solution better in person than in prose.