### PR TITLE
revert websocket godep import to be code.google.com/p/go.net/websocket for googollee

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -27,9 +27,9 @@
 			"Rev": "60fd543d979a4ad532fafb8bc24426d4f48181c4"
 		},
 		{
-			"ImportPath": "golang.org/x/net/websocket",
+			"ImportPath": "code.google.com/p/go.net/websocket",
 			"Comment": "null-139",
-			"Rev": "b6fdb7d8a4ccefede406f8fe0f017fb58265054c"
+			"Rev": "98fd1f5506373df1033b67a1881078705456e2ee"
 		},
 		{
 			"ImportPath": "github.com/gorilla/mux",


### PR DESCRIPTION
http://jenkins.zendev.org/view/Control%20Center/job/1.0.x-serviced-build/1/console

ISSUE:
```
~/src/develop/src/golang/src/github.com/control-center/serviced
# plu@plu-9: BUILD_NUMBER=1 make INSTALL_TEMPLATES=0 docker_buildandpackage
...
go build  -ldflags "-X main.Version 1.1.0 -X main.Giturl '' -X main.Gitcommit 1ce546e -X main.Gitbranch develop -X main.Date 'Mon Mar  2 23:16:35 UTC 2015' -X main.Buildtag 0"
../../googollee/go-socket.io/client.go:4:2: cannot find package "code.google.com/p/go.net/websocket" in any of:
	/usr/local/go/src/code.google.com/p/go.net/websocket (from $GOROOT)
	/go/src/code.google.com/p/go.net/websocket (from $GOPATH)
make: *** [serviced] Error 1
make: *** [docker_buildandpackage] Error 2
```

FIX: revert changes to websocket godep:
  https://github.com/control-center/serviced/commit/46c178df


DEMO:
```
~/src/develop/src/golang/src/github.com/control-center/serviced
# plu@plu-9: BUILD_NUMBER=1 make INSTALL_TEMPLATES=0 docker_buildandpackage
...
chown 0:0 /tmp/serviced-bdb00a7e76576f16715a65aca2d9e5823ca34e5c.tgz
mv /tmp/serviced-bdb00a7e76576f16715a65aca2d9e5823ca34e5c.tgz .
make[1]: Leaving directory `/go/src/github.com/control-center/serviced/pkg'

```