### PR TITLE
fixes CC-882: write monitor fsid file to var/volumes/monitor/ instead of serviced_var_volumes/monitor

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -414,10 +414,11 @@ func (d *daemon) startMaster() error {
 		return err
 	}
 
-	if nfsDriver, err := nfs.NewServer(path.Join(options.VarPath, "volumes"), "serviced_var_volumes", "0.0.0.0/0"); err != nil {
+	volumesPath := path.Join(options.VarPath, "volumes")
+	if nfsDriver, err := nfs.NewServer(volumesPath, "serviced_var_volumes", "0.0.0.0/0"); err != nil {
 		return err
 	} else {
-		d.storageHandler, err = storage.NewServer(nfsDriver, thisHost)
+		d.storageHandler, err = storage.NewServer(nfsDriver, thisHost, volumesPath)
 		if err != nil {
 			return err
 		}

--- a/coordinator/storage/monitor.go
+++ b/coordinator/storage/monitor.go
@@ -44,15 +44,18 @@ type Monitor struct {
 
 	conn               client.Connection
 	storageClientsPath string
+
+	volumesPath string
 }
 
 // NewMonitor returns a Monitor object to monitor the exported file system
-func NewMonitor(driver StorageDriver, monitorInterval time.Duration) (*Monitor, error) {
+func NewMonitor(driver StorageDriver, monitorInterval time.Duration, volumesPath string) (*Monitor, error) {
 	m := &Monitor{
 		driver:          driver,
 		monitoredHosts:  make(map[string]bool),
 		shouldRestart:   getShouldRestartDFSOnFailure(),
 		monitorInterval: monitorInterval,
+		volumesPath:     volumesPath,
 	}
 
 	return m, nil
@@ -159,17 +162,23 @@ func (m *Monitor) MonitorDFSVolume(mountpoint string, leaderIP string, checkValu
 
 	m.previousRestart = time.Now()
 
-	monitorPath := path.Join(mountpoint, monitorSubDir)
-	os.RemoveAll(monitorPath)
-	if err := os.MkdirAll(monitorPath, 0755); err != nil {
-		glog.Errorf("no longer monitoring status for DFS volume %s - unable to mkdir %+v: %s", mountpoint, monitorPath, err)
+	volumesMonitorPath := path.Join(m.volumesPath, monitorSubDir)
+	os.RemoveAll(volumesMonitorPath)
+	if err := os.MkdirAll(volumesMonitorPath, 0755); err != nil {
+		glog.Errorf("no longer monitoring status for DFS volume %s - unable to mkdir %+v: %s", mountpoint, volumesMonitorPath, err)
 		return
 	}
 
-	checkFileName := path.Join(monitorPath, leaderIP+"-fsid.txt")
+	checkFileName := path.Join(volumesMonitorPath, leaderIP+"-fsid.txt")
 	glog.Infof("Writing checkValue of %s to file %s", checkValue, checkFileName)
 	if err := ioutil.WriteFile(checkFileName, []byte(checkValue), 0644); err != nil {
 		glog.Errorf("no longer monitoring status for DFS volume %s - unable to write checkfile  %+v: %s", mountpoint, checkFileName, err)
+		return
+	}
+
+	monitorPath := path.Join(mountpoint, monitorSubDir)
+	if err := os.MkdirAll(monitorPath, 0755); err != nil {
+		glog.Errorf("no longer monitoring status for DFS volume %s - unable to mkdir %+v: %s", mountpoint, monitorPath, err)
 		return
 	}
 

--- a/coordinator/storage/monitor_test.go
+++ b/coordinator/storage/monitor_test.go
@@ -67,7 +67,7 @@ func TestMonitorVolume(t *testing.T) {
 	}
 
 	// ---- start monitor
-	monitor, err := NewMonitor(driver, time.Duration(3*time.Second))
+	monitor, err := NewMonitor(driver, time.Duration(3*time.Second), tmpPath)
 	if err != nil {
 		t.Fatalf("unable to create new monitor %s", err)
 	}

--- a/coordinator/storage/server.go
+++ b/coordinator/storage/server.go
@@ -42,12 +42,12 @@ type StorageDriver interface {
 }
 
 // NewServer returns a Server object to manage the exported file system
-func NewServer(driver StorageDriver, host *host.Host) (*Server, error) {
+func NewServer(driver StorageDriver, host *host.Host, volumesPath string) (*Server, error) {
 	if len(driver.ExportPath()) < 9 {
 		return nil, fmt.Errorf("export path can not be empty")
 	}
 
-	monitor, err := NewMonitor(driver, getDefaultNFSMonitorMasterInterval())
+	monitor, err := NewMonitor(driver, getDefaultNFSMonitorMasterInterval(), volumesPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create new monitor %s", err)
 	}

--- a/coordinator/storage/server_test.go
+++ b/coordinator/storage/server_test.go
@@ -118,7 +118,7 @@ func TestServer(t *testing.T) {
 	}
 
 	// TODO: this gets stuck at server.go:90 call to conn.CreateDir hangs
-	s, err := NewServer(mockNfsDriver, hostServer)
+	s, err := NewServer(mockNfsDriver, hostServer, path.Join(mockNfsDriver.exportPath, mockNfsDriver.exportName))
 	if err != nil {
 		t.Fatalf("unexpected error creating Server: %s", err)
 	}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-882

ISSUE - On a fresh install, serviced monitor server is writing fsid file to /exports/serviced_var_volumes/monitor/ before that directory is exported by NFS.  When NFS starts after the fsid write, /opt/serviced/var/volumes is mounted on top of /exports/serviced_var_volumes/.

DEMO - write fsid file to /opt/serviced/var/volumes/monitor/ instead of /exports/serviced_var_volumes/monitor/:
```
[root@resmgr-50x ~]# journalctl -u serviced -o cat
...
I0427 19:41:23.735875 31589 monitor.go:165] monitoring DFS export info for DFS volume /exports/serviced_var_volumes at polling interval: 3m0s
I0427 19:41:23.736021 31589 monitor.go:177] Writing checkValue of 13d8f64b0224438d to file /opt/serviced/var/volumes/monitor/10.87.208.121-fsid.txt
...
[root@resmgr-50x bin]# ls -al /opt/serviced/var/volumes/monitor/
total 28
drwxr-xr-x 1 root root  96 Apr 27 15:52 .
drwxr-xr-x 1 root root 146 Apr 27 15:41 ..
-rw------- 1 root root  13 Apr 27 15:53 10.87.208.121
-rw-r--r-- 1 root root  16 Apr 27 15:41 10.87.208.121-fsid.txt
-rw------- 1 root root  13 Apr 27 15:53 10.87.208.122
[root@resmgr-50x bin]# ls -al /exports/serviced_var_volumes/monitor/
total 28
drwxr-xr-x 1 root root  96 Apr 27 15:52 .
drwxr-xr-x 1 root root 146 Apr 27 15:41 ..
-rw------- 1 root root  13 Apr 27 15:53 10.87.208.121
-rw-r--r-- 1 root root  16 Apr 27 15:41 10.87.208.121-fsid.txt
-rw------- 1 root root  13 Apr 27 15:54 10.87.208.122
```

REMOTE host:
```
[root@resmgr-50x-host1 ~]# df -H /opt/serviced/var/volumes
Filesystem                           Size  Used Avail Use% Mounted on
10.87.208.121:/serviced_var_volumes   33G  1.9G   29G   7% /opt/serviced/var/volumes
[root@resmgr-50x-host1 ~]# ls -l /opt/serviced/var/volumes/monitor/
total 12
-rw------- 1 root root 13 Apr 27 14:53 10.87.208.121
-rw-r--r-- 1 root root 16 Apr 27 14:41 10.87.208.121-fsid.txt
-rw------- 1 root root 13 Apr 27 14:53 10.87.208.122
```
