### PR TITLE
only mutate endpoint name for exported endpoints (not imports)

### DIFF
--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -224,10 +224,12 @@ func CloneService(fromSvc *Service, suffix string) (*Service, error) {
 		suffix = "-" + svc.ID[0:12]
 	}
 	svc.Name += suffix
-	for idx := range svc.Endpoints {
-		svc.Endpoints[idx].Name += suffix
-		svc.Endpoints[idx].Application += suffix
-		svc.Endpoints[idx].ApplicationTemplate += suffix
+	for idx, ep := range svc.Endpoints {
+		if ep.Purpose == "export" {
+			svc.Endpoints[idx].Name += suffix
+			svc.Endpoints[idx].Application += suffix
+			svc.Endpoints[idx].ApplicationTemplate += suffix
+		}
 	}
 	for idx := range svc.Volumes {
 		svc.Volumes[idx].ResourcePath += suffix


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-877

follow on to #1659 and #1660 

Only mutate exported endpoint names, not imported endpoint names of the clone

DEMO - save zeneventserver svcdef, clone it, save that svcdef:
```
# plu@plu-9: serviced service list zeneventserver > /tmp/zeneventserver.txt
# plu@plu-9: serviced service clone --suffix=-copy zeneventserver
5m2uvx5ij4v9e3rr13pxu1h91
# plu@plu-9: serviced service list zeneventserver-copy > /tmp/zeneventserver-copy.txt
```

DEMO - show that only exported endpoint names were mutated:
```
# plu@plu-9: diff -Nurp /tmp/zeneventserver.txt /tmp/zeneventserver-copy.txt
--- /tmp/zeneventserver.txt	2015-03-20 15:08:33.905985297 -0500
+++ /tmp/zeneventserver-copy.txt	2015-03-20 15:08:47.274018237 -0500
@@ -1,6 +1,6 @@
 {
-   "ID": "3lvf2j80772r9qlqhui08qh44",
-   "Name": "zeneventserver",
+   "ID": "5m2uvx5ij4v9e3rr13pxu1h91",
+   "Name": "zeneventserver-copy",
    "Title": "",
    "Version": "",
    "Context": null,
@@ -214,14 +214,14 @@
        }
      },
      {
-       "Name": "zep",
+       "Name": "zep-copy",
        "Purpose": "export",
        "Protocol": "tcp",
        "PortNumber": 8084,
        "PortTemplate": "",
        "VirtualAddress": "",
-       "Application": "zep",
-       "ApplicationTemplate": "zep",
+       "Application": "zep-copy",
+       "ApplicationTemplate": "zep-copy",
        "AddressConfig": {
          "Port": 0,
          "Protocol": ""
@@ -270,27 +270,27 @@
      {
        "Owner": "zenoss:zenoss",
        "Permission": "0775",
-       "ResourcePath": "zeneventserver",
+       "ResourcePath": "zeneventserver-copy",
        "ContainerPath": "/opt/zenoss/var/zeneventserver",
        "Type": ""
      },
      {
        "Owner": "zenoss:zenoss",
        "Permission": "0755",
-       "ResourcePath": ".ssh",
+       "ResourcePath": ".ssh-copy",
        "ContainerPath": "/home/zenoss/.ssh",
        "Type": ""
      },
      {
        "Owner": "zenoss:zenoss",
        "Permission": "0775",
-       "ResourcePath": "var-zenpacks",
+       "ResourcePath": "var-zenpacks-copy",
        "ContainerPath": "/var/zenoss",
        "Type": ""
      }
    ],
-   "CreatedAt": "2015-03-20T20:06:27.038375766Z",
-   "UpdatedAt": "2015-03-20T20:06:27.038375766Z",
+   "CreatedAt": "2015-03-20T20:08:38.305607062Z",
+   "UpdatedAt": "2015-03-20T20:08:38.305607062Z",
    "DeploymentID": "HBase",
    "DisableImage": false,
    "LogConfigs": [

# plu@plu-9: grep --before=2 Purpose /tmp/zeneventserver.txt
     {
       "Name": "mariadb",
       "Purpose": "import",
--
     {
       "Name": "memcached",
       "Purpose": "import",
--
     {
       "Name": "redis",
       "Purpose": "import",
--
     {
       "Name": "rabbitmq",
       "Purpose": "import",
--
     {
       "Name": "zproxy",
       "Purpose": "import",
--
     {
       "Name": "zep",
       "Purpose": "export",
--
     {
       "Name": "controlplane_consumer",
       "Purpose": "import",

# plu@plu-9: grep --before=2 Purpose /tmp/zeneventserver-copy.txt
     {
       "Name": "mariadb",
       "Purpose": "import",
--
     {
       "Name": "memcached",
       "Purpose": "import",
--
     {
       "Name": "redis",
       "Purpose": "import",
--
     {
       "Name": "rabbitmq",
       "Purpose": "import",
--
     {
       "Name": "zproxy",
       "Purpose": "import",
--
     {
       "Name": "zep-copy",
       "Purpose": "export",
--
     {
       "Name": "controlplane_consumer",
       "Purpose": "import",
```