### PR TITLE
ZEN-18620: Use UUID for container name

### DIFF
--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -31,7 +31,6 @@ import (
 	"github.com/control-center/serviced/cli/api"
 	dockerclient "github.com/control-center/serviced/commons/docker"
 	"github.com/control-center/serviced/dao"
-	"github.com/control-center/serviced/dfs"
 	"github.com/control-center/serviced/domain/host"
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/node"
@@ -1011,12 +1010,14 @@ func (c *ServicedCli) cmdServiceRun(ctx *cli.Context) error {
 		argv = args[2:]
 	}
 
+	uuid, _ := utils.NewUUID62()
+
 	config := api.ShellConfig{
 		ServiceID:        svc.ID,
 		Command:          command,
 		Username:         ctx.GlobalString("user"),
 		Args:             argv,
-		SaveAs:           dfs.NewLabel(svc.ID),
+		SaveAs:           uuid,
 		IsTTY:            ctx.GlobalBool("interactive"),
 		Mounts:           ctx.GlobalStringSlice("mount"),
 		ServicedEndpoint: fmt.Sprintf("localhost:%s", api.GetOptionsRPCPort()),

--- a/dfs/snapshot.go
+++ b/dfs/snapshot.go
@@ -453,10 +453,6 @@ func (dfs *DistributedFilesystem) restoreServices(tenantID string, svcs []*servi
 	return nil
 }
 
-func NewLabel(tenantID string) string {
-	return fmt.Sprintf("%s_%s", tenantID, time.Now().UTC().Format(timeFormat))
-}
-
 func parseLabel(snapshotID string) (string, string, error) {
 	parts := strings.SplitN(snapshotID, "_", 2)
 	if len(parts) < 2 {


### PR DESCRIPTION
Previously, container names could conflict if more than one  'serviced service run' commands executed within the same second.

Fixes [ZEN-18620](https://jira.zenoss.com/browse/ZEN-18620)