### PR TITLE
fixes CC-924: check var/volumes instead of var for btrfs

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -758,8 +758,9 @@ func (d *daemon) initWeb() {
 
 func (d *daemon) initDFS() error {
 	if options.FSType == "btrfs" {
-		if err := btrfs.IsBtrfsFilesystem(options.VarPath); err != nil {
-			return fmt.Errorf("varpath at %s is not a btrfs filesystem\n%s", options.VarPath, err)
+		volumesPath := path.Join(options.VarPath, "volumes")
+		if err := btrfs.IsBtrfsFilesystem(volumesPath); err != nil {
+			return fmt.Errorf("volumes path at %s is not a btrfs filesystem\n%s", volumesPath, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-924

This is only an issue for serviced 1.1 (develop) not 1.0.* (support) due to fix for CC-617
  CC-617: https://github.com/control-center/serviced/pull/1471
  CC-812: https://github.com/control-center/serviced/pull/1584

ISSUE: - serviced fails to start on a system with /opt/serviced/var not btrfs and /opt/serviced/var/volumes as btrfs:
```
[root@resmgr-510 ~]# mount |grep /opt/serviced/var
/dev/sdd1 on /opt/serviced/var/volumes type btrfs (rw,noatime,nodatasum,nodatacow,space_cache)

[root@resmgr-510 ~]# journalctl -u serviced -o cat -f
...
E0428 16:48:29.178805 04267 container.go:538] healthcheck timed out for serviced-isvcs_elasticsearch-logstash
E0428 16:48:29.403543 04267 container.go:538] healthcheck timed out for serviced-isvcs_elasticsearch-serviced
E0428 16:48:29.405228 04267 btrfs.go:359] unable to run cmd:[btrfs filesystem df /opt/serviced/var]  output:ERROR: couldn't get space info - Inappropriate ioctl for device
ERROR: get_df failed Inappropriate ioctl for device
error:exit status 1
F0428 16:48:29.405279 04267 daemon.go:277] varpath at /opt/serviced/var is not a btrfs filesystem
unable to run cmd:[btrfs filesystem df /opt/serviced/var]  output:ERROR: couldn't get space info - Inappropriate ioctl for device
ERROR: get_df failed Inappropriate ioctl for device
error:exit status 1
serviced.service: main process exited, code=exited, status=255/n/a
```

DEMO - serviced starts:
```
E0428 17:16:05.358585 09218 container.go:538] healthcheck timed out for serviced-isvcs_elasticsearch-serviced
E0428 17:16:05.623220 09218 container.go:538] healthcheck timed out for serviced-isvcs_elasticsearch-logstash
I0428 17:16:05.724039 09218 daemon.go:336] zookeeper dsn: {"Servers":["127.0.0.1:2181"],"Timeout":15000000000}
...
[root@resmgr-510 ~]# serviced host list
This master has been configured to be in pool: default
ID            Pool         Name                             Addr               RPCPort      Cores      RAM        Cur/Max/Avg             Network                     Release
570a7cd0      default      resmgr-510-host1.zenoss.loc      10.87.208.124      4979         8          39.3G      5.7G / 5.7G / 4.6G      172.17.0.0/255.255.0.0      1.1.0-0.0.2235.unstable
570a7bd0      default      resmgr-510.zenoss.loc            10.87.208.123      4979         8          39.1G      3G / 20.5G / 17.6G      172.17.0.0/255.255.0.0      1.1.0-0.0.2235.unstable
```