### PR TITLE
allow scripts to edit services using EDITOR

### DIFF
--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -93,10 +93,11 @@ func openEditor(data []byte, name, editor string) (reader io.Reader, err error) 
 			return nil, fmt.Errorf("could not seek file: %s", err)
 		}
 
-		data, err := ioutil.ReadAll(f)
+		data, err := ioutil.ReadFile(f.Name())
 		if err != nil {
 			return nil, fmt.Errorf("could not read file: %s", err)
 		}
+
 		reader = bytes.NewReader(data)
 	} else {
 		if _, err := os.Stdout.Write(data); err != nil {


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-887

DEMO - make sure regression was not introduced - add POTUS to Title with vi editor:
```
# plu@plu-9: serviced service list rabbitmq | head -4
{
   "ID": "cak02y6bauzn6ntnoom2zp3oh",
   "Name": "RabbitMQ",
   "Title": "",

# plu@plu-9: serviced service edit rabbitmq
cak02y6bauzn6ntnoom2zp3oh

# plu@plu-9: serviced service list rabbitmq | head -4
{
   "ID": "cak02y6bauzn6ntnoom2zp3oh",
   "Name": "RabbitMQ",
   "Title": "POTUS",
```

DEMO - use /tmp/rename script to change RabbitMQ to rabbitmq:
```
# plu@plu-9: cat /tmp/rename 
#!/bin/bash
sed -i -e 's/RabbitMQ/rabbitmq/' "$1"

# plu@plu-9: EDITOR=/tmp/rename serviced service edit RabbitMQ
cak02y6bauzn6ntnoom2zp3oh

# plu@plu-9: serviced service list rabbitmq | head -4
{
   "ID": "cak02y6bauzn6ntnoom2zp3oh",
   "Name": "rabbitmq",
   "Title": "POTUS",
```