### PR TITLE
fixes CC-949: use docker/registry.IndexServerAddress() as default URL for DockerLogin

### DIFF
--- a/makefile
+++ b/makefile
@@ -158,7 +158,8 @@ docker_SRC = github.com/docker/docker
 # '$(GO) build' determine if the target needs to be rebuilt.
 FORCE:
 
-serviced: FORCE
+serviced: $(GODEP)
+serviced: FORCE 
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS}
 	make govet
 	if [ -n "$(GOBIN)" ]; then cp serviced $(GOBIN)/serviced; fi
@@ -190,7 +191,7 @@ docker_build: docker_ok
 #
 missing_godep_SRC = $(filter-out $(wildcard $(GOSRC)/$(godep_SRC)), $(GOSRC)/$(godep_SRC))
 $(GODEP): | $(missing_godep_SRC)
-	$(GO) install $(godep_SRC)
+	go install $(godep_SRC)
 
 #---------------------#
 # Install targets     #
@@ -426,7 +427,7 @@ clean_js:
 	cd web/ui && make clean
 
 .PHONY: clean_serviced
-clean_serviced:
+clean_serviced: $(GODEP)
 	@for target in serviced $(serviced) ;\
         do \
                 if [ -f "$${target}" ];then \
@@ -441,7 +442,7 @@ clean_pkg:
 	cd pkg && make clean
 
 .PHONY: clean_dao
-clean_dao:
+clean_dao: $(GODEP)
 	cd dao && make "GO=$(GO)" clean
 
 .PHONY: clean

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -18,15 +18,15 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/control-center/serviced/commons/docker"
 	"github.com/docker/docker/registry"
+	"github.com/zenoss/glog"
 )
 
 func DockerLogin(username, password, email string) (string, error) {
 
-	u, err := url.Parse(docker.DEFAULT_REGISTRY)
+	u, err := url.Parse(registry.IndexServerAddress())
 	if err != nil {
-		return "", fmt.Errorf("Error: bad URL %s: %s", docker.DEFAULT_REGISTRY, err)
+		return "", fmt.Errorf("Error: bad URL %s: %s", registry.IndexServerAddress(), err)
 	}
 	endpoint := registry.Endpoint{URL: u, Version: 1, IsSecure: false}
 
@@ -36,8 +36,10 @@ func DockerLogin(username, password, email string) (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 		authconfig, ok := configFile.Configs[registry.IndexServerAddress()]
 		if !ok {
+			glog.Warningf("unable to login to docker.io using credentials in %s/.dockercfg", os.Getenv("HOME"))
 			return "", fmt.Errorf("Error: Unable to login, no data for index server.")
 		}
 		status, err := registry.Login(&authconfig, &endpoint, registry.HTTPRequestFactory(nil))


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-949

DEMO - no error in serviced log when .dockercfg exists and UI is used to deploy template:
```
root@plu-9:~# ls -al .dockercfg 
-rw------- 1 root root 88 Jan 31 01:54 .dockercfg
root@plu-9:~# tail -F /var/log/upstart/serviced.log
...
I0511 18:19:04.920211 20319 servicetemplate.go:456] Pulling image zenoss/resmgr_5.0:5.0.3_101_unstable
I0511 18:25:30.715487 20319 servicetemplate.go:456] Pulling image zenoss/opentsdb:v13
I0511 18:25:33.956256 20319 servicetemplate.go:456] Pulling image zenoss/hbase:v6
I0511 18:25:36.299455 20319 servicetemplate.go:212] Deploying application Zenoss.resmgr to demo
...
```

DEMO - error in serviced log when .dockercfg does not exist and UI is used to deploy template:
```
root@plu-9:~# ls -al .dockercfg
ls: cannot access .dockercfg: No such file or directory
root@plu-9:~# stop docker
docker stop/waiting
root@plu-9:~# start docker
docker start/running, process 26815
root@plu-9:~# docker pull zenoss/resmgr_5.0:5.0.3_101_unstable
Pulling repository zenoss/resmgr_5.0
FATA[0000] Error: image zenoss/resmgr_5.0:5.0.3_101_unstable not found
root@plu-9:~# tail -F /var/log/upstart/serviced.log
...
W0511 19:41:02.017730 05477 docker.go:42] unable to login to docker.io using credentials in /root/.dockercfg
I0511 19:41:13.599246 05477 servicetemplate.go:456] Pulling image zenoss/hbase:v6
I0511 19:41:14.599052 05477 servicetemplate.go:456] Pulling image zenoss/resmgr_5.0:5.0.3_101_unstable
E0511 19:41:14.859445 05477 api.go:718] Unable to pull image zenoss/resmgr_5.0:5.0.3_101_unstable
W0511 19:41:14.859531 05477 servicetemplate.go:458] Unable to pull image zenoss/resmgr_5.0:5.0.3_101_unstable
...
```