### PR TITLE
update GOBIN/serviced for zendev serviced when made

### DIFF
--- a/makefile
+++ b/makefile
@@ -161,12 +161,7 @@ FORCE:
 serviced: FORCE
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS}
 	make govet
-	$(GO) install $(GOBUILD_FLAGS) ${LDFLAGS}
-
-serviced = $(GOBIN)/serviced
-$(serviced): FORCE
-	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS}
-	$(GO) install $(GOBUILD_FLAGS) ${LDFLAGS}
+	if [ -n "$(GOBIN)" ]; then cp serviced $(GOBIN)/serviced; fi
 
 .PHONY: docker_build
 pkg_build_tmp = pkg/build/tmp


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-949

serviced in $GOBIN was not being updated when serviced was being built

DEMO:
```
# plu@plu-9: which serviced
/home/plu/src/europa/src/golang/bin/serviced
~/src/europa/src/golang/src/github.com/control-center/serviced
# plu@plu-9: rm $(which serviced)
~/src/europa/src/golang/src/github.com/control-center/serviced
# plu@plu-9: make
...
/home/plu/src/europa/src/golang/bin/godep go build  -ldflags "-X main.Version 1.1.0 -X main.Giturl '' -X main.Gitcommit 1722a21 -X main.Gitbranch feature/CC-949.3 -X main.Date 'Fri May  8 18:52:58 UTC 2015' -X main.Buildtag 0"
make govet
make[1]: Entering directory `/home/plu/src/europa/src/golang/src/github.com/control-center/serviced'
GOVET_TARGET_DIRS='cli/ commons/ container/ coordinator/ dao/ datastore/ dfs/ dita/ doc/ domain/ facade/ health/ isvcs/ metrics/ node/ pkg/ proxy/ rpc/ scheduler/ script/ servicedversion/ shell/ stats/ testfiles/ utils/ validation/ volume/ web/ zzk/'
go tool vet -composites=false  cli/ commons/ container/ coordinator/ dao/ datastore/ dfs/ dita/ doc/ domain/ facade/ health/ isvcs/ metrics/ node/ pkg/ proxy/ rpc/ scheduler/ script/ servicedversion/ shell/ stats/ testfiles/ utils/ validation/ volume/ web/ zzk/
make[1]: Leaving directory `/home/plu/src/europa/src/golang/src/github.com/control-center/serviced'
if [ -n "/home/plu/src/europa/src/golang/bin" ]; then cp serviced /home/plu/src/europa/src/golang/bin/serviced; fi
~/src/europa/src/golang/src/github.com/control-center/serviced
# plu@plu-9: ls -l $(which serviced)
-rwxr-xr-x 1 plu plu 19924908 May  8 13:53 /home/plu/src/europa/src/golang/bin/serviced
~/src/europa/src/golang/src/github.com/control-center/serviced
# plu@plu-9: ls -l serviced
-rwxr-xr-x 1 plu plu 19924908 May  8 13:53 serviced

```