### PR TITLE
Lock down isvcs to localhost

### DIFF
--- a/isvcs/celery.go
+++ b/isvcs/celery.go
@@ -24,12 +24,12 @@ func init() {
 	command := "exec supervisord -n -c /opt/celery/etc/supervisor.conf"
 	celery, err = NewIService(
 		IServiceDefinition{
-			Name:    "celery",
-			Repo:    IMAGE_REPO,
-			Tag:     IMAGE_TAG,
-			Command: func() string { return command },
-			Ports:   []uint16{},
-			Volumes: map[string]string{"celery": "/opt/celery/var"},
+			Name:         "celery",
+			Repo:         IMAGE_REPO,
+			Tag:          IMAGE_TAG,
+			Command:      func() string { return command },
+			PortBindings: []portBinding{},
+			Volumes:      map[string]string{"celery": "/opt/celery/var"},
 		})
 	if err != nil {
 		glog.Fatalf("Error initializing celery container: %s", err)

--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -231,9 +231,13 @@ func (svc *IService) create() (*docker.Container, error) {
 	config.Image = commons.JoinRepoTag(svc.Repo, svc.Tag)
 	config.Cmd = []string{"/bin/sh", "-c", "trap 'kill 0' 15; " + svc.Command()}
 
-	// set the host network (if enabled)
+	// NOTE: USE WITH CARE
+	// Enabling host networking for an isvc may expose ports
+	// of the isvcs to access outside of the serviced host, potentially
+	// compromising security.
 	if svc.HostNetwork {
 		cd.NetworkMode = "host"
+		glog.Warningf("Host networking enabled for isvc %s", svc.Name)
 	}
 
 	// attach all exported ports

--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -124,6 +124,7 @@ type IServiceDefinition struct {
 	Notify        func(*IService, interface{}) error // A function to run when notified of a data event
 	PostStart     func(*IService) error              // A function to run after the initial start of the service
 	HostNetwork   bool                               // enables host network in the container
+	Links         []string                           // List of links to other containers in the form of <name>:<alias>
 }
 
 type IService struct {
@@ -274,6 +275,13 @@ func (svc *IService) create() (*docker.Container, error) {
 		}
 	}
 	glog.V(1).Infof("Bindings for %s = %v", svc.Name, cd.PortBindings)
+
+	// copy any links to other isvcs
+	if svc.Links != nil && len(svc.Links) > 0 {
+		cd.Links = make([]string, len(svc.Links))
+		copy(cd.Links, svc.Links)
+		glog.V(1).Infof("Links for %s = %v", svc.Name, cd.Links)
+	}
 
 	// attach all exported volumes
 	config.Volumes = make(map[string]struct{})

--- a/isvcs/docker_registry.go
+++ b/isvcs/docker_registry.go
@@ -37,6 +37,11 @@ func init() {
 		DEFAULT_HEALTHCHECK_NAME: defaultHealthCheck,
 	}
 
+	dockerPortBinding := portBinding{
+		HostIp:         "0.0.0.0",
+		HostIpOverride: "", // docker registry should always be open
+		HostPort:       registryPort,
+	}
 	command := `DOCKER_REGISTRY_CONFIG=/docker-registry/config/config_sample.yml SETTINGS_FLAVOR=serviced exec docker-registry`
 	dockerRegistry, err = NewIService(
 		IServiceDefinition{
@@ -44,7 +49,7 @@ func init() {
 			Repo:         IMAGE_REPO,
 			Tag:          IMAGE_TAG,
 			Command:      func() string { return command },
-			Ports:        []uint16{registryPort},
+			PortBindings: []portBinding{dockerPortBinding},
 			Volumes:      map[string]string{"registry": "/tmp/registry"},
 			HealthChecks: healthChecks,
 		},

--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -46,6 +46,11 @@ func init() {
 	healthChecks := map[string]healthCheckDefinition{
 		DEFAULT_HEALTHCHECK_NAME: defaultHealthCheck,
 	}
+	elasticsearch_servicedPortBinding := portBinding{
+		HostIp:         "127.0.0.1",
+		HostIpOverride: "SERVICED_ISVC_ELASTICSEARCH_SERVICED_PORT_9200_HOSTIP",
+		HostPort:       9200,
+	}
 
 	elasticsearch_serviced, err = NewIService(
 		IServiceDefinition{
@@ -53,7 +58,7 @@ func init() {
 			Repo:          IMAGE_REPO,
 			Tag:           IMAGE_TAG,
 			Command:       func() string { return "" },
-			Ports:         []uint16{9200},
+			PortBindings:  []portBinding{elasticsearch_servicedPortBinding},
 			Volumes:       map[string]string{"data": "/opt/elasticsearch-0.90.9/data"},
 			Configuration: make(map[string]interface{}),
 			HealthChecks:  healthChecks,
@@ -76,6 +81,11 @@ func init() {
 	healthChecks = map[string]healthCheckDefinition{
 		DEFAULT_HEALTHCHECK_NAME: logStashHealthCheck,
 	}
+	elasticsearch_logstashPortBinding := portBinding{
+		HostIp:         "127.0.0.1",
+		HostIpOverride: "SERVICED_ISVC_ELASTICSEARCH_LOGSTASH_PORT_9100_HOSTIP",
+		HostPort:       9100,
+	}
 
 	elasticsearch_logstash, err = NewIService(
 		IServiceDefinition{
@@ -83,7 +93,7 @@ func init() {
 			Repo:          IMAGE_REPO,
 			Tag:           IMAGE_TAG,
 			Command:       func() string { return "" },
-			Ports:         []uint16{9100},
+			PortBindings:  []portBinding{elasticsearch_logstashPortBinding},
 			Volumes:       map[string]string{"data": "/opt/elasticsearch-1.3.1/data"},
 			Configuration: make(map[string]interface{}),
 			HealthChecks:  healthChecks,
@@ -166,7 +176,7 @@ func getElasticHealth(baseUrl string) (cluster.ClusterHealthResponse, error) {
 
 func PurgeLogstashIndices(days int, gb int) error {
 	iservice := elasticsearch_logstash
-	port := iservice.Ports[0]
+	port := iservice.PortBindings[0].HostPort
 	glog.Infof("Purging logstash entries older than %d days", days)
 	err := iservice.Exec([]string{
 		"/usr/local/bin/curator", "--port", fmt.Sprintf("%d", port),

--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -57,7 +57,6 @@ func init() {
 			Volumes:       map[string]string{"data": "/opt/elasticsearch-0.90.9/data"},
 			Configuration: make(map[string]interface{}),
 			HealthChecks:  healthChecks,
-			HostNetwork:   true,
 		},
 	)
 	if err != nil {

--- a/isvcs/logstash.go
+++ b/isvcs/logstash.go
@@ -29,14 +29,13 @@ func init() {
 	command := "exec /opt/logstash-1.4.2/bin/logstash agent -f /usr/local/serviced/resources/logstash/logstash.conf"
 	logstash, err = NewIService(
 		IServiceDefinition{
-			Name:        "logstash",
-			Repo:        IMAGE_REPO,
-			Tag:         IMAGE_TAG,
-			Command:     func() string { return command },
-			Ports:       []uint16{5042, 5043, 9292},
-			Volumes:     map[string]string{},
-			Notify:      notifyLogstashConfigChange,
-			HostNetwork: true,
+			Name:    "logstash",
+			Repo:    IMAGE_REPO,
+			Tag:     IMAGE_TAG,
+			Command: func() string { return command },
+			Ports:   []uint16{5042, 5043, 9292},
+			Volumes: map[string]string{},
+			Notify:  notifyLogstashConfigChange,
 		})
 	if err != nil {
 		glog.Fatalf("Error initializing logstash_master container: %s", err)

--- a/isvcs/logstash.go
+++ b/isvcs/logstash.go
@@ -55,6 +55,7 @@ func init() {
 				webserverPortBinding},
 			Volumes: map[string]string{},
 			Notify:  notifyLogstashConfigChange,
+			Links:   []string{"serviced-isvcs_elasticsearch-logstash:elasticsearch"},
 		})
 	if err != nil {
 		glog.Fatalf("Error initializing logstash_master container: %s", err)

--- a/isvcs/logstash.go
+++ b/isvcs/logstash.go
@@ -27,13 +27,32 @@ var logstash *IService
 func init() {
 	var err error
 	command := "exec /opt/logstash-1.4.2/bin/logstash agent -f /usr/local/serviced/resources/logstash/logstash.conf"
+	localFilePortBinding := portBinding{
+		HostIp:         "0.0.0.0",
+		HostIpOverride: "", // logstash should always be open
+		HostPort:       5042,
+	}
+	lumberJackPortBinding := portBinding{
+		HostIp:         "0.0.0.0",
+		HostIpOverride: "", // lumberjack should always be open
+		HostPort:       5043,
+	}
+	webserverPortBinding := portBinding{
+		HostIp:         "127.0.0.1",
+		HostIpOverride: "SERVICED_ISVC_LOGSTASH_PORT_9292_HOSTIP",
+		HostPort:       9292,
+	}
+
 	logstash, err = NewIService(
 		IServiceDefinition{
 			Name:    "logstash",
 			Repo:    IMAGE_REPO,
 			Tag:     IMAGE_TAG,
 			Command: func() string { return command },
-			Ports:   []uint16{5042, 5043, 9292},
+			PortBindings: []portBinding{
+				localFilePortBinding,
+				lumberJackPortBinding,
+				webserverPortBinding},
 			Volumes: map[string]string{},
 			Notify:  notifyLogstashConfigChange,
 		})

--- a/isvcs/logstash.go
+++ b/isvcs/logstash.go
@@ -53,9 +53,10 @@ func init() {
 				localFilePortBinding,
 				lumberJackPortBinding,
 				webserverPortBinding},
-			Volumes: map[string]string{},
-			Notify:  notifyLogstashConfigChange,
-			Links:   []string{"serviced-isvcs_elasticsearch-logstash:elasticsearch"},
+			Volumes:    map[string]string{},
+			Notify:     notifyLogstashConfigChange,
+			Links:      []string{"serviced-isvcs_elasticsearch-logstash:elasticsearch"},
+			StartGroup: 1,
 		})
 	if err != nil {
 		glog.Fatalf("Error initializing logstash_master container: %s", err)

--- a/isvcs/manager.go
+++ b/isvcs/manager.go
@@ -78,10 +78,11 @@ type managerRequest struct {
 
 // A manager of docker services run in ephemeral containers
 type Manager struct {
-	imagesDir  string              // local directory where images could be loaded from
-	volumesDir string              // local directory where volumes are stored
-	requests   chan managerRequest // the main loops request channel
-	services   map[string]*IService
+	imagesDir   string              // local directory where images could be loaded from
+	volumesDir  string              // local directory where volumes are stored
+	requests    chan managerRequest // the main loops request channel
+	services    map[string]*IService
+	startGroups map[int][]string // map by group number of a list of service names
 }
 
 // Returns a new Manager struct and starts the Manager's main loop()
@@ -89,10 +90,11 @@ func NewManager(imagesDir, volumesDir string) *Manager {
 	loadvolumes()
 
 	manager := &Manager{
-		imagesDir:  imagesDir,
-		volumesDir: volumesDir,
-		requests:   make(chan managerRequest),
-		services:   make(map[string]*IService),
+		imagesDir:   imagesDir,
+		volumesDir:  volumesDir,
+		requests:    make(chan managerRequest),
+		services:    make(map[string]*IService),
+		startGroups: make(map[int][]string),
 	}
 	go manager.loop()
 	return manager
@@ -313,37 +315,18 @@ func (m *Manager) loop() {
 					continue
 				}
 
-				// track the number of services that haven't started
-				var noStart = make([]int, len(m.services))
-
-				// start services in parallel
-				var wg sync.WaitGroup
-				index := 0
-				for name, svc := range m.services {
-					if !svc.IsRunning() {
-						wg.Add(1)
-						go func(svc *IService, i int) {
-							defer wg.Done()
-							if err := svc.Start(); err != nil {
-								glog.Errorf("Error starting isvc %s: %s", svc.Name, err)
-								noStart[i] = 1
-								return
-							}
-						}(m.services[name], index)
-					}
-					index++
+				// Start each group of services in group-number order
+				unstartedServices := 0
+				for _, group := range m.orderedStartGroups() {
+					unstartedServices += m.startServiceGroup(group)
 				}
-				wg.Wait()
 
-				count := 0
-				for _, i := range noStart {
-					count += i
-				}
-				if count > 0 {
-					request.response <- StartError(count)
+				if unstartedServices > 0 {
+					request.response <- StartError(unstartedServices)
 				} else {
 					request.response <- nil
 				}
+
 			case managerOpStop:
 				// track the number of services that haven't stopped
 				var noStop = make([]int, len(m.services))
@@ -381,6 +364,7 @@ func (m *Manager) loop() {
 					request.response <- ErrManagerUnknownArg
 				} else {
 					m.services[svc.Name] = svc
+					m.addServiceToStartGroup(svc)
 					request.response <- nil
 				}
 			case managerOpInit:
@@ -390,6 +374,61 @@ func (m *Manager) loop() {
 			}
 		}
 	}
+}
+
+func (m *Manager) addServiceToStartGroup(svc *IService) {
+	startGroup := int(svc.StartGroup)
+	if m.startGroups[startGroup] == nil {
+		m.startGroups[startGroup] = make([]string, 0)
+	}
+	m.startGroups[startGroup] = append(m.startGroups[startGroup], svc.Name)
+}
+
+// Returns a list of start groups in numeric order (lowest to highest)
+func (m *Manager) orderedStartGroups() []int {
+	result := make([]int, len(m.startGroups))
+	i := 0
+	for key, _ := range m.startGroups {
+		result[i] = int(key)
+		i++
+	}
+	sort.Ints(result)
+	return result
+}
+
+// Start all of the services in the specified start group and wait for all of
+// them to finish. Returns the number of services which failed to start.
+func (m *Manager) startServiceGroup(group int) int {
+	glog.V(1).Infof("Starting isvcs in group %d: %v", group, m.startGroups[group])
+
+	// track the number of services that haven't started
+	var noStart = make([]int, len(m.startGroups[group]))
+
+	// start all of the services for this group in parallel
+	var wg sync.WaitGroup
+	index := 0
+	for _, name := range m.startGroups[group] {
+		svc := m.services[name]
+		if !svc.IsRunning() {
+			wg.Add(1)
+			go func(svc *IService, i int) {
+				defer wg.Done()
+				if err := svc.Start(); err != nil {
+					glog.Errorf("Error starting isvc %s: %s", svc.Name, err)
+					noStart[i] = 1
+					return
+				}
+			}(m.services[name], index)
+		}
+		index++
+	}
+	wg.Wait()
+
+	unstartedServices := 0
+	for _, i := range noStart {
+		unstartedServices += i
+	}
+	return unstartedServices
 }
 
 // makeRequest sends a manager operation request to the *Manager's loop()

--- a/isvcs/opentsdb.go
+++ b/isvcs/opentsdb.go
@@ -27,14 +27,50 @@ var opentsdb *IService
 func init() {
 	var err error
 	command := `cd /opt/zenoss && exec supervisord -n -c /opt/zenoss/etc/supervisor.conf`
+	opentsdbPortBinding := portBinding{
+		HostIp:         "0.0.0.0",
+		HostIpOverride: "SERVICED_ISVC_OPENTSDB_PORT_4242_HOSTIP",
+		HostPort:       4242,
+	}
+	metricConsumerPortBinding := portBinding{
+		HostIp:         "0.0.0.0",
+		HostIpOverride: "", // metric-consumer should always be open
+		HostPort:       8443,
+	}
+	metricConsumerAdminPortBinding := portBinding{
+		HostIp:         "127.0.0.1",
+		HostIpOverride: "SERVICED_ISVC_OPENTSDB_PORT_58443_HOSTIP",
+		HostPort:       58443,
+	}
+	centralQueryPortBinding := portBinding{
+		HostIp:         "127.0.0.1",
+		HostIpOverride: "SERVICED_ISVC_OPENTSDB_PORT_8888_HOSTIP",
+		HostPort:       8888,
+	}
+	centralQueryAdminPortBinding := portBinding{
+		HostIp:         "127.0.0.1",
+		HostIpOverride: "SERVICED_ISVC_OPENTSDB_PORT_58888_HOSTIP",
+		HostPort:       58888,
+	}
+	hbasePortBinding := portBinding{
+		HostIp:         "127.0.0.1",
+		HostIpOverride: "SERVICED_ISVC_OPENTSDB_PORT_9090_HOSTIP",
+		HostPort:       9090,
+	}
+
 	opentsdb, err = NewIService(
 		IServiceDefinition{
 			Name:    "opentsdb",
 			Repo:    IMAGE_REPO,
 			Tag:     IMAGE_TAG,
 			Command: func() string { return command },
-			//only expose 8443 (the consumer port to the host)
-			Ports:   []uint16{4242, 8443, 8888, 9090},
+			PortBindings: []portBinding{
+				opentsdbPortBinding,
+				metricConsumerPortBinding,
+				metricConsumerAdminPortBinding,
+				centralQueryPortBinding,
+				centralQueryAdminPortBinding,
+				hbasePortBinding},
 			Volumes: map[string]string{"hbase": "/opt/zenoss/var/hbase"},
 		})
 	if err != nil {

--- a/isvcs/opentsdb.go
+++ b/isvcs/opentsdb.go
@@ -34,9 +34,8 @@ func init() {
 			Tag:     IMAGE_TAG,
 			Command: func() string { return command },
 			//only expose 8443 (the consumer port to the host)
-			Ports:       []uint16{4242, 8443, 8888, 9090},
-			Volumes:     map[string]string{"hbase": "/opt/zenoss/var/hbase"},
-			HostNetwork: true,
+			Ports:   []uint16{4242, 8443, 8888, 9090},
+			Volumes: map[string]string{"hbase": "/opt/zenoss/var/hbase"},
 		})
 	if err != nil {
 		glog.Fatalf("Error initializing opentsdb container: %s", err)

--- a/isvcs/resources/logstash/logstash.conf.in
+++ b/isvcs/resources/logstash/logstash.conf.in
@@ -13,7 +13,7 @@ input {
 }
 
 
-# 
+#
 filter {
 # NOTE the filters are generated from the service definitions
 
@@ -23,7 +23,7 @@ filter {
 output {
 	elasticsearch {
 		protocol => "http"
-		host => "172.17.42.1"
+		host => "elasticsearch"
 		port => 9100
 	}
 }

--- a/isvcs/resources/logstash/logstash.conf.template
+++ b/isvcs/resources/logstash/logstash.conf.template
@@ -18,7 +18,7 @@ input {
 output {
 	elasticsearch {
 		protocol => "http"
-		host => "172.17.42.1"
+		host => "elasticsearch"
 		port => 9100
 	}
 }

--- a/isvcs/zk.go
+++ b/isvcs/zk.go
@@ -25,13 +25,25 @@ import (
 	"time"
 )
 
+var zookeeperPortBinding = portBinding{
+	HostIp:         "0.0.0.0",
+	HostIpOverride: "", // zookeeper should always be open
+	HostPort:       2181,
+}
+
+var exhibitorPortBinding = portBinding{
+	HostIp:         "127.0.0.1",
+	HostIpOverride: "SERVICED_ISVC_ZOOKEEPER_PORT_12181_HOSTIP",
+	HostPort:       12181,
+}
+
 var Zookeeper = IServiceDefinition{
-	Name:    "zookeeper",
-	Repo:    IMAGE_REPO,
-	Tag:     IMAGE_TAG,
-	Command: func() string { return "exec /opt/zookeeper-3.4.5/bin/zkServer.sh start-foreground" },
-	Ports:   []uint16{2181, 12181},
-	Volumes: map[string]string{"data": "/tmp"},
+	Name:         "zookeeper",
+	Repo:         IMAGE_REPO,
+	Tag:          IMAGE_TAG,
+	Command:      func() string { return "exec /opt/zookeeper-3.4.5/bin/zkServer.sh start-foreground" },
+	PortBindings: []portBinding{zookeeperPortBinding, exhibitorPortBinding},
+	Volumes:      map[string]string{"data": "/tmp"},
 }
 
 var zookeeper *IService


### PR DESCRIPTION
Addresses:
 * https://jira.zenoss.com/browse/CC-950
 * https://jira.zenoss.com/browse/CC-875

See comments in [CC-950](https://jira.zenoss.com/browse/CC-950) for a list of which services are always open, open by default and closed by default.  Note that use of docker links to wire logstash to elasticsearch-logstash required a change to order isvcs startup so that logstash is started after elasticsearch-logstash; see changeset 80fa349