### PR TITLE
invert precedence of mount sources - cmdline overrides service

### DIFF
--- a/cli/api/shell.go
+++ b/cli/api/shell.go
@@ -77,10 +77,20 @@ func buildMounts(lbClientPort string, serviceID string, defaultMounts []string) 
 		return nil, err
 	}
 
+	dsts := map[string]string{}
+	for _, mnt := range defaultMounts {
+		parts := strings.Split(mnt, ",")
+		if len(parts) > 1 {
+			dsts[parts[1]] = parts[0] // dsts[dst] = src
+		}
+	}
+
 	mounts := defaultMounts
 	for hostPath, containerPath := range bindmounts {
-		bind := hostPath + "," + containerPath
-		mounts = append(mounts, bind)
+		if _, ok := dsts[containerPath]; !ok {
+			bind := hostPath + "," + containerPath
+			mounts = append(mounts, bind)
+		}
 	}
 
 	return mounts, nil


### PR DESCRIPTION
DEMO:
```
eedgar@ip-10-111-5-207:~/src/europa$ zendev devshell zenpack --list
I0128 21:28:55.628465 14395 server.go:341] Connected to the control center at port 10.111.5.207:4979
I0128 21:28:55.736268 14395 server.go:435] Acquiring image from the dfs...
I0128 21:28:55.737317 14395 server.go:437] Acquired!  Starting shell
Trying to connect to logstash server... 127.0.0.1:5042
Connected to logstash server.
ZenPacks.zenoss.PythonCollector (/mnt/src/zenpacks/ZenPacks.zenoss.PythonCollector)
ZenPacks.zenoss.ZenJMX (/mnt/src/zenpacks/ZenPacks.zenoss.ZenJMX)
eedgar@ip-10-111-5-207:~/src/europa$ 

```