### PR TITLE
fixes CC-745: add unstable build number to MAINTAINER in deb/rpm

### DIFF
--- a/pkg/makefile
+++ b/pkg/makefile
@@ -52,6 +52,7 @@ CATEGORY      = admin
 PKG_VERSION = $(VERSION)
 ifeq "$(RELEASE_PHASE)" ""
     ITERATION = 0.0.$(BUILD_NUMBER).unstable
+    BUILD_LABEL = build-$(BUILD_NUMBER)
 else
     # This else portion is no longer used - replaced by:
     #   http://jenkins.zendev.org/view/Promotions/job/serviced-promote/
@@ -63,6 +64,7 @@ else
     else
         ITERATION = 0.1.$(RELEASE_PHASE)
     endif
+    BUILD_LABEL =
 endif
 
 ifeq "$(SUBPRODUCT)" ""
@@ -72,7 +74,7 @@ FULL_NAME=$(NAME)-$(SUBPRODUCT)
 endif
 
 define DESCRIPTION
-Zenoss Serviced PaaS runtime 
+Zenoss Serviced PaaS runtime.  $(BUILD_LABEL)
 Allows services to be uniformly created, scaled, and managed.
 endef
 export DESCRIPTION


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-745

DEMO:
```
~/src/europa/src/golang/src/github.com/control-center/serviced
# plu@plu-9: BUILD_NUMBER=12345 make INSTALL_TEMPLATES=0 docker_buildandpackage
fpm \
...
Created package {:path=>"serviced_1.1.0~trusty-0.0.12345.unstable_amd64.deb"}

fpm \
...
Created package {:path=>"serviced-1.1.0-0.0.12345.unstable.x86_64.rpm"}

# plu@plu-9: dpkg -I pkg/serviced_1.1.0~trusty-0.0.12345.unstable_amd64.deb |grep build-
 Description: Zenoss Serviced PaaS runtime.  build-12345
```