### PR TITLE
fixes CC-861: log error if unable to retrieve release

### DIFF
--- a/servicedversion/servicedversion.go
+++ b/servicedversion/servicedversion.go
@@ -24,6 +24,7 @@ import (
 
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 var Version string
@@ -77,7 +78,8 @@ func GetPackageRelease(pkg string) (string, error) {
 	}
 
 	glog.V(1).Infof("Successfully ran command:'%s' output: %s\n", command, output)
-	return string(output), nil
+	release := strings.TrimSuffix(string(output), "\n")
+	return release, nil
 }
 
 // getCommandToGetPackageRelease returns the command to get the package release
@@ -86,7 +88,7 @@ func getCommandToGetPackageRelease(pkg string) []string {
 	if utils.Platform == utils.Rhel {
 		command = []string{"bash", "-c", fmt.Sprintf("rpm -q --qf '%%{VERSION}-%%{Release}\n' %s", pkg)}
 	} else {
-		command = []string{"bash", "-c", fmt.Sprintf("dpkg -s %s | awk '/^Version/{print $NF;exit}'", pkg)}
+		command = []string{"bash", "-o", "pipefail", "-c", fmt.Sprintf("dpkg -s %s | awk '/^Version/{print $NF;exit}'", pkg)}
 	}
 
 	return command

--- a/servicedversion/servicedversion_test.go
+++ b/servicedversion/servicedversion_test.go
@@ -29,7 +29,7 @@ func TestGetPackageRelease(t *testing.T) {
 	if utils.Platform == utils.Rhel {
 		expected = []string{"bash", "-c", "rpm -q --qf '%{VERSION}-%{Release}\n' serviced"}
 	} else {
-		expected = []string{"bash", "-c", "dpkg -s serviced | awk '/^Version/{print $NF;exit}'"}
+		expected = []string{"bash", "-o", "pipefail", "-c", "dpkg -s serviced | awk '/^Version/{print $NF;exit}'"}
 	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatalf("expected: %+v != actual: %+v", expected, actual)


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-861

DEMO - Do not show error in serviced host list when unable to retrieve serviced release (i.e. serviced not installed):
```
E0309 09:21:16.073230 15907 servicedversion.go:52] unable to retrieve release of package 'serviced' with command:'[bash -o pipefail -c dpkg -s serviced | awk '/^Version/{print $NF;exit}']' output: dpkg-query: package 'serviced' is not installed and no information is available
Use dpkg --info (= dpkg-deb --info) to examine archive files,
and dpkg --contents (= dpkg-deb --contents) to list their contents.
  error: exit status 1

# plu@plu-9: serviced host list
ID		POOL		NAME	ADDR		RPCPORT		CORES	MEM		NETWORK			RELEASE
570a276e	default		plu-9	172.17.42.1	4979		12	33659494400	172.17.0.0/255.255.0.0	
```

DEMO - show serviced version in serviced host list - (serviced is installed):
```
# plu@plu-9: serviced host list
ID		POOL		NAME	ADDR		RPCPORT		CORES	MEM		NETWORK			RELEASE
570a276e	default		plu-9	172.17.42.1	4979		12	33659494400	172.17.0.0/255.255.0.0	1.0.0~trusty-0.1.CR11
```