### PR TITLE
add merge build script to source control for jenkins 1.0.x-serviced-merge job

### DIFF
--- a/jenkins-merge-build.sh
+++ b/jenkins-merge-build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+set -x
+unset EDITOR # so we don't fail a cli test :\
+gvm use go1.4.2
+go version
+docker version
+export GOPATH=$WORKSPACE/gopath
+export PATH=$GOPATH/bin:$PATH
+cd gopath/src/github.com/control-center/serviced
+docker pull zenoss/ubuntu:wget
+make clean test smoketest


### PR DESCRIPTION
DO NOT MERGE UNTIL WE HAVE A NEW 1.0.x BUILD FOR QA.

The goal is to build/test any changes on the support/1.0.x branch just like we do on the develop branch.

The jenkins-merge-build.sh script encapsulates that build logic. Originally, committed to the develop branch for CC 1.1, this PR adds the same script to the support/1.0.x branch for use in a new Jenkins job, [1.0.x-serviced-merge](http://jenkins.zendev.org/view/Control%20Center/job/1.0.x-serviced-merge/)