### PR TITLE
fixes CC-757: replace sleep 5s with sync for optimized service volume initialization

### DIFF
--- a/node/utils.go
+++ b/node/utils.go
@@ -310,6 +310,8 @@ func createVolumeDir(hostPath, containerSpec, imageSpec, userSpec, permissionSpe
 	createVolumeDirMutex.Lock()
 	defer createVolumeDirMutex.Unlock()
 
+	starttime := time.Now()
+
 	// FIXME: this relies on the underlying container to have /bin/sh that supports
 	// some advanced shell options. This should be rewriten so that serviced injects itself in the
 	// container and performs the operations using only go!
@@ -336,7 +338,7 @@ if [ ! -d "%s" ]; then
 elif [ ${#files[@]} -eq 0 ]; then
 	cp -rp %s/* /mnt/dfs/
 fi
-sleep 5s
+sync
 `, userSpec, permissionSpec, containerSpec, containerSpec, containerSpec),
 	}
 
@@ -344,6 +346,8 @@ sleep 5s
 		docker := exec.Command(command[0], command[1:]...)
 		output, err = docker.CombinedOutput()
 		if err == nil {
+			duration := time.Now().Sub(starttime)
+			glog.V(2).Infof("volume init took %s for src:%s dst:%s image:%s user:%s perm:%s", duration, hostPath, containerSpec, imageSpec, userSpec, permissionSpec)
 			return nil
 		}
 		time.Sleep(time.Second)


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-757

I would prefer the 2 optimizations here https://github.com/control-center/serviced/pull/1547

After a fresh deploy of zenoss.resmgr using the 'sync' fix, waiting for all services to start (assigned containers) took 2 minutes 30 seconds 

DEMO
```
[root@ip-10-111-3-218 bin]# date;serviced service start zenoss.resmgr
Wed Jan 28 22:22:21 EST 2015
Scheduled 43 service(s) to start
[root@ip-10-111-3-218 bin]# date;serviced service status
Wed Jan 28 22:24:53 EST 2015
NAME			ID				STATUS		UPTIME			HOST				IN_SYNC		DOCKER_ID
└─Zenoss.resmgr		a618rho6hh8awfstyfyq8wfyb	Running		2m21.443244445s		ip-10-111-3-218.zenoss.loc	Y		8c0a3e80e1e6
  ├─CentralQuery	2e3y3lrkpqf86g9s9tr3k5l6u	Running		2m23.32310351s		ip-10-111-3-218.zenoss.loc	Y		dc4b5d52562d
  ├─zeneventd		3m4xovi50znaohebc6lwg5van	Running		48.486694989s		ip-10-111-3-218.zenoss.loc	Y		9b4599c166d7
  ├─Zope/0		4b7plsd0rhs3pgiu6fud5jef9/0	Running		32.449687145s		ip-10-111-3-218.zenoss.loc	Y		eee80a657d29
  ├─Zope/1		4b7plsd0rhs3pgiu6fud5jef9/1	Running		18.518201469s		ip-10-111-3-218.zenoss.loc	Y		7e0b6cc5e11e
  ├─Zope/2		4b7plsd0rhs3pgiu6fud5jef9/2	Running		18.589388896s		ip-10-111-3-218.zenoss.loc	Y		68773ea77f05
  ├─Zope/3		4b7plsd0rhs3pgiu6fud5jef9/3	Running		50.771535778s		ip-10-111-3-218.zenoss.loc	Y		5f86979ee761
  ├─Zope/4		4b7plsd0rhs3pgiu6fud5jef9/4	Running		25.71256166s		ip-10-111-3-218.zenoss.loc	Y		6a6e9375e5ae
  ├─Zope/5		4b7plsd0rhs3pgiu6fud5jef9/5	Running		7.683491051s		ip-10-111-3-218.zenoss.loc	Y		936f0d717611
  ├─redis		6eefyai4rj6zki9ho93541emu	Running		2m17.875256933s		ip-10-111-3-218.zenoss.loc	Y		7832764132da
  ├─zencatalogservice	6hbib14iv5esv6i3sb8y2xa2s	Running		1m10.672537077s		ip-10-111-3-218.zenoss.loc	Y		1640956cb2d9
  ├─RabbitMQ		6yqnwii5tc3tw8lmaynortbym	Running		1m32.602838963s		ip-10-111-3-218.zenoss.loc	Y		b6cdf5fcf7d8
  ├─MetricShipper	83nta5vhork4ij758vt3n3v0f	Running		2m27.536481963s		ip-10-111-3-218.zenoss.loc	Y		adde77237402
  ├─zeneventserver	8qbgqkwmi60n423l8z6pu2u3a	Running		1m26.605622022s		ip-10-111-3-218.zenoss.loc	Y		667cb3bc98bb
  ├─memcached		8yuphe9rgxlqfh0k4pcukmnax	Running		2m18.828752738s		ip-10-111-3-218.zenoss.loc	Y		eb9690b0caf5
  ├─zenjobs		9lpfeeovkp9hgdznewykbe7e5	Running		38.008380258s		ip-10-111-3-218.zenoss.loc	Y		e8ec31d2077e
  ├─HBase		9whmp742bhch6wdl4h7zbiz5l												
  │ ├─ZooKeeper/0	1itmo19xkyigy0aozvshi7jpf/0	Running		1m30.321449478s		ip-10-111-3-218.zenoss.loc	Y		7f931a26100c
  │ ├─ZooKeeper/1	1itmo19xkyigy0aozvshi7jpf/1	Running		1m7.81898964s		ip-10-111-3-218.zenoss.loc	Y		aa73974169bc
  │ ├─ZooKeeper/2	1itmo19xkyigy0aozvshi7jpf/2	Running		1m30.42076162s		ip-10-111-3-218.zenoss.loc	Y		53bcf1bae913
  │ ├─HMaster		5ltsq2ixkvrf5z4c202qacepv	Running		1m39.024534015s		ip-10-111-3-218.zenoss.loc	Y		b98dd8bf39e7
  │ ├─RegionServer/0	ekan7wowyx26kyvqt5lkjottb/0	Running		1m38.793036931s		ip-10-111-3-218.zenoss.loc	Y		d3f0f4e206e2
  │ ├─RegionServer/1	ekan7wowyx26kyvqt5lkjottb/1	Running		1m38.981229542s		ip-10-111-3-218.zenoss.loc	Y		fc5631336534
  │ └─RegionServer/2	ekan7wowyx26kyvqt5lkjottb/2	Running		1m38.877049416s		ip-10-111-3-218.zenoss.loc	Y		e69dbc415d32
  ├─MariaDB		afxzycg7yddou1u17zds1zsrr	Running		1m38.707437102s		ip-10-111-3-218.zenoss.loc	Y		acfd1c0e973b
  ├─Zauth		c3rijqzvm4vxuetx99uenkm37	Running		1m59.720468612s		ip-10-111-3-218.zenoss.loc	Y		0c256fbfc132
  ├─localhost		c54stn8hq9mydaq0uryjpnmql												
  │ ├─localhost		28n2us9y2va86g1ckled99j23												
  │ │ ├─zensyslog	1xj8i6ghh5tvtg5occuk1ey4z	Running		1m5.674731496s		ip-10-111-3-218.zenoss.loc	Y		840125526f82
  │ │ ├─zenstatus	457cwhvxai1g5c6ox4ejzi5y5	Running		1m3.576911304s		ip-10-111-3-218.zenoss.loc	Y		5bdf5fbdb96a
  │ │ ├─zenmailtx	4aspsge63vayq30te5mbyuu9	Running		1m22.784383201s		ip-10-111-3-218.zenoss.loc	Y		756ef8125e4c
  │ │ ├─zminion		4lh681gsq0h4l8hacb2vlix24	Running		2m7.654783125s		ip-10-111-3-218.zenoss.loc	Y		22e3d450bf28
  │ │ ├─zenping		4sfb0lhssmg0t6qizbniv1zqk	Running		1m34.431590395s		ip-10-111-3-218.zenoss.loc	Y		c6bb860faed0
  │ │ ├─zenperfsnmp	5gxl4kpx18ldkdehknlp76ziy	Running		2m25.200469887s		ip-10-111-3-218.zenoss.loc	Y		c196007a9826
  │ │ ├─zenucsevents	5ox2aglmama6sw0x8xlzjyii1	Running		2m11.987743796s		ip-10-111-3-218.zenoss.loc	Y		a57159320090
  │ │ ├─zenvsphere	6hjyhkzlb5dyy3iugrcl5ps4t	Running		2m15.39331708s		ip-10-111-3-218.zenoss.loc	Y		a44dde5f761c
  │ │ ├─zenpython	6vg4kralt6yvzowgyoy8jeyfn	Running		43.121193193s		ip-10-111-3-218.zenoss.loc	Y		8c18ae99b85d
  │ │ ├─zenprocess	8h2c96eefdxlm2j8pbrntl1ux	Running		1m17.985354609s		ip-10-111-3-218.zenoss.loc	Y		044e60e91710
  │ │ ├─MetricShipper	d33laka7o98pvxpbgnblq0g4c	Running		2m25.718118417s		ip-10-111-3-218.zenoss.loc	Y		4302cb421903
  │ │ ├─zenwebtx	dumic00zj406m73uo81hqi0kr	Running		2m11.814332235s		ip-10-111-3-218.zenoss.loc	Y		a62d782ad37d
  │ │ ├─collectorredis	dwtdi0nbozlyayy1ga22yexyx	Running		2m22.609152755s		ip-10-111-3-218.zenoss.loc	Y		764946bfac18
  │ │ ├─zencommand	e1cogecfm0rswmragcr6c9t0j	Running		2m20.628484152s		ip-10-111-3-218.zenoss.loc	Y		316182583ceb
  │ │ ├─zentrap		e396q19dx9y867kmt8m9rflw1	Running		1m32.334824272s		ip-10-111-3-218.zenoss.loc	Y		535313db329f
  │ │ ├─zenjmx		wk18m14ywm3cgfz92joishet	Running		1m59.836872382s		ip-10-111-3-218.zenoss.loc	Y		29aebd4070e6
  │ │ └─zenmodeler	x9o2zkainoay6t5gv9ihrkqp	Running		2m22.600645855s		ip-10-111-3-218.zenoss.loc	Y		fe61ee4a2fe2
  │ └─zenhub		2a3arq08xuqe8zr629zfd27uq	Running		1m3.764523745s		ip-10-111-3-218.zenoss.loc	Y		8af1a461ff8d
  ├─MetricConsumer	eo8s6rm7akhpjfnnle1oo7k7b	Running		2m27.534495248s		ip-10-111-3-218.zenoss.loc	Y		81ee78238830
  ├─opentsdb		ki4ltqhoqgucglaytvp5y5iw												
  │ ├─reader		3r2piofverpif13mf309kszhf	Running		2m16.122981685s		ip-10-111-3-218.zenoss.loc	Y		23c7ebb996c8
  │ └─writer		499xp36mtauhaoah480hjago6	Running		2m23.552207292s		ip-10-111-3-218.zenoss.loc	Y		3a130e9e471d
  ├─zenjserver		ufrlic3vm4znha1hshszm01s	Running		1m27.554798248s		ip-10-111-3-218.zenoss.loc	Y		6019cbbf1971
  └─zenactiond		xldh7a0mhb4170voa8d4nl3m	Running		1m10.233281316s		ip-10-111-3-218.zenoss.loc	Y		f905457e1fb9
[root@ip-10-111-3-218 bin]# 
```

DEMO - journal of some volume inits
```
[root@ip-10-111-3-218 bin]# journalctl -u serviced -o cat |grep "volume init"
...
I0129 02:54:42.082612 13053 utils.go:349] volume init took 2015-01-29 02:54:40.912171688 +0000 UTC for src:/opt/serviced/var/volumes/9vay35yyq1ilq9xfhvumiar6i/zeneventserver dst:/opt/zenoss/var/zeneventserver image:localhost:5000/9vay35yyq1ilq9xfhvumiar6i/resmgr-unstable user:zenoss:zenoss perm:0775
I0129 02:54:53.760689 13053 utils.go:349] volume init took 2015-01-29 02:54:52.452538267 +0000 UTC for src:/opt/serviced/var/volumes/9vay35yyq1ilq9xfhvumiar6i/redis dst:/var/lib/redis image:localhost:5000/9vay35yyq1ilq9xfhvumiar6i/resmgr-unstable user:root:root perm:0755
I0129 02:55:05.570552 13053 utils.go:349] volume init took 2015-01-29 02:55:04.290522601 +0000 UTC for src:/opt/serviced/var/volumes/9vay35yyq1ilq9xfhvumiar6i/localhost/localhost_collectorredis dst:/var/lib/redis image:localhost:5000/9vay35yyq1ilq9xfhvumiar6i/resmgr-unstable user:root:root perm:0755
I0129 02:55:07.125040 13053 utils.go:349] volume init took 2015-01-29 02:55:05.574170678 +0000 UTC for src:/opt/serviced/var/volumes/9vay35yyq1ilq9xfhvumiar6i/rabbitmq dst:/var/lib/rabbitmq image:localhost:5000/9vay35yyq1ilq9xfhvumiar6i/resmgr-unstable user:rabbitmq:rabbitmq perm:0750
I0129 02:55:21.692511 13053 utils.go:349] volume init took 2015-01-29 02:55:20.575823586 +0000 UTC for src:/opt/serviced/var/volumes/9vay35yyq1ilq9xfhvumiar6i/hbase-master dst:/var/hbase image:localhost:5000/9vay35yyq1ilq9xfhvumiar6i/hbase user:hbase:hbase perm:0755
I0129 02:55:22.545441 13053 utils.go:349] volume init took 2015-01-29 02:55:21.692584984 +0000 UTC for src:/opt/serviced/var/volumes/9vay35yyq1ilq9xfhvumiar6i/hbase-master dst:/var/hbase image:localhost:5000/9vay35yyq1ilq9xfhvumiar6i/hbase user:hbase:hbase perm:0755
I0129 02:55:28.053037 13053 utils.go:349] volume init took 2015-01-29 02:55:27.085077448 +0000 UTC for src:/opt/serviced/var/volumes/9vay35yyq1ilq9xfhvumiar6i/zencatalogservice dst:/opt/zenoss/var/zencatalogservice image:localhost:5000/9vay35yyq1ilq9xfhvumiar6i/resmgr-unstable user:zenoss:zenoss perm:0755
I0129 02:55:28.884381 13053 utils.go:349] volume init took 2015-01-29 02:55:28.053120597 +0000 UTC for src:/opt/serviced/var/volumes/9vay35yyq1ilq9xfhvumiar6i/hbase-master dst:/var/hbase image:localhost:5000/9vay35yyq1ilq9xfhvumiar6i/hbase user:hbase:hbase perm:0755
I0129 02:55:30.681872 13053 utils.go:349] volume init took 2015-01-29 02:55:29.788692083 +0000 UTC for src:/opt/serviced/var/volumes/9vay35yyq1ilq9xfhvumiar6i/hbase-zookeeper-1 dst:/var/lib/zookeeper/version-2 image:localhost:5000/9vay35yyq1ilq9xfhvumiar6i/hbase user:zookeeper:zookeeper perm:0755
I0129 02:55:31.839956 13053 utils.go:349] volume init took 2015-01-29 02:55:30.682097654 +0000 UTC for src:/opt/serviced/var/volumes/9vay35yyq1ilq9xfhvumiar6i/hbase-zookeeper-3 dst:/var/lib/zookeeper/version-2 image:localhost:5000/9vay35yyq1ilq9xfhvumiar6i/hbase user:zookeeper:zookeeper perm:0755
I0129 02:55:32.923288 13053 utils.go:349] volume init took 2015-01-29 02:55:31.843511869 +0000 UTC for src:/opt/serviced/var/volumes/9vay35yyq1ilq9xfhvumiar6i/hbase-zookeeper-2 dst:/var/lib/zookeeper/version-2 image:localhost:5000/9vay35yyq1ilq9xfhvumiar6i/hbase user:zookeeper:zookeeper perm:0755
I0129 02:55:54.661306 13053 utils.go:349] volume init took 2015-01-29 02:55:33.82499357 +0000 UTC for src:/opt/serviced/var/volumes/9vay35yyq1ilq9xfhvumiar6i/mariadb dst:/var/lib/mysql image:localhost:5000/9vay35yyq1ilq9xfhvumiar6i/resmgr-unstable user:mysql:mysql perm:0755
I0129 02:56:19.032925 13053 utils.go:349] volume init took 2015-01-29 02:56:18.168812431 +0000 UTC for src:/opt/serviced/var/volumes/9vay35yyq1ilq9xfhvumiar6i/hbase-master dst:/var/hbase image:localhost:5000/9vay35yyq1ilq9xfhvumiar6i/hbase user:hbase:hbase perm:0755
I0129 03:22:35.261606 13157 utils.go:350] volume init took 1.439263209s for src:/opt/serviced/var/volumes/a618rho6hh8awfstyfyq8wfyb/redis dst:/var/lib/redis image:localhost:5000/a618rho6hh8awfstyfyq8wfyb/resmgr-unstable user:root:root perm:0755
I0129 03:22:38.469439 13157 utils.go:350] volume init took 1.031270748s for src:/opt/serviced/var/volumes/a618rho6hh8awfstyfyq8wfyb/zeneventserver dst:/opt/zenoss/var/zeneventserver image:localhost:5000/a618rho6hh8awfstyfyq8wfyb/resmgr-unstable user:zenoss:zenoss perm:0775
I0129 03:23:13.973198 13157 utils.go:350] volume init took 19.109528916s for src:/opt/serviced/var/volumes/a618rho6hh8awfstyfyq8wfyb/mariadb dst:/var/lib/mysql image:localhost:5000/a618rho6hh8awfstyfyq8wfyb/resmgr-unstable user:mysql:mysql perm:0755
I0129 03:23:20.863791 13157 utils.go:350] volume init took 1.165471775s for src:/opt/serviced/var/volumes/a618rho6hh8awfstyfyq8wfyb/rabbitmq dst:/var/lib/rabbitmq image:localhost:5000/a618rho6hh8awfstyfyq8wfyb/resmgr-unstable user:rabbitmq:rabbitmq perm:0750
I0129 03:23:23.509193 13157 utils.go:350] volume init took 1.132786273s for src:/opt/serviced/var/volumes/a618rho6hh8awfstyfyq8wfyb/hbase-zookeeper-1 dst:/var/lib/zookeeper/version-2 image:localhost:5000/a618rho6hh8awfstyfyq8wfyb/hbase user:zookeeper:zookeeper perm:0755
I0129 03:23:40.912241 13157 utils.go:350] volume init took 1.294295737s for src:/opt/serviced/var/volumes/a618rho6hh8awfstyfyq8wfyb/zencatalogservice dst:/opt/zenoss/var/zencatalogservice image:localhost:5000/a618rho6hh8awfstyfyq8wfyb/resmgr-unstable user:zenoss:zenoss perm:0755
I0129 03:23:45.764700 13157 utils.go:350] volume init took 1.570528655s for src:/opt/serviced/var/volumes/a618rho6hh8awfstyfyq8wfyb/hbase-zookeeper-2 dst:/var/lib/zookeeper/version-2 image:localhost:5000/a618rho6hh8awfstyfyq8wfyb/hbase user:zookeeper:zookeeper perm:0755
```