### PR TITLE
fixes CC-775: added release to servicedversion

### DIFF
--- a/cli/cmd/host.go
+++ b/cli/cmd/host.go
@@ -148,9 +148,9 @@ func (c *ServicedCli) cmdHostList(ctx *cli.Context) {
 		}
 	} else {
 		tableHost := newtable(0, 8, 2)
-		tableHost.printrow("ID", "POOL", "NAME", "ADDR", "RPCPORT", "CORES", "MEM", "NETWORK")
+		tableHost.printrow("ID", "POOL", "NAME", "ADDR", "RPCPORT", "CORES", "MEM", "NETWORK", "RELEASE")
 		for _, h := range hosts {
-			tableHost.printrow(h.ID, h.PoolID, h.Name, h.IPAddr, h.RPCPort, h.Cores, h.Memory, h.PrivateNetwork)
+			tableHost.printrow(h.ID, h.PoolID, h.Name, h.IPAddr, h.RPCPort, h.Cores, h.Memory, h.PrivateNetwork, h.ServiceD.Release)
 		}
 		tableHost.flush()
 	}

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -39,5 +39,6 @@ func (c *ServicedCli) cmdVersion(ctx *cli.Context) {
 	fmt.Printf("Giturl:    %s\n", servicedversion.Giturl)
 	fmt.Printf("Date:      %s\n", servicedversion.Date)
 	fmt.Printf("Buildtag:  %s\n", servicedversion.Buildtag)
+	fmt.Printf("Release:   %s\n", servicedversion.Release)
 	fmt.Printf("IsvcsImage: %s:%s\n", isvcs.IMAGE_REPO, isvcs.IMAGE_TAG)
 }

--- a/domain/host/host.go
+++ b/domain/host/host.go
@@ -48,6 +48,7 @@ type Host struct {
 		Gitbranch string
 		Giturl    string
 		Buildtag  string
+		Release   string
 	}
 	MonitoringProfile domain.MonitorProfile
 	datastore.VersionedEntity
@@ -148,13 +149,14 @@ func Build(ip string, rpcport string, poolid string, ipAddrs ...string) (*Host, 
 	}
 	host.IPs = hostIPs
 
-	// get ebedded host information
+	// get embedded host information
 	host.ServiceD.Version = servicedversion.Version
 	host.ServiceD.Gitbranch = servicedversion.Gitbranch
 	host.ServiceD.Gitcommit = servicedversion.Gitcommit
 	host.ServiceD.Giturl = servicedversion.Giturl
 	host.ServiceD.Date = servicedversion.Date
 	host.ServiceD.Buildtag = servicedversion.Buildtag
+	host.ServiceD.Release = servicedversion.Release
 
 	return host, nil
 }

--- a/domain/host/utils.go
+++ b/domain/host/utils.go
@@ -74,6 +74,7 @@ func currentHost(ip string, rpcPort int, poolID string) (host *Host, err error) 
 	host.ServiceD.Giturl = servicedversion.Giturl
 	host.ServiceD.Date = servicedversion.Date
 	host.ServiceD.Buildtag = servicedversion.Buildtag
+	host.ServiceD.Release = servicedversion.Release
 
 	host.KernelVersion, host.KernelRelease, err = getOSKernelData()
 	if err != nil {

--- a/servicedversion/servicedversion.go
+++ b/servicedversion/servicedversion.go
@@ -18,29 +18,76 @@
 
 package servicedversion
 
+import (
+	"github.com/control-center/serviced/utils"
+	"github.com/zenoss/glog"
+
+	"fmt"
+	"os/exec"
+)
+
 var Version string
 var Date string
 var Gitbranch string
 var Gitcommit string
 var Giturl string
 var Buildtag string
+var Release string
 
 type ServicedVersion struct {
-	Version string
-	Date string
+	Version   string
+	Date      string
 	Gitbranch string
 	Gitcommit string
-	Giturl string
-	Buildtag string
+	Giturl    string
+	Buildtag  string
+	Release   string
+}
+
+func init() {
+	var err error
+	Release, err = GetPackageRelease("serviced")
+	if err != nil {
+		glog.Errorf("%s", err)
+	}
 }
 
 func GetVersion() ServicedVersion {
+
 	return ServicedVersion{
-		Version,
-		Date,
-		Gitbranch,
-		Gitcommit,
-		Giturl,
-		Buildtag,
+		Version:   Version,
+		Date:      Date,
+		Gitbranch: Gitbranch,
+		Gitcommit: Gitcommit,
+		Giturl:    Giturl,
+		Buildtag:  Buildtag,
+		Release:   Release,
 	}
+}
+
+// GetPackageRelease returns the release version of the installed package
+func GetPackageRelease(pkg string) (string, error) {
+	command := getCommandToGetPackageRelease(pkg)
+
+	thecmd := exec.Command(command[0], command[1:]...)
+	output, err := thecmd.CombinedOutput()
+	if err != nil {
+		e := fmt.Errorf("unable to retrieve release of package '%s' with command:'%s' output: %s  error: %s\n", pkg, command, output, err)
+		return "", e
+	}
+
+	glog.V(1).Infof("Successfully ran command:'%s' output: %s\n", command, output)
+	return string(output), nil
+}
+
+// getCommandToGetPackageRelease returns the command to get the package release
+func getCommandToGetPackageRelease(pkg string) []string {
+	command := []string{}
+	if utils.Platform == utils.Rhel {
+		command = []string{"bash", "-c", fmt.Sprintf("rpm -q --qf '%%{VERSION}-%%{Release}\n' %s", pkg)}
+	} else {
+		command = []string{"bash", "-c", fmt.Sprintf("dpkg -s %s | awk '/^Version/{print $NF;exit}'", pkg)}
+	}
+
+	return command
 }

--- a/servicedversion/servicedversion_test.go
+++ b/servicedversion/servicedversion_test.go
@@ -1,0 +1,37 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package servicedversion
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/control-center/serviced/utils"
+)
+
+func TestGetPackageRelease(t *testing.T) {
+	t.Log("verifying command to get package release")
+
+	actual := getCommandToGetPackageRelease("serviced")
+
+	expected := []string{}
+	if utils.Platform == utils.Rhel {
+		expected = []string{"bash", "-c", "rpm -q --qf '%{VERSION}-%{Release}\n' serviced"}
+	} else {
+		expected = []string{"bash", "-c", "dpkg -s serviced | awk '/^Version/{print $NF;exit}'"}
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected: %+v != actual: %+v", expected, actual)
+	}
+}

--- a/web/ui/src/Hosts/view-host-details.html
+++ b/web/ui/src/Hosts/view-host-details.html
@@ -33,6 +33,11 @@
     </div>
 
     <div class="vertical-info">
+      <label for="host_data_serviced_release" translate>label_host_serviced_release</label>
+      <div id="host_data_serviced_release">{{currentHost.model.ServiceD.Release}}</div>
+    </div>
+
+    <div class="vertical-info">
       <label for="host_data_ip_addr" translate>label_host_ip_addr</label>
       <div id="host_data_ip_addr">{{currentHost.model.IPAddr}}</div>
     </div>

--- a/web/ui/src/Hosts/view-hosts.html
+++ b/web/ui/src/Hosts/view-hosts.html
@@ -27,6 +27,7 @@
       <th translate>label_host_memory</th>
       <th translate>label_host_cores</th>
       <th translate>label_host_kernel_version</th>
+      <th translate>label_host_serviced_release</th>
       <th translate>actions</th>
     </tr>
   </thead>
@@ -47,6 +48,7 @@
       <td>{{host.model.Memory | toGB}}</td>
       <td>{{host.model.Cores}}</td>
       <td>{{host.model.KernelVersion}}</td>
+      <td>{{host.model.ServiceD.Release}}</td>
       <td><button ng-click="remove_host(host.id)" class="btn btn-link action"><i class="glyphicon glyphicon-remove-sign"></i> Delete</button></td>
     </tr>
   </tbody>

--- a/web/ui/static/i18n/en_US.json
+++ b/web/ui/static/i18n/en_US.json
@@ -207,6 +207,7 @@
     "label_ip_assignments": "IP Assignments",
     "label_host_kernel_version": "Kernel Version",
     "label_host_kernel_release": "Kernel Release",
+    "label_host_serviced_release": "CC Release",
     "label_messages": "Messages",
     "label_netmask": "Netmask",
     "label_owner": "Owner",

--- a/web/ui/static/i18n/es_US.json
+++ b/web/ui/static/i18n/es_US.json
@@ -184,6 +184,7 @@
     "label_hosts_search": "Buscar",
     "label_host_kernel_version": "Versi\u00f3n del kernel",
     "label_host_kernel_release": "Revisi\u00f3n del kernel",
+    "label_host_serviced_release": "Revisi\u00f3n del CC",
     "label_ip_assignments": "Asignación de IP",
     "label_messages": "Mensajes",
     "label_netmask": "Mascara de Red",


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-775

DEMO - serviced host list shows release version:
```
# plu@plu-9: serviced host list
ID		POOL		NAME	ADDR		RPCPORT		CORES	MEM		NETWORK			RELEASE
570a276e	default		plu-9	172.17.42.1	4979		12	33659494400	172.17.0.0/255.255.0.0	1.0.0~trusty-0.1.CR7
```

DEMO - serviced version shows release:
```
# plu@plu-9: serviced version |grep Release
Release:   1.0.0~trusty-0.1.CR7
```

CC UI About shows Release:
![screen shot 2015-03-02 at 15 36 08](https://cloud.githubusercontent.com/assets/2837923/6451142/13652302-c0f2-11e4-9e25-3dcc6e4af174.png)

CC UI Hosts:
![screen shot 2015-03-02 at 15 52 43](https://cloud.githubusercontent.com/assets/2837923/6451481/51a11ed0-c0f4-11e4-99e3-7391e955d211.png)

CC UI Host Detail:
![screen shot 2015-03-02 at 15 52 34](https://cloud.githubusercontent.com/assets/2837923/6451490/662cc7aa-c0f4-11e4-9b8f-eaf7cba8bad3.png)
