### PR TITLE
fixes CC-954: changed CLI for curator 3.0.3

### DIFF
--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -165,18 +165,21 @@ func getElasticHealth(baseUrl string) (cluster.ClusterHealthResponse, error) {
 	return healthResponse, err
 }
 
-func PurgeLogstashIndices(days int, gb int) error {
+func PurgeLogstashIndices(days int, gb int) {
 	iservice := elasticsearch_logstash
 	port := iservice.Ports[0]
 	glog.Infof("Purging logstash entries older than %d days", days)
 	err := iservice.Exec([]string{
 		"/usr/local/bin/curator", "--port", fmt.Sprintf("%d", port),
-		"delete", "--older-than", fmt.Sprintf("%d", days)})
+		"delete", "indices", "--older-than", fmt.Sprintf("%d", days), "--time-unit", "days", "--timestring", "%Y.%m.%d"})
 	if err != nil {
-		return err
+		glog.Errorf("Unable to purge logstash entries older than %d days: %s", days, err)
 	}
 	glog.Infof("Purging oldest logstash entries to limit disk usage to %d GB.", gb)
-	return iservice.Exec([]string{
+	err = iservice.Exec([]string{
 		"/usr/local/bin/curator", "--port", fmt.Sprintf("%d", port),
-		"delete", "--disk-space", fmt.Sprintf("%d", gb)})
+		"delete", "--disk-space", fmt.Sprintf("%d", gb), "indices", "--all-indices"})
+	if err != nil {
+		glog.Errorf("Unable to purge logstash entries to limit disk usage to %d GB: %s", gb, err)
+	}
 }

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -27,7 +27,7 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO = "zenoss/serviced-isvcs"
-	IMAGE_TAG  = "v28"
+	IMAGE_TAG  = "v29"
 )
 
 func Init() {


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-954

Pin es curator version to 3.0.3: https://github.com/control-center/serviced-isvcs/pull/18

DEMO:
```
I0511 21:58:55.258519 18832 es.go:171] Purging logstash entries older than 14 days
E0511 21:58:55.646308 18832 docker_exec.go:48] Error running command:'[/usr/bin/docker exec 3bb32be13411e36ec3ef10658bad421fed7d06861798f3e803391d7d9631090e /bin/bash -c /usr/local/bin/curator --port 9100 delete indices --older-than 14 --time-unit days --timestring %Y.%m.%d]' output: 2015-05-11 21:58:55,598 INFO      Job starting: delete indices
ERROR. No indices found in Elasticsearch.
  error: exit status 1
E0511 21:58:55.646441 18832 es.go:176] Unable to purge logstash entries older than 14 days: exit status 1
I0511 21:58:55.646486 18832 es.go:178] Purging oldest logstash entries to limit disk usage to 10 GB.
E0511 21:58:55.977868 18832 docker_exec.go:48] Error running command:'[/usr/bin/docker exec 3bb32be13411e36ec3ef10658bad421fed7d06861798f3e803391d7d9631090e /bin/bash -c /usr/local/bin/curator --port 9100 delete --disk-space 10 indices --all-indices]' output: 2015-05-11 21:58:55,943 INFO      Job starting: delete indices
ERROR. No indices found in Elasticsearch.
  error: exit status 1
E0511 21:58:55.977990 18832 es.go:183] Unable to purge logstash entries to limit disk usage to 10 GB: exit status 1
```