### PR TITLE
fixes CC-769: replaced in memory lock with zookeeper path based lock for volume initialization

### DIFF
--- a/node/agent.go
+++ b/node/agent.go
@@ -770,7 +770,12 @@ func (a *HostAgent) setupVolume(tenantID string, service *service.Service, volum
 		return "", fmt.Errorf("Could not create resource path: %s, %s", resourcePath, err)
 	}
 
-	if err := createVolumeDir(resourcePath, volume.ContainerPath, service.ImageID, volume.Owner, volume.Permission); err != nil {
+	conn, err := a.zkClient.GetConnection()
+	if err != nil {
+		return "", fmt.Errorf("Could not get zk connection for resource path: %s, %s", resourcePath, err)
+	}
+
+	if err := createVolumeDir(conn, resourcePath, volume.ContainerPath, service.ImageID, volume.Owner, volume.Permission); err != nil {
 		glog.Errorf("Error populating resource path: %s with container path: %s, %v", resourcePath, volume.ContainerPath, err)
 		return "", err
 	}

--- a/node/utils_test.go
+++ b/node/utils_test.go
@@ -31,7 +31,21 @@ import (
 	"syscall"
 
 	"github.com/zenoss/glog"
+
+	"github.com/control-center/serviced/coordinator/client"
+	"github.com/control-center/serviced/zzk"
+	. "gopkg.in/check.v1"
 )
+
+var _ = Suite(&ZZKTest{})
+
+type ZZKTest struct {
+	zzk.ZZKTestSuite
+}
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
 
 // Test validOwnerSpec
 func TestValidOwnerSpec(t *testing.T) {
@@ -104,8 +118,18 @@ Last stable version: 0.6.6
 	}
 }
 
+func getTestConn(c *C, path string) client.Connection {
+	root, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+	err = root.CreateDir(path)
+	c.Assert(err, IsNil)
+	conn, err := zzk.GetLocalConnection(path)
+	c.Assert(err, IsNil)
+	return conn
+}
+
 // Test createVolumeDir
-func TestCreateVolumeDir(t *testing.T) {
+func (ts *ZZKTest) TestCreateVolumeDir(t *C) {
 	// create temporary proc dir
 	tmpPath, err := ioutil.TempDir("", "node_util")
 	if err != nil {
@@ -132,7 +156,8 @@ func TestCreateVolumeDir(t *testing.T) {
 		perm:          "755",
 	}
 
-	if err := createVolumeDir(v.hostPath, v.containerPath, v.image, v.user, v.perm); err != nil {
+	conn := getTestConn(t, "/vinit")
+	if err := createVolumeDir(conn, v.hostPath, v.containerPath, v.image, v.user, v.perm); err != nil {
 		t.Fatalf("unable to create volume %+v: %s", tmpPath, err)
 	}
 

--- a/utils/filelock.go
+++ b/utils/filelock.go
@@ -1,0 +1,151 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+//#include <stdlib.h>
+//extern int fd_lock(int fd, char* filepath);
+//extern int fd_unlock(int fd, char* filepath);
+import "C"
+import (
+	"github.com/zenoss/glog"
+	//"golang.org/x/sys/unix"  // requires go 1.4
+
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// LockFile opens and locks the file at the given path - it will block and wait for unlock
+func LockFile(filelockpath string) (*os.File, error) {
+
+	if true {
+		// take advantage of Open and O_EXCL (man creat for more info)
+		// the downside of this approach is that killing the application
+		// will prevent file lockfile cleanup even if there is a defer os.Remove(lockfile)
+	WAIT_FOR_LOCK:
+		for {
+			glog.V(2).Infof("locking file: %s", filelockpath)
+			fp, err := os.OpenFile(filelockpath, syscall.O_RDWR|syscall.O_CREAT|syscall.O_EXCL, 0600)
+			if err != nil {
+				if !strings.Contains(err.Error(), syscall.EEXIST.Error()) {
+					return nil, err
+				}
+			} else {
+				glog.V(2).Infof("locked file: %s", filelockpath)
+				return fp, nil
+			}
+
+			glog.Infof("waiting to lock file: %s", filelockpath)
+			select {
+			case <-time.After(1 * time.Second):
+				continue WAIT_FOR_LOCK
+			}
+		}
+
+		//return nil, fmt.Errorf("timed out waiting to lock file %s", filelockpath)
+	} else {
+
+		// other failed attempts to lock file using fcntl/flock/...
+		fp, err := os.OpenFile(filelockpath, syscall.O_RDWR|syscall.O_CREAT, 0600)
+		if err != nil {
+			return nil, err
+		}
+
+		glog.V(2).Infof("locking file: %s", filelockpath)
+		if false {
+			// FIXME: this is not working from GO, but works from C - thread issue even when sync mutex is used
+			var flp = C.CString(filelockpath)
+			defer C.free(unsafe.Pointer(flp))
+			rc := C.fd_lock(C.int(fp.Fd()), flp)
+			if 0 != rc {
+				return nil, fmt.Errorf("unable to lock file %s", filelockpath)
+			}
+			/*
+				} else if false {
+					// BEWARE: flock does not work when two hosts are NFS locking
+					// flock tested and works on ubuntu: ext4, btrfs, NFS (same host)
+					// flock tested on centos: tmpfs, ext4, btrfs, NFS (same host)
+					if err := unix.Flock(int(fp.Fd()), unix.LOCK_EX); err != nil {
+						return nil, err
+					}
+				} else if false {
+					// FIXME: unix.FcntlFlock is not working - thread issue and NFS issue
+					ft := unix.Flock_t{
+						Type:   syscall.F_WRLCK,         //Type of lock: F_RDLCK, F_WRLCK, F_UNLCK
+						Whence: int16(os.SEEK_SET),      // How to interpret l_start: SEEK_SET, SEEK_CUR, SEEK_END
+						Start:  0,                       // Starting offset for lock
+						Len:    0,                       // Number of bytes to lock
+						Pid:    int32(syscall.Getpid()), // PID of process blocking our lock (F_GETLK only)
+					}
+					glog.V(2).Infof("syscall.Flock_t %#v", ft)
+
+					if err := unix.FcntlFlock(fp.Fd(), syscall.F_SETLKW, &ft); err != nil {
+						return nil, err
+					}
+			*/
+		} else if false {
+			// FIXME: flock does not work when two hosts are NFS locking
+			// flock tested and works on ubuntu: ext4, btrfs, NFS (same host)
+			// flock tested on centos: tmpfs, ext4, btrfs, NFS (same host)
+			if err := syscall.Flock(int(fp.Fd()), syscall.LOCK_EX); err != nil {
+				return nil, err
+			}
+		} else if false {
+			// FIXME: syscall.FcntlFlock is not working - thread issue and syscall issue and NFS issue
+			ft := syscall.Flock_t{
+				Type:   syscall.F_WRLCK,         //Type of lock: F_RDLCK, F_WRLCK, F_UNLCK
+				Whence: int16(os.SEEK_SET),      // How to interpret l_start: SEEK_SET, SEEK_CUR, SEEK_END
+				Start:  0,                       // Starting offset for lock
+				Len:    0,                       // Number of bytes to lock
+				Pid:    int32(syscall.Getpid()), // PID of process blocking our lock (F_GETLK only)
+			}
+			glog.V(2).Infof("syscall.Flock_t %#v", ft)
+
+			if err := syscall.FcntlFlock(fp.Fd(), syscall.F_SETLKW /* F_GETLK, F_SETLK, F_SETLKW */, &ft); err != nil {
+				return nil, err
+			}
+		} else if false {
+			// FIXME: syscall.FcntlFlock is not working - thread issue and syscall issue and NFS issue
+			// This type matches C's "struct flock" defined in /usr/include/x86_64-linux-gnu/bits/fcntl.h
+			k := struct {
+				Type   uint32
+				Whence uint32
+				Start  uint64
+				Len    uint64
+				Pid    uint32
+			}{
+				Type:   syscall.F_WRLCK,
+				Whence: uint32(os.SEEK_SET),
+				Start:  0,
+				Len:    0, // 0 means to lock the entire file.
+				Pid:    uint32(os.Getpid()),
+			}
+
+			glog.V(2).Infof("mimic /usr/include/x86_64-linux-gnu/bits/fcntl.h syscall.Flock_t %#v", k)
+			_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, fp.Fd(), uintptr(syscall.F_SETLK), uintptr(unsafe.Pointer(&k)))
+			if errno != 0 {
+				fp.Close()
+				return nil, fmt.Errorf("syscall.Syscall error: %s", errno)
+			}
+		} else {
+			return nil, fmt.Errorf("all filelocking implementations fail")
+		}
+
+		glog.V(2).Infof("locked  file: %s", filelockpath)
+		return fp, nil
+	}
+}

--- a/utils/filelock_fd.c
+++ b/utils/filelock_fd.c
@@ -1,0 +1,84 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <error.h>
+#include <errno.h>
+
+#define ERRORF(fmt, ...) \
+            do { fprintf(stderr, "ERROR %s:%d] " fmt, __FILE__, __LINE__, __VA_ARGS__); } while (0)
+
+
+int fd_fcntl(int fd, int cmd, short type, char* filepath)
+{
+    struct flock ft;
+    memset(&ft, 0, sizeof(ft));
+    ft.l_type = type;      /* Type of lock: F_RDLCK, F_WRLCK, F_UNLCK */
+    ft.l_whence = SEEK_SET;   /* How to interpret l_start: SEEK_SET, SEEK_CUR, SEEK_END */
+    ft.l_start = 0;           /* Starting offset for lock */
+    ft.l_len = 0;             /* Number of bytes to lock */
+    ft.l_pid = getpid();      /* PID of process blocking our lock (F_GETLK only) */
+
+    if (fcntl(fd, cmd, &ft) == -1) {
+        char errstr[128];
+        memset(&errstr, 0, sizeof(errstr));
+        int n = strerror_r(errno, errstr, sizeof(errstr)-0);
+        ERRORF("unable to fcntl file %s: %s", filepath, errstr);
+        return -1;
+    }
+
+    return 0;
+}
+
+int fd_lock(int fd, char* filepath)
+{
+    return fd_fcntl(fd, F_SETLKW, F_WRLCK, filepath);
+}
+
+int fd_unlock(int fd, char* filepath)
+{
+    return fd_fcntl(fd, F_SETLK, F_UNLCK, filepath);
+}
+
+#if defined(UNIT_TEST_FILELOCK)
+/* compile unit test with: gcc -DUNIT_TEST_FILELOCK -o filelock_fd filelock_fd.c */
+int main(int argc, char *argv[])
+{
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s FILE\n", argv[0]);
+        exit(-1);
+    }
+
+    char* filepath = argv[1];
+    int fd = 0;
+    if ((fd = open(filepath, O_RDWR|O_CREAT, 0664)) == -1) {
+        perror("open");
+        exit(1);
+    }
+
+    int rc = 0;
+
+    // lock file
+    fprintf(stdout, "locking:  %s\n", filepath);
+    rc = fd_lock(fd, filepath);
+    if (0 != rc) {
+        exit(2);
+    }
+    fprintf(stdout, "locked:   %s\n", filepath);
+
+    // sleep interval
+    int interval = 10;
+    fprintf(stdout, "sleeping %d\n", interval);
+    sleep(interval);
+
+    // unlock file
+    rc = fd_unlock(fd, filepath);
+    if (0 != rc) {
+        exit(3);
+    }
+    fprintf(stdout, "unlocked: %s\n", filepath);
+
+    return rc;
+}
+#endif

--- a/utils/filelock_test.go
+++ b/utils/filelock_test.go
@@ -1,0 +1,94 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"reflect"
+	"time"
+
+	"github.com/zenoss/glog"
+)
+
+// TestFileLock
+func TestFileLock(t *testing.T) {
+	t.Skip("filelock with flock/fcntl fails - unused until go sys/unix subrepo is fixed")
+
+	var err error
+	hostid, err := HostID()
+	if err != nil {
+		t.Fatalf("unable to get hostid: %s", err)
+	}
+
+	lockdir := os.Getenv("FILELOCK_TESTPATH")
+	if len(lockdir) == 0 {
+		// create temporary proc dir
+		if lockdir, err = ioutil.TempDir("", "file_lock"); err != nil {
+			t.Fatalf("could not create tempdir %+v: %s", lockdir, err)
+		}
+		defer os.RemoveAll(lockdir)
+	}
+
+	if err := os.MkdirAll(lockdir, 0755); err != nil {
+		t.Fatalf("unable to mkdir %+v: %s", lockdir, err)
+	}
+
+	filelock := path.Join(lockdir, "file.lck")
+	lockuser := func(id int, events chan string) {
+		glog.V(0).Infof("%s:%d locking  %s", hostid, id, lockdir)
+		fp, err := LockFile(filelock)
+		if err != nil {
+			t.Fatalf("unable to lock %+v: %s", filelock, err)
+		}
+		defer fp.Close()
+		defer os.Remove(filelock) // uncomment to test Open(O_EXCL)
+		fp.WriteString(fmt.Sprintf("%s:%d\n", hostid, id))
+		events <- "locked"
+		duration := 5 * time.Second
+		glog.V(0).Infof("%s:%d locked    %s - sleeping %s", hostid, id, lockdir, duration)
+		time.Sleep(duration)
+		events <- "done"
+		glog.V(0).Infof("%s:%d unlocking %s", hostid, id, lockdir)
+	}
+
+	events := make(chan string)
+	expected := []string{"locked", "done", "locked", "done", "locked", "done", "locked", "done"}
+	numClients := len(expected) / 2
+	for id := 0; id < numClients; id++ {
+		go lockuser(id, events)
+	}
+
+	reported := []string{}
+WAIT_FOR_REPORTERS:
+	for {
+		glog.V(2).Infof("waiting for reporters - reported: %+v", reported)
+		select {
+		case <-time.After(time.Duration(numClients*5+numClients) * time.Second):
+			break WAIT_FOR_REPORTERS
+
+		case ev := <-events:
+			reported = append(reported, ev)
+			glog.V(2).Infof("reported: %+v", reported)
+		}
+	}
+
+	if !reflect.DeepEqual(expected, reported) {
+		t.Fatalf("expected: %+v != actual: %+v", expected, reported)
+	}
+}

--- a/zzk/service/host.go
+++ b/zzk/service/host.go
@@ -191,22 +191,22 @@ func (l *HostStateListener) Spawn(shutdown <-chan interface{}, stateID string) {
 			var err error
 			if !state.IsRunning() {
 				// process has stopped
-				glog.Infof("Starting a new instance for %s", state.ID)
+				glog.Infof("Starting a new instance for %s %s", state.ID, svc.Name)
 				processDone, err = l.startInstance(&svc, state)
 			} else if processDone == nil {
-				glog.Infof("Attaching to instance %s via %s", state.ID, state.DockerID)
+				glog.Infof("Attaching to instance %s %s via %s", state.ID, svc.Name, state.DockerID)
 				processDone, err = l.attachInstance(&svc, state)
 			}
 
 			if err != nil {
-				glog.Errorf("Error trying to start or attach to service instance %s: %s", state.ID, err)
+				glog.Errorf("Error trying to start or attach to service instance %s %s: %s", state.ID, svc.Name, err)
 				return
 			}
 
 			if state.IsPaused() {
-				glog.Infof("Resuming a paused instance for %s", state.ID)
+				glog.Infof("Resuming a paused instance for %s %s", state.ID, svc.Name)
 				if err := l.resumeInstance(&svc, state); err != nil {
-					glog.Errorf("Could not resume paused instance %s: %s", state.ID, err)
+					glog.Errorf("Could not resume paused instance %s %s: %s", state.ID, svc.Name, err)
 					return
 				}
 			}
@@ -214,7 +214,7 @@ func (l *HostStateListener) Spawn(shutdown <-chan interface{}, stateID string) {
 			if state.IsPaused() {
 				// service instance is not running, pass
 			} else if err := l.pauseInstance(&svc, state); err != nil {
-				glog.Errorf("Could not pause service instance %s; stopping: %s", state.ID, err)
+				glog.Errorf("Could not pause service instance %s %s; stopping: %s", state.ID, svc.Name, err)
 				return
 			}
 		case service.SVCStop:


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-769

DEMO:
```
...
I0302 15:53:15.706068 18289 host.go:194] Starting a new instance for c4clwkw5m3cx2h2tu8xi2tm5j redis
...
I0302 15:53:21.271407 18289 utils.go:378] DFS volume init #0 took 5.289621524s for src:/home/plu/src/europa/var/serviced/volumes/czfh98migvm0x5rymiclwnsje/redis dst:/var/lib/redis image:localhost:5000/czfh98migvm0x5rymiclwnsje/devimg user:root:root perm:0755

...
W0302 15:53:23.592520 18289 utils.go:374] WARNING: DFS mount /opt/zenoss/.pc does not exist in image localhost:5000/czfh98migvm0x5rymiclwnsje/devimg
I0302 15:53:23.592579 18289 utils.go:378] DFS volume init #0 took 6.368358186s for src:/home/plu/src/europa/var/serviced/volumes/czfh98migvm0x5rymiclwnsje/zenoss-custom-patches-pc dst:/opt/zenoss/.pc image:localhost:5000/czfh98migvm0x5rymiclwnsje/devimg user:zenoss:zenoss perm:0755
...

```