### PR TITLE
fixes CC-898: update the serviced release alongside host.UpdatedAt

### DIFF
--- a/coordinator/storage/client.go
+++ b/coordinator/storage/client.go
@@ -201,6 +201,7 @@ func (c *Client) setNode(nodePath string, node *Node, doGetBeforeSet bool) error
 	}
 
 	node.Host.UpdatedAt = time.Now()
+	node.Host.ServiceD.Release = c.host.ServiceD.Release
 	if err := c.conn.Set(nodePath, node); err != nil {
 		return err
 	}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-898

DEMO - host list shows release on an upgraded system:
```
[root@resmgr-500 ~]# rpm -qa |egrep 'serviced|zenoss'
zenoss-docker-1.5.0-2.x86_64
zenoss-resmgr-service-5.0.0-2.noarch
zenoss-repo-1-1.x86_64
serviced-1.0.0-2.x86_64

[root@resmgr-500 ~]# cd /opt/serviced/bin/

[root@resmgr-500 bin]# /tmp/serviced host list
This master has been configured to be in pool: default
ID            Pool         Name                       Addr               RPCPort      Cores      RAM        Cur/Max/Avg      Network                     Release
570a6ed0      default      resmgr-500.zenoss.loc      10.87.208.110      4979         8          39.1G      --               172.17.0.0/255.255.0.0      
[root@resmgr-500 bin]# serviced host list 570a6ed0 | grep --after=7 ServiceD
   "ServiceD": {
     "Version": "1.0.0",
     "Date": "Thu Mar  5 22:45:47 UTC 2015",
     "Gitcommit": "ddf9208",
     "Gitbranch": "HEAD",
     "Giturl": "",
     "Buildtag": "jenkins-serviced-build-2182"
   },
[root@resmgr-500 bin]# systemctl stop serviced
[root@resmgr-500 bin]# cp /tmp/serviced .
cp: overwrite ‘./serviced’? y
[root@resmgr-500 bin]# serviced version
This master has been configured to be in pool: default
Version:   1.1.0
Gitcommit: 172e9e4-dirty
Gitbranch: feature/CC-898
Giturl:    
Date:      Tue May 19 13:24:00 UTC 2015
Buildtag:  0
Release:   1.0.0-2
IsvcsImage: zenoss/serviced-isvcs:v29
[root@resmgr-500 bin]# systemctl start serviced
[root@resmgr-500 bin]# serviced host list
This master has been configured to be in pool: default
ID            Pool         Name                       Addr               RPCPort      Cores      RAM        Cur/Max/Avg                 Network                     Release
570a6ed0      default      resmgr-500.zenoss.loc      10.87.208.110      4979         8          39.1G      499.3M / 25.5G / 21.7G      172.17.0.0/255.255.0.0      1.0.0-2

[root@resmgr-500 bin]# serviced host list 570a6ed0 | grep --after=8 ServiceD
   "ServiceD": {
     "Version": "1.1.0",
     "Date": "Tue May 19 13:24:00 UTC 2015",
     "Gitcommit": "172e9e4-dirty",
     "Gitbranch": "feature/CC-898",
     "Giturl": "",
     "Buildtag": "0",
     "Release": "1.0.0-2"
   },
[root@resmgr-500 bin]# 
```