### PR TITLE
fixes CC-955: keep isvcs v27 in support/5.0.x

### DIFF
--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -27,7 +27,7 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO = "zenoss/serviced-isvcs"
-	IMAGE_TAG  = "v29"
+	IMAGE_TAG  = "v27"
 )
 
 func Init() {


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-955

revert isvcs:v29 back to isvcs:v27