### PR TITLE
CC-792 - Wrap ZK connection Xid back to zero rather than overflowing to negatve int32

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -73,8 +73,8 @@
 			"Rev": "43bd4e6d53ee382fd09bb6ede8b4029247444945"
 		},
 		{
-			"ImportPath": "github.com/samuel/go-zookeeper/zk",
-			"Rev": "4a222ca51b4c7ca6f2895e0e68af2e9254acfdcc"
+			"ImportPath": "github.com/control-center/go-zookeeper/zk",
+			"Rev": "34c03e01311eb52816e48da2da97b5681bfbb1be"
 		},
 		{
 			"ImportPath": "github.com/zenoss/glog",

--- a/coordinator/client/zookeeper/connection.go
+++ b/coordinator/client/zookeeper/connection.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"time"
 
+	zklib "github.com/control-center/go-zookeeper/zk"
 	"github.com/control-center/serviced/coordinator/client"
-	zklib "github.com/samuel/go-zookeeper/zk"
 	"github.com/zenoss/glog"
 )
 

--- a/coordinator/client/zookeeper/connection_test.go
+++ b/coordinator/client/zookeeper/connection_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
+	zklib "github.com/control-center/go-zookeeper/zk"
 	coordclient "github.com/control-center/serviced/coordinator/client"
-	zklib "github.com/samuel/go-zookeeper/zk"
 	"github.com/zenoss/glog"
 )
 

--- a/coordinator/client/zookeeper/driver.go
+++ b/coordinator/client/zookeeper/driver.go
@@ -17,7 +17,7 @@ import (
 	"encoding/json"
 	"time"
 
-	zklib "github.com/samuel/go-zookeeper/zk"
+	zklib "github.com/control-center/go-zookeeper/zk"
 	"github.com/control-center/serviced/coordinator/client"
 )
 

--- a/coordinator/client/zookeeper/errors.go
+++ b/coordinator/client/zookeeper/errors.go
@@ -14,7 +14,7 @@
 package zookeeper
 
 import (
-	zklib "github.com/samuel/go-zookeeper/zk"
+	zklib "github.com/control-center/go-zookeeper/zk"
 	"github.com/control-center/serviced/coordinator/client"
 )
 

--- a/coordinator/client/zookeeper/leader.go
+++ b/coordinator/client/zookeeper/leader.go
@@ -21,8 +21,8 @@ import (
 	"strconv"
 	"strings"
 
+	zklib "github.com/control-center/go-zookeeper/zk"
 	"github.com/control-center/serviced/coordinator/client"
-	zklib "github.com/samuel/go-zookeeper/zk"
 	"github.com/zenoss/glog"
 )
 

--- a/coordinator/client/zookeeper/leader_test.go
+++ b/coordinator/client/zookeeper/leader_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	zklib "github.com/samuel/go-zookeeper/zk"
+	zklib "github.com/control-center/go-zookeeper/zk"
 )
 
 func TestLeader(t *testing.T) {

--- a/coordinator/client/zookeeper/lock.go
+++ b/coordinator/client/zookeeper/lock.go
@@ -14,7 +14,7 @@
 package zookeeper
 
 import (
-	zklib "github.com/samuel/go-zookeeper/zk"
+	zklib "github.com/control-center/go-zookeeper/zk"
 )
 
 // Lock creates a object to facilitate create a locking pattern in zookeeper.

--- a/coordinator/client/zookeeper/lock_test.go
+++ b/coordinator/client/zookeeper/lock_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	zklib "github.com/samuel/go-zookeeper/zk"
+	zklib "github.com/control-center/go-zookeeper/zk"
 )
 
 func TestLock(t *testing.T) {

--- a/coordinator/storage/client_test.go
+++ b/coordinator/storage/client_test.go
@@ -14,7 +14,7 @@
 package storage
 
 import (
-	zklib "github.com/samuel/go-zookeeper/zk"
+	zklib "github.com/control-center/go-zookeeper/zk"
 
 	"github.com/control-center/serviced/coordinator/client"
 	"github.com/control-center/serviced/coordinator/client/zookeeper"

--- a/coordinator/storage/server_test.go
+++ b/coordinator/storage/server_test.go
@@ -14,7 +14,7 @@
 package storage
 
 import (
-	zklib "github.com/samuel/go-zookeeper/zk"
+	zklib "github.com/control-center/go-zookeeper/zk"
 
 	"github.com/control-center/serviced/coordinator/client"
 	"github.com/control-center/serviced/coordinator/client/zookeeper"

--- a/isvcs/zk.go
+++ b/isvcs/zk.go
@@ -19,7 +19,7 @@
 package isvcs
 
 import (
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/control-center/go-zookeeper/zk"
 	"github.com/zenoss/glog"
 
 	"fmt"


### PR DESCRIPTION
Related: https://github.com/control-center/go-zookeeper/pull/1