### PR TITLE
fixes CC-993: use dash instead of colon in veth pair names

### DIFF
--- a/container/vif.go
+++ b/container/vif.go
@@ -99,7 +99,7 @@ func (reg *VIFRegistry) RegisterVirtualAddress(address, toport, protocol string)
 		viface = &vif{
 			hostname: host,
 			ip:       ip,
-			name:     "eth0:" + host,
+			name:     "eth0-" + host,
 			tcpPorts: make(map[string]string),
 			udpPorts: make(map[string]string),
 		}
@@ -140,7 +140,7 @@ func (viface *vif) createCommand() error {
 	c.Stderr = os.Stdout
 
 	if err := c.Run(); err != nil {
-		glog.Errorf("Adding virtual interface failed: %+v", err)
+		glog.Errorf("Adding virtual interface failed using cmd:%+v  error:%+v", command, err)
 		return err
 	}
 	command = []string{
@@ -150,7 +150,7 @@ func (viface *vif) createCommand() error {
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stdout
 	if err := c.Run(); err != nil {
-		glog.Errorf("Adding IP to virtual interface failed: %+v", err)
+		glog.Errorf("Adding IP to virtual interface failed using cmd:%+v  error:%+v", command, err)
 		return err
 	}
 	command = []string{
@@ -160,7 +160,7 @@ func (viface *vif) createCommand() error {
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stdout
 	if err := c.Run(); err != nil {
-		glog.Errorf("Bringing interface %s up failed: %+v", viface.name, err)
+		glog.Errorf("Bringing interface %s up failed using cmd:%+v  error:%+v", viface.name, command, err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-993

DEMO - on latest kernel, veth setup succeeds - no RTNETLINK error:
```
root@ip-10-111-23-155:/opt/serviced/bin# uname -a
Linux ip-10-111-23-155 3.13.0-53-generic #89-Ubuntu SMP Wed May 20 10:34:39 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux

root@ip-10-111-23-155:/opt/serviced/bin# serviced service logs hmaster -- -f 2>&1 | grep --after=2 RegisterVirtualAddress
I0529 13:50:43.148040 00001 vif.go:78] RegisterVirtualAddress address:zk1:2181 toport:2181 protocol:tcp
I0529 13:50:43.158155 00001 vif.go:171] Trying to set up redirect zk1:2181->:2181 tcp
I0529 13:50:43.183829 00001 vif.go:193] AddToEtcHosts(zk1, 10.3.0.2)
--
I0529 13:50:43.307959 00001 vif.go:78] RegisterVirtualAddress address:zk2:2181 toport:2182 protocol:tcp
I0529 13:50:43.320169 00001 vif.go:171] Trying to set up redirect zk2:2181->:2182 tcp
I0529 13:50:43.327619 00001 vif.go:193] AddToEtcHosts(zk2, 10.3.0.3)
--
I0529 13:50:43.388849 00001 vif.go:78] RegisterVirtualAddress address:zk3:2181 toport:2183 protocol:tcp
I0529 13:50:43.407629 00001 vif.go:171] Trying to set up redirect zk3:2181->:2183 tcp
I0529 13:50:43.412383 00001 vif.go:193] AddToEtcHosts(zk3, 10.3.0.4)
```

DEMO - on older kernel, make sure there is not a regression - no RTNETLINK error:
```
[root@resmgr-510 bin]# uname -a
Linux resmgr-510.zenoss.loc 3.10.0-229.1.2.el7.x86_64 #1 SMP Fri Mar 27 03:04:26 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux

[root@resmgr-510 bin]# serviced service logs hmaster -- -f 2>&1 | grep --after=2 RegisterVirtualAddress
I0529 14:17:42.816866 00001 vif.go:78] RegisterVirtualAddress address:zk3:2181 toport:2183 protocol:tcp
I0529 14:17:42.830702 00001 vif.go:170] Trying to set up redirect zk3:2181->:2183 tcp
I0529 14:17:42.835818 00001 controller.go:724] Kicking off health check cluster_healthy.
--
I0529 14:17:42.984816 00001 vif.go:78] RegisterVirtualAddress address:zk1:2181 toport:2181 protocol:tcp
I0529 14:17:42.998814 00001 vif.go:170] Trying to set up redirect zk1:2181->:2181 tcp
I0529 14:17:43.011237 00001 vif.go:192] AddToEtcHosts(zk1, 10.3.0.3)
--
I0529 14:17:43.080256 00001 vif.go:78] RegisterVirtualAddress address:zk2:2181 toport:2182 protocol:tcp
I0529 14:17:43.093443 00001 vif.go:170] Trying to set up redirect zk2:2181->:2182 tcp
I0529 14:17:43.106408 00001 vif.go:192] AddToEtcHosts(zk2, 10.3.0.4)
```