### PR TITLE
fixes CC-848: update with go 1.4 imports

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -6,9 +6,9 @@
 	],
 	"Deps": [
 		{
-			"ImportPath": "code.google.com/p/go.crypto/ssh/terminal",
+			"ImportPath": "golang.org/x/crypto/ssh/terminal",
 			"Comment": "null-187",
-			"Rev": "ebfe91cdc0348163deedb0e75d680c9305e4f1ff"
+			"Rev": "1351f936d976c60a0a48d728281922cf63eafb8d"
 		},
 		{
 			"ImportPath": "github.com/kr/pretty",
@@ -27,9 +27,9 @@
 			"Rev": "60fd543d979a4ad532fafb8bc24426d4f48181c4"
 		},
 		{
-			"ImportPath": "code.google.com/p/go.net/websocket",
+			"ImportPath": "golang.org/x/net/websocket",
 			"Comment": "null-139",
-			"Rev": "98fd1f5506373df1033b67a1881078705456e2ee"
+			"Rev": "b6fdb7d8a4ccefede406f8fe0f017fb58265054c"
 		},
 		{
 			"ImportPath": "github.com/gorilla/mux",

--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 	"syscall"
 
-	"code.google.com/p/go.crypto/ssh/terminal"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 func remove(index int, list ...interface{}) []interface{} {


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-848

http://grokbase.com/t/gg/golang-nuts/14b5zdma3z/go-nuts-new-import-paths-for-go-sub-respositories
```
code.google.com/p/go.net -> golang.org/x/net
code.google.com/p/go.crypto -> golang.org/x/crypto
```

These are the files that need fixing
```
cli/cmd/utils.go
25:	"code.google.com/p/go.crypto/ssh/terminal"
Godeps
9:			"ImportPath": "code.google.com/p/go.crypto/ssh/terminal",
30:			"ImportPath": "code.google.com/p/go.net/websocket",
```

Commit hashes for Godeps retrieved from here:
https://go.googlesource.com/net
https://go.googlesource.com/crypto

