### PR TITLE
fixes CC-809: upon resource busy, retry rollback subvolume delete for timeout of SERVICED_BTRFS_ROLLBACK_TIMEOUT

### DIFF
--- a/volume/btrfs/btrfs.go
+++ b/volume/btrfs/btrfs.go
@@ -23,8 +23,10 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 const (
@@ -199,6 +201,24 @@ func (c *BtrfsConn) Unmount() error {
 	return err
 }
 
+// getEnvMinDuration returns the time.Duration env var meeting minimum and default duration
+func getEnvMinDuration(envvar string, def, min int32) time.Duration {
+	duration := def
+	envval := os.Getenv(envvar)
+	if len(strings.TrimSpace(envval)) == 0 {
+		// ignore unset envvar
+	} else if intVal, intErr := strconv.ParseInt(envval, 0, 32); intErr != nil {
+		glog.Warningf("ignoring invalid %s of '%s': %s", envvar, envval, intErr)
+		duration = min
+	} else if int32(intVal) < min {
+		glog.Warningf("ignoring invalid %s of '%s' < minimum:%v seconds", envvar, envval, min)
+	} else {
+		duration = int32(intVal)
+	}
+
+	return time.Duration(duration) * time.Second
+}
+
 // Rollback rolls back the volume to the given snapshot
 func (c *BtrfsConn) Rollback(label string) error {
 	if exists, err := c.snapshotExists(label); err != nil || !exists {
@@ -217,13 +237,42 @@ func (c *BtrfsConn) Rollback(label string) error {
 		return err
 	}
 
+	glog.Infof("starting rollback of snapshot %s", label)
+
+	start := time.Now()
 	if dirp {
-		if _, err := runcmd(c.sudoer, "subvolume", "delete", vd); err != nil {
-			return err
+		timeout := getEnvMinDuration("SERVICED_BTRFS_ROLLBACK_TIMEOUT", 300, 120)
+		glog.Infof("rollback using env var SERVICED_BTRFS_ROLLBACK_TIMEOUT:%s", timeout)
+
+		for {
+			cmd := []string{"subvolume", "delete", vd}
+			output, deleteError := runcmd(c.sudoer, cmd...)
+			if deleteError == nil {
+				break
+			}
+
+			now := time.Now()
+			if now.Sub(start) > timeout {
+				glog.Errorf("rollback of snapshot %s failed - btrfs subvolume deletes took %s for cmd:%s", label, timeout, cmd)
+				return deleteError
+			} else if strings.Contains(string(output), "Device or resource busy") {
+				waitTime := time.Duration(5 * time.Second)
+				glog.Warningf("retrying rollback subvolume delete in %s - unable to run cmd:%s  output:%s  error:%s", waitTime, cmd, string(output), deleteError)
+				time.Sleep(waitTime)
+			} else {
+				return deleteError
+			}
 		}
 	}
 
-	_, err = runcmd(c.sudoer, "subvolume", "snapshot", c.SnapshotPath(label), vd)
+	cmd := []string{"subvolume", "snapshot", c.SnapshotPath(label), vd}
+	_, err = runcmd(c.sudoer, cmd...)
+	if err != nil {
+		glog.Errorf("rollback of snapshot %s failed for cmd:%s", label, cmd)
+	} else {
+		duration := time.Now().Sub(start)
+		glog.Infof("rollback of snapshot %s took %s", label, duration)
+	}
 	return err
 }
 
@@ -293,5 +342,11 @@ func runcmd(sudoer bool, args ...string) ([]byte, error) {
 		cmd = append([]string{"sudo", "-n"}, cmd...)
 	}
 	glog.V(4).Infof("Executing: %v", cmd)
-	return exec.Command(cmd[0], cmd[1:]...).CombinedOutput()
+	output, err := exec.Command(cmd[0], cmd[1:]...).CombinedOutput()
+	if err != nil {
+		e := fmt.Errorf("unable to run cmd:%s  output:%s  error:%s", cmd, string(output), err)
+		glog.Errorf("%s", e)
+		return output, e
+	}
+	return output, err
 }


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-809

NFS flush is likely causing 'Device or resource busy' when trying to delete the original subvolume.

DEMO - takes 45 seconds before subvolume delete works:
```
I0209 21:07:43.579106 29343 snapshot.go:177] Performing rollback for Zenoss.resmgr (67j8sabc51exzd1lnpo4atd9f) using 67j8sabc51exzd1lnpo4atd9f_20150209-204313
I0209 21:07:43.582133 29343 btrfs.go:240] starting rollback of snapshot 67j8sabc51exzd1lnpo4atd9f_20150209-204313
I0209 21:07:43.582175 29343 btrfs.go:245] rollback using env var SERVICED_BTRFS_ROLLBACK_TIMEOUT:5m0s
E0209 21:07:43.587983 29343 btrfs.go:348] unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
W0209 21:07:43.588052 29343 btrfs.go:260] retrying rollback subvolume delete in 5s - unable to run cmd:[subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
E0209 21:07:48.593003 29343 btrfs.go:348] unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
W0209 21:07:48.593071 29343 btrfs.go:260] retrying rollback subvolume delete in 5s - unable to run cmd:[subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
E0209 21:07:53.597942 29343 btrfs.go:348] unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
W0209 21:07:53.597984 29343 btrfs.go:260] retrying rollback subvolume delete in 5s - unable to run cmd:[subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
E0209 21:07:58.602845 29343 btrfs.go:348] unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
W0209 21:07:58.602910 29343 btrfs.go:260] retrying rollback subvolume delete in 5s - unable to run cmd:[subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
E0209 21:08:03.607783 29343 btrfs.go:348] unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
W0209 21:08:03.607844 29343 btrfs.go:260] retrying rollback subvolume delete in 5s - unable to run cmd:[subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
E0209 21:08:08.612796 29343 btrfs.go:348] unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
W0209 21:08:08.612867 29343 btrfs.go:260] retrying rollback subvolume delete in 5s - unable to run cmd:[subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
E0209 21:08:13.617636 29343 btrfs.go:348] unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
W0209 21:08:13.617677 29343 btrfs.go:260] retrying rollback subvolume delete in 5s - unable to run cmd:[subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
E0209 21:08:18.622546 29343 btrfs.go:348] unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
W0209 21:08:18.622602 29343 btrfs.go:260] retrying rollback subvolume delete in 5s - unable to run cmd:[subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
E0209 21:08:23.627513 29343 btrfs.go:348] unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
W0209 21:08:23.627557 29343 btrfs.go:260] retrying rollback subvolume delete in 5s - unable to run cmd:[subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:unable to run cmd:[btrfs subvolume delete /opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f]  output:ERROR: cannot delete '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f' - Device or resource busy
Delete subvolume '/opt/serviced/var/volumes/67j8sabc51exzd1lnpo4atd9f'
  error:exit status 1
I0209 21:08:28.798949 29343 btrfs.go:274] rollback of snapshot 67j8sabc51exzd1lnpo4atd9f_20150209-204313 took 45.216776557s
I0209 21:08:28.799025 29343 snapshot.go:184] Restoring image tags for 67j8sabc51exzd1lnpo4atd9f_20150209-204313
```

DEMO:
```
root@ip-10-111-2-24:~# serviced snapshot list
67j8sabc51exzd1lnpo4atd9f_20150209-203430
67j8sabc51exzd1lnpo4atd9f_20150209-204313
root@ip-10-111-2-24:~# btrfs subvolume list /opt/serviced/var/volumes
ID 259 gen 2716 top level 5 path volumes
ID 330 gen 2694 top level 259 path 67j8sabc51exzd1lnpo4atd9f_20150209-203430
ID 331 gen 2631 top level 259 path 8hrazotq1prj6jl6m9utxnc8f
ID 332 gen 2795 top level 259 path 67j8sabc51exzd1lnpo4atd9f
ID 333 gen 2716 top level 259 path 67j8sabc51exzd1lnpo4atd9f_20150209-204313

root@ip-10-111-2-24:~# serviced snapshot rollback 67j8sabc51exzd1lnpo4atd9f_20150209-204313 --force-restart
67j8sabc51exzd1lnpo4atd9f_20150209-204313

root@ip-10-111-2-24:~# serviced snapshot list
67j8sabc51exzd1lnpo4atd9f_20150209-203430
67j8sabc51exzd1lnpo4atd9f_20150209-204313
root@ip-10-111-2-24:~# btrfs subvolume list /opt/serviced/var/volumes
ID 259 gen 2832 top level 5 path volumes
ID 330 gen 2694 top level 259 path 67j8sabc51exzd1lnpo4atd9f_20150209-203430
ID 331 gen 2631 top level 259 path 8hrazotq1prj6jl6m9utxnc8f
ID 333 gen 2832 top level 259 path 67j8sabc51exzd1lnpo4atd9f_20150209-204313
ID 334 gen 2832 top level 259 path 67j8sabc51exzd1lnpo4atd9f

```