### PR TITLE
Temporary workaround so that QE can test the initial SDK

### DIFF
--- a/facade/service.go
+++ b/facade/service.go
@@ -1331,6 +1331,26 @@ func createTempMigrationDir(serviceID string) (string, error) {
 		return "", fmt.Errorf("Unable to create temporary directory: %s", err)
 	}
 
+	// HACK ALERT: The following is temporary so QE can do some basic integration testing
+	//             with the migration SDK and the serviced CLI. When the implementation
+	//             evolves to run the migration within a docker container, this code
+	//             will go away because the docker image will contain the migration SDK.
+	//
+	// To setup the migration SDK for use with this hack, do the following:
+	//
+	// $ zendev cd serviced
+	// $ sudo mkdir -p /tmp/serviced-root/service-migration/servicedmigration
+	// $ sudo cp migration/servicedmigration/*.py /tmp/serviced-root/service-migration/servicedmigration
+	//
+	// Once the setup is done, then you can run a migration script from the serviced CLI.
+	//
+	pythonPath := os.Getenv("PYTHONPATH")
+	if pythonPath == "" {
+		os.Setenv("PYTHONPATH", tmpParentDir)
+	} else if !strings.Contains(pythonPath, tmpParentDir) {
+		os.Setenv("PYTHONPATH", os.ExpandEnv("${PYTHONPATH};"+tmpParentDir))
+	}
+
 	var migrationDir string
 	dirPrefix := fmt.Sprintf("%s-", serviceID)
 	migrationDir, err = ioutil.TempDir(tmpParentDir, dirPrefix)


### PR DESCRIPTION
Sets PYTHONPATH to the temp dir created for migration.

For QE to test the SDK with this change, they must make the following one-time changes on the host where serviced is running.
```
$ zendev cd serviced
$ sudo mkdir -p /tmp/serviced-root/service-migration/servicedmigration
$ sudo cp migration/servicedmigration/*.py /tmp/serviced-root/service-migration/servicedmigration
```
Once that setup is done, then QE can execute a migration script with the CLI using something like:
```
$ serviced service migrate zenhub testsdk.py
```
where `testsdk.py` contains something like:
```
import servicedmigration as sdm
sdm.require(sdm.version.API_VERSION)

svc = sdm.receiveService()
svc.setDescription("an_unlikely-description")
svc.commit()
```