### PR TITLE
inject the env var CONTROLPLANE_SERVICE_ID into each isvc container

### DIFF
--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -153,6 +153,7 @@ func NewIService(sd IServiceDefinition) (*IService, error) {
 	}
 
 	envPerService[sd.Name] = make(map[string]string)
+	envPerService[sd.Name]["CONTROLPLANE_SERVICE_ID"] = svc.Name
 	go svc.run()
 
 	return &svc, nil

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -27,7 +27,7 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO = "zenoss/serviced-isvcs"
-	IMAGE_TAG  = "v27"
+	IMAGE_TAG  = "v28"
 )
 
 func Init() {


### PR DESCRIPTION
Part of the fixes for https://jira.zenoss.com/browse/CC-575

Other PRs required to address CC-575:
https://github.com/zenoss/zenoss.metric.consumer/pull/62
https://github.com/control-center/serviced-isvcs/pull/17
