### PR TITLE
Fix collision with Firefox global name

### DIFF
--- a/web/ui/src/Hosts/HostDetailsController.js
+++ b/web/ui/src/Hosts/HostDetailsController.js
@@ -82,7 +82,7 @@
                 sorting: {
                     InterfaceName: "asc"
                 },
-                watch: function(){
+                watchExpression: function(){
                     return hostsFactory.lastUpdate;
                 }
             };
@@ -91,7 +91,7 @@
                 sorting: {
                     name: "asc"
                 },
-                watch: function(){
+                watchExpression: function(){
                     return instancesFactory.lastUpdate;
                 }
             };

--- a/web/ui/src/Hosts/HostsController.js
+++ b/web/ui/src/Hosts/HostsController.js
@@ -117,7 +117,7 @@
                 sorting: {
                     name: "asc"
                 },
-                watch: function(){
+                watchExpression: function(){
                     return hostsFactory.lastUpdate;
                 }
             };

--- a/web/ui/src/Pools/PoolDetailsController.js
+++ b/web/ui/src/Pools/PoolDetailsController.js
@@ -142,7 +142,7 @@
                 sorting: {
                     IP: "asc"
                 },
-                watch: function(){
+                watchExpression: function(){
                     // if poolsFactory updates, update view
                     return poolsFactory.lastUpdate;
                 }
@@ -152,7 +152,7 @@
                 sorting: {
                     name: "asc"
                 },
-                watch: function(){
+                watchExpression: function(){
                     return hostsFactory.lastUpdate;
                 }
             };

--- a/web/ui/src/Pools/PoolsController.js
+++ b/web/ui/src/Pools/PoolsController.js
@@ -115,7 +115,7 @@
                 sorting: {
                     id: "asc"
                 },
-                watch: function(){
+                watchExpression: function(){
                     // if poolsFactory updates, update view
                     return poolsFactory.lastUpdate;
                 }

--- a/web/ui/src/Services/AppsController.js
+++ b/web/ui/src/Services/AppsController.js
@@ -293,7 +293,7 @@
 
                     return orderedData;
                 },
-                watch: function(){
+                watchExpression: function(){
                     // TODO - check $scope.deployingServices as well
                     return servicesFactory.lastUpdate;
                 }

--- a/web/ui/src/Services/ServiceDetailsController.js
+++ b/web/ui/src/Services/ServiceDetailsController.js
@@ -72,7 +72,7 @@
                 ],
                 validate: function(){
                     var name = $scope.vhosts.add.name;
-                    
+
                     // if no name
                     if(!name || !name.length){
                         this.createNotification("Unabled to add Virtual Host", "Missing name").error();
@@ -84,7 +84,7 @@
                         this.createNotification("Unable to add Virtual Host", "No available application and service").error();
                         return false;
                     }
-                    
+
                     // if name already exists
                     for (var i in $scope.vhosts.data) {
                         if (name === $scope.vhosts.data[i].Name) {
@@ -491,7 +491,7 @@
                 $scope.services.subservices = $scope.services.current.descendents;
                 $scope.vhosts.data = $scope.services.current.hosts;
                 $scope.ips.data = $scope.services.current.addresses;
-                
+
                 // update instances
                 $scope.services.current.getServiceInstances();
 
@@ -552,7 +552,7 @@
 
             // clone service for editing
             $scope.editableService = angular.copy($scope.services.current.model);
-            
+
             $modalService.create({
                 templateUrl: "edit-service.html",
                 model: $scope,
@@ -587,7 +587,7 @@
                     if($scope.editableService.InstanceLimits.Min > $scope.editableService.Instances || $scope.editableService.Instances === undefined){
                         return false;
                     }
-                    
+
                     return true;
                 }
             });
@@ -635,7 +635,7 @@
                 },
                 // instead of watching for a change, always
                 // reload at a specified interval
-                watch: (function(){
+                watchExpression: (function(){
                     var last = new Date().getTime(),
                         now,
                         interval = 1000;

--- a/web/ui/src/common/jellyTable.js
+++ b/web/ui/src/common/jellyTable.js
@@ -89,7 +89,7 @@
                     // TODO - create a "defaultSort" property and use
                     // it to compose the `sorting` config option
                     config().counts = config().counts || [];
-                    config().watch = config().watch || function(){ return data(); };
+                    config().watchExpression = config().watchExpression || function(){ return data(); };
 
                     timezone = jstz.determine().name();
 
@@ -195,7 +195,7 @@
                     toggleNoData(false);
 
                     // watch data for changes
-                    $scope.$watch(config().watch, function(){
+                    $scope.$watch(config().watchExpression, function(){
                         $scope[tableID].reload();
                     });
 


### PR DESCRIPTION
Fixes CC-947: use 'watcher' instead of 'watch' to sidestep FF global of the same name