### PR TITLE
Run migration script from a service's docker container

### DIFF
--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -59,6 +59,7 @@ type API interface {
 	RemoveService(string) error
 	UpdateService(io.Reader) (*service.Service, error)
 	MigrateService(string, io.Reader, bool, string) (*service.Service, error)
+	MigrateServiceWithEmbeddedScript(string, string, bool, string) (*service.Service, error)
 	StartService(SchedulerConfig) (int, error)
 	RestartService(SchedulerConfig) (int, error)
 	StopService(SchedulerConfig) (int, error)

--- a/cli/api/script.go
+++ b/cli/api/script.go
@@ -16,7 +16,6 @@ package api
 import (
 	"fmt"
 	"math"
-	"os"
 	"path"
 	"time"
 
@@ -167,13 +166,7 @@ func cliServiceIDFromPath(a *api) script.ServiceIDFromPath {
 
 func cliServiceMigrate(a API) script.ServiceMigrate {
 	return func(svcID string, scriptFile string, sdkVersion string) error {
-		input, err := os.Open(scriptFile)
-		if err != nil {
-			return fmt.Errorf("Could not open migration script: %s", err)
-		}
-		defer input.Close()
-
-		if _, err := a.MigrateService(svcID, input, false, sdkVersion); err != nil {
+		if _, err := a.MigrateServiceWithEmbeddedScript(svcID, scriptFile, false, sdkVersion); err != nil {
 			return fmt.Errorf("Migration failed for service %s: %s", svcID, err)
 		}
 		return nil

--- a/cli/api/service.go
+++ b/cli/api/service.go
@@ -190,29 +190,48 @@ func (a *api) CloneService(serviceID string, suffix string) (*service.Service, e
 	return a.GetService(clonedServiceID)
 }
 
-// MigrateService migrates an existing service
-func (a *api) MigrateService(serviceID string, input io.Reader, dryRun bool, sdkVersion string) (*service.Service, error) {
+// MigrateService migrates an existing service using a local script
+func (a *api) MigrateService(serviceID string, localScript io.Reader, dryRun bool, sdkVersion string) (*service.Service, error) {
+	inputBuffer := bytes.NewBuffer(nil)
+	if _, err := io.Copy(inputBuffer, localScript); err != nil {
+		return nil, fmt.Errorf("could not read migration script: %s", err)
+	}
+
+	request := dao.ServiceMigrationRequest{
+		ServiceID:  serviceID,
+		ScriptBody: string(inputBuffer.Bytes()),
+		DryRun:     dryRun,
+		SDKVersion: sdkVersion,
+	}
+	if len(request.ScriptBody) == 0 {
+		return nil, fmt.Errorf("migration failed: script is empty")
+	}
+
+	return a.migrateService(request)
+}
+
+// MigrateServiceWithEmbeddedScript migrates an existing service using script embeded in the service's docker image
+func (a *api) MigrateServiceWithEmbeddedScript(serviceID string, scriptName string, dryRun bool, sdkVersion string) (*service.Service, error) {
+	request := dao.ServiceMigrationRequest{
+		ServiceID:  serviceID,
+		ScriptName: scriptName,
+		DryRun:     dryRun,
+		SDKVersion: sdkVersion,
+	}
+
+	return a.migrateService(request)
+}
+
+func (a *api) migrateService(request dao.ServiceMigrationRequest) (*service.Service, error) {
 	client, err := a.connectDAO()
 	if err != nil {
 		return nil, err
 	}
 
-	inputBuffer := bytes.NewBuffer(nil)
-	_, err = io.Copy(inputBuffer, input)
-	if err != nil {
-		return nil, fmt.Errorf("could not read migration script: %s", err)
-	}
-
-	request := dao.ServiceMigrationRequest{ServiceID: serviceID, DryRun: dryRun, SDKVersion: sdkVersion}
-	request.ScriptBody = string(inputBuffer.Bytes())
-	if len(request.ScriptBody) == 0 {
-		return nil, fmt.Errorf("migration failed: script is empty")
-	}
-
 	if err := client.MigrateService(request, &unusedInt); err != nil {
 		return nil, fmt.Errorf("migration failed: %s", err)
 	}
-	return a.GetService(serviceID)
+	return a.GetService(request.ServiceID)
 }
 
 // RemoveService removes an existing service

--- a/cli/api/service.go
+++ b/cli/api/service.go
@@ -204,8 +204,8 @@ func (a *api) MigrateService(serviceID string, input io.Reader, dryRun bool, sdk
 	}
 
 	request := dao.ServiceMigrationRequest{ServiceID: serviceID, DryRun: dryRun, SDKVersion: sdkVersion}
-	request.MigrationScript = string(inputBuffer.Bytes())
-	if len(request.MigrationScript) == 0 {
+	request.ScriptBody = string(inputBuffer.Bytes())
+	if len(request.ScriptBody) == 0 {
 		return nil, fmt.Errorf("migration failed: script is empty")
 	}
 

--- a/cli/api/service_test.go
+++ b/cli/api/service_test.go
@@ -117,7 +117,7 @@ func (st *serviceAPITest) TestMigrateService_works(c *C) {
 
 	request := args[0].(dao.ServiceMigrationRequest)
 	c.Assert(request.ServiceID, Equals, serviceID)
-	c.Assert(request.MigrationScript, Equals, scriptBody)
+	c.Assert(request.ScriptBody, Equals, scriptBody)
 	c.Assert(request.DryRun, Equals, true)
 	c.Assert(request.SDKVersion, Equals, sdkVersion)
 }

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -289,9 +289,9 @@ func (dt *DaoTest) TestDao_MigrateService(t *C) {
 	newDescription := "New Description"
 	scriptExitCode := 0
 	request := dao.ServiceMigrationRequest{
-		ServiceID:       svc.ID,
-		MigrationScript: dt.getMigrationScript(newDescription, scriptExitCode),
-		DryRun:          false,
+		ServiceID:  svc.ID,
+		ScriptBody: dt.getMigrationScript(newDescription, scriptExitCode),
+		DryRun:     false,
 	}
 
 	err = dt.Dao.MigrateService(request, &unused)
@@ -310,9 +310,9 @@ func (dt *DaoTest) TestDao_MigrateServiceWithDryRun(t *C) {
 	newDescription := "New Description"
 	scriptExitCode := 0
 	request := dao.ServiceMigrationRequest{
-		ServiceID:       svc.ID,
-		MigrationScript: dt.getMigrationScript(newDescription, scriptExitCode),
-		DryRun:          true,
+		ServiceID:  svc.ID,
+		ScriptBody: dt.getMigrationScript(newDescription, scriptExitCode),
+		DryRun:     true,
 	}
 
 	err = dt.Dao.MigrateService(request, &unused)
@@ -330,9 +330,9 @@ func (dt *DaoTest) TestDao_MigrateServiceFailsForInvalidID(t *C) {
 	t.Assert(err, IsNil)
 
 	request := dao.ServiceMigrationRequest{
-		ServiceID:       "Some Undefined Service",
-		MigrationScript: dt.getMigrationScript("unused", 0),
-		DryRun:          false,
+		ServiceID:  "Some Undefined Service",
+		ScriptBody: dt.getMigrationScript("unused", 0),
+		DryRun:     false,
 	}
 
 	err = dt.Dao.MigrateService(request, &unused)
@@ -362,9 +362,9 @@ func (dt *DaoTest) testMigrationScriptFails(t *C, dryRun bool) {
 	newDescription := "New Description"
 	scriptExitCode := 1
 	request := dao.ServiceMigrationRequest{
-		ServiceID:       svc.ID,
-		MigrationScript: dt.getMigrationScript(newDescription, scriptExitCode),
-		DryRun:          dryRun,
+		ServiceID:  svc.ID,
+		ScriptBody: dt.getMigrationScript(newDescription, scriptExitCode),
+		DryRun:     dryRun,
 	}
 
 	err = dt.Dao.MigrateService(request, &unused)
@@ -391,9 +391,9 @@ func (dt *DaoTest) testMigrationScriptFailsValidation(t *C, dryRun bool) {
 	svc, err := dt.setupMigrationTest()
 	t.Assert(err, IsNil)
 	request := dao.ServiceMigrationRequest{
-		ServiceID:       svc.ID,
-		MigrationScript: dt.getInvalidMigrationScript(),
-		DryRun:          true,
+		ServiceID:  svc.ID,
+		ScriptBody: dt.getInvalidMigrationScript(),
+		DryRun:     true,
 	}
 
 	err = dt.Dao.MigrateService(request, &unused)

--- a/dao/elasticsearch/service.go
+++ b/dao/elasticsearch/service.go
@@ -65,25 +65,14 @@ func (this *ControlPlaneDao) UpdateService(svc service.Service, unused *int) err
 //
 func (this *ControlPlaneDao) MigrateService(request dao.ServiceMigrationRequest, unused *int) error {
 	glog.V(2).Infof("ControlPlaneDao.MigrateService: start migration for service id %+v", request.ServiceID)
-	svc, err := this.facade.GetService(datastore.Get(), request.ServiceID)
-	if err != nil {
-		glog.Errorf("ControlPlaneDao.MigrateService: could not find service id %+v: %s", request.ServiceID, err)
-		return err
-	}
-
-	err = this.facade.MigrateService(datastore.Get(),
-		svc,
-		request.MigrationScript,
-		request.DryRun,
-		request.SDKVersion)
-	if err != nil {
+	if err := this.facade.MigrateService(datastore.Get(), request); err != nil {
 		glog.Errorf("ControlPlaneDao.MigrateService: migration failed for id %+v: %s", request.ServiceID, err)
 		return err
 	}
 
 	glog.Infof("ControlPlaneDao.MigrateService: migrated service %+v (dry-run=%v)", request.ServiceID, request.DryRun)
 	if !request.DryRun {
-		this.createTenantVolume(svc.ID)
+		this.createTenantVolume(request.ServiceID)
 	}
 	return nil
 }

--- a/dao/interface.go
+++ b/dao/interface.go
@@ -51,10 +51,10 @@ type ServiceCloneRequest struct {
 }
 
 type ServiceMigrationRequest struct {
-	ServiceID       string
-	MigrationScript string
-	SDKVersion      string
-	DryRun          bool
+	ServiceID  string // The ID of the service to migrate.
+	ScriptBody string // The content of the service migration script to use.
+	SDKVersion string // The version of the service migration SDK to use.
+	DryRun     bool
 }
 
 type ServiceStateRequest struct {

--- a/dao/interface.go
+++ b/dao/interface.go
@@ -50,9 +50,11 @@ type ServiceCloneRequest struct {
 	Suffix    string
 }
 
+// Only use one of ScriptName or ScriptBody. If both are specified, ScriptBody has precedence.
 type ServiceMigrationRequest struct {
 	ServiceID  string // The ID of the service to migrate.
 	ScriptBody string // The content of the service migration script to use.
+	ScriptName string // The name of the service migration script in the docker image for the specified service.
 	SDKVersion string // The version of the service migration SDK to use.
 	DryRun     bool
 }

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -38,7 +38,7 @@ type FacadeInterface interface {
 
 	GetTenantID(ctx datastore.Context, serviceID string) (string, error)
 
-	MigrateService(ctx datastore.Context, svc *service.Service, script string, dryRun bool, sdkVersion string) error
+	MigrateService(ctx datastore.Context, request dao.ServiceMigrationRequest) error
 
 	RemoveService(ctx datastore.Context, id string) error
 

--- a/facade/service.go
+++ b/facade/service.go
@@ -1580,7 +1580,7 @@ func createServiceContainer(service *service.Service) (*docker.Container, error)
 // resides in the serviceContainer; i.e. under the directory specified by EMBEDDED_MIGRATION_DIRECTORY
 //
 // Returns the name of the file under tmpDir containing the output from the migration script
-func executeMigrationScript(serviceID string, serviceContainer *docker.Container, tmpDir, containerScript, inputFilePath string, sdkVersion string) (string, error) {
+func executeMigrationScript(serviceID string, serviceContainer *docker.Container, tmpDir, containerScript, inputFilePath, sdkVersion string) (string, error) {
 	const SERVICE_MIGRATION_IMAGE_NAME = "zenoss/service-migration"
 	const SERVICE_MIGRATION_TAG_NAME = "1.0.0"
 	const OUTPUT_FILE = "output.json"

--- a/facade/service.go
+++ b/facade/service.go
@@ -34,6 +34,16 @@ import (
 	"github.com/control-center/serviced/commons/docker"
 
 	"github.com/control-center/serviced/utils"
+
+	dockerclient "github.com/zenoss/go-dockerclient"
+)
+
+const (
+	// The mount point in the service migration docker image
+	MIGRATION_MOUNT_POINT = "/migration"
+
+	// The well-known path within the service's docker image of the directory which contains the service's migration script
+	EMBEDDED_MIGRATION_DIRECTORY = "/opt/serviced/migration"
 )
 
 // AddService adds a service; return error if service already exists
@@ -114,11 +124,10 @@ func (f *Facade) MigrateService(ctx datastore.Context, request dao.ServiceMigrat
 		return err
 	}
 
-	var migrationDir, inputFileName, scriptFileName, outputFileName string
-
 	glog.V(2).Infof("Facade:MigrateService: start for service id %+v (dry-run=%v, sdkVersion=%s)",
 		svc.ID, request.DryRun, request.SDKVersion)
 
+	var migrationDir, inputFileName, scriptFileName, outputFileName string
 	migrationDir, err = createTempMigrationDir(svc.ID)
 	defer os.RemoveAll(migrationDir)
 	if err != nil {
@@ -136,14 +145,35 @@ func (f *Facade) MigrateService(ctx datastore.Context, request dao.ServiceMigrat
 		return err
 	}
 
-	scriptFileName, err = createServiceMigrationScriptFile(migrationDir, request.ScriptBody)
-	if err != nil {
-		return err
-	}
+	if request.ScriptBody != "" {
+		scriptFileName, err = createServiceMigrationScriptFile(migrationDir, request.ScriptBody)
+		if err != nil {
+			return err
+		}
 
-	outputFileName, err = executeMigrationScript(svc.ID, migrationDir, scriptFileName, inputFileName, request.SDKVersion)
-	if err != nil {
-		return err
+		_, scriptFile := path.Split(scriptFileName)
+		containerScript := path.Join(MIGRATION_MOUNT_POINT, scriptFile)
+		outputFileName, err = executeMigrationScript(svc.ID, nil, migrationDir, containerScript, inputFileName, request.SDKVersion)
+		if err != nil {
+			return err
+		}
+	} else {
+		container, err := createServiceContainer(svc)
+		if err != nil {
+			return err
+		} else {
+			defer func() {
+				if err := container.Delete(true); err != nil {
+					glog.Errorf("Could not remove container %s (%s): %s", container.ID, svc.ImageID, err)
+				}
+			}()
+		}
+
+		containerScript := path.Join(EMBEDDED_MIGRATION_DIRECTORY, request.ScriptName)
+		outputFileName, err = executeMigrationScript(svc.ID, container, migrationDir, containerScript, inputFileName, request.SDKVersion)
+		if err != nil {
+			return err
+		}
 	}
 
 	svcs, err = readNewServiceDefinitions(outputFileName)
@@ -1511,21 +1541,54 @@ func createServiceMigrationScriptFile(tmpDir, scriptBody string) (string, error)
 	return scriptFileName, nil
 }
 
-// Execute the migration script. The script is executed in a docker container which assumes that
-// scriptFilePath and inputFilePath are rooted under tmpDir
+func createServiceContainer(service *service.Service) (*docker.Container, error) {
+	var emptyStruct struct{}
+	containerName := fmt.Sprintf("%s-%s", service.Name, "migration")
+	containerDefinition := &docker.ContainerDefinition{
+		dockerclient.CreateContainerOptions{
+			Name: containerName,
+			Config: &dockerclient.Config{
+				Image:   service.ImageID,
+				Volumes: map[string]struct{}{EMBEDDED_MIGRATION_DIRECTORY: emptyStruct},
+			},
+		},
+		dockerclient.HostConfig{},
+	}
+
+	container, err := docker.NewContainer(containerDefinition, false, 0, nil, nil)
+	if err != nil {
+		glog.Errorf("Error trying to create container %v: %v", containerDefinition, err)
+		return nil, err
+	}
+
+	glog.V(1).Infof("Created container %s named %s based on image %s", container.ID, containerName, service.ImageID)
+	return container, nil
+}
+
+// executeMigrationScript executes containerScript in a docker container based
+// the service migration SDK image.
+//
+// tmpDir is the temporary directory that is mounted into the service migration container under
+// the directory identified by MIGRATON_MOUNT_POINT. Both the input and output files are written to
+// tmpDir/MIGRATION_MOUNT_POINT
+//
+// The value of containerScript should be always be a fully qualified, container-local path
+// to the service migration script, though the path may vary depending on the value of serviceContainer.
+// If serviceContainer is not specified, then containerScript should start with MIGRATON_MOUNT_POINT
+// If serviceContainer is specified, then the service-migration container will be run
+// with volume(s) mounted from serviceContainer. This allows for cases where containerScript physically
+// resides in the serviceContainer; i.e. under the directory specified by EMBEDDED_MIGRATION_DIRECTORY
+//
 // Returns the name of the file under tmpDir containing the output from the migration script
-func executeMigrationScript(serviceID, tmpDir, scriptFilePath, inputFilePath string, sdkVersion string) (string, error) {
+func executeMigrationScript(serviceID string, serviceContainer *docker.Container, tmpDir, containerScript, inputFilePath string, sdkVersion string) (string, error) {
 	const SERVICE_MIGRATION_IMAGE_NAME = "zenoss/service-migration"
 	const SERVICE_MIGRATION_TAG_NAME = "1.0.0"
-	const MOUNT_POINT = "/migration"
 	const OUTPUT_FILE = "output.json"
 
-	_, scriptFile := path.Split(scriptFilePath)
-	containerScript := path.Join(MOUNT_POINT, scriptFile)
-
+	// get the container-local path names for the input and output files.
 	_, inputFile := path.Split(inputFilePath)
-	containerInputFile := path.Join(MOUNT_POINT, inputFile)
-	containerOutputFile := path.Join(MOUNT_POINT, OUTPUT_FILE)
+	containerInputFile := path.Join(MIGRATION_MOUNT_POINT, inputFile)
+	containerOutputFile := path.Join(MIGRATION_MOUNT_POINT, OUTPUT_FILE)
 
 	tagName := SERVICE_MIGRATION_TAG_NAME
 	if sdkVersion != "" {
@@ -1534,18 +1597,22 @@ func executeMigrationScript(serviceID, tmpDir, scriptFilePath, inputFilePath str
 		tagName = tagOverride
 	}
 
-	if tagName != "" {
-		glog.V(2).Infof("Facade:executeMigrationScript: using docker tag=%q", tagName)
-	}
+	glog.V(2).Infof("Facade:executeMigrationScript: using docker tag=%q", tagName)
 	dockerImage := fmt.Sprintf("%s:%s", SERVICE_MIGRATION_IMAGE_NAME, tagName)
 
-	mountPath := fmt.Sprintf("%s:/migration", tmpDir)
-	cmd := exec.Command("docker",
+	mountPath := fmt.Sprintf("%s:%s:rw", tmpDir, MIGRATION_MOUNT_POINT)
+	runArgs := []string{
 		"run", "--rm", "-t",
 		"--name", "service-migration",
 		"-v", mountPath,
-		dockerImage,
-		"python", containerScript, containerInputFile, containerOutputFile)
+	}
+	if serviceContainer != nil {
+		runArgs = append(runArgs, "--volumes-from", serviceContainer.ID)
+	}
+	runArgs = append(runArgs, dockerImage)
+	runArgs = append(runArgs, "python", containerScript, containerInputFile, containerOutputFile)
+
+	cmd := exec.Command("docker", runArgs...)
 
 	glog.V(2).Infof("Facade:executeMigrationScript: service ID %+v: cmd: %v", serviceID, cmd)
 

--- a/facade/test/mockFacade.go
+++ b/facade/test/mockFacade.go
@@ -69,8 +69,8 @@ func (mf *MockFacade) GetTenantID(ctx datastore.Context, serviceID string) (stri
 	return args.String(0), args.Error(1)
 }
 
-func (mf *MockFacade) MigrateService(ctx datastore.Context, svc *service.Service, script string, dryRun bool, sdkVersion string) error {
-	return mf.Mock.Called(ctx, svc, script, dryRun, sdkVersion).Error(0)
+func (mf *MockFacade) MigrateService(ctx datastore.Context, request dao.ServiceMigrationRequest) error {
+	return mf.Mock.Called(ctx, request).Error(0)
 }
 
 func (mf *MockFacade) RemoveService(ctx datastore.Context, id string) error {

--- a/script/eval.go
+++ b/script/eval.go
@@ -328,7 +328,6 @@ func evalSvcMigrate(r *runner, n node) error {
 		if sdkVersion, err = findSDKVersion(n.args[0]); err != nil {
 			return err
 		}
-
 	}
 
 	migrationScript := n.args[len(n.args)-1]


### PR DESCRIPTION
Change SVC_MIGRATE implementation to mount a service's container as a data volume from the service-migration container so that we can execute the service migration script residing in the service's container.

The story in Rally is [US12345: Migrate a Tenant using the script in the Tenant](https://rally1.rallydev.com/#/30873679006d/detail/userstory/32597943942).

There's an example of running in the design [document](https://docs.google.com/a/zenoss.com/document/d/1fgWu9e2P7H1MNj1MU0RDPjTrEGVh5zP2lLHUrgthDDw/edit#heading=h.1okfpfhl02s5).