### PR TITLE
Require authentication for all REST requests for customer data

### DIFF
--- a/web/cpserver.go
+++ b/web/cpserver.go
@@ -200,6 +200,11 @@ func routeToInternalServiceProxy(path string, target string, routes []rest.Route
 	}
 	// Wrap the normal http.Handler in a rest.handlerFunc
 	handlerFunc := func(w *rest.ResponseWriter, r *rest.Request) {
+		// All proxied requests should be authenticated first
+		if !loginOK(r) {
+			restUnauthorized(w)
+			return
+		}
 		proxy := node.NewReverseProxy(path, targetURL)
 		proxy.ServeHTTP(w.ResponseWriter, r.Request)
 	}

--- a/web/routes.go
+++ b/web/routes.go
@@ -108,6 +108,7 @@ func (sc *ServiceConfig) getRoutes() []rest.Route {
 
 		// Generic static data
 		rest.Route{"GET", "/favicon.ico", gz(favIcon)},
+		rest.Route{"GET", "/static/logview/*resource", gz(sc.checkAuth(getProtectedLogViewData))},
 		rest.Route{"GET", "/static/*resource", gz(staticData)},
 		rest.Route{"GET", "/licenses.html", gz(licenses)},
 	}

--- a/web/util.go
+++ b/web/util.go
@@ -16,11 +16,12 @@ package web
 import (
 	"flag"
 	"fmt"
-	"github.com/zenoss/go-json-rest"
 	"net/http"
 	"os"
 	"path"
 	"runtime"
+
+	"github.com/zenoss/go-json-rest"
 )
 
 var webroot string
@@ -127,7 +128,7 @@ func favIcon(w *rest.ResponseWriter, r *rest.Request) {
 	http.ServeFile(
 		w.ResponseWriter,
 		r.Request,
-			staticRoot()+"/ico/favicon.png")
+		staticRoot()+"/ico/favicon.png")
 }
 
 /*
@@ -141,10 +142,22 @@ func licenses(w *rest.ResponseWriter, r *rest.Request) {
 }
 
 /*
- * Serves content from static/
+ * Serves content from static/* which does NOT require authentication
  */
 func staticData(w *rest.ResponseWriter, r *rest.Request) {
 	fileToServe := path.Join(staticRoot(), r.PathParam("resource"))
+	http.ServeFile(
+		w.ResponseWriter,
+		r.Request,
+		fileToServe)
+}
+
+/*
+ * Serves content from static/logview/* which DOES require authentication
+ */
+// func getProtectedLogViewData(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClient) {
+func getProtectedLogViewData(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
+	fileToServe := path.Join(staticRoot(), "logview", r.PathParam("resource"))
 	http.ServeFile(
 		w.ResponseWriter,
 		r.Request,

--- a/web/util.go
+++ b/web/util.go
@@ -155,7 +155,6 @@ func staticData(w *rest.ResponseWriter, r *rest.Request) {
 /*
  * Serves content from static/logview/* which DOES require authentication
  */
-// func getProtectedLogViewData(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClient) {
 func getProtectedLogViewData(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
 	fileToServe := path.Join(staticRoot(), "logview", r.PathParam("resource"))
 	http.ServeFile(


### PR DESCRIPTION
Fixes CC-976: require authentication for elasticsearch log data and central-query data exposed via the serviced web end points.