### PR TITLE
fixes CC-1014: added logrotate for docker logs

### DIFF
--- a/makefile
+++ b/makefile
@@ -229,6 +229,7 @@ install_DIRS += $(_DESTDIR)$(prefix)/isvcs
 install_DIRS += $(_DESTDIR)$(sysconfdir)/default
 install_DIRS += $(_DESTDIR)$(sysconfdir)/bash_completion.d
 install_DIRS += $(_DESTDIR)$(sysconfdir)/cron.daily
+install_DIRS += $(_DESTDIR)$(sysconfdir)/cron.hourly
 
 # Specify the stuff to install as attributes of the various
 # install directories we know about.
@@ -240,7 +241,9 @@ install_DIRS += $(_DESTDIR)$(sysconfdir)/cron.daily
 #
 default_INSTCMD = cp
 $(_DESTDIR)$(sysconfdir)/cron.daily_TARGETS        = pkg/cron.daily:serviced
+$(_DESTDIR)$(sysconfdir)/cron.hourly_TARGETS       = pkg/cron.hourly:serviced
 $(_DESTDIR)$(prefix)/etc_TARGETS                   = pkg/serviced.logrotate:logrotate.conf
+$(_DESTDIR)$(prefix)/etc_TARGETS                  += pkg/logrotate-docker.conf:logrotate-docker.conf
 $(_DESTDIR)$(prefix)/bin_TARGETS                   = serviced
 $(_DESTDIR)$(prefix)/bin_LINK_TARGETS             += $(prefix)/bin/serviced:$(_DESTDIR)/usr/bin/serviced
 $(_DESTDIR)$(prefix)/doc_TARGETS                   = doc/copyright:.

--- a/pkg/cron.hourly
+++ b/pkg/cron.hourly
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/sbin/logrotate /opt/serviced/etc/logrotate-docker.conf

--- a/pkg/logrotate-docker.conf
+++ b/pkg/logrotate-docker.conf
@@ -1,0 +1,9 @@
+
+/var/lib/docker/containers/*/*.log {
+  hourly
+  rotate 5
+  size=10M
+  compress
+  delaycompress
+  copytruncate
+}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-1014

DEMO:
```
~/src/europa/src/golang/src/github.com/control-center/serviced/pkg
# plu@plu-9: make deb
...
mkdir -p /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/pkg/pkgroot/opt/serviced/etc
cp  pkg/serviced.logrotate /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/pkg/pkgroot/opt/serviced/etc/logrotate.conf
cp  pkg/logrotate-docker.conf /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/pkg/pkgroot/opt/serviced/etc/logrotate-docker.conf
...
mkdir -p /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/pkg/pkgroot/etc/cron.daily
cp  pkg/cron.daily /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/pkg/pkgroot/etc/cron.daily/serviced
mkdir -p /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/pkg/pkgroot/etc/cron.hourly
cp  pkg/cron.hourly /home/plu/src/europa/src/golang/src/github.com/control-center/serviced/pkg/pkgroot/etc/cron.hourly/serviced
...
Created package {:path=>"serviced_1.0.4~trusty-0.0..unstable_amd64.deb"}
```

DEMO - show that logrotate-docker.conf and cron.hourly/serviced are alongside previous logrotate files:
```
# plu@plu-9: dpkg -c serviced_1.0.4~trusty-0.0..unstable_amd64.deb  |egrep 'cron|logrotate'
-rw-rw-r-- 0/0              87 2015-06-17 09:45 ./opt/serviced/etc/logrotate.conf
-rw-rw-r-- 0/0             113 2015-06-17 09:45 ./opt/serviced/etc/logrotate-docker.conf
drwxrwxr-x 0/0               0 2015-06-17 09:45 ./etc/cron.daily/
-rwxrwxr-x 0/0              64 2015-06-17 09:45 ./etc/cron.daily/serviced
drwxrwxr-x 0/0               0 2015-06-17 09:45 ./etc/cron.hourly/
-rwxrwxr-x 0/0              71 2015-06-17 09:45 ./etc/cron.hourly/serviced
```

DEMO - This does not negatively affect docker logs (for earlier logs, you will have to use 'less' instead of 'docker logs')::
```
[root@jwhitworth-tb12 ~]# ls -l /var/lib/docker/containers/df527da8e7883efd0c0f73f0c2f1822a77a4138f07daf4eaa168bdd45a3419e3
total 112
-rw------- 1 root root 34394 Jun 17 10:07 df527da8e7883efd0c0f73f0c2f1822a77a4138f07daf4eaa168bdd45a3419e3-json.log
-rw------- 1 root root 30895 Jun 17 09:01 df527da8e7883efd0c0f73f0c2f1822a77a4138f07daf4eaa168bdd45a3419e3-json.log.1
-rw------- 1 root root  3973 Jun 17 08:01 df527da8e7883efd0c0f73f0c2f1822a77a4138f07daf4eaa168bdd45a3419e3-json.log.2.gz
-rw------- 1 root root  3970 Jun 17 07:01 df527da8e7883efd0c0f73f0c2f1822a77a4138f07daf4eaa168bdd45a3419e3-json.log.3.gz
-rw------- 1 root root  3953 Jun 17 06:01 df527da8e7883efd0c0f73f0c2f1822a77a4138f07daf4eaa168bdd45a3419e3-json.log.4.gz
-rw------- 1 root root  3932 Jun 17 05:01 df527da8e7883efd0c0f73f0c2f1822a77a4138f07daf4eaa168bdd45a3419e3-json.log.5.gz
...
[root@jwhitworth-tb12 ~]# docker logs df527da8e7883efd0c0f73f0c2f1822a77a4138f07daf4eaa168bdd45a3419e3
2015/06/17 14:01:06 200 1.651718ms POST /api/metrics/store
2015/06/17 14:01:21 200 2.19088ms POST /api/metrics/store
2015/06/17 14:01:36 200 1.619374ms POST /api/metrics/store
2015/06/17 14:01:51 200 2.065522ms POST /api/metrics/store

```