### PR TITLE
fixes CC-1017: provide friendlier message when there are no logstash entries to purge

### DIFF
--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -205,18 +205,18 @@ func (svc *IService) Restart() error {
 	return <-response
 }
 
-func (svc *IService) Exec(command []string) error {
+func (svc *IService) Exec(command []string) ([]byte, error) {
 	ctr, err := docker.FindContainer(svc.name())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	output, err := utils.AttachAndRun(ctr.ID, command)
 	if err != nil {
-		return err
+		return output, err
 	}
 	os.Stdout.Write(output)
-	return nil
+	return output, nil
 }
 
 func (svc *IService) getResourcePath(p string) string {

--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -185,7 +185,7 @@ func PurgeLogstashIndices(days int, gb int) {
 	if output, err := iservice.Exec(append(append(prefix, "delete"), indices...)); err != nil {
 		if strings.Contains(string(output), "No indices found in Elasticsearch") ||
 			strings.Contains(string(output), "No indices matched provided args") {
-			glog.Infof("Nothing to purge - logstash entries are not older than %d days", days)
+			glog.Infof("Ignore previous error - nothing to purge - logstash entries are not older than %d days", days)
 		} else {
 			glog.Errorf("Unable to purge logstash entries older than %d days: %s", days, err)
 		}
@@ -196,7 +196,7 @@ func PurgeLogstashIndices(days int, gb int) {
 	if output, err := iservice.Exec(append(append(prefix, "delete"), indices...)); err != nil {
 		if strings.Contains(string(output), "No indices found in Elasticsearch") ||
 			strings.Contains(string(output), "No indices matched provided args") {
-			glog.Infof("Nothing to purge - logstash entries are using less than %d GB", gb)
+			glog.Infof("Ignore previous error - nothing to purge - logstash entries are using less than %d GB", gb)
 		} else {
 			glog.Errorf("Unable to purge logstash entries to limit disk usage to %d GB: %s", gb, err)
 		}

--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -177,18 +178,27 @@ func getElasticHealth(baseUrl string) (cluster.ClusterHealthResponse, error) {
 func PurgeLogstashIndices(days int, gb int) {
 	iservice := elasticsearch_logstash
 	port := iservice.PortBindings[0].HostPort
+	prefix := []string{"/usr/local/bin/curator", "--port", fmt.Sprintf("%d", port)}
+
 	glog.Infof("Purging logstash entries older than %d days", days)
-	err := iservice.Exec([]string{
-		"/usr/local/bin/curator", "--port", fmt.Sprintf("%d", port),
-		"delete", "indices", "--older-than", fmt.Sprintf("%d", days), "--time-unit", "days", "--timestring", "%Y.%m.%d"})
-	if err != nil {
-		glog.Errorf("Unable to purge logstash entries older than %d days: %s", days, err)
+	indices := []string{"indices", "--older-than", fmt.Sprintf("%d", days), "--time-unit", "days", "--timestring", "%Y.%m.%d"}
+	if output, err := iservice.Exec(append(append(prefix, "delete"), indices...)); err != nil {
+		if strings.Contains(string(output), "No indices found in Elasticsearch") ||
+			strings.Contains(string(output), "No indices matched provided args") {
+			glog.Infof("Nothing to purge - logstash entries are not older than %d days", days)
+		} else {
+			glog.Errorf("Unable to purge logstash entries older than %d days: %s", days, err)
+		}
 	}
+
 	glog.Infof("Purging oldest logstash entries to limit disk usage to %d GB.", gb)
-	err = iservice.Exec([]string{
-		"/usr/local/bin/curator", "--port", fmt.Sprintf("%d", port),
-		"delete", "--disk-space", fmt.Sprintf("%d", gb), "indices", "--all-indices"})
-	if err != nil {
-		glog.Errorf("Unable to purge logstash entries to limit disk usage to %d GB: %s", gb, err)
+	indices = []string{"--disk-space", fmt.Sprintf("%d", gb), "indices", "--all-indices"}
+	if output, err := iservice.Exec(append(append(prefix, "delete"), indices...)); err != nil {
+		if strings.Contains(string(output), "No indices found in Elasticsearch") ||
+			strings.Contains(string(output), "No indices matched provided args") {
+			glog.Infof("Nothing to purge - logstash entries are using less than %d GB", gb)
+		} else {
+			glog.Errorf("Unable to purge logstash entries to limit disk usage to %d GB: %s", gb, err)
+		}
 	}
 }


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-1017

DEMO1 - provide friendly message about not purging when there are no indices:
```
I0615 15:20:22.464080 31443 es.go:183] Purging logstash entries older than 14 days
E0615 15:20:22.870193 31443 docker_exec.go:48] Error running command:'[/usr/bin/docker exec e060a19f5374bd891e77002effa528d76c8147e62e9b10e6206b3caa912ebe40 /bin/bash -c /usr/local/bin/curator --port 9100 delete indices --older-than 14 --time-unit days --timestring %Y.%m.%d]' output: 2015-06-15 15:20:22,820 INFO      Job starting: delete indices
ERROR. No indices found in Elasticsearch.
  error: exit status 1
I0615 15:20:22.870338 31443 es.go:188] Nothing to purge - logstash entries are not older than 14 days
I0615 15:20:22.870367 31443 es.go:194] Purging oldest logstash entries to limit disk usage to 10 GB.
E0615 15:20:23.242325 31443 docker_exec.go:48] Error running command:'[/usr/bin/docker exec e060a19f5374bd891e77002effa528d76c8147e62e9b10e6206b3caa912ebe40 /bin/bash -c /usr/local/bin/curator --port 9100 delete --disk-space 10 indices --all-indices]' output: 2015-06-15 15:20:23,196 INFO      Job starting: delete indices
ERROR. No indices found in Elasticsearch.
  error: exit status 1
I0615 15:20:23.242450 31443 es.go:199] Nothing to purge - logstash entries are using less than 10 GB
```

DEMO2 - provide friendly message about not purging when indices did not meet purge criteria:
```
I0615 15:42:18.629851 17429 es.go:183] Purging logstash entries older than 14 days
E0615 15:42:21.119585 17429 docker_exec.go:48] Error running command:'[/usr/bin/docker exec ed836762aaa9a49be3e5389f80a118037beedcdebe1e2d83454592dde38db90a /bin/bash -c /usr/local/bin/curator --port 9100 delete indices --older-than 14 --time-unit days --timestring %Y.%m.%d]' output: 2015-06-15 15:42:21,085 INFO      Job starting: delete indices
2015-06-15 15:42:21,098 INFO      Pruning Kibana-related indices to prevent accidental deletion.
2015-06-15 15:42:21,098 WARNING   No indices matched provided args: {'regex': None, 'index': (), 'suffix': None, 'newer_than': None, 'prefix': None, 'time_unit': 'days', 'timestring': '%Y.%m.%d', 'exclude': (), 'older_than': 14, 'all_indices': False}
No indices matched provided args.
error: exit status 99
I0615 15:42:21.119699 17429 es.go:188] Nothing to purge - logstash entries are not older than 14 days
I0615 15:42:21.119720 17429 es.go:194] Purging oldest logstash entries to limit disk usage to 10 GB.
E0615 15:42:21.477230 17429 docker_exec.go:48] Error running command:'[/usr/bin/docker exec ed836762aaa9a49be3e5389f80a118037beedcdebe1e2d83454592dde38db90a /bin/bash -c /usr/local/bin/curator --port 9100 delete --disk-space 10 indices --all-indices]' output: 2015-06-15 15:42:21,358 INFO      Job starting: delete indices
2015-06-15 15:42:21,364 INFO      Matching all indices. Ignoring flags other than --exclude.
2015-06-15 15:42:21,364 INFO      Pruning Kibana-related indices to prevent accidental deletion.
2015-06-15 15:42:21,454 INFO      skipping logstash-2015.06.15, summed disk usage is 0.284 GB and disk limit is 10.000 GB.
2015-06-15 15:42:21,454 WARNING   No indices matched provided args: {'all_indices': True, 'regex': None, 'suffix': None, 'index': (), 'newer_than': None, 'prefix': None, 'time_unit': None, 'timestring': None, 'exclude': (), 'older_than': None}
No indices matched provided args.
error: exit status 99
I0615 15:42:21.477338 17429 es.go:199] Nothing to purge - logstash entries are using less than 10 GB
```