### PR TITLE
added serviced service clone [--suffix SUFFIX] SERVICE

### DIFF
--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -55,6 +55,7 @@ type API interface {
 	GetService(string) (*service.Service, error)
 	GetServicesByName(string) ([]service.Service, error)
 	AddService(ServiceConfig) (*service.Service, error)
+	CloneService(string, string) (*service.Service, error)
 	RemoveService(string) error
 	UpdateService(io.Reader) (*service.Service, error)
 	MigrateService(string, io.Reader, bool) (*service.Service, error)

--- a/cli/api/service.go
+++ b/cli/api/service.go
@@ -175,6 +175,21 @@ func (a *api) AddService(config ServiceConfig) (*service.Service, error) {
 	return a.GetService(serviceID)
 }
 
+// CloneService copies an existing service
+func (a *api) CloneService(serviceID string, suffix string) (*service.Service, error) {
+	client, err := a.connectDAO()
+	if err != nil {
+		return nil, err
+	}
+
+	request := dao.ServiceCloneRequest{ServiceID: serviceID, Suffix: suffix}
+	clonedServiceID := ""
+	if err := client.CloneService(request, &clonedServiceID); err != nil {
+		return nil, fmt.Errorf("copy service failed: %s", err)
+	}
+	return a.GetService(clonedServiceID)
+}
+
 // MigrateService migrates an existing service
 func (a *api) MigrateService(serviceID string, input io.Reader, dryRun bool) (*service.Service, error) {
 	client, err := a.connectDAO()

--- a/dao/elasticsearch/service.go
+++ b/dao/elasticsearch/service.go
@@ -31,6 +31,29 @@ func (this *ControlPlaneDao) AddService(svc service.Service, serviceId *string) 
 	return nil
 }
 
+// CloneService clones a service.  Return error if given serviceID is not found
+func (this *ControlPlaneDao) CloneService(request dao.ServiceCloneRequest, clonedServiceId *string) error {
+	svc, err := this.facade.GetService(datastore.Get(), request.ServiceID)
+	if err != nil {
+		glog.Errorf("ControlPlaneDao.CloneService: unable to find service id %+v: %s", request.ServiceID, err)
+		return err
+	}
+
+	cloned, err := service.CloneService(svc, request.Suffix)
+	if err != nil {
+		glog.Errorf("ControlPlaneDao.CloneService: unable to rename service %+v %v: %s", svc.ID, svc.Name, err)
+		return err
+	}
+
+	if err := this.facade.AddService(datastore.Get(), *cloned); err != nil {
+		return err
+	}
+
+	this.createTenantVolume(svc.ID)
+	*clonedServiceId = svc.ID
+	return nil
+}
+
 //
 func (this *ControlPlaneDao) UpdateService(svc service.Service, unused *int) error {
 	if err := this.facade.UpdateService(datastore.Get(), svc); err != nil {

--- a/dao/interface.go
+++ b/dao/interface.go
@@ -45,6 +45,11 @@ type ServiceRequest struct {
 	NameRegex    string
 }
 
+type ServiceCloneRequest struct {
+	ServiceID string
+	Suffix    string
+}
+
 type ServiceMigrationRequest struct {
 	ServiceID       string
 	MigrationScript string
@@ -104,6 +109,9 @@ type ControlPlane interface {
 
 	// Add a new service
 	AddService(service service.Service, serviceId *string) error
+
+	// Clones a new service
+	CloneService(request ServiceCloneRequest, serviceId *string) error
 
 	// Deploy a new service
 	DeployService(service ServiceDeploymentRequest, serviceId *string) error

--- a/dao/test/mockControlPlane.go
+++ b/dao/test/mockControlPlane.go
@@ -81,6 +81,14 @@ func (mcp *MockControlPlane) AddService(service service.Service, serviceId *stri
 	return mcp.Mock.Called(service, serviceId).Error(0)
 }
 
+// Clone a new service
+func (mcp *MockControlPlane) CloneService(request dao.ServiceCloneRequest, serviceId *string) error {
+	if mcp.Responses["CloneService"] != nil {
+		*serviceId = *((*string)(mcp.Responses["CloneService"]))
+	}
+	return mcp.Mock.Called(request, serviceId).Error(0)
+}
+
 // Deploy a new service
 func (mcp *MockControlPlane) DeployService(service dao.ServiceDeploymentRequest, serviceId *string) error {
 	if mcp.Responses["DeployService"] != nil {

--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -203,6 +203,39 @@ func BuildService(sd servicedefinition.ServiceDefinition, parentServiceID string
 	return &svc, nil
 }
 
+//CloneService copies a service and mutates id and names
+func CloneService(fromSvc *Service, suffix string) (*Service, error) {
+	svcuuid, err := utils.NewUUID36()
+	if err != nil {
+		return nil, err
+	}
+
+	svc := *fromSvc
+	svc.ID = svcuuid
+	svc.DesiredState = int(SVCStop)
+
+	now := time.Now()
+	svc.CreatedAt = now
+	svc.UpdatedAt = now
+
+	// add suffix to make certain things unique
+	suffix = strings.TrimSpace(suffix)
+	if len(suffix) == 0 {
+		suffix = "-" + svc.ID[0:12]
+	}
+	svc.Name += suffix
+	for idx := range svc.Endpoints {
+		svc.Endpoints[idx].Name += suffix
+		svc.Endpoints[idx].Application += suffix
+		svc.Endpoints[idx].ApplicationTemplate += suffix
+	}
+	for idx := range svc.Volumes {
+		svc.Volumes[idx].ResourcePath += suffix
+	}
+
+	return &svc, nil
+}
+
 // GetServiceImports retrieves service endpoints whose purpose is "import"
 func (s *Service) GetServiceImports() []ServiceEndpoint {
 	result := []ServiceEndpoint{}

--- a/node/cp_client.go
+++ b/node/cp_client.go
@@ -84,6 +84,10 @@ func (s *ControlClient) AddService(service service.Service, serviceId *string) (
 	return s.rpcClient.Call("ControlPlane.AddService", service, serviceId)
 }
 
+func (s *ControlClient) CloneService(request dao.ServiceCloneRequest, copiedServiceId *string) (err error) {
+	return s.rpcClient.Call("ControlPlane.CloneService", request, copiedServiceId)
+}
+
 func (s *ControlClient) DeployService(service dao.ServiceDeploymentRequest, serviceId *string) (err error) {
 	return s.rpcClient.Call("ControlPlane.DeployService", service, serviceId)
 }


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-877

DEMO - clone mariadb, start it, and see volumes:
```
# plu@plu-9: serviced service status |grep -i mariadb
    MariaDB		cfgc4zcvtiietymxs1dnbo8k9	Running		3.023046088s	plu-9	Y		d137747a9ea6

# plu@plu-9: tree -L 2 /home/plu/src/europa/var/serviced/volumes/
/home/plu/src/europa/var/serviced/volumes/
├── 8nz0rk7kiz5nv94egzuvck8bk
│   └── mariadb
└── monitor
    └── 10.87.110.39

3 directories, 1 file

# plu@plu-9: serviced service clone --suffix=-events mariadb
cfgc4zcvtiietymxs1dnbo8k9
~/src/europa/src/golang/src/github.com/control-center/serviced/domain/service
# plu@plu-9: serviced service status |grep -i mariadb
    MariaDB-events	4i87nbitt9h3wxvi0rahjag6z	Stopped							
    MariaDB		cfgc4zcvtiietymxs1dnbo8k9	Running		23.542968266s	plu-9	Y		d137747a9ea6

# plu@plu-9: serviced service start MariaDB-events
Scheduled 1 service(s) to start

# plu@plu-9: serviced service status |grep -i mariadb
    MariaDB-events	4i87nbitt9h3wxvi0rahjag6z	Running		4.995590951s	plu-9	Y		9dd7c7111f26
    MariaDB		cfgc4zcvtiietymxs1dnbo8k9	Running		46.21330013s	plu-9	Y		d137747a9ea6

# plu@plu-9: tree -L 2 /home/plu/src/europa/var/serviced/volumes/
/home/plu/src/europa/var/serviced/volumes/
├── 8nz0rk7kiz5nv94egzuvck8bk
│   ├── mariadb
│   └── mariadb-events
└── monitor
    └── 10.87.110.39

4 directories, 1 file
```

DEMO - differences of original and cloned service:
```
# plu@plu-9: serviced service list mariadb > /tmp/mariadb.txt

# plu@plu-9: serviced service list mariadb-events > /tmp/mariadb-events.txt

# plu@plu-9: diff -Nurp /tmp/mariadb.txt /tmp/mariadb-events.txt 
--- /tmp/mariadb.txt	2015-03-19 10:01:39.063157922 -0500
+++ /tmp/mariadb-events.txt	2015-03-19 10:01:48.615171475 -0500
@@ -1,6 +1,6 @@
 {
-   "ID": "cfgc4zcvtiietymxs1dnbo8k9",
-   "Name": "MariaDB",
+   "ID": "4i87nbitt9h3wxvi0rahjag6z",
+   "Name": "MariaDB-events",
    "Title": "",
    "Version": "",
    "Context": null,
@@ -41,14 +41,14 @@
    "Launch": "auto",
    "Endpoints": [
      {
-       "Name": "mariadb",
+       "Name": "mariadb-events",
        "Purpose": "export",
        "Protocol": "tcp",
        "PortNumber": 3306,
        "PortTemplate": "",
        "VirtualAddress": "",
-       "Application": "zodb_mariadb",
-       "ApplicationTemplate": "zodb_mariadb",
+       "Application": "zodb_mariadb-events",
+       "ApplicationTemplate": "zodb_mariadb-events",
        "AddressConfig": {
          "Port": 0,
          "Protocol": ""
@@ -72,13 +72,13 @@
      {
        "Owner": "mysql:mysql",
        "Permission": "0755",
-       "ResourcePath": "mariadb",
+       "ResourcePath": "mariadb-events",
        "ContainerPath": "/var/lib/mysql",
        "Type": ""
      }
    ],
-   "CreatedAt": "2015-03-19T14:57:27.151801134Z",
-   "UpdatedAt": "2015-03-19T14:58:16.282320044Z",
+   "CreatedAt": "2015-03-19T14:58:37.941125108Z",
+   "UpdatedAt": "2015-03-19T14:58:55.660160736Z",
    "DeploymentID": "HBase",
    "DisableImage": false,
    "LogConfigs": [

```