### PR TITLE
CSS selectors moved into page files

### DIFF
--- a/acceptance/ui/features/hosts.feature
+++ b/acceptance/ui/features/hosts.feature
@@ -116,10 +116,11 @@ Feature: Host Management
       And I fill in the RAM Commitment field with "10%"
       And I click "Add Host"
     Then I should see "Success"
+      And I should see an entry for "vagrant" in the table
       And I should see "roei-dev" in the "Name" column
-      And I should see "default" in the "Research Pool" column
+      And I should see "default" in the "Resource Pool" column
       And I should see "vagrant" in the "Name" column
-      And I should see "default" in the "Research Pool" column
+      And I should see "default" in the "Resource Pool" column
       And I should see "Showing 2 Results"
 
   @login-required

--- a/acceptance/ui/features/pages/applications.rb
+++ b/acceptance/ui/features/pages/applications.rb
@@ -11,4 +11,7 @@ class Applications < SitePrism::Page
     element :addAppTemplate_button, "[ng-click='modal_addTemplate()']"
     element :servicesMap_button, "a[href='/#/servicesmap'][class='btn-link']"
     element :deploymentID_field, "input[name='deploymentID']"
+    element :services_table, "table[data-config='servicesTable']"
+    element :templates_table, "table[data-config='templatesTable']"
+    elements :status_icons, "[data-status$='service.status']"
 end

--- a/acceptance/ui/features/pages/hosts.rb
+++ b/acceptance/ui/features/pages/hosts.rb
@@ -12,4 +12,9 @@ class Hosts < SitePrism::Page
     element :hostName_input, "#new_host_name"
     element :resourcePool_input, "[name='new_host_parent']"
     element :ramCommitment_input, "[name='new_host_ram_commitment']"
+    element :addHost_dialog, ".modal-content"
+    element :host_entry, "[ng-repeat='host in $data']"
+    element :invalidHost_input, "[class$='ng-invalid ng-invalid-pattern']#new_host_name"
+    elements :active_icons, "[ng-if$='host.active']"
+    elements :host_entries, "[ng-repeat='host in $data']"
 end

--- a/acceptance/ui/features/pages/servicesmap.rb
+++ b/acceptance/ui/features/pages/servicesmap.rb
@@ -1,0 +1,11 @@
+require_relative 'navbar'
+require 'site_prism'
+
+class ServicesMap < SitePrism::Page
+    set_url applicationURL("#/servicesmap")
+    set_url_matcher /servicesmap/
+
+    section :navbar, NavBarSection, ".navbar-collapse"
+    
+    element :map, "svg[class='tall']"
+end

--- a/acceptance/ui/features/pages/user.rb
+++ b/acceptance/ui/features/pages/user.rb
@@ -3,4 +3,10 @@ require 'site_prism'
 
 class User < SitePrism::Page
     section :navbar, NavBarSection, ".navbar-collapse"
+
+    element :clearMessages_button, "[ng-click='clearMessages()']"
+    element :unreadMessage, "[class='message unreadMessage ng-scope']"
+    element :english_button, "input[value='en_US']"
+    element :spanish_button, "input[value='es_US']"
+    element :message, "[class^='message ']"
 end

--- a/acceptance/ui/features/steps/applications_steps.rb
+++ b/acceptance/ui/features/steps/applications_steps.rb
@@ -12,6 +12,7 @@ end
 
 When(/^I click the Services Map button$/) do
     @applications_page.servicesMap_button.click()
+    @servicesMap_page = ServicesMap.new
 end
 
 When(/^I fill in the Deployment ID field with "(.*?)"$/) do |deploymentID|
@@ -19,20 +20,20 @@ When(/^I fill in the Deployment ID field with "(.*?)"$/) do |deploymentID|
 end
 
 When(/^I remove "(.*?)" from the Applications list$/) do |name|
-    within("table[data-config='servicesTable']", :text => name) do
+    within(@applications_page.services_table, :text => name) do
         click_link_or_button("Delete")
     end
 end
 
 When(/^I remove "(.*?)" from the Application Templates list$/) do |name|
-    within("table[data-config='templatesTable']", :text => name) do
+    within(@applications_page.templates_table, :text => name) do
         click_link_or_button("Delete")
     end
 end
 
 
 Then /^the "Status" column should be sorted with active applications on (top|the bottom)$/ do |order|
-    list = page.all("[data-status$='service.status']")
+    list = @applications_page.status_icons
     for i in 0..(list.size - 2)
         if order == "top"
             # assuming - (ng-isolate-scope down) before + (ng-isolate-scope good)
@@ -44,7 +45,7 @@ Then /^the "Status" column should be sorted with active applications on (top|the
 end
 
 Then (/^I should see "([^"]*)" in the Services Map$/) do |node|
-    within("svg") do
+    within(@servicesMap_page.map) do
         assert_text(node)
     end
 end

--- a/acceptance/ui/features/steps/generic_steps.rb
+++ b/acceptance/ui/features/steps/generic_steps.rb
@@ -55,7 +55,11 @@ end
 Then (/^I should see "(.*?)" in the "([^"]*)" column$/) do |text, column|
     # attribute that includes name of column of all table cells
     list = page.all("td[data-title-text='#{column}']")
-    list.include?(:text => text)
+    hasEntry = false
+    for i in 0..(list.size - 1)
+        hasEntry = true if list[i].text == text
+    end
+    expect(hasEntry).to be true
 end
 
 Then (/^the "([^"]*)" column should be sorted in ([^"]*) order$/) do |category, order|

--- a/acceptance/ui/features/steps/hosts_steps.rb
+++ b/acceptance/ui/features/steps/hosts_steps.rb
@@ -50,7 +50,7 @@ When /^I click the Add-Host button$/ do
 end
 
 Then (/^the "Active" column should be sorted with active hosts on (top|the bottom)$/) do |order|
-    list = page.all("[ng-if$='host.active']")
+    list = @hosts_page.active_icons
     for i in 0..(list.size - 2)
         if order == "top"
              # assuming + (good ng-scope) before - (down ng-scope) before ! (bad ng-scope)
@@ -62,7 +62,7 @@ Then (/^the "Active" column should be sorted with active hosts on (top|the botto
 end
 
 Then /^I should see the Add Host dialog$/ do
-    @hosts_page.assert_selector '.modal-content'                # class for dialog box
+    @hosts_page.addHost_dialog.visible?
 end
 
 Then /^I should see the Host and port field$/ do
@@ -78,7 +78,7 @@ Then /^I should see the RAM Commitment field$/ do
 end
 
 Then /^I should see an empty Hosts page$/ do
-    @hosts_page.assert_no_selector("[ng-repeat='host in $data']")
+    expect(@hosts_page).to have_no_host_entry
     @hosts_page.assert_text("Showing 0 Results")
     @hosts_page.assert_text("No Data Found")
 end
@@ -118,7 +118,7 @@ end
 def removeAllHosts()
     defaultMatch = Capybara.match
     Capybara.match=:first
-    while @hosts_page.all("[ng-repeat='host in $data']").size != 0 do
+    while @hosts_page.host_entries.size != 0 do
         click_link_or_button("Delete")
         click_link_or_button("Remove Host")
     end

--- a/acceptance/ui/features/steps/user_steps.rb
+++ b/acceptance/ui/features/steps/user_steps.rb
@@ -19,39 +19,39 @@ When(/^I view user details$/) do
 end
 
 When (/^I clear my messages$/) do
-    page.find("[ng-click='clearMessages()']").click()
+    @user_page.clearMessages_button.click()
 end
 
-When (/^I click on the unread message "(.*?)"$/) do |title|
+When (/^I click on the first unread message$/) do
     defaultMatch = Capybara.match
     Capybara.match=:first
-    page.find("[class='message unreadMessage ng-scope']", :text => title).click()
+    @user_page.unreadMessage.click()
     Capybara.match = defaultMatch
 end
 
 When (/^I switch the language to English$/) do
-    page.find("input[value='en_US']").click()
+    @user_page.english_button.click()
 end
 
 When (/^I switch the language to Spanish$/) do
-    page.find("input[value='es_US']").click()
+    @user_page.spanish_button.click()
 end
 
 Then /^I should see my messages$/ do
-    page.assert_selector("[ng-repeat='message in messages.messages track by message.id']")
+    defaultMatch = Capybara.match
+    Capybara.match=:first
+    expect(@user_page.message.visible?).to be true
+    Capybara.match = defaultMatch
 end
 
 Then /^I should not see any messages$/ do
-    page.assert_no_selector("[ng-repeat='message in messages.messages track by message.id']")
+    expect(@user_page.has_selector?("div[class^='message ']")).to be false
 end
 
-Then /^I should see that the "(.*?)" message is marked as read$/ do |title|
+Then /^I should see that the first unread message is marked as read$/ do
     defaultMatch = Capybara.match
     Capybara.match=:first
-    within("ul[class='well list-group']") do
-        message = page.find("[class^='message']", :text => title)
-        expect(message[:class]).to include("message readMessage ng-scope")
-    end
+    expect(@user_page.message[:class]).to include("message readMessage ng-scope")
     Capybara.match = defaultMatch
 end
 

--- a/acceptance/ui/features/user.feature
+++ b/acceptance/ui/features/user.feature
@@ -21,8 +21,8 @@ Feature: User Details
   Scenario: Mark messages as read
     Given I have messages
     When I view user details
-      And I click on the unread message "resource pool exists"
-    Then I should see that the "resource pool exists" message is marked as read
+      And I click on the first unread message
+    Then I should see that the first unread message is marked as read
 
   @login-required
   Scenario: Clear messages


### PR DESCRIPTION
I'm having trouble changing the steps testing whether a class includes some text (invalid field, read/unread messages) and the steps asserting that an element is not present. I'll come back to it later.