### PR TITLE
fixes CC-965: made serviced script service paths case insensitive

### DIFF
--- a/cli/api/script.go
+++ b/cli/api/script.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/control-center/serviced/dao"
@@ -154,9 +155,9 @@ func cliServiceIDFromPath(a *api) script.ServiceIDFromPath {
 				fullpath = path.Join(svcMap[parentServiceID].Name, fullpath)
 				parentServiceID = svcMap[parentServiceID].ParentServiceID
 			}
-			pathmap[fullpath] = svc.ID
+			pathmap[strings.ToLower(fullpath)] = svc.ID
 		}
-		svcID, found := pathmap[svcPath]
+		svcID, found := pathmap[strings.ToLower(svcPath)]
 		if !found {
 			return "", fmt.Errorf("did not find service %s", svcPath)
 		}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-965

ISSUE - the service path is case sensitive:
```
[root@ip-10-111-22-22 ~]# serviced service status mariadb
NAME            ID                              STATUS          UPTIME  HOST    IN_SYNC         DOCKER_ID
└─Zenoss.core   2hup7n59yt3z5gg08vvaflp77       Stopped
  └─MariaDB     ak0fydfzsb6hxfoq9t5x3s860       Stopped
[root@ip-10-111-22-22 ~]# serviced script run /root/5.0.x/5.0.2-upgrade-core.txt --service Zenoss.core
...
I0513 14:37:46.052814 29172 runner.go:160] executing step 5: SVC_START Zenoss.core/mariadb
E0513 14:37:46.392006 29172 runner.go:162] error executing step 5: SVC_START: did not find service Zenoss.core/mariadb
```

DEMO - allow service path to be case insensitive:
```
[root@resmgr-500 templates]# serviced service status mariadb
This master has been configured to be in pool: default
Name                   ServiceID                      Status       Uptime      RAM      Cur/Max/Avg      Hostname      InSync      DockerID
└─Zenoss.core          5mow9ys4ltpb55hfigz7c9y2x      Stopped                  1G                                                  
  └─MariaDB            8ijgjwj9zc51knla6etc01vn6      Stopped                  2G                                                  
[root@resmgr-500 templates]# ls /root/5.0.x/
5.0.1-migrate-from-5.0.0.sh  5.0.1-upgrade-impact.txt  5.0.2-upgrade-core.txt    5.0.2-upgrade-resmgr.txt
5.0.1-upgrade-core.txt       5.0.1-upgrade-resmgr.txt  5.0.2-upgrade-impact.txt
[root@resmgr-500 templates]# serviced script run /root/5.0.x/5.0.2-upgrade-core.txt --service Zenoss.core
...
I0513 13:06:54.797055 20887 runner.go:165] executing step 5: SVC_START Zenoss.core/mariadb
I0513 13:06:55.719236 20887 eval.go:159] starting service Zenoss.core/mariadb 8ijgjwj9zc51knla6etc01vn6
...
I0513 13:06:58.963624 20887 runner.go:165] executing step 9: SVC_WAIT Zenoss.core/mariadb Zenoss.core/RabbitMQ Zenoss.core/zeneventserver Zenoss.core/redis started 600
I0513 13:07:01.456609 20887 eval.go:123] waiting 600 for services Zenoss.core/mariadb, Zenoss.core/RabbitMQ, Zenoss.core/zeneventserver, Zenoss.core/redis to be started
I0513 13:07:11.131890 20887 runner.go:165] executing step 10: SVC_RUN Zenoss.core/Zope upgrade
I0513 13:07:11.764904 20887 eval.go:259] running: serviced service run 9schfy3ogkd9c4spkt65ek0wj upgrade
...
```