### PR TITLE
CC-996: Ading a command to serviced to tell it when to start

### DIFF
--- a/cli/api/api.go
+++ b/cli/api/api.go
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -97,6 +97,25 @@ func GetOptionsRPCEndpoint() string {
 // GetOptionsRPCPort returns the serviced RPC port from options
 func GetOptionsRPCPort() string {
 	return options.RPCPort
+}
+
+// GetOptionsMaster returns the master mode setting from options
+func GetOptionsMaster() bool {
+	return options.Master
+}
+
+// GetOptionsAgent returns the agent mode setting from options
+func GetOptionsAgent() bool {
+	return options.Agent
+}
+
+// GetOptionsMasterPoolID returns the master pool ID from options
+func GetOptionsMasterPoolID() string {
+	return options.MasterPoolID
+}
+
+func GetOptionsMaxRPCClients() int {
+	return options.MaxRPCClients
 }
 
 type api struct {

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,7 +22,6 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/control-center/serviced/cli/api"
 	"github.com/control-center/serviced/isvcs"
-	"github.com/control-center/serviced/rpc/rpcutils"
 	"github.com/control-center/serviced/servicedversion"
 	"github.com/control-center/serviced/validation"
 	"github.com/zenoss/glog"
@@ -123,6 +122,7 @@ func New(driver api.API, config ConfigReader) *ServicedCli {
 	c.initMetric()
 	c.initDocker()
 	c.initScript()
+	c.initServer()
 
 	return c
 }
@@ -136,6 +136,13 @@ func (c *ServicedCli) Run(args []string) {
 
 // cmdInit starts the server if no subcommands are called
 func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
+	// DEBUG: KWW: Remove
+	fmt.Println("--- ctx.Args ---")
+	for _, ctxarg := range ctx.Args() {
+		fmt.Println(ctxarg)
+	}
+	fmt.Println("----------------")
+
 	options := api.Options{
 		DockerRegistry:       ctx.GlobalString("docker-registry"),
 		NFSClient:            ctx.GlobalString("nfs-client"),
@@ -203,17 +210,6 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 		return err
 	}
 
-	if options.Master {
-		fmt.Println("This master has been configured to be in pool: " + options.MasterPoolID)
-	}
-
-	// Start server mode
-	if (options.Master || options.Agent) && len(ctx.Args()) == 0 {
-		rpcutils.RPC_CLIENT_SIZE = options.MaxRPCClients
-		c.driver.StartServer()
-		return fmt.Errorf("running server mode")
-	}
-
 	return nil
 }
 
@@ -268,7 +264,7 @@ func setLogging(ctx *cli.Context) error {
 	}
 
 	// Listen for SIGUSR1 and, when received, toggle the log level between
-	// 0 and 2.  If the log level is anything but 0, we set it to 0, and on
+	// 0 and 2.	 If the log level is anything but 0, we set it to 0, and on
 	// subsequent signals, set it to 2.
 	go func() {
 		signalChan := make(chan os.Signal, 1)

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -136,13 +136,6 @@ func (c *ServicedCli) Run(args []string) {
 
 // cmdInit starts the server if no subcommands are called
 func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
-	// DEBUG: KWW: Remove
-	fmt.Println("--- ctx.Args ---")
-	for _, ctxarg := range ctx.Args() {
-		fmt.Println(ctxarg)
-	}
-	fmt.Println("----------------")
-
 	options := api.Options{
 		DockerRegistry:       ctx.GlobalString("docker-registry"),
 		NFSClient:            ctx.GlobalString("nfs-client"),

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -75,10 +75,10 @@ func (t APITest) StartServer() error {
 }
 
 func ExampleServicedCLI_CmdInit_logging() {
-	InitAPITest("serviced", "--logtostderr", "--alsologtostderr", "--master")
-	InitAPITest("serviced", "--logstashurl", "127.0.0.1", "-v", "4", "--agent")
-	InitAPITest("serviced", "--stderrthreshold", "2", "--vmodule", "a=1,b=2,c=3", "--master", "--agent")
-	InitAPITest("serviced", "--log_backtrace_at", "file.go:123", "--master", "--agent")
+	InitAPITest("serviced", "--logtostderr", "--alsologtostderr", "--master", "server")
+	InitAPITest("serviced", "--logstashurl", "127.0.0.1", "-v", "4", "--agent", "server")
+	InitAPITest("serviced", "--stderrthreshold", "2", "--vmodule", "a=1,b=2,c=3", "--master", "--agent", "server")
+	InitAPITest("serviced", "--log_backtrace_at", "file.go:123", "--master", "--agent", "server")
 
 	// Output:
 	// This master has been configured to be in pool: default
@@ -91,9 +91,9 @@ func ExampleServicedCLI_CmdInit_logging() {
 }
 
 func ExampleServicedCLI_CmdInit_logerr() {
-	InitAPITest("serviced", "--master", "--stderrthreshold", "abc")
-	InitAPITest("serviced", "--agent", "--vmodule", "abc")
-	InitAPITest("serviced", "--master", "--log_backtrace_at", "abc")
+	InitAPITest("serviced", "--master", "--stderrthreshold", "abc", "server")
+	InitAPITest("serviced", "--agent", "--vmodule", "abc", "server")
+	InitAPITest("serviced", "--master", "--log_backtrace_at", "abc", "server")
 
 	// Output:
 	// strconv.ParseInt: parsing "abc": invalid syntax

--- a/cli/cmd/server.go
+++ b/cli/cmd/server.go
@@ -1,0 +1,53 @@
+// Copyright 2015 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/codegangsta/cli"
+	"github.com/control-center/serviced/cli/api"
+	"github.com/control-center/serviced/rpc/rpcutils"
+)
+
+// Initializer for serviced server
+func (c *ServicedCli) initServer() {
+	c.app.Commands = append(c.app.Commands, cli.Command{
+		Name:        "server",
+		Usage:       "Starts serviced",
+		Description: "serviced server",
+		Action:      c.cmdServer,
+	})
+}
+
+// serviced server
+func (c *ServicedCli) cmdServer(ctx *cli.Context) {
+	master := api.GetOptionsMaster()
+	agent := api.GetOptionsAgent()
+
+	// Make sure one of the configurations was specified
+	if !master && !agent {
+		fmt.Fprintf(os.Stderr, "serviced cannot be started: no mode (master or agent) was specified\n")
+		return
+	}
+
+	if master {
+		fmt.Println("This master has been configured to be in pool: " + api.GetOptionsMasterPoolID())
+	}
+
+	// Start server mode
+	rpcutils.RPC_CLIENT_SIZE = api.GetOptionsMaxRPCClients()
+	c.driver.StartServer()
+}

--- a/main.go
+++ b/main.go
@@ -44,7 +44,15 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "WARNING: could not read default configs: %s\n", err)
 	}
-	cmd.New(api.New(), config).Run(os.Args)
+
+	// DEBUG: KWW: Restore original code
+	//cmd.New(api.New(), config).Run(os.Args)
+	mycmd := cmd.New(api.New(), config)
+	fmt.Println("--- os.Args ---")
+	for _, osarg := range os.Args {
+		fmt.Println(osarg)
+	}
+	mycmd.Run(os.Args)
 }
 
 func getConfigs(args []string) (*cmd.EnvironConfigReader, error) {

--- a/main.go
+++ b/main.go
@@ -45,14 +45,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "WARNING: could not read default configs: %s\n", err)
 	}
 
-	// DEBUG: KWW: Restore original code
-	//cmd.New(api.New(), config).Run(os.Args)
-	mycmd := cmd.New(api.New(), config)
-	fmt.Println("--- os.Args ---")
-	for _, osarg := range os.Args {
-		fmt.Println(osarg)
-	}
-	mycmd.Run(os.Args)
+	cmd.New(api.New(), config).Run(os.Args)
 }
 
 func getConfigs(args []string) (*cmd.EnvironConfigReader, error) {

--- a/pkg/serviced.service
+++ b/pkg/serviced.service
@@ -8,7 +8,7 @@ Environment=SERVICED_HOME=/opt/serviced SERVICED_MASTER=1 SERVICED_AGENT=1 TZ=UT
 EnvironmentFile=/etc/default/serviced
 WorkingDirectory=/opt/serviced
 ExecStartPre=/opt/serviced/bin/serviced-systemd.sh pre-start
-ExecStart=/opt/serviced/bin/serviced
+ExecStart=/opt/serviced/bin/serviced server
 ExecReload=/bin/pkill --signal SIGHUP -f /opt/serviced/bin/serviced
 ExecStopPost=/opt/serviced/bin/serviced-systemd.sh post-stop
 TimeoutStopSec=60

--- a/pkg/serviced.supervisord
+++ b/pkg/serviced.supervisord
@@ -1,5 +1,5 @@
 [program:serviced]
-command=bin/serviced -agent -master
+command=bin/serviced -agent -master server
 directory=/opt/serviced
 redirect_stderr=true
 environment=

--- a/pkg/serviced.upstart
+++ b/pkg/serviced.upstart
@@ -36,7 +36,7 @@ script
     fi
 
     cd $SERVICED_HOME 
-    exec ./bin/serviced $SERVICED_OPTS
+    exec ./bin/serviced $SERVICED_OPTS server
 
 end script
 

--- a/smoke.sh
+++ b/smoke.sh
@@ -52,7 +52,7 @@ trap cleanup EXIT
 
 start_serviced() {
     echo "Starting serviced..."
-    sudo GOPATH=${GOPATH} PATH=${PATH} SERVICED_NOREGISTRY="true" ${SERVICED} -master -agent &
+    sudo GOPATH=${GOPATH} PATH=${PATH} SERVICED_NOREGISTRY="true" ${SERVICED} -master -agent server &
     echo "Waiting 120 seconds for serviced to become the leader..."
     retry 180 wget --no-check-certificate http://${HOSTNAME}:443 -O- &>/dev/null
     return $?


### PR DESCRIPTION
Previously it started when --master or --agent was specified, but now the
existance of /etc/default/serviced often sets Master or Agent mode so we
were trying to start the server way too often...

Original complaint in JIRA ticket was that no command-line options did
not lead to help text being displayed, which used to happen.