### PR TITLE
call dao.AddService from dao.CloneService instead of calling facade.AddService

### DIFF
--- a/dao/elasticsearch/service.go
+++ b/dao/elasticsearch/service.go
@@ -45,12 +45,10 @@ func (this *ControlPlaneDao) CloneService(request dao.ServiceCloneRequest, clone
 		return err
 	}
 
-	if err := this.facade.AddService(datastore.Get(), *cloned); err != nil {
+	if err := this.AddService(*cloned, clonedServiceId); err != nil {
 		return err
 	}
 
-	this.createTenantVolume(svc.ID)
-	*clonedServiceId = svc.ID
 	return nil
 }
 


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-877

DEMO - clone mariadb, start it, and see volumes:
```
# plu@plu-9: serviced service status |grep -i mariadb
    MariaDB		2t6v32pkyyaceevuic2mupwl9	Running		26.143206983s	plu-9	Y		0ba2da3ad738

# plu@plu-9: tree -L 2 /home/plu/src/europa/var/serviced/volumes/axnbxe56ot2lgvy54sxx7p4m8/
/home/plu/src/europa/var/serviced/volumes/axnbxe56ot2lgvy54sxx7p4m8/
└── mariadb
    ├── 0ba2da3ad738.pid
    ├── 0c53053ac15a.err
    ├── aria_log.00000001
    ├── aria_log_control
    ├── ibdata1
    ├── ib_logfile0
    ├── ib_logfile1
    ├── mysql
    ├── mysql.sock
    ├── performance_schema
    ├── test
    ├── zenoss_zep
    ├── zodb
    └── zodb_session

7 directories, 8 files

# plu@plu-9: serviced service clone --suffix=-events mariadb
620t8kyttl3ebn98kopi36owj

# plu@plu-9: serviced service start MariaDB-events
Scheduled 1 service(s) to start

# plu@plu-9: serviced service status |grep -i mariadb
    MariaDB		2t6v32pkyyaceevuic2mupwl9	Running		57.778163699s	plu-9	Y		0ba2da3ad738
    MariaDB-events	620t8kyttl3ebn98kopi36owj	Running		9.82574376s	plu-9	Y		596e2b04ed57

# plu@plu-9: tree -L 2 /home/plu/src/europa/var/serviced/volumes/axnbxe56ot2lgvy54sxx7p4m8/
/home/plu/src/europa/var/serviced/volumes/axnbxe56ot2lgvy54sxx7p4m8/
├── mariadb
│   ├── 0ba2da3ad738.pid
│   ├── 0c53053ac15a.err
│   ├── aria_log.00000001
│   ├── aria_log_control
│   ├── ibdata1
│   ├── ib_logfile0
│   ├── ib_logfile1
│   ├── mysql
│   ├── mysql.sock
│   ├── performance_schema
│   ├── test
│   ├── zenoss_zep
│   ├── zodb
│   └── zodb_session
└── mariadb-events
    ├── 0c53053ac15a.err
    ├── 596e2b04ed57.pid
    ├── aria_log.00000001
    ├── aria_log_control
    ├── ibdata1
    ├── ib_logfile0
    ├── ib_logfile1
    ├── mysql
    ├── mysql.sock
    ├── performance_schema
    ├── test
    ├── zenoss_zep
    ├── zodb
    └── zodb_session

14 directories, 16 files
```

DEMO - differences of original and cloned service:
```
# plu@plu-9: serviced service list mariadb > /tmp/mariadb.txt

# plu@plu-9: serviced service list mariadb-events > /tmp/mariadb-events.txt

# plu@plu-9: diff -Nurp /tmp/mariadb.txt /tmp/mariadb-events.txt 
--- /tmp/mariadb.txt	2015-03-19 15:05:50.094118562 -0500
+++ /tmp/mariadb-events.txt	2015-03-19 15:05:54.474122871 -0500
@@ -1,6 +1,6 @@
 {
-   "ID": "2t6v32pkyyaceevuic2mupwl9",
-   "Name": "MariaDB",
+   "ID": "620t8kyttl3ebn98kopi36owj",
+   "Name": "MariaDB-events",
    "Title": "",
    "Version": "",
    "Context": null,
@@ -41,14 +41,14 @@
    "Launch": "auto",
    "Endpoints": [
      {
-       "Name": "mariadb",
+       "Name": "mariadb-events",
        "Purpose": "export",
        "Protocol": "tcp",
        "PortNumber": 3306,
        "PortTemplate": "",
        "VirtualAddress": "",
-       "Application": "zodb_mariadb",
-       "ApplicationTemplate": "zodb_mariadb",
+       "Application": "zodb_mariadb-events",
+       "ApplicationTemplate": "zodb_mariadb-events",
        "AddressConfig": {
          "Port": 0,
          "Protocol": ""
@@ -72,13 +72,13 @@
      {
        "Owner": "mysql:mysql",
        "Permission": "0755",
-       "ResourcePath": "mariadb",
+       "ResourcePath": "mariadb-events",
        "ContainerPath": "/var/lib/mysql",
        "Type": ""
      }
    ],
-   "CreatedAt": "2015-03-19T20:03:41.286126419Z",
-   "UpdatedAt": "2015-03-19T20:04:34.692762943Z",
+   "CreatedAt": "2015-03-19T20:05:16.271143774Z",
+   "UpdatedAt": "2015-03-19T20:05:22.227444845Z",
    "DeploymentID": "HBase",
    "DisableImage": false,
    "LogConfigs": [

# plu@plu-9: 

```