### PR TITLE
add godep to serviced docker build image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -30,6 +30,7 @@ RUN	apt-get update -qq && apt-get install -y -q wget curl git
 RUN	curl -s https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz | tar -v -C /usr/local -xz
 ENV	GOPATH  /go
 ENV	PATH $PATH:/go/bin:/usr/local/go/bin
+RUN	go get github.com/tools/godep
 
 # Install nodejs, npm, gulp, etc
 RUN apt-get update -qq && apt-get install -y -q nodejs=0.10.25~dfsg2-2ubuntu1 npm=1.3.10~dfsg-1


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-949

ISSUE http://jenkins.zendev.org/job/serviced-build/2250/console:
```
/go/bin/godep go build  -ldflags "-X main.Version 1.1.0 -X main.Giturl '' -X main.Gitcommit e621363-dirty -X main.Gitbranch HEAD -X main.Date 'Fri May  8 05:46:13 UTC 2015' -X main.Buildtag jenkins-serviced-build-2250"
/bin/sh: 1: /go/bin/godep: not found
make: *** [serviced] Error 127
make: *** [docker_buildandpackage] Error 2
```

DEMO:
```
# plu@plu-9: BUILD_NUMBER=111 make docker_buildandpackage
...
Step 7 : RUN go get github.com/tools/godep
 ---> Running in 98ddcc0532d5
 ---> da65bea2a055
...
/go/bin/godep go build  -ldflags "-X main.Version 1.1.0 -X main.Giturl '' -X main.Gitcommit 687afb0 -X main.Gitbranch feature/CC-949.2 -X main.Date 'Fri May  8 14:37:05 UTC 2015' -X main.Buildtag 0"
make govet
make[1]: Entering directory `/go/src/github.com/control-center/serviced'
GOVET_TARGET_DIRS='cli/ commons/ container/ coordinator/ dao/ datastore/ dfs/ dita/ doc/ domain/ facade/ health/ isvcs/ metrics/ node/ pkg/ proxy/ rpc/ scheduler/ script/ servicedversion/ shell/ stats/ testfiles/ utils/ validation/ volume/ web/ zzk/'
go tool vet -composites=false  cli/ commons/ container/ coordinator/ dao/ datastore/ dfs/ dita/ doc/ domain/ facade/ health/ isvcs/ metrics/ node/ pkg/ proxy/ rpc/ scheduler/ script/ servicedversion/ shell/ stats/ testfiles/ utils/ validation/ volume/ web/ zzk/
make[1]: Leaving directory `/go/src/github.com/control-center/serviced'
/go/bin/godep go install  -ldflags "-X main.Version 1.1.0 -X main.Giturl '' -X main.Gitcommit 687afb0 -X main.Gitbranch feature/CC-949.2 -X main.Date 'Fri May  8 14:37:05 UTC 2015' -X main.Buildtag 0"
cd pkg && make IN_DOCKER=1 INSTALL_TEMPLATES=1 deb rpm tgz
make[1]: Entering directory `/go/src/github.com/control-center/serviced/pkg'

```