### PR TITLE
fixes CC-812: nfs export /opt/serviced/var/volumes instead of var

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -409,7 +409,7 @@ func (d *daemon) startMaster() error {
 		return err
 	}
 
-	if nfsDriver, err := nfs.NewServer(options.VarPath, "serviced_var", "0.0.0.0/0"); err != nil {
+	if nfsDriver, err := nfs.NewServer(path.Join(options.VarPath, "volumes"), "serviced_var_volumes", "0.0.0.0/0"); err != nil {
 		return err
 	} else {
 		d.storageHandler, err = storage.NewServer(nfsDriver, thisHost)
@@ -563,7 +563,7 @@ func (d *daemon) startAgent() error {
 			glog.Errorf("Error in getting a connection based on pool %v: %v", poolID, err)
 		}
 
-		nfsClient, err := storage.NewClient(thisHost, options.VarPath)
+		nfsClient, err := storage.NewClient(thisHost, path.Join(options.VarPath, "volumes"))
 		if err != nil {
 			glog.Fatalf("could not create an NFS client: %s", err)
 		}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-812

DEMO1 - remote uses new path /opt/serviced/var/volumes:

```
I0209 21:38:17.778822 04336 monitor.go:65] updating DFS volume monitor file /opt/serviced/var/volumes/monitor/10.111.2.46 at write interval: 1m0s
I0209 21:38:17.778877 04336 monitor.go:75] created DFS volume monitor path /opt/serviced/var/volumes/monitor
I0209 21:38:17.778925 04336 client.go:133] creating /storage/clients/10.111.2.46
I0209 21:38:17.778939 04336 client.go:213] updating DFS remote client UpdatedAt for node /storage/clients/10.111.2.46 at interval 1m0s

W0209 21:38:17.857160 04336 nfsfs.go:190] could not find mountpoint:/opt/serviced/var/volumes with command:[bash -c /bin/findmnt --raw --noheading -o MAJ:MIN,FSTYPE,SOURCE,TARGET,OPTIONS /opt/serviced/var/volumes]  output: (exit status 1)
I0209 21:38:17.857244 04336 common.go:154] Creating new mount for 10.111.2.24:/serviced_var_volumes -> /opt/serviced/var/volumes
I0209 21:38:17.857260 04336 common.go:90] Mounting 10.111.2.24:/serviced_var_volumes -> /opt/serviced/var/volumes
I0209 21:38:17.905834 04336 common.go:171] Mount Info: {MountInfo:{DeviceID:0:35 FSType:nfs4 RemotePath:10.111.2.24:/serviced_var_volumes LocalPath:/opt/serviced/var/volumes ServerIP:10.111.2.24} Version:v4 ServerID:0a6f0218 Port:801 FSID:fde78dba7b42a74d FSCache:no}
...
root@ip-10-111-2-46:/opt/serviced/bin# df -H
Filesystem                         Size  Used Avail Use% Mounted on
/dev/xvda1                          64G   23G   38G  38% /
10.111.2.24:/serviced_var_volumes  108G  8.4G   98G   8% /opt/serviced/var/volumes
```

DEMO - master exports /opt/serviced/var/volumes as /exports/serviced_var_volumes:
```
I0209 21:38:16.535868 28216 daemon.go:584] Waiting for Storage Leader
I0209 21:38:16.535934 28216 monitor.go:65] updating DFS volume monitor file /opt/serviced/var/volumes/monitor/10.111.2.24 at write interval: 1m0s
I0209 21:38:16.536139 28216 monitor.go:75] created DFS volume monitor path /opt/serviced/var/volumes/monitor
I0209 21:38:16.536217 28216 client.go:213] updating DFS remote client UpdatedAt for node /storage/clients/10.111.2.24 at interval 1m0s
...
I0209 21:41:16.149027 28216 monitor.go:187] DFS active remotes to be monitored has changed to: [10.111.2.24 10.111.2.46 10.111.2.94]

root@ip-10-111-2-24:/opt/serviced/bin# df -Ha
Filesystem                 Size  Used Avail Use% Mounted on
/dev/xvda1                  64G   25G   36G  41% /
...
/dev/xvdb1                 108G  8.4G   98G   8% /opt/serviced/var
/opt/serviced/var/volumes  108G  8.4G   98G   8% /exports/serviced_var_volumes
```

![screen shot 2015-02-09 at 16 04 46](https://cloud.githubusercontent.com/assets/2837923/6116815/66d88354-b075-11e4-9904-07b165f5748f.png)
