### PR TITLE
Feature/cli migration

### DIFF
--- a/cli/api/api.go
+++ b/cli/api/api.go
@@ -94,9 +94,14 @@ type api struct {
 	dao    dao.ControlPlane // Deprecated
 }
 
-// New creates a new API type
 func New() API {
-	return &api{}
+	// let lazy init populate each interface as necessary
+	return NewAPI(nil, nil, nil, nil)
+}
+
+// New creates a new API type
+func NewAPI(master *master.Client, agent *agent.Client, docker *dockerclient.Client, dao dao.ControlPlane) API {
+	return &api{master: master, agent: agent, docker: docker, dao: dao}
 }
 
 // Starts the agent or master services on this host

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -57,7 +57,7 @@ type API interface {
 	AddService(ServiceConfig) (*service.Service, error)
 	RemoveService(string) error
 	UpdateService(io.Reader) (*service.Service, error)
-	MigrateService(string, io.Reader) (*service.Service, error)
+	MigrateService(string, io.Reader, bool) (*service.Service, error)
 	StartService(SchedulerConfig) (int, error)
 	RestartService(SchedulerConfig) (int, error)
 	StopService(SchedulerConfig) (int, error)

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -57,6 +57,7 @@ type API interface {
 	AddService(ServiceConfig) (*service.Service, error)
 	RemoveService(string) error
 	UpdateService(io.Reader) (*service.Service, error)
+	MigrateService(string, io.Reader) (*service.Service, error)
 	StartService(SchedulerConfig) (int, error)
 	RestartService(SchedulerConfig) (int, error)
 	StopService(SchedulerConfig) (int, error)

--- a/cli/api/service.go
+++ b/cli/api/service.go
@@ -176,7 +176,7 @@ func (a *api) AddService(config ServiceConfig) (*service.Service, error) {
 }
 
 // MigrateService migrates an existing service
-func (a *api) MigrateService(serviceID string, input io.Reader) (*service.Service, error) {
+func (a *api) MigrateService(serviceID string, input io.Reader, dryRun bool) (*service.Service, error) {
 	client, err := a.connectDAO()
 	if err != nil {
 		return nil, err
@@ -188,7 +188,7 @@ func (a *api) MigrateService(serviceID string, input io.Reader) (*service.Servic
 		return nil, fmt.Errorf("could not read migration script: %s", err)
 	}
 
-	request := dao.ServiceMigrationRequest{ServiceID: serviceID}
+	request := dao.ServiceMigrationRequest{ServiceID: serviceID, DryRun: dryRun}
 	request.MigrationScript = string(inputBuffer.Bytes())
 	if len(request.MigrationScript) == 0 {
 		return nil, fmt.Errorf("migration failed: script is empty")

--- a/cli/api/service_test.go
+++ b/cli/api/service_test.go
@@ -15,9 +15,12 @@ package api
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"unsafe"
 
+	"github.com/control-center/serviced/dao"
 	daotest "github.com/control-center/serviced/dao/test"
 	"github.com/control-center/serviced/domain/service"
 
@@ -25,9 +28,16 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+var tGlobal *testing.T
+
 // This plumbs gocheck into testing
 func Test(t *testing.T) {
 	TestingT(t)
+
+	// HACK ALERT: Some functions in testify.Mock require testing.T, but
+	//	gocheck doesn't offer access to it, so we have to save a copy in
+	//	a global variable :=(
+	tGlobal = t
 }
 
 var _ = Suite(&serviceAPITest{})
@@ -79,4 +89,93 @@ func (st *serviceAPITest) TestGetService_fails(c *C) {
 
 	c.Assert(actual, IsNil)
 	c.Assert(err, Equals, errorStub)
+}
+
+func (st *serviceAPITest) TestMigrateService_works(c *C) {
+	serviceID := "test-service"
+	scriptBody := "# no-op script"
+	inputScript := strings.NewReader(scriptBody)
+	expected, _ := service.NewService()
+
+	st.mockControlPlane.
+		On("MigrateService", mock.Anything, mock.Anything).
+		Return(nil)
+
+	st.mockControlPlane.Responses["GetService"] = (unsafe.Pointer)(expected)
+	st.mockControlPlane.
+		On("GetService", serviceID, mock.Anything).
+		Return(nil)
+
+	actual, err := st.api.MigrateService(serviceID, inputScript)
+
+	c.Assert(err, IsNil)
+	c.Assert(actual.ID, Equals, expected.ID)
+
+	args := st.mockControlPlane.GetArgsForMockCall("MigrateService")
+	c.Assert(args, Not(IsNil))
+
+	request := args[0].(dao.ServiceMigrationRequest)
+	c.Assert(request.ServiceID, Equals, serviceID)
+	c.Assert(request.MigrationScript, Equals, scriptBody)
+}
+
+type mockInputReader struct {
+	Mock *mock.Mock
+}
+
+func (m mockInputReader) Read(p []byte) (n int, err error) {
+	args := m.Mock.Called(p)
+	return args.Int(0), args.Error(1)
+}
+
+func (st *serviceAPITest) TestMigrateService_failsToReadScript(c *C) {
+	serviceID := "test-service"
+	errorStub := errors.New("errorStub: Read() failed")
+	mockInput := mockInputReader{Mock: &mock.Mock{}}
+	mockInput.Mock.
+		On("Read", mock.Anything).
+		Return(0, errorStub)
+
+	actual, err := st.api.MigrateService(serviceID, mockInput)
+
+	c.Assert(actual, IsNil)
+	expectedError := fmt.Errorf("could not read migration script: %s", errorStub)
+	c.Assert(err.Error(), Equals, expectedError.Error())
+
+	// MigrateService should never be called if we can't read the script
+	args := st.mockControlPlane.GetArgsForMockCall("MigrateServce")
+	c.Assert(len(args), Equals, 0)
+}
+
+func (st *serviceAPITest) TestMigrateService_failsForEmptyScript(c *C) {
+	serviceID := "test-service"
+	scriptBody := ""
+	inputScript := strings.NewReader(scriptBody)
+
+	actual, err := st.api.MigrateService(serviceID, inputScript)
+
+	c.Assert(actual, IsNil)
+	expectedError := fmt.Errorf("migration failed: script is empty")
+	c.Assert(err.Error(), Equals, expectedError.Error())
+
+	// MigrateService should never be called if we can't read the script
+	args := st.mockControlPlane.GetArgsForMockCall("MigrateServce")
+	c.Assert(len(args), Equals, 0)
+}
+
+func (st *serviceAPITest) TestMigrateService_fails(c *C) {
+	serviceID := "test-service"
+	scriptBody := "# no-op script"
+	inputScript := strings.NewReader(scriptBody)
+
+	errorStub := errors.New("errorStub: migrate failed")
+	st.mockControlPlane.
+		On("MigrateService", mock.Anything, mock.Anything).
+		Return(errorStub)
+
+	actual, err := st.api.MigrateService(serviceID, inputScript)
+
+	c.Assert(actual, IsNil)
+	expectedError := fmt.Errorf("migration failed: %s", errorStub)
+	c.Assert(err.Error(), Equals, expectedError.Error())
 }

--- a/cli/api/service_test.go
+++ b/cli/api/service_test.go
@@ -106,7 +106,7 @@ func (st *serviceAPITest) TestMigrateService_works(c *C) {
 		On("GetService", serviceID, mock.Anything).
 		Return(nil)
 
-	actual, err := st.api.MigrateService(serviceID, inputScript)
+	actual, err := st.api.MigrateService(serviceID, inputScript, true)
 
 	c.Assert(err, IsNil)
 	c.Assert(actual.ID, Equals, expected.ID)
@@ -117,6 +117,7 @@ func (st *serviceAPITest) TestMigrateService_works(c *C) {
 	request := args[0].(dao.ServiceMigrationRequest)
 	c.Assert(request.ServiceID, Equals, serviceID)
 	c.Assert(request.MigrationScript, Equals, scriptBody)
+	c.Assert(request.DryRun, Equals, true)
 }
 
 type mockInputReader struct {
@@ -136,7 +137,7 @@ func (st *serviceAPITest) TestMigrateService_failsToReadScript(c *C) {
 		On("Read", mock.Anything).
 		Return(0, errorStub)
 
-	actual, err := st.api.MigrateService(serviceID, mockInput)
+	actual, err := st.api.MigrateService(serviceID, mockInput, false)
 
 	c.Assert(actual, IsNil)
 	expectedError := fmt.Errorf("could not read migration script: %s", errorStub)
@@ -152,7 +153,7 @@ func (st *serviceAPITest) TestMigrateService_failsForEmptyScript(c *C) {
 	scriptBody := ""
 	inputScript := strings.NewReader(scriptBody)
 
-	actual, err := st.api.MigrateService(serviceID, inputScript)
+	actual, err := st.api.MigrateService(serviceID, inputScript, false)
 
 	c.Assert(actual, IsNil)
 	expectedError := fmt.Errorf("migration failed: script is empty")
@@ -173,7 +174,7 @@ func (st *serviceAPITest) TestMigrateService_fails(c *C) {
 		On("MigrateService", mock.Anything, mock.Anything).
 		Return(errorStub)
 
-	actual, err := st.api.MigrateService(serviceID, inputScript)
+	actual, err := st.api.MigrateService(serviceID, inputScript, false)
 
 	c.Assert(actual, IsNil)
 	expectedError := fmt.Errorf("migration failed: %s", errorStub)

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -91,6 +91,9 @@ func (c *ServicedCli) initService() {
 				Description:  "serviced service migrate SERVICEID PATH_TO_SCRIPT",
 				BashComplete: c.printServicesAll,
 				Action:       c.cmdServiceMigrate,
+				Flags: []cli.Flag{
+					cli.BoolFlag{"dry-run", "Executes the migration and validation without updateing anything"},
+				},
 			}, {
 				Name:         "remove",
 				ShortName:    "rm",
@@ -713,7 +716,7 @@ func (c *ServicedCli) cmdServiceMigrate(ctx *cli.Context) {
 		input = os.Stdin
 	}
 
-	if migratedSvc, err := c.driver.MigrateService(svc.ID, input); err != nil {
+	if migratedSvc, err := c.driver.MigrateService(svc.ID, input, ctx.Bool("dry-run")); err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", svc.ID, err)
 	} else {
 		fmt.Println(migratedSvc.ID)

--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -163,7 +163,7 @@ func (t ServiceAPITest) AddService(config api.ServiceConfig) (*service.Service, 
 	return &s, nil
 }
 
-func (t ServiceAPITest) MigrateService(id string, script io.Reader) (*service.Service, error) {
+func (t ServiceAPITest) MigrateService(id string, script io.Reader, dryRun bool) (*service.Service, error) {
 	if t.errs["MigrateService"] != nil {
 		return nil, t.errs["MigrateService"]
 	}
@@ -437,7 +437,7 @@ func ExampleServicedCLI_CmdServiceMigrate_usage() {
 	//    serviced service migrate SERVICEID PATH_TO_SCRIPT
 	//
 	// OPTIONS:
-
+	//    --dry-run	Executes the migration and validation without updateing anything
 }
 
 func ExampleServicedCLI_CmdServiceMigrate_err() {

--- a/dao/elasticsearch/service.go
+++ b/dao/elasticsearch/service.go
@@ -53,6 +53,23 @@ func (this *ControlPlaneDao) UpdateService(svc service.Service, unused *int) err
 }
 
 //
+func (this *ControlPlaneDao) MigrateService(request dao.ServiceMigrationRequest, unused *int) error {
+	glog.V(2).Infof("ControlPlaneDao.MigrateService: id %+v", request.ServiceID)
+	svc, err := this.facade.GetService(datastore.Get(), request.ServiceID)
+	if err != nil {
+		return err
+	}
+
+	if err := this.facade.MigrateService(datastore.Get(), svc, request.MigrationScript); err != nil {
+		return err
+	}
+
+	var unusedInt int
+	glog.V(2).Infof("ControlPlaneDao.MigrateService: migration script complete, updating serviceID %+v", svc.ID)
+	return this.UpdateService(*svc, &unusedInt)
+}
+
+//
 func (this *ControlPlaneDao) RemoveService(id string, unused *int) error {
 	if err := this.facade.RemoveService(datastore.Get(), id); err != nil {
 		return err

--- a/dao/interface.go
+++ b/dao/interface.go
@@ -48,6 +48,7 @@ type ServiceRequest struct {
 type ServiceMigrationRequest struct {
 	ServiceID       string
 	MigrationScript string
+	DryRun          bool
 }
 
 type ServiceStateRequest struct {

--- a/dao/interface.go
+++ b/dao/interface.go
@@ -45,6 +45,11 @@ type ServiceRequest struct {
 	NameRegex    string
 }
 
+type ServiceMigrationRequest struct {
+	ServiceID       string
+	MigrationScript string
+}
+
 type ServiceStateRequest struct {
 	ServiceID      string
 	ServiceStateID string
@@ -104,6 +109,9 @@ type ControlPlane interface {
 
 	// Update an existing service
 	UpdateService(service service.Service, unused *int) error
+
+	// Migrate a service definition
+	MigrateService(request ServiceMigrationRequest, unused *int) error
 
 	// Remove a service definition
 	RemoveService(serviceId string, unused *int) error

--- a/dao/test/mockControlPlane.go
+++ b/dao/test/mockControlPlane.go
@@ -1,0 +1,347 @@
+// Copyright 2015 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	// "fmt"
+	"github.com/control-center/serviced/dao"
+	"github.com/control-center/serviced/domain"
+	"github.com/control-center/serviced/domain/addressassignment"
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/domain/servicestate"
+	"github.com/control-center/serviced/domain/servicetemplate"
+	"github.com/control-center/serviced/domain/user"
+	"github.com/control-center/serviced/volume"
+	"unsafe"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// assert the interface
+var _ dao.ControlPlane = &MockControlPlane{}
+
+type MockControlPlane struct {
+	mock.Mock
+
+	//
+	// The methods on the ControlPlane interface all take 2 arguments.
+	// The names and types vary, but the first is request argument and the second is
+	// the response from the function. In many cases, the callers of ControlPlane
+	// are passing pointers to local variables for the response argument, which makes
+	// those cases impossible to mock using the native capabilities of the testify.Mock
+	//
+	// Sooo, for cases like that the caller can store the values they want for the response
+	// in this map.
+	//
+	// NOTE: Not all methods below have been updated to use Responses, so depending on what
+	//       you are trying to test, you may need to update one or more methods below to use
+	//       Responses.
+	Responses map[string]unsafe.Pointer
+}
+
+func New() *MockControlPlane {
+	mcp := &MockControlPlane{}
+	mcp.Responses = make(map[string]unsafe.Pointer)
+	return mcp
+}
+
+//for a service, get it's tenant Id
+func (mcp *MockControlPlane) GetTenantId(serviceId string, tenantId *string) error {
+	if mcp.Responses["GetTenantId"] != nil {
+		*tenantId = *((*string)(mcp.Responses["GetTenantId"]))
+	}
+	return mcp.Mock.Called(serviceId, tenantId).Error(0)
+}
+
+// Add a new service
+func (mcp *MockControlPlane) AddService(service service.Service, serviceId *string) error {
+	if mcp.Responses["AddService"] != nil {
+		*serviceId = *((*string)(mcp.Responses["AddService"]))
+	}
+	return mcp.Mock.Called(service, serviceId).Error(0)
+}
+
+// Deploy a new service
+func (mcp *MockControlPlane) DeployService(service dao.ServiceDeploymentRequest, serviceId *string) error {
+	if mcp.Responses["DeployService"] != nil {
+		*serviceId = *((*string)(mcp.Responses["DeployService"]))
+	}
+	return mcp.Mock.Called(service, serviceId).Error(0)
+}
+
+// Update an existing service
+func (mcp *MockControlPlane) UpdateService(service service.Service, unused *int) error {
+	return mcp.Mock.Called(service, unused).Error(0)
+}
+
+// Migrate a service definition
+func (mcp *MockControlPlane) MigrateService(request dao.ServiceMigrationRequest, unused *int) error {
+	return mcp.Mock.Called(request, unused).Error(0)
+}
+
+// Remove a service definition
+func (mcp *MockControlPlane) RemoveService(serviceId string, unused *int) error {
+	return mcp.Mock.Called(serviceId, unused).Error(0)
+}
+
+// Get a service from serviced
+func (mcp *MockControlPlane) GetService(serviceId string, response *service.Service) error {
+	if mcp.Responses["GetService"] != nil {
+		*response = *((*service.Service)(mcp.Responses["GetService"]))
+	}
+	return mcp.Mock.Called(serviceId, response).Error(0)
+}
+
+// Get a list of services from serviced
+func (mcp *MockControlPlane) GetServices(request dao.ServiceRequest, services *[]service.Service) error {
+	if mcp.Responses["GetServices"] != nil {
+		*services = *((*[]service.Service)(mcp.Responses["GetServices"]))
+	}
+	return mcp.Mock.Called(request, services).Error(0)
+}
+
+// Find a child service with the given name
+func (mcp *MockControlPlane) FindChildService(request dao.FindChildRequest, response *service.Service) error {
+	if mcp.Responses["FindChildService"] != nil {
+		*response = *((*service.Service)(mcp.Responses["FindChildService"]))
+	}
+	return mcp.Mock.Called(request, response).Error(0)
+}
+
+// Get services with the given tag(s)
+func (mcp *MockControlPlane) GetTaggedServices(request dao.ServiceRequest, services *[]service.Service) error {
+	if mcp.Responses["GetTaggedServices"] != nil {
+		*services = *((*[]service.Service)(mcp.Responses["GetTaggedServices"]))
+	}
+	return mcp.Mock.Called(request, services).Error(0)
+}
+
+// Find all service endpoint matches
+func (mcp *MockControlPlane) GetServiceEndpoints(serviceId string, response *map[string][]dao.ApplicationEndpoint) error {
+	return mcp.Mock.Called(serviceId, response).Error(0)
+}
+
+// Assign IP addresses to all services at and below the provided service
+func (mcp *MockControlPlane) AssignIPs(assignmentRequest dao.AssignmentRequest, unused *struct{}) (err error) {
+	return mcp.Mock.Called(assignmentRequest, unused).Error(0)
+}
+
+// Get the IP addresses assigned to an service
+func (mcp *MockControlPlane) GetServiceAddressAssignments(serviceID string, addresses *[]addressassignment.AddressAssignment) error {
+	return mcp.Mock.Called(serviceID, addresses).Error(0)
+}
+
+//---------------------------------------------------------------------------
+//ServiceState CRUD
+
+// Schedule the given service to start
+func (mcp *MockControlPlane) StartService(request dao.ScheduleServiceRequest, affected *int) error {
+	return mcp.Mock.Called(request, affected).Error(0)
+}
+
+// Schedule the given service to restart
+func (mcp *MockControlPlane) RestartService(request dao.ScheduleServiceRequest, affected *int) error {
+	return mcp.Mock.Called(request, affected).Error(0)
+}
+
+// Schedule the given service to stop
+func (mcp *MockControlPlane) StopService(request dao.ScheduleServiceRequest, affected *int) error {
+	return mcp.Mock.Called(request, affected).Error(0)
+}
+
+// Stop a running instance of a service
+func (mcp *MockControlPlane) StopRunningInstance(request dao.HostServiceRequest, unused *int) error {
+	return mcp.Mock.Called(request, unused).Error(0)
+}
+
+// Wait for a particular service state
+func (mcp *MockControlPlane) WaitService(request dao.WaitServiceRequest, unused *struct{}) error {
+	return mcp.Mock.Called(request, unused).Error(0)
+}
+
+// Update the service state
+func (mcp *MockControlPlane) UpdateServiceState(state servicestate.ServiceState, unused *int) error {
+	return mcp.Mock.Called(state, unused).Error(0)
+}
+
+// Computes the status of the service based on its service instances
+func (mcp *MockControlPlane) GetServiceStatus(serviceID string, statusmap *map[string]dao.ServiceStatus) error {
+	return mcp.Mock.Called(serviceID, statusmap).Error(0)
+}
+
+// Get the services instances for a given service
+func (mcp *MockControlPlane) GetServiceStates(serviceId string, states *[]servicestate.ServiceState) error {
+	return mcp.Mock.Called(serviceId, states).Error(0)
+}
+
+// Get logs for the given app
+func (mcp *MockControlPlane) GetServiceLogs(serviceId string, logs *string) error {
+	return mcp.Mock.Called(serviceId, logs).Error(0)
+}
+
+// Get logs for the given app
+func (mcp *MockControlPlane) GetServiceStateLogs(request dao.ServiceStateRequest, logs *string) error {
+	return mcp.Mock.Called(request, logs).Error(0)
+}
+
+// Get all running services
+func (mcp *MockControlPlane) GetRunningServices(request dao.EntityRequest, runningServices *[]dao.RunningService) error {
+	return mcp.Mock.Called(request, runningServices).Error(0)
+}
+
+// Get the services instances for a given service
+func (mcp *MockControlPlane) GetRunningServicesForHost(hostId string, runningServices *[]dao.RunningService) error {
+	return mcp.Mock.Called(hostId, runningServices).Error(0)
+}
+
+// Get the service instances for a given service
+func (mcp *MockControlPlane) GetRunningServicesForService(serviceId string, runningServices *[]dao.RunningService) error {
+	return mcp.Mock.Called(serviceId, runningServices).Error(0)
+}
+
+// Attach to a running container with a predefined action
+func (mcp *MockControlPlane) Action(request dao.AttachRequest, unused *int) error {
+	return mcp.Mock.Called(request, unused).Error(0)
+}
+
+//---------------------------------------------------------------------------
+// ServiceTemplate CRUD
+
+// Deploy an application template in to production
+func (mcp *MockControlPlane) DeployTemplate(request dao.ServiceTemplateDeploymentRequest, tenantIDs *[]string) error {
+	return mcp.Mock.Called(request, tenantIDs).Error(0)
+}
+
+// Add a new service Template
+func (mcp *MockControlPlane) AddServiceTemplate(serviceTemplate servicetemplate.ServiceTemplate, templateId *string) error {
+	return mcp.Mock.Called(serviceTemplate, templateId).Error(0)
+}
+
+// Update a new service Template
+func (mcp *MockControlPlane) UpdateServiceTemplate(serviceTemplate servicetemplate.ServiceTemplate, unused *int) error {
+	return mcp.Mock.Called(serviceTemplate, unused).Error(0)
+}
+
+// Update a new service Template
+func (mcp *MockControlPlane) RemoveServiceTemplate(serviceTemplateID string, unused *int) error {
+	return mcp.Mock.Called(serviceTemplateID, unused).Error(0)
+}
+
+// Get a list of ServiceTemplates
+func (mcp *MockControlPlane) GetServiceTemplates(unused int, serviceTemplates *map[string]servicetemplate.ServiceTemplate) error {
+	return mcp.Mock.Called(unused, serviceTemplates).Error(0)
+}
+
+//---------------------------------------------------------------------------
+// Service CRUD
+
+//GetSystemUser retrieves the credentials for the system_user account
+func (mcp *MockControlPlane) GetSystemUser(unused int, user *user.User) error {
+	return mcp.Mock.Called(unused, user).Error(0)
+}
+
+//ValidateCredentials verifies if the passed in user has the correct username and password
+func (mcp *MockControlPlane) ValidateCredentials(user user.User, result *bool) error {
+	return mcp.Mock.Called(user, result).Error(0)
+}
+
+// Register a health check result
+func (mcp *MockControlPlane) LogHealthCheck(result domain.HealthCheckResult, unused *int) error {
+	return mcp.Mock.Called(result, unused).Error(0)
+}
+
+// Return the number of layers in an image
+func (mcp *MockControlPlane) ImageLayerCount(imageUUID string, layers *int) error {
+	return mcp.Mock.Called(imageUUID, layers).Error(0)
+}
+
+// Volume returns a service's volume
+func (mcp *MockControlPlane) GetVolume(serviceID string, volume volume.Volume) error {
+	return mcp.Mock.Called(serviceID, volume).Error(0)
+}
+
+// SetRegistry resets the path to the docker registry
+func (mcp *MockControlPlane) ResetRegistry(request dao.EntityRequest, unused *int) error {
+	return mcp.Mock.Called(request, unused).Error(0)
+}
+
+// Deletes a particular snapshot
+func (mcp *MockControlPlane) DeleteSnapshot(snapshotID string, unused *int) error {
+	return mcp.Mock.Called(snapshotID, unused).Error(0)
+}
+
+// Deletes all snapshots for a specific tenant
+func (mcp *MockControlPlane) DeleteSnapshots(tenantID string, unused *int) error {
+	return mcp.Mock.Called(tenantID, unused).Error(0)
+}
+
+// Rollback a service to a particular snapshot
+func (mcp *MockControlPlane) Rollback(request dao.RollbackRequest, unused *int) error {
+	return mcp.Mock.Called(request, unused).Error(0)
+}
+
+// Snapshot takes a snapshot of the filesystem and images
+func (mcp *MockControlPlane) Snapshot(request dao.SnapshotRequest, snapshotID *string) error {
+	return mcp.Mock.Called(request, snapshotID).Error(0)
+}
+
+// AsyncSnapshot performs a snapshot asynchronously
+func (mcp *MockControlPlane) AsyncSnapshot(serviceID string, snapshotID *string) error {
+	return mcp.Mock.Called(serviceID, snapshotID).Error(0)
+}
+
+// ListSnapshots lists all the snapshots for a particular service
+func (mcp *MockControlPlane) ListSnapshots(serviceID string, snapshots *[]dao.SnapshotInfo) error {
+	return mcp.Mock.Called(serviceID, snapshots).Error(0)
+}
+
+// Commit commits a docker container to a service image
+func (mcp *MockControlPlane) Commit(containerID string, snapshotID *string) error {
+	return mcp.Mock.Called(containerID, snapshotID).Error(0)
+}
+
+// ReadyDFS notifies whether there are any running operations
+func (mcp *MockControlPlane) ReadyDFS(unused bool, unusedint *int) error {
+	return mcp.Mock.Called(unused, unusedint).Error(0)
+}
+
+// ListBackups lists the backup files for a particular directory
+func (mcp *MockControlPlane) ListBackups(dirpath string, files *[]dao.BackupFile) error {
+	return mcp.Mock.Called(dirpath, files).Error(0)
+}
+
+// Backup backs up dfs and imagesWrite a tgz file containing all templates and services
+func (mcp *MockControlPlane) Backup(dirpath string, filename *string) error {
+	return mcp.Mock.Called(dirpath, filename).Error(0)
+}
+
+// AsyncBackup performs asynchronous backups
+func (mcp *MockControlPlane) AsyncBackup(dirpath string, filename *string) error {
+	return mcp.Mock.Called(dirpath, filename).Error(0)
+}
+
+// Restore templates and services from a tgz file (inverse of Backup)
+func (mcp *MockControlPlane) Restore(filename string, unused *int) error {
+	return mcp.Mock.Called(filename, unused).Error(0)
+}
+
+// AsyncRestore performs an asynchronous restore
+func (mcp *MockControlPlane) AsyncRestore(filename string, unused *int) error {
+	return mcp.Mock.Called(filename, unused).Error(0)
+}
+
+// BackupStatus monitors the status of a backup or restore
+func (mcp *MockControlPlane) BackupStatus(unused int, status *string) error {
+	return mcp.Mock.Called(unused, status).Error(0)
+}

--- a/dao/test/mockControlPlane.go
+++ b/dao/test/mockControlPlane.go
@@ -14,7 +14,6 @@
 package test
 
 import (
-	// "fmt"
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/domain"
 	"github.com/control-center/serviced/domain/addressassignment"
@@ -54,6 +53,16 @@ func New() *MockControlPlane {
 	mcp := &MockControlPlane{}
 	mcp.Responses = make(map[string]unsafe.Pointer)
 	return mcp
+}
+
+// Helper method that returns the arguments for first call to the specified mock
+func (mcp *MockControlPlane) GetArgsForMockCall(methodName string) mock.Arguments {
+	for _, call := range mcp.Calls {
+		if call.Method == methodName {
+			return call.Arguments
+		}
+	}
+	return nil
 }
 
 //for a service, get it's tenant Id

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -38,7 +38,7 @@ type FacadeInterface interface {
 
 	GetTenantID(ctx datastore.Context, serviceID string) (string, error)
 
-	MigrateService(ctx datastore.Context, svc *service.Service, script string) error
+	MigrateService(ctx datastore.Context, svc *service.Service, script string, dryRun bool) error
 
 	RemoveService(ctx datastore.Context, id string) error
 

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -1,4 +1,3 @@
-
 // Copyright 2014 The Serviced Authors.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,8 +16,8 @@ package facade
 import (
 	"time"
 
-	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/dao"
+	"github.com/control-center/serviced/datastore"
 
 	"github.com/control-center/serviced/domain/host"
 	"github.com/control-center/serviced/domain/pool"
@@ -29,22 +28,23 @@ import (
 
 // The FacadeInterface is the API for a Facade
 type FacadeInterface interface {
-
 	AddService(ctx datastore.Context, svc service.Service) error
 
 	GetService(ctx datastore.Context, id string) (*service.Service, error)
 
 	GetServices(ctx datastore.Context, request dao.EntityRequest) ([]service.Service, error)
 
- 	GetServiceStates(ctx datastore.Context, serviceID string) ([]servicestate.ServiceState, error)
+	GetServiceStates(ctx datastore.Context, serviceID string) ([]servicestate.ServiceState, error)
 
- 	GetTenantID(ctx datastore.Context, serviceID string) (string, error)
+	GetTenantID(ctx datastore.Context, serviceID string) (string, error)
+
+	MigrateService(ctx datastore.Context, svc *service.Service, script string) error
 
 	RemoveService(ctx datastore.Context, id string) error
 
 	RestoreIPs(ctx datastore.Context, svc service.Service) error
 
- 	ScheduleService(ctx datastore.Context, serviceID string, autoLaunch bool, desiredState service.DesiredState) (int, error)
+	ScheduleService(ctx datastore.Context, serviceID string, autoLaunch bool, desiredState service.DesiredState) (int, error)
 
 	UpdateService(ctx datastore.Context, svc service.Service) error
 
@@ -62,7 +62,7 @@ type FacadeInterface interface {
 
 	GetResourcePools(ctx datastore.Context) ([]pool.ResourcePool, error)
 
- 	HasIP(ctx datastore.Context, poolID string, ipAddr string) (bool, error)
+	HasIP(ctx datastore.Context, poolID string, ipAddr string) (bool, error)
 
 	UpdateResourcePool(ctx datastore.Context, entity *pool.ResourcePool) error
 }

--- a/facade/test/mockFacade.go
+++ b/facade/test/mockFacade.go
@@ -69,7 +69,7 @@ func (mf *MockFacade) GetTenantID(ctx datastore.Context, serviceID string) (stri
 	return args.String(0), args.Error(1)
 }
 
-func (mf *MockFacade) MigrateService(ctx datastore.Context, svc *service.Service, script string) error {
+func (mf *MockFacade) MigrateService(ctx datastore.Context, svc *service.Service, script string, dryRun bool) error {
 	return mf.Mock.Called(ctx, svc, script).Error(0)
 }
 

--- a/facade/test/mockFacade.go
+++ b/facade/test/mockFacade.go
@@ -69,6 +69,10 @@ func (mf *MockFacade) GetTenantID(ctx datastore.Context, serviceID string) (stri
 	return args.String(0), args.Error(1)
 }
 
+func (mf *MockFacade) MigrateService(ctx datastore.Context, svc *service.Service, script string) error {
+	return mf.Mock.Called(ctx, svc, script).Error(0)
+}
+
 func (mf *MockFacade) RemoveService(ctx datastore.Context, id string) error {
 	return mf.Mock.Called(ctx, id).Error(0)
 }

--- a/node/cp_client.go
+++ b/node/cp_client.go
@@ -92,6 +92,10 @@ func (s *ControlClient) UpdateService(service service.Service, unused *int) (err
 	return s.rpcClient.Call("ControlPlane.UpdateService", service, unused)
 }
 
+func (s *ControlClient) MigrateService(request dao.ServiceMigrationRequest, unused *int) (err error) {
+	return s.rpcClient.Call("ControlPlane.MigrateService", request, unused)
+}
+
 func (s *ControlClient) RemoveService(serviceId string, unused *int) (err error) {
 	return s.rpcClient.Call("ControlPlane.RemoveService", serviceId, unused)
 }


### PR DESCRIPTION
An initial implement of service migration. Still very simple at this stage. This PR just addresses the first two tasks of the Rally story [\[Service Migration\] Invoke migration script](https://rally1.rallydev.com/#/30873679006d/detail/userstory/31069383245)

Please look at 8226df1 very closely. I refactored out a function to validate a service definition so that 'migrate --dry-run' shares the same validation as a regular add or edit operation, but I had to rearrange a few things that could break add/edit if a I made a mistake.