### PR TITLE
refine isvcs healthchecks

### DIFF
--- a/cli/cmd/healthcheck.go
+++ b/cli/cmd/healthcheck.go
@@ -20,7 +20,6 @@ import (
 	"github.com/codegangsta/cli"
 )
 
-
 // Initializer for serviced healthcheck subcommands
 func (c *ServicedCli) initHealthCheck() {
 	c.app.Commands = append(c.app.Commands, cli.Command{
@@ -50,6 +49,10 @@ func (c *ServicedCli) cmdHealthCheck(ctx *cli.Context) error {
 				if status.Status != "passed" {
 					exitStatus = 1
 				}
+				if serviceHealth.ContainerID == "" {
+					serviceHealth.ContainerID = "<none>"
+				}
+
 				t.AddRow(map[string]interface{}{
 					"Service Name":   serviceHealth.ServiceName,
 					"Container Name": serviceHealth.ContainerName,

--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -506,7 +506,7 @@ func (svc *IService) run() {
 	}
 }
 
-// Return true if the service is flapping (starting/stopping repeatedly).
+// isFlapping returns true if the service is flapping (starting/stopping repeatedly).
 //
 // A service is considered flappping, if has been running for less than 60 seconds
 // in 3 consecutive calls to this function.
@@ -558,7 +558,7 @@ func (svc *IService) checkvolumes(ctr *docker.Container) bool {
 	return true
 }
 
-// Run the default healthcheck (if any) and the return the result.
+// startupHealthcheck runs the default healthchecks (if any) and the return the result.
 // If the healthcheck fails, then this method will sleep 1 second, and then
 // repeat the healthcheck, continuing that sleep/retry pattern until
 // the healthcheck succeeds or 2 minutes has elapsed.

--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -611,7 +611,7 @@ func (svc *IService) runCheckOrTimeout(checkDefinition healthCheckDefinition) er
 	case err := <-finished:
 		result = err
 	case <-time.After(checkDefinition.Timeout):
-		glog.Errorf("healthcheck timed out for %s", svc.name())
+		glog.Errorf("healthcheck timed out for %s", svc.Name)
 		result = fmt.Errorf("healthcheck timed out")
 		halt <- struct{}{}
 	}
@@ -627,7 +627,7 @@ func (svc *IService) doHealthChecks(halt <-chan struct{}) {
 	var found bool
 	var checkDefinition healthCheckDefinition
 	if checkDefinition, found = svc.HealthChecks[DEFAULT_HEALTHCHECK_NAME]; !found {
-		glog.Warningf("Default healthcheck %q not found for isvc %s", DEFAULT_HEALTHCHECK_NAME, svc.name())
+		glog.Warningf("Default healthcheck %q not found for isvc %s", DEFAULT_HEALTHCHECK_NAME, svc.Name)
 		return
 	}
 
@@ -635,14 +635,14 @@ func (svc *IService) doHealthChecks(halt <-chan struct{}) {
 	for {
 		select {
 		case <-halt:
-			glog.Infof("Stopped healthchecks for %s", svc.name())
+			glog.Infof("Stopped healthchecks for %s", svc.Name)
 			return
 
 		case currentTime := <-timer:
 			err := svc.runCheckOrTimeout(checkDefinition)
 			svc.setHealthStatus(err, currentTime.Unix())
 			if err != nil {
-				glog.Errorf("Healthcheck for isvc %s failed: %s", svc.name(), err)
+				glog.Errorf("Healthcheck for isvc %s failed: %s", svc.Name, err)
 			}
 		}
 	}
@@ -712,7 +712,7 @@ func (svc *IService) stats(halt <-chan struct{}) {
 	for {
 		select {
 		case <-halt:
-			glog.Infof("stop collecting stats for %s", svc.name())
+			glog.Infof("stop collecting stats for %s", svc.Name)
 			return
 		case t := <-tc:
 			ctr, err := docker.FindContainer(svc.name())

--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -614,6 +614,9 @@ func (svc *IService) setHealthStatus(result error, currentTime int64) {
 
 	if healthStatus, found := svc.healthStatuses[DEFAULT_HEALTHCHECK_NAME]; found {
 		if result == nil {
+			if healthStatus.Status != "passed" && healthStatus.Status != "unknown" {
+				glog.Infof("Health status for %s returned to 'passed'", svc.Name)
+			}
 			healthStatus.Status = "passed"
 			healthStatus.Failure = ""
 		} else {

--- a/isvcs/docker_registry.go
+++ b/isvcs/docker_registry.go
@@ -65,7 +65,7 @@ func registryHealthCheck(halt <-chan struct{}) error {
 
 		select {
 		case <-halt:
-			glog.Infof("Quit healthcheck for docker registry at %s", url)
+			glog.V(1).Infof("Quit healthcheck for docker registry at %s", url)
 			return nil
 		default:
 			time.Sleep(time.Second)

--- a/isvcs/docker_registry.go
+++ b/isvcs/docker_registry.go
@@ -54,7 +54,7 @@ func init() {
 	}
 }
 
-func registryHealthCheck() error {
+func registryHealthCheck(halt <-chan struct{}) error {
 	url := fmt.Sprintf("http://localhost:%d/", registryPort)
 	for {
 		if _, err := http.Get(url); err == nil {
@@ -62,7 +62,14 @@ func registryHealthCheck() error {
 		} else {
 			glog.V(1).Infof("Still trying to connect to docker registry at %s: %v", url, err)
 		}
-		time.Sleep(time.Second)
+
+		select {
+		case <-halt:
+			glog.Infof("Quit healthcheck for docker registry at %s", url)
+			return nil
+		default:
+			time.Sleep(time.Second)
+		}
 	}
 	glog.V(1).Infof("docker registry running, browser at %s", url)
 	return nil

--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -116,7 +116,6 @@ func elasticsearchHealthCheck(port int) HealthCheckFunction {
 				break
 			} else {
 				lastError = time.Now()
-				glog.Infof("Still trying to connect to elasticsearch at %s: %v: %s", baseUrl, err, healthResponse.Status)
 				glog.V(1).Infof("Still trying to connect to elasticsearch at %s: %v: %s", baseUrl, err, healthResponse.Status)
 			}
 
@@ -126,7 +125,7 @@ func elasticsearchHealthCheck(port int) HealthCheckFunction {
 
 			select {
 			case <-halt:
-				glog.Infof("Quit healthcheck for elasticsearch at %s", baseUrl)
+				glog.V(1).Infof("Quit healthcheck for elasticsearch at %s", baseUrl)
 				return nil
 			default:
 				time.Sleep(time.Second)

--- a/isvcs/manager.go
+++ b/isvcs/manager.go
@@ -147,20 +147,16 @@ func (m *Manager) GetHealthStatus(name string) (dao.IServiceHealthResult, error)
 		return dao.IServiceHealthResult{}, fmt.Errorf("could not find isvc %q", name)
 	}
 
-	// FIXME: Does it make sense to exit with a failure when the container is
-	//        not found, or should we return an instance of IServiceHealthResult
-	//        with HealthStatuses["running"] == a-failed-instance?
-	ctr, err := docker.FindContainer(svc.name())
-	if err != nil {
-		glog.Errorf("Could not find container for isvc %s: %s", svc.Name, err)
-		return dao.IServiceHealthResult{}, err
+	if ctr, err := docker.FindContainer(svc.name()); err == nil {
+		result.ContainerID = ctr.ID
+	} else {
+		result.ContainerID = "<none>"
 	}
 
 	svc.lock.RLock()
 	defer svc.lock.RUnlock()
 
 	result.ContainerName = svc.name()
-	result.ContainerID = ctr.ID
 	for _, value := range svc.healthStatuses {
 		result.HealthStatuses = append(result.HealthStatuses, *value)
 	}

--- a/isvcs/manager.go
+++ b/isvcs/manager.go
@@ -149,8 +149,6 @@ func (m *Manager) GetHealthStatus(name string) (dao.IServiceHealthResult, error)
 
 	if ctr, err := docker.FindContainer(svc.name()); err == nil {
 		result.ContainerID = ctr.ID
-	} else {
-		result.ContainerID = "<none>"
 	}
 
 	svc.lock.RLock()

--- a/isvcs/zk.go
+++ b/isvcs/zk.go
@@ -75,7 +75,7 @@ func zkHealthCheck(halt <-chan struct{}) error {
 
 		select {
 		case <-halt:
-			glog.Infof("Quit healthcheck for zookeeper")
+			glog.V(1).Infof("Quit healthcheck for zookeeper")
 			return nil
 		default:
 			time.Sleep(time.Second)


### PR DESCRIPTION
Refinements to periodic health checking of iservices:
 1.  At startup, repeat attempts at healthcheck for up to 2 minutes. Fail serviced startup if the health check is still negative after 2 minutes. 
 1. After startup, if a periodic health check fails, then don't restart; just report a failed status.
 1. After startup, if an isvc exits, then restart it, UNLESS it has failed to start and run for more than 1 minute 3 times in a row (i.e. if it's starting/exiting repeatedly, then don't continue trying to restart it).