### PR TITLE
fixes CC-984: disable HostNetwork for es 9200 by default

### DIFF
--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -63,7 +63,7 @@ func init() {
 			Volumes:       map[string]string{"data": "/opt/elasticsearch-0.90.9/data"},
 			Configuration: make(map[string]interface{}),
 			HealthChecks:  healthChecks,
-			HostNetwork:   true,
+			HostNetwork:   false,
 		},
 	)
 	if err != nil {
@@ -100,6 +100,7 @@ func init() {
 			Volumes:       map[string]string{"data": "/opt/elasticsearch-1.3.1/data"},
 			Configuration: make(map[string]interface{}),
 			HealthChecks:  healthChecks,
+			HostNetwork:   false,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-984


DEMO - notice how netstat shows 9200 only on 127.0.0.1 for LocalAddress:
```
# plu@plu-9: docker ps |grep isvcs
6ec5d9745c27        zenoss/serviced-isvcs:v27.1   "/bin/sh -c '/opt/lo   28 seconds ago      Up 28 seconds       0.0.0.0:5042->5042/tcp, 0.0.0.0:5043->5043/tcp, 127.0.0.1:9292->9292/tcp                                                                                     serviced-isvcs_logstash                 
fba28161d672        zenoss/serviced-isvcs:v27.1   "/bin/sh -c 'DOCKER_   37 seconds ago      Up 36 seconds       0.0.0.0:5000->5000/tcp                                                                                                                                       serviced-isvcs_docker-registry          
fdd809f1a9da        zenoss/serviced-isvcs:v27.1   "/bin/sh -c 'supervi   37 seconds ago      Up 36 seconds                                                                                                                                                                    serviced-isvcs_celery                   
ee3d7cbdc35d        zenoss/serviced-isvcs:v27.1   "/bin/sh -c 'cd /opt   37 seconds ago      Up 36 seconds       0.0.0.0:4242->4242/tcp, 0.0.0.0:8443->8443/tcp, 127.0.0.1:8888->8888/tcp, 127.0.0.1:9090->9090/tcp, 127.0.0.1:58443->58443/tcp, 127.0.0.1:58888->58888/tcp   serviced-isvcs_opentsdb                 
832a4c0c4c82        zenoss/serviced-isvcs:v27.1   "/bin/sh -c '/opt/zo   37 seconds ago      Up 36 seconds       0.0.0.0:2181->2181/tcp, 127.0.0.1:12181->12181/tcp                                                                                                           serviced-isvcs_zookeeper                
d062699e64e4        zenoss/serviced-isvcs:v27.1   "/bin/sh -c '/opt/el   37 seconds ago      Up 36 seconds       127.0.0.1:9100->9100/tcp                                                                                                                                     serviced-isvcs_elasticsearch-logstash   
55ba93f0e057        zenoss/serviced-isvcs:v27.1   "/bin/sh -c '/opt/el   37 seconds ago      Up 37 seconds       127.0.0.1:9200->9200/tcp                                                                                                                                     serviced-isvcs_elasticsearch-serviced   

# plu@plu-9: sudo netstat -plant |grep 9200
[sudo] password for plu: 
Active Internet connections (servers and established)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
tcp        0      0 127.0.0.1:9200          0.0.0.0:*               LISTEN      23156/docker-proxy
tcp        0      0 127.0.0.1:9200          127.0.0.1:36217         ESTABLISHED 23156/docker-proxy
tcp        0      0 172.17.42.1:54274       172.17.6.246:9200       ESTABLISHED 23156/docker-proxy
tcp        0      0 127.0.0.1:9200          127.0.0.1:36202         ESTABLISHED 23156/docker-proxy
tcp        0      0 127.0.0.1:36217         127.0.0.1:9200          ESTABLISHED 23107/serviced  
tcp        0      0 172.17.42.1:54289       172.17.6.246:9200       ESTABLISHED 23156/docker-proxy
tcp        0      0 127.0.0.1:36202         127.0.0.1:9200          ESTABLISHED 23107/serviced  
```