### PR TITLE
remove dotfile for volume init error; retry init for docker error; removed fatal for setupVolume error

### DIFF
--- a/node/agent.go
+++ b/node/agent.go
@@ -602,7 +602,7 @@ func configureContainer(a *HostAgent, client *ControlClient,
 
 		resourcePath, err := a.setupVolume(tenantID, svc, volume)
 		if err != nil {
-			glog.Fatalf("%s", err)
+			return nil, nil, err
 		}
 
 		binding := fmt.Sprintf("%s:%s", resourcePath, volume.ContainerPath)
@@ -767,6 +767,7 @@ func (a *HostAgent) setupVolume(tenantID string, service *service.Service, volum
 
 	if err := createVolumeDir(resourcePath, volume.ContainerPath, service.ImageID, volume.Owner, volume.Permission); err != nil {
 		glog.Errorf("Error populating resource path: %s with container path: %s, %v", resourcePath, volume.ContainerPath, err)
+		return "", err
 	}
 
 	glog.V(4).Infof("resourcePath: %s  containerPath: %s", resourcePath, volume.ContainerPath)

--- a/node/utils.go
+++ b/node/utils.go
@@ -22,6 +22,7 @@ import (
 	"github.com/zenoss/glog"
 
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -311,22 +312,20 @@ func createVolumeDir(hostPath, containerSpec, imageSpec, userSpec, permissionSpe
 	createVolumeDirMutex.Lock()
 	defer createVolumeDirMutex.Unlock()
 
-	dotfile := ".serviced.initialized"
-	dotfileHostPath := path.Join(hostPath, dotfile)
-	_, err := os.Stat(dotfileHostPath)
-	if err == nil {
-		glog.V(2).Infof("volume initialized earlier for src:%s dst:%s image:%s user:%s perm:%s", hostPath, containerSpec, imageSpec, userSpec, permissionSpec)
-		return nil
+	dotfileCompatibility := path.Join(hostPath, ".serviced.initialized") // for compatibility with previous versions of serviced
+	dotfileHostPath := path.Join(filepath.Dir(hostPath), fmt.Sprintf(".%s.serviced.initialized", filepath.Base(hostPath)))
+	dotfiles := []string{dotfileCompatibility, dotfileHostPath}
+	for _, dotfileHostPath := range dotfiles {
+		_, err := os.Stat(dotfileHostPath)
+		if err == nil {
+			glog.V(2).Infof("DFS volume initialized earlier for src:%s dst:%s image:%s user:%s perm:%s", hostPath, containerSpec, imageSpec, userSpec, permissionSpec)
+			return nil
+		}
 	}
 
 	starttime := time.Now()
 
-	// FIXME: this relies on the underlying container to have /bin/sh that supports
-	// some advanced shell options. This should be rewriten so that serviced injects itself in the
-	// container and performs the operations using only go!
-	// the file globbing checks that /mnt/dfs is empty before the copy - should initially be empty
-	//    we don't want the copy to occur multiple times if restarting services.
-
+	var err error
 	var output []byte
 	command := [...]string{
 		"docker", "run",
@@ -335,34 +334,41 @@ func createVolumeDir(hostPath, containerSpec, imageSpec, userSpec, permissionSpe
 		imageSpec,
 		"/bin/bash", "-c",
 		fmt.Sprintf(`
-chown %s /mnt/dfs && \
-chmod %s /mnt/dfs && \
-shopt -s nullglob && \
-shopt -s dotglob && \
-files=(/mnt/dfs/*) && \
+set -e
 if [ ! -d "%s" ]; then
-	echo "ERROR: srcdir %s does not exist in container"
-	exit 2
-elif [ ${#files[@]} -eq 0 ]; then
-	cp -rp %s/* /mnt/dfs/
+	echo "WARNING: DFS mount %s does not exist in image %s"
+else
+	cp -rp %s/. /mnt/dfs/
 fi
-touch /mnt/dfs/%s
+chown %s /mnt/dfs
+chmod %s /mnt/dfs
 sync
-`, userSpec, permissionSpec, containerSpec, containerSpec, containerSpec, dotfile),
+`, containerSpec, containerSpec, imageSpec, containerSpec, userSpec, permissionSpec),
 	}
 
-	for i := 0; i < 1; i++ {
+	for i := 0; i < 2; i++ {
 		docker := exec.Command(command[0], command[1:]...)
 		output, err = docker.CombinedOutput()
 		if err == nil {
 			duration := time.Now().Sub(starttime)
-			glog.V(2).Infof("volume init took %s for src:%s dst:%s image:%s user:%s perm:%s", duration, hostPath, containerSpec, imageSpec, userSpec, permissionSpec)
+			if strings.Contains(string(output), "WARNING:") {
+				glog.Warning(string(output))
+			} else {
+				glog.Info(string(output))
+			}
+			glog.Infof("DFS volume init #%d took %s for src:%s dst:%s image:%s user:%s perm:%s", i, duration, hostPath, containerSpec, imageSpec, userSpec, permissionSpec)
+
+			if e := ioutil.WriteFile(dotfileHostPath, []byte(""), 0664); e != nil {
+				glog.Errorf("unable to create DFS volume initialized dotfile %s: %s", dotfileHostPath, e)
+				return e
+			}
 			return nil
 		}
 		time.Sleep(time.Second)
+		glog.Warningf("retrying due to error creating DFS volume %+v: %s", hostPath, string(output))
 	}
 
-	glog.Errorf("could not create host volume: %+v, %s", command, string(output))
+	glog.Errorf("could not create DFS volume %+v: %s", hostPath, string(output))
 	return err
 }
 

--- a/node/utils_test.go
+++ b/node/utils_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -143,7 +144,7 @@ func TestCreateVolumeDir(t *testing.T) {
 		"--rm",
 		"-v", expectedPath + ":" + containerMount,
 		v.image,
-		"bash", "-c", fmt.Sprintf("shopt -s nullglob && shopt -s dotglob && cp -pr %s/* %s/ && touch %s/.serviced.initialized\n", v.containerPath, containerMount, containerMount),
+		"bash", "-c", fmt.Sprintf("shopt -s nullglob && shopt -s dotglob && cp -pr %s/* %s/\n", v.containerPath, containerMount),
 
 		// FIXME: use rsync instead of cp to use a different command to copy
 		// "bash", "-c", fmt.Sprintf("apt-get -y install rsync; rsync -a %s/ %s/\n", v.containerPath, containerMount),
@@ -187,5 +188,11 @@ func TestCreateVolumeDir(t *testing.T) {
 		if expectedGID != fmt.Sprintf("%d", actualGID) {
 			t.Fatalf("actualGID:%+v != expectedGID:%+v", actualGID, expectedGID)
 		}
+	}
+
+	// make sure initialized dotfile exists
+	dotfileHostPath := path.Join(filepath.Dir(v.hostPath), fmt.Sprintf(".%s.serviced.initialized", filepath.Base(v.hostPath)))
+	if _, err := os.Stat(dotfileHostPath); err != nil {
+		t.Fatalf("could not stat serviced initialized dotfile %s: %s", dotfileHostPath, err)
 	}
 }


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-783

During service volume initialization, we call docker --rm to copy the data from the image.  That docker container may return an error.  Retry if error.  If that fails, return the error to StartService for it to retry starting the service.

ISSUE:
```
root@ip-10-111-2-53:~# grep --after=20 'could not create host volume' /var/log/upstart/serviced*
E0131 03:14:11.840662 02975 utils.go:365] could not create host volume: [docker run --rm -v /opt/serviced/var/volumes/f25ns1sauk5qavkhhbf88mnzm/hbase-zookeeper-1:/mnt/dfs localhost:5000/f25ns1sauk5qavkhhbf88mnzm/hbase /bin/bash -c 
chown zookeeper:zookeeper /mnt/dfs && \
chmod 0755 /mnt/dfs && \
shopt -s nullglob && \
shopt -s dotglob && \
files=(/mnt/dfs/*) && \
if [ ! -d "/var/lib/zookeeper/version-2" ]; then
	echo "ERROR: srcdir /var/lib/zookeeper/version-2 does not exist in container"
	exit 2
elif [ ${#files[@]} -eq 0 ]; then
	cp -rp /var/lib/zookeeper/version-2/* /mnt/dfs/
fi
touch /mnt/dfs/.serviced.initialized
sync
], cp: missing destination file operand after `/mnt/dfs/'
Try `cp --help' for more information.
2015/01/31 03:14:10 Error response from daemon: Cannot destroy container f2b9de3cf2ecd972a8f527e0c84ac32dd52ff60664967887bbd192e289ff1240: Driver aufs failed to remove root filesystem f2b9de3cf2ecd972a8f527e0c84ac32dd52ff60664967887bbd192e289ff1240: rename /var/lib/docker/aufs/mnt/f2b9de3cf2ecd972a8f527e0c84ac32dd52ff60664967887bbd192e289ff1240 /var/lib/docker/aufs/mnt/f2b9de3cf2ecd972a8f527e0c84ac32dd52ff60664967887bbd192e289ff1240-removing: device or resource busy
E0131 03:14:11.840751 02975 agent.go:769] Error populating resource path: /opt/serviced/var/volumes/f25ns1sauk5qavkhhbf88mnzm/hbase-zookeeper-1 with container path: /var/lib/zookeeper/version-2, exit status 1
```

DEMO - normal behavior for initializing volume:
```
I0202 18:34:10.687414 05165 utils.go:359] DFS volume init #0 took 2.364882148s for src:/opt/serviced/var/volumes/1lif1atry59vjj90zmgild4uc/rabbitmq dst:/var/lib/rabbitmq image:localhost:5000/1lif1atry59vjj90zmgild4uc/core_5.0 user:rabbitmq:rabbitmq perm:0750
...
I0202 18:34:12.132231 05165 agent.go:405] Instance 5d0hy62qpqypmdgo2tbtscoce (40953e95b4a4fae7b4478d634767a05930d3e71d2acbd688ba73761245722cb6) for RabbitMQ (d8kh9qe9jq44finbv1y17cqhc) has started
```

DEMO - retry on docker error for initializing:
```
W0202 18:34:15.195086 05165 utils.go:367] retrying due to error creating DFS volume /opt/serviced/var/volumes/1lif1atry59vjj90zmgild4uc/redis: 2015/02/02 18:34:14 Error response from daemon: Cannot destroy container 12b78c31be13160869ea086f0f5f3050da7523c2ab3b482ef7e53674edfd55d5: Driver aufs failed to remove root filesystem 12b78c31be13160869ea086f0f5f3050da7523c2ab3b482ef7e53674edfd55d5: rename /var/lib/docker/aufs/mnt/12b78c31be13160869ea086f0f5f3050da7523c2ab3b482ef7e53674edfd55d5 /var/lib/docker/aufs/mnt/12b78c31be13160869ea086f0f5f3050da7523c2ab3b482ef7e53674edfd55d5-removing: device or resource busy
E0202 18:34:15.195137 05165 utils.go:370] could not create DFS volume /opt/serviced/var/volumes/1lif1atry59vjj90zmgild4uc/redis: 2015/02/02 18:34:14 Error response from daemon: Cannot destroy container 12b78c31be13160869ea086f0f5f3050da7523c2ab3b482ef7e53674edfd55d5: Driver aufs failed to remove root filesystem 12b78c31be13160869ea086f0f5f3050da7523c2ab3b482ef7e53674edfd55d5: rename /var/lib/docker/aufs/mnt/12b78c31be13160869ea086f0f5f3050da7523c2ab3b482ef7e53674edfd55d5 /var/lib/docker/aufs/mnt/12b78c31be13160869ea086f0f5f3050da7523c2ab3b482ef7e53674edfd55d5-removing: device or resource busy
...
I0202 18:34:25.935886 05165 utils.go:359] DFS volume init #0 took 755.079172ms for src:/opt/serviced/var/volumes/1lif1atry59vjj90zmgild4uc/redis dst:/var/lib/redis image:localhost:5000/1lif1atry59vjj90zmgild4uc/core_5.0 user:root:root perm:0755
I0202 18:34:26.404330 05165 agent.go:405] Instance a77vsmq1d7be00vdjlhj4mscm (fef902b8d92ddd468547c49c65e327b1cffe0c7b3fe1ccef1f495b65d3bc1cec) for redis (5fmswonoh80idyuo40w4l63l1) has started
```

DEMO - warns for devimg not having initial container volume:
```
W0202 02:14:27.994820 01046 utils.go:351] WARNING: DFS mount /opt/zenoss/.ZenPacks does not exist in image localhost:5000/92pusb1jghaudxk4jxdd0qu4h/devimg
```
