### PR TITLE
update isvcs to use image v27

### DIFF
--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -27,7 +27,7 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO = "zenoss/serviced-isvcs"
-	IMAGE_TAG  = "v26"
+	IMAGE_TAG  = "v27"
 )
 
 func Init() {


### PR DESCRIPTION
This is dependent on isvcs image v27 being in docker-hub. Jenkins is building that change now. I will issue a review request for this PR after that job completes and I have ensured that isvcs v27 is in docker hub.