### PR TITLE
Require authentication for all REST requests for customer data 

### DIFF
--- a/web/cpserver.go
+++ b/web/cpserver.go
@@ -192,7 +192,7 @@ func (sc *ServiceConfig) ServeUI() {
 
 var methods = []string{"GET", "POST", "PUT", "DELETE"}
 
-func routeToInternalServiceProxy(path string, target string, routes []rest.Route) []rest.Route {
+func routeToInternalServiceProxy(path string, target string, requiresAuth bool, routes []rest.Route) []rest.Route {
 	targetURL, err := url.Parse(target)
 	if err != nil {
 		glog.Errorf("Unable to parse proxy target URL: %s", target)
@@ -201,7 +201,7 @@ func routeToInternalServiceProxy(path string, target string, routes []rest.Route
 	// Wrap the normal http.Handler in a rest.handlerFunc
 	handlerFunc := func(w *rest.ResponseWriter, r *rest.Request) {
 		// All proxied requests should be authenticated first
-		if !loginOK(r) {
+		if requiresAuth && !loginOK(r) {
 			restUnauthorized(w)
 			return
 		}

--- a/web/cpserver.go
+++ b/web/cpserver.go
@@ -200,6 +200,11 @@ func routeToInternalServiceProxy(path string, target string, routes []rest.Route
 	}
 	// Wrap the normal http.Handler in a rest.handlerFunc
 	handlerFunc := func(w *rest.ResponseWriter, r *rest.Request) {
+		// All proxied requests should be authenticated first
+		if !loginOK(r) {
+			restUnauthorized(w)
+			return
+		}
 		proxy := node.NewReverseProxy(path, targetURL)
 		proxy.ServeHTTP(w.ResponseWriter, r.Request)
 	}

--- a/web/routes.go
+++ b/web/routes.go
@@ -115,8 +115,13 @@ func (sc *ServiceConfig) getRoutes() []rest.Route {
 
 	// Hardcoding these target URLs for now.
 	// TODO: When internal services are allowed to run on other hosts, look that up.
-	routes = routeToInternalServiceProxy("/api/controlplane/elastic", "http://127.0.0.1:9100/", routes)
-	routes = routeToInternalServiceProxy("/metrics", "http://127.0.0.1:8888/", routes)
+	// All API calls require authentication
+	routes = routeToInternalServiceProxy("/api/controlplane/elastic", "http://127.0.0.1:9100/", true, routes)
+	routes = routeToInternalServiceProxy("/metrics/api", "http://127.0.0.1:8888/api", true, routes)
+
+	// Allow static assets for metrics data to be loaded without authentication since they are
+	// included in index.html by default.
+	routes = routeToInternalServiceProxy("/metrics/static", "http://127.0.0.1:8888/static", false, routes)
 
 	return routes
 }

--- a/web/routes.go
+++ b/web/routes.go
@@ -108,6 +108,7 @@ func (sc *ServiceConfig) getRoutes() []rest.Route {
 
 		// Generic static data
 		rest.Route{"GET", "/favicon.ico", gz(favIcon)},
+		rest.Route{"GET", "/static/logview/*resource", gz(sc.checkAuth(getProtectedLogViewData))},
 		rest.Route{"GET", "/static/*resource", gz(staticData)},
 		rest.Route{"GET", "/licenses.html", gz(licenses)},
 	}

--- a/web/ui/static/logview/app/app.js
+++ b/web/ui/static/logview/app/app.js
@@ -74,13 +74,14 @@ function (angular, $, _, appLevelRequire) {
 
     $httpProvider.interceptors.push(['$location', function($location) {
       return {
-        responseError: function(resp) {
-          if (resp.status === 0) {
-            console.log("redirecting");
-            $location.path('/connectionFailed');
-            console.log(resp);
+          responseError: function(resp) {
+              if (resp.status === 401) {
+                  console.error('You don\'t appear to be logged in.');
+                  var servicedUrl = window.location.href.slice(0,window.location.href.indexOf("/static/logview"))
+                  var loginUrl = servicedUrl + "/#/login"
+                  window.top.location.href = loginUrl;
+              }
           }
-        }
       };
     }]);
 

--- a/web/util.go
+++ b/web/util.go
@@ -16,11 +16,12 @@ package web
 import (
 	"flag"
 	"fmt"
-	"github.com/zenoss/go-json-rest"
 	"net/http"
 	"os"
 	"path"
 	"runtime"
+
+	"github.com/zenoss/go-json-rest"
 )
 
 var webroot string
@@ -127,7 +128,7 @@ func favIcon(w *rest.ResponseWriter, r *rest.Request) {
 	http.ServeFile(
 		w.ResponseWriter,
 		r.Request,
-			staticRoot()+"/ico/favicon.png")
+		staticRoot()+"/ico/favicon.png")
 }
 
 /*
@@ -141,10 +142,22 @@ func licenses(w *rest.ResponseWriter, r *rest.Request) {
 }
 
 /*
- * Serves content from static/
+ * Serves content from static/* which does NOT require authentication
  */
 func staticData(w *rest.ResponseWriter, r *rest.Request) {
 	fileToServe := path.Join(staticRoot(), r.PathParam("resource"))
+	http.ServeFile(
+		w.ResponseWriter,
+		r.Request,
+		fileToServe)
+}
+
+/*
+ * Serves content from static/logview/* which DOES require authentication
+ */
+// func getProtectedLogViewData(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClient) {
+func getProtectedLogViewData(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
+	fileToServe := path.Join(staticRoot(), "logview", r.PathParam("resource"))
 	http.ServeFile(
 		w.ResponseWriter,
 		r.Request,

--- a/web/util.go
+++ b/web/util.go
@@ -155,7 +155,6 @@ func staticData(w *rest.ResponseWriter, r *rest.Request) {
 /*
  * Serves content from static/logview/* which DOES require authentication
  */
-// func getProtectedLogViewData(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClient) {
 func getProtectedLogViewData(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
 	fileToServe := path.Join(staticRoot(), "logview", r.PathParam("resource"))
 	http.ServeFile(


### PR DESCRIPTION
Fixes CC-976: require authentication for elasticsearch log data and central-query data exposed via the serviced web end points.

Originally part of #1759, but this PR was created after rebasing my local branch to pick up several recent fixes (isvcs v30 image, docker 2.0 registry, docker 1.6 compatibility).