### PR TITLE
removed DEBUG to deal with build error

### DIFF
--- a/web/ui/src/common/miscUtils.js
+++ b/web/ui/src/common/miscUtils.js
@@ -1,5 +1,3 @@
-/* globals DEBUG: true */
-
 /* miscUtils.js
  * miscellaneous utils and stuff that
  * doesn't quite fit in elsewhere


### PR DESCRIPTION
build issue with:
  https://github.com/control-center/serviced/pull/1707

ISSUE - DEBUG in miscUtils.js is causing build failure:
```
# plu@plu-9: make
...
/mnt/src/common/miscUtils.js
  line 1  col 1  'DEBUG' is defined but never used.

  ⚠  1 warning

[18:40:51] 'lint' errored after 1.21 s
[18:40:51] Error in plugin 'gulp-jshint'
```

DEMO - make sure serviced builds:
```
# plu@plu-9: git diff
diff --git a/web/ui/src/common/miscUtils.js b/web/ui/src/common/miscUtils.js
index 4bb7d01..b66fa0f 100644
--- a/web/ui/src/common/miscUtils.js
+++ b/web/ui/src/common/miscUtils.js
@@ -1,4 +1,3 @@
-/* globals DEBUG: true */
 
 /* miscUtils.js
  * miscellaneous utils and stuff that


# plu@plu-9: make
...
[18:44:04] Using gulpfile /mnt/gulpfile.js
[18:44:04] Starting 'release'...
[18:44:04] Starting 'lint'...
[18:44:04] Finished 'release' after 29 ms
[18:44:05] Finished 'lint' after 1.18 s
[18:44:05] Starting 'concat'...
```