### PR TITLE
Add support for timeouts to RPC calls.

### DIFF
--- a/node/cp_client.go
+++ b/node/cp_client.go
@@ -58,253 +58,253 @@ func (s *ControlClient) Close() (err error) {
 }
 
 func (s *ControlClient) GetServiceEndpoints(serviceId string, response *map[string][]dao.ApplicationEndpoint) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetServiceEndpoints", serviceId, response, 0)
+	return s.rpcClient.Call("ControlPlane.GetServiceEndpoints", serviceId, response, 0, true)
 }
 
 func (s *ControlClient) GetServices(request dao.ServiceRequest, replyServices *[]service.Service) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetServices", request, replyServices, 0)
+	return s.rpcClient.Call("ControlPlane.GetServices", request, replyServices, 0, true)
 }
 
 func (s *ControlClient) GetTaggedServices(request dao.ServiceRequest, replyServices *[]service.Service) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetTaggedServices", request, replyServices, 0)
+	return s.rpcClient.Call("ControlPlane.GetTaggedServices", request, replyServices, 0, true)
 }
 
 func (s *ControlClient) GetService(serviceId string, service *service.Service) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetService", serviceId, &service, 0)
+	return s.rpcClient.Call("ControlPlane.GetService", serviceId, &service, 0, true)
 }
 
 func (s *ControlClient) FindChildService(request dao.FindChildRequest, service *service.Service) (err error) {
-	return s.rpcClient.Call("ControlPlane.FindChildService", request, &service, 0)
+	return s.rpcClient.Call("ControlPlane.FindChildService", request, &service, 0, true)
 }
 
 func (s *ControlClient) GetTenantId(serviceId string, tenantId *string) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetTenantId", serviceId, tenantId, 0)
+	return s.rpcClient.Call("ControlPlane.GetTenantId", serviceId, tenantId, 0, true)
 }
 
 func (s *ControlClient) AddService(service service.Service, serviceId *string) (err error) {
-	return s.rpcClient.Call("ControlPlane.AddService", service, serviceId, 0)
+	return s.rpcClient.Call("ControlPlane.AddService", service, serviceId, 0, true)
 }
 
 func (s *ControlClient) CloneService(request dao.ServiceCloneRequest, copiedServiceId *string) (err error) {
-	return s.rpcClient.Call("ControlPlane.CloneService", request, copiedServiceId, 0)
+	return s.rpcClient.Call("ControlPlane.CloneService", request, copiedServiceId, 0, true)
 }
 
 func (s *ControlClient) DeployService(service dao.ServiceDeploymentRequest, serviceId *string) (err error) {
-	return s.rpcClient.Call("ControlPlane.DeployService", service, serviceId, 0)
+	return s.rpcClient.Call("ControlPlane.DeployService", service, serviceId, 0, true)
 }
 
 func (s *ControlClient) UpdateService(service service.Service, unused *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.UpdateService", service, unused, 0)
+	return s.rpcClient.Call("ControlPlane.UpdateService", service, unused, 0, true)
 }
 
 func (s *ControlClient) RunMigrationScript(request dao.RunMigrationScriptRequest, unused *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.RunMigrationScript", request, unused, 0)
+	return s.rpcClient.Call("ControlPlane.RunMigrationScript", request, unused, 0, true)
 }
 
 func (s *ControlClient) MigrateServices(request dao.ServiceMigrationRequest, unused *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.MigrateServices", request, unused, 0)
+	return s.rpcClient.Call("ControlPlane.MigrateServices", request, unused, 0, true)
 }
 
 func (s *ControlClient) GetServiceList(serviceID string, services *[]service.Service) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetServiceList", serviceID, services, 0)
+	return s.rpcClient.Call("ControlPlane.GetServiceList", serviceID, services, 0, true)
 }
 
 func (s *ControlClient) RemoveService(serviceId string, unused *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.RemoveService", serviceId, unused, 0)
+	return s.rpcClient.Call("ControlPlane.RemoveService", serviceId, unused, 0, true)
 }
 
 func (s *ControlClient) AssignIPs(assignmentRequest dao.AssignmentRequest, _ *struct{}) (err error) {
-	return s.rpcClient.Call("ControlPlane.AssignIPs", assignmentRequest, nil, 0)
+	return s.rpcClient.Call("ControlPlane.AssignIPs", assignmentRequest, nil, 0, true)
 }
 
 func (s *ControlClient) GetServiceAddressAssignments(serviceID string, addresses *[]addressassignment.AddressAssignment) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetServiceAddressAssignments", serviceID, addresses, 0)
+	return s.rpcClient.Call("ControlPlane.GetServiceAddressAssignments", serviceID, addresses, 0, true)
 }
 
 func (s *ControlClient) GetServiceLogs(serviceId string, logs *string) error {
-	return s.rpcClient.Call("ControlPlane.GetServiceLogs", serviceId, logs, 0)
+	return s.rpcClient.Call("ControlPlane.GetServiceLogs", serviceId, logs, 0, true)
 }
 
 func (s *ControlClient) GetServiceStateLogs(request dao.ServiceStateRequest, logs *string) error {
-	return s.rpcClient.Call("ControlPlane.GetServiceStateLogs", request, logs, 0)
+	return s.rpcClient.Call("ControlPlane.GetServiceStateLogs", request, logs, 0, true)
 }
 
 func (s *ControlClient) GetRunningServicesForHost(hostId string, runningServices *[]dao.RunningService) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetRunningServicesForHost", hostId, runningServices, 0)
+	return s.rpcClient.Call("ControlPlane.GetRunningServicesForHost", hostId, runningServices, 0, true)
 }
 
 func (s *ControlClient) GetRunningServicesForService(serviceId string, runningServices *[]dao.RunningService) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetRunningServicesForService", serviceId, runningServices, 0)
+	return s.rpcClient.Call("ControlPlane.GetRunningServicesForService", serviceId, runningServices, 0, true)
 }
 
 func (s *ControlClient) StopRunningInstance(request dao.HostServiceRequest, unused *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.StopRunningInstance", request, unused, 0)
+	return s.rpcClient.Call("ControlPlane.StopRunningInstance", request, unused, 0, true)
 }
 
 func (s *ControlClient) GetRunningServices(request dao.EntityRequest, runningServices *[]dao.RunningService) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetRunningServices", request, runningServices, 0)
+	return s.rpcClient.Call("ControlPlane.GetRunningServices", request, runningServices, 10, false)
 }
 
 func (s *ControlClient) GetServiceState(request dao.ServiceStateRequest, state *servicestate.ServiceState) error {
-	return s.rpcClient.Call("ControlPlane.GetServiceState", request, state, 0)
+	return s.rpcClient.Call("ControlPlane.GetServiceState", request, state, 0, true)
 }
 
 func (s *ControlClient) GetRunningService(request dao.ServiceStateRequest, running *dao.RunningService) error {
-	return s.rpcClient.Call("ControlPlane.GetRunningService", request, running, 0)
+	return s.rpcClient.Call("ControlPlane.GetRunningService", request, running, 0, true)
 }
 
 func (s *ControlClient) GetServiceStates(serviceId string, states *[]servicestate.ServiceState) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetServiceStates", serviceId, states, 0)
+	return s.rpcClient.Call("ControlPlane.GetServiceStates", serviceId, states, 0, true)
 }
 
 func (s *ControlClient) StartService(request dao.ScheduleServiceRequest, affected *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.StartService", request, affected, 0)
+	return s.rpcClient.Call("ControlPlane.StartService", request, affected, 0, true)
 }
 
 func (s *ControlClient) RestartService(request dao.ScheduleServiceRequest, affected *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.RestartService", request, affected, 0)
+	return s.rpcClient.Call("ControlPlane.RestartService", request, affected, 0, true)
 }
 
 func (s *ControlClient) StopService(request dao.ScheduleServiceRequest, affected *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.StopService", request, affected, 0)
+	return s.rpcClient.Call("ControlPlane.StopService", request, affected, 0, true)
 }
 
 func (s *ControlClient) WaitService(request dao.WaitServiceRequest, _ *struct{}) (err error) {
-	return s.rpcClient.Call("ControlPlane.WaitService", request, nil, 0)
+	return s.rpcClient.Call("ControlPlane.WaitService", request, nil, 0, true)
 }
 
 func (s *ControlClient) UpdateServiceState(state servicestate.ServiceState, unused *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.UpdateServiceState", state, unused, 0)
+	return s.rpcClient.Call("ControlPlane.UpdateServiceState", state, unused, 0, true)
 }
 
 func (s *ControlClient) GetServiceStatus(serviceID string, statusmap *map[string]dao.ServiceStatus) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetServiceStatus", serviceID, statusmap, 0)
+	return s.rpcClient.Call("ControlPlane.GetServiceStatus", serviceID, statusmap, 0, true)
 }
 
 func (s *ControlClient) DeployTemplate(request dao.ServiceTemplateDeploymentRequest, tenantIDs *[]string) error {
-	return s.rpcClient.Call("ControlPlane.DeployTemplate", request, tenantIDs, 0)
+	return s.rpcClient.Call("ControlPlane.DeployTemplate", request, tenantIDs, 0, true)
 }
 
 func (s *ControlClient) DeployTemplateStatus(request dao.ServiceTemplateDeploymentRequest, status *string) error {
-	return s.rpcClient.Call("ControlPlane.DeployTemplateStatus", request, status, 0)
+	return s.rpcClient.Call("ControlPlane.DeployTemplateStatus", request, status, 0, true)
 }
 
 func (s *ControlClient) DeployTemplateActive(notUsed string, active *[]map[string]string) error {
-	return s.rpcClient.Call("ControlPlane.DeployTemplateActive", notUsed, active, 0)
+	return s.rpcClient.Call("ControlPlane.DeployTemplateActive", notUsed, active, 0, true)
 }
 
 func (s *ControlClient) GetServiceTemplates(unused int, serviceTemplates *map[string]servicetemplate.ServiceTemplate) error {
-	return s.rpcClient.Call("ControlPlane.GetServiceTemplates", unused, serviceTemplates, 0)
+	return s.rpcClient.Call("ControlPlane.GetServiceTemplates", unused, serviceTemplates, 0, true)
 }
 
 func (s *ControlClient) AddServiceTemplate(serviceTemplate servicetemplate.ServiceTemplate, templateId *string) error {
-	return s.rpcClient.Call("ControlPlane.AddServiceTemplate", serviceTemplate, templateId, 0)
+	return s.rpcClient.Call("ControlPlane.AddServiceTemplate", serviceTemplate, templateId, 0, true)
 }
 
 func (s *ControlClient) UpdateServiceTemplate(serviceTemplate servicetemplate.ServiceTemplate, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.UpdateServiceTemplate", serviceTemplate, unused, 0)
+	return s.rpcClient.Call("ControlPlane.UpdateServiceTemplate", serviceTemplate, unused, 0, true)
 }
 
 func (s *ControlClient) RemoveServiceTemplate(serviceTemplateID string, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.RemoveServiceTemplate", serviceTemplateID, unused, 0)
+	return s.rpcClient.Call("ControlPlane.RemoveServiceTemplate", serviceTemplateID, unused, 0, true)
 }
 
 func (s *ControlClient) GetVolume(serviceID string, volume volume.Volume) error {
-	return s.rpcClient.Call("ControlPlane.GetVolume", serviceID, volume, 0)
+	return s.rpcClient.Call("ControlPlane.GetVolume", serviceID, volume, 0, true)
 }
 
 func (s *ControlClient) ResetRegistry(request dao.EntityRequest, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.ResetRegistry", request, unused, 0)
+	return s.rpcClient.Call("ControlPlane.ResetRegistry", request, unused, 0, true)
 }
 
 func (s *ControlClient) DeleteSnapshot(snapshotId string, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.DeleteSnapshot", snapshotId, unused, 0)
+	return s.rpcClient.Call("ControlPlane.DeleteSnapshot", snapshotId, unused, 0, true)
 }
 
 func (s *ControlClient) DeleteSnapshots(serviceId string, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.DeleteSnapshots", serviceId, unused, 0)
+	return s.rpcClient.Call("ControlPlane.DeleteSnapshots", serviceId, unused, 0, true)
 }
 
 func (s *ControlClient) Rollback(request dao.RollbackRequest, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.Rollback", request, unused, 0)
+	return s.rpcClient.Call("ControlPlane.Rollback", request, unused, 0, true)
 }
 
 func (s *ControlClient) Snapshot(request dao.SnapshotRequest, label *string) error {
-	return s.rpcClient.Call("ControlPlane.Snapshot", request, label, 0)
+	return s.rpcClient.Call("ControlPlane.Snapshot", request, label, 0, true)
 }
 
 func (s *ControlClient) AsyncSnapshot(serviceId string, label *string) error {
-	return s.rpcClient.Call("ControlPlane.AsyncSnapshot", serviceId, label, 0)
+	return s.rpcClient.Call("ControlPlane.AsyncSnapshot", serviceId, label, 0, true)
 }
 
 func (s *ControlClient) ListSnapshots(serviceId string, snapshots *[]dao.SnapshotInfo) error {
-	return s.rpcClient.Call("ControlPlane.ListSnapshots", serviceId, snapshots, 0)
+	return s.rpcClient.Call("ControlPlane.ListSnapshots", serviceId, snapshots, 0, true)
 }
 
 func (s *ControlClient) Commit(containerId string, label *string) error {
-	return s.rpcClient.Call("ControlPlane.Commit", containerId, label, 0)
+	return s.rpcClient.Call("ControlPlane.Commit", containerId, label, 0, true)
 }
 
 func (s *ControlClient) ReadyDFS(unused bool, unusedint *int) error {
-	return s.rpcClient.Call("ControlPlane.ReadyDFS", unused, unusedint, 0)
+	return s.rpcClient.Call("ControlPlane.ReadyDFS", unused, unusedint, 0, true)
 }
 
 func (s *ControlClient) ListBackups(backupDirectory string, backupFiles *[]dao.BackupFile) error {
-	return s.rpcClient.Call("ControlPlane.ListBackups", backupDirectory, backupFiles, 0)
+	return s.rpcClient.Call("ControlPlane.ListBackups", backupDirectory, backupFiles, 0, true)
 }
 
 func (s *ControlClient) Backup(backupDirectory string, backupFilePath *string) error {
-	return s.rpcClient.Call("ControlPlane.Backup", backupDirectory, backupFilePath, 0)
+	return s.rpcClient.Call("ControlPlane.Backup", backupDirectory, backupFilePath, 0, true)
 }
 
 func (s *ControlClient) AsyncBackup(backupDirectory string, backupFilePath *string) error {
-	return s.rpcClient.Call("ControlPlane.AsyncBackup", backupDirectory, backupFilePath, 0)
+	return s.rpcClient.Call("ControlPlane.AsyncBackup", backupDirectory, backupFilePath, 0, true)
 }
 
 func (s *ControlClient) Restore(backupFilePath string, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.Restore", backupFilePath, unused, 0)
+	return s.rpcClient.Call("ControlPlane.Restore", backupFilePath, unused, 0, true)
 }
 
 func (s *ControlClient) AsyncRestore(backupFilePath string, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.AsyncRestore", backupFilePath, unused, 0)
+	return s.rpcClient.Call("ControlPlane.AsyncRestore", backupFilePath, unused, 0, true)
 }
 
 func (s *ControlClient) BackupStatus(notUsed int, backupStatus *string) error {
-	return s.rpcClient.Call("ControlPlane.BackupStatus", notUsed, backupStatus, 0)
+	return s.rpcClient.Call("ControlPlane.BackupStatus", notUsed, backupStatus, 0, true)
 }
 
 func (s *ControlClient) ImageLayerCount(imageUUID string, layers *int) error {
-	return s.rpcClient.Call("ControlPlane.ImageLayerCount", imageUUID, layers, 0)
+	return s.rpcClient.Call("ControlPlane.ImageLayerCount", imageUUID, layers, 0, true)
 }
 
 func (s *ControlClient) ValidateCredentials(user user.User, result *bool) error {
-	return s.rpcClient.Call("ControlPlane.ValidateCredentials", user, result, 0)
+	return s.rpcClient.Call("ControlPlane.ValidateCredentials", user, result, 0, true)
 }
 
 func (s *ControlClient) GetSystemUser(unused int, user *user.User) error {
-	return s.rpcClient.Call("ControlPlane.GetSystemUser", unused, user, 0)
+	return s.rpcClient.Call("ControlPlane.GetSystemUser", unused, user, 0, true)
 }
 
 func (s *ControlClient) Action(req dao.AttachRequest, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.Action", req, unused, 0)
+	return s.rpcClient.Call("ControlPlane.Action", req, unused, 0, true)
 }
 
 func (s *ControlClient) GetHostMemoryStats(req dao.MetricRequest, stats *metrics.MemoryUsageStats) error {
-	return s.rpcClient.Call("ControlPlane.GetHostMemoryStats", req, stats, 0)
+	return s.rpcClient.Call("ControlPlane.GetHostMemoryStats", req, stats, 5, false)
 }
 
 func (s *ControlClient) GetServiceMemoryStats(req dao.MetricRequest, stats *metrics.MemoryUsageStats) error {
-	return s.rpcClient.Call("ControlPlane.GetServiceMemoryStats", req, stats, 0)
+	return s.rpcClient.Call("ControlPlane.GetServiceMemoryStats", req, stats, 5, false)
 }
 
 func (s *ControlClient) GetInstanceMemoryStats(req dao.MetricRequest, stats *[]metrics.MemoryUsageStats) error {
-	return s.rpcClient.Call("ControlPlane.GetInstanceMemoryStats", req, stats, 0)
+	return s.rpcClient.Call("ControlPlane.GetInstanceMemoryStats", req, stats, 5, false)
 }
 
 func (s *ControlClient) LogHealthCheck(result domain.HealthCheckResult, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.LogHealthCheck", result, unused, 0)
+	return s.rpcClient.Call("ControlPlane.LogHealthCheck", result, unused, 0, true)
 }
 
 func (s *ControlClient) ServicedHealthCheck(IServiceNames []string, results *[]dao.IServiceHealthResult) error {
-	return s.rpcClient.Call("ControlPlane.ServicedHealthCheck", IServiceNames, results, 0)
+	return s.rpcClient.Call("ControlPlane.ServicedHealthCheck", IServiceNames, results, 0, true)
 }

--- a/node/cp_client.go
+++ b/node/cp_client.go
@@ -58,253 +58,253 @@ func (s *ControlClient) Close() (err error) {
 }
 
 func (s *ControlClient) GetServiceEndpoints(serviceId string, response *map[string][]dao.ApplicationEndpoint) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetServiceEndpoints", serviceId, response)
+	return s.rpcClient.Call("ControlPlane.GetServiceEndpoints", serviceId, response, 0)
 }
 
 func (s *ControlClient) GetServices(request dao.ServiceRequest, replyServices *[]service.Service) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetServices", request, replyServices)
+	return s.rpcClient.Call("ControlPlane.GetServices", request, replyServices, 0)
 }
 
 func (s *ControlClient) GetTaggedServices(request dao.ServiceRequest, replyServices *[]service.Service) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetTaggedServices", request, replyServices)
+	return s.rpcClient.Call("ControlPlane.GetTaggedServices", request, replyServices, 0)
 }
 
 func (s *ControlClient) GetService(serviceId string, service *service.Service) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetService", serviceId, &service)
+	return s.rpcClient.Call("ControlPlane.GetService", serviceId, &service, 0)
 }
 
 func (s *ControlClient) FindChildService(request dao.FindChildRequest, service *service.Service) (err error) {
-	return s.rpcClient.Call("ControlPlane.FindChildService", request, &service)
+	return s.rpcClient.Call("ControlPlane.FindChildService", request, &service, 0)
 }
 
 func (s *ControlClient) GetTenantId(serviceId string, tenantId *string) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetTenantId", serviceId, tenantId)
+	return s.rpcClient.Call("ControlPlane.GetTenantId", serviceId, tenantId, 0)
 }
 
 func (s *ControlClient) AddService(service service.Service, serviceId *string) (err error) {
-	return s.rpcClient.Call("ControlPlane.AddService", service, serviceId)
+	return s.rpcClient.Call("ControlPlane.AddService", service, serviceId, 0)
 }
 
 func (s *ControlClient) CloneService(request dao.ServiceCloneRequest, copiedServiceId *string) (err error) {
-	return s.rpcClient.Call("ControlPlane.CloneService", request, copiedServiceId)
+	return s.rpcClient.Call("ControlPlane.CloneService", request, copiedServiceId, 0)
 }
 
 func (s *ControlClient) DeployService(service dao.ServiceDeploymentRequest, serviceId *string) (err error) {
-	return s.rpcClient.Call("ControlPlane.DeployService", service, serviceId)
+	return s.rpcClient.Call("ControlPlane.DeployService", service, serviceId, 0)
 }
 
 func (s *ControlClient) UpdateService(service service.Service, unused *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.UpdateService", service, unused)
+	return s.rpcClient.Call("ControlPlane.UpdateService", service, unused, 0)
 }
 
 func (s *ControlClient) RunMigrationScript(request dao.RunMigrationScriptRequest, unused *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.RunMigrationScript", request, unused)
+	return s.rpcClient.Call("ControlPlane.RunMigrationScript", request, unused, 0)
 }
 
 func (s *ControlClient) MigrateServices(request dao.ServiceMigrationRequest, unused *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.MigrateServices", request, unused)
+	return s.rpcClient.Call("ControlPlane.MigrateServices", request, unused, 0)
 }
 
 func (s *ControlClient) GetServiceList(serviceID string, services *[]service.Service) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetServiceList", serviceID, services)
+	return s.rpcClient.Call("ControlPlane.GetServiceList", serviceID, services, 0)
 }
 
 func (s *ControlClient) RemoveService(serviceId string, unused *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.RemoveService", serviceId, unused)
+	return s.rpcClient.Call("ControlPlane.RemoveService", serviceId, unused, 0)
 }
 
 func (s *ControlClient) AssignIPs(assignmentRequest dao.AssignmentRequest, _ *struct{}) (err error) {
-	return s.rpcClient.Call("ControlPlane.AssignIPs", assignmentRequest, nil)
+	return s.rpcClient.Call("ControlPlane.AssignIPs", assignmentRequest, nil, 0)
 }
 
 func (s *ControlClient) GetServiceAddressAssignments(serviceID string, addresses *[]addressassignment.AddressAssignment) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetServiceAddressAssignments", serviceID, addresses)
+	return s.rpcClient.Call("ControlPlane.GetServiceAddressAssignments", serviceID, addresses, 0)
 }
 
 func (s *ControlClient) GetServiceLogs(serviceId string, logs *string) error {
-	return s.rpcClient.Call("ControlPlane.GetServiceLogs", serviceId, logs)
+	return s.rpcClient.Call("ControlPlane.GetServiceLogs", serviceId, logs, 0)
 }
 
 func (s *ControlClient) GetServiceStateLogs(request dao.ServiceStateRequest, logs *string) error {
-	return s.rpcClient.Call("ControlPlane.GetServiceStateLogs", request, logs)
+	return s.rpcClient.Call("ControlPlane.GetServiceStateLogs", request, logs, 0)
 }
 
 func (s *ControlClient) GetRunningServicesForHost(hostId string, runningServices *[]dao.RunningService) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetRunningServicesForHost", hostId, runningServices)
+	return s.rpcClient.Call("ControlPlane.GetRunningServicesForHost", hostId, runningServices, 0)
 }
 
 func (s *ControlClient) GetRunningServicesForService(serviceId string, runningServices *[]dao.RunningService) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetRunningServicesForService", serviceId, runningServices)
+	return s.rpcClient.Call("ControlPlane.GetRunningServicesForService", serviceId, runningServices, 0)
 }
 
 func (s *ControlClient) StopRunningInstance(request dao.HostServiceRequest, unused *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.StopRunningInstance", request, unused)
+	return s.rpcClient.Call("ControlPlane.StopRunningInstance", request, unused, 0)
 }
 
 func (s *ControlClient) GetRunningServices(request dao.EntityRequest, runningServices *[]dao.RunningService) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetRunningServices", request, runningServices)
+	return s.rpcClient.Call("ControlPlane.GetRunningServices", request, runningServices, 0)
 }
 
 func (s *ControlClient) GetServiceState(request dao.ServiceStateRequest, state *servicestate.ServiceState) error {
-	return s.rpcClient.Call("ControlPlane.GetServiceState", request, state)
+	return s.rpcClient.Call("ControlPlane.GetServiceState", request, state, 0)
 }
 
 func (s *ControlClient) GetRunningService(request dao.ServiceStateRequest, running *dao.RunningService) error {
-	return s.rpcClient.Call("ControlPlane.GetRunningService", request, running)
+	return s.rpcClient.Call("ControlPlane.GetRunningService", request, running, 0)
 }
 
 func (s *ControlClient) GetServiceStates(serviceId string, states *[]servicestate.ServiceState) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetServiceStates", serviceId, states)
+	return s.rpcClient.Call("ControlPlane.GetServiceStates", serviceId, states, 0)
 }
 
 func (s *ControlClient) StartService(request dao.ScheduleServiceRequest, affected *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.StartService", request, affected)
+	return s.rpcClient.Call("ControlPlane.StartService", request, affected, 0)
 }
 
 func (s *ControlClient) RestartService(request dao.ScheduleServiceRequest, affected *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.RestartService", request, affected)
+	return s.rpcClient.Call("ControlPlane.RestartService", request, affected, 0)
 }
 
 func (s *ControlClient) StopService(request dao.ScheduleServiceRequest, affected *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.StopService", request, affected)
+	return s.rpcClient.Call("ControlPlane.StopService", request, affected, 0)
 }
 
 func (s *ControlClient) WaitService(request dao.WaitServiceRequest, _ *struct{}) (err error) {
-	return s.rpcClient.Call("ControlPlane.WaitService", request, nil)
+	return s.rpcClient.Call("ControlPlane.WaitService", request, nil, 0)
 }
 
 func (s *ControlClient) UpdateServiceState(state servicestate.ServiceState, unused *int) (err error) {
-	return s.rpcClient.Call("ControlPlane.UpdateServiceState", state, unused)
+	return s.rpcClient.Call("ControlPlane.UpdateServiceState", state, unused, 0)
 }
 
 func (s *ControlClient) GetServiceStatus(serviceID string, statusmap *map[string]dao.ServiceStatus) (err error) {
-	return s.rpcClient.Call("ControlPlane.GetServiceStatus", serviceID, statusmap)
+	return s.rpcClient.Call("ControlPlane.GetServiceStatus", serviceID, statusmap, 0)
 }
 
 func (s *ControlClient) DeployTemplate(request dao.ServiceTemplateDeploymentRequest, tenantIDs *[]string) error {
-	return s.rpcClient.Call("ControlPlane.DeployTemplate", request, tenantIDs)
+	return s.rpcClient.Call("ControlPlane.DeployTemplate", request, tenantIDs, 0)
 }
 
 func (s *ControlClient) DeployTemplateStatus(request dao.ServiceTemplateDeploymentRequest, status *string) error {
-	return s.rpcClient.Call("ControlPlane.DeployTemplateStatus", request, status)
+	return s.rpcClient.Call("ControlPlane.DeployTemplateStatus", request, status, 0)
 }
 
 func (s *ControlClient) DeployTemplateActive(notUsed string, active *[]map[string]string) error {
-	return s.rpcClient.Call("ControlPlane.DeployTemplateActive", notUsed, active)
+	return s.rpcClient.Call("ControlPlane.DeployTemplateActive", notUsed, active, 0)
 }
 
 func (s *ControlClient) GetServiceTemplates(unused int, serviceTemplates *map[string]servicetemplate.ServiceTemplate) error {
-	return s.rpcClient.Call("ControlPlane.GetServiceTemplates", unused, serviceTemplates)
+	return s.rpcClient.Call("ControlPlane.GetServiceTemplates", unused, serviceTemplates, 0)
 }
 
 func (s *ControlClient) AddServiceTemplate(serviceTemplate servicetemplate.ServiceTemplate, templateId *string) error {
-	return s.rpcClient.Call("ControlPlane.AddServiceTemplate", serviceTemplate, templateId)
+	return s.rpcClient.Call("ControlPlane.AddServiceTemplate", serviceTemplate, templateId, 0)
 }
 
 func (s *ControlClient) UpdateServiceTemplate(serviceTemplate servicetemplate.ServiceTemplate, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.UpdateServiceTemplate", serviceTemplate, unused)
+	return s.rpcClient.Call("ControlPlane.UpdateServiceTemplate", serviceTemplate, unused, 0)
 }
 
 func (s *ControlClient) RemoveServiceTemplate(serviceTemplateID string, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.RemoveServiceTemplate", serviceTemplateID, unused)
+	return s.rpcClient.Call("ControlPlane.RemoveServiceTemplate", serviceTemplateID, unused, 0)
 }
 
 func (s *ControlClient) GetVolume(serviceID string, volume volume.Volume) error {
-	return s.rpcClient.Call("ControlPlane.GetVolume", serviceID, volume)
+	return s.rpcClient.Call("ControlPlane.GetVolume", serviceID, volume, 0)
 }
 
 func (s *ControlClient) ResetRegistry(request dao.EntityRequest, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.ResetRegistry", request, unused)
+	return s.rpcClient.Call("ControlPlane.ResetRegistry", request, unused, 0)
 }
 
 func (s *ControlClient) DeleteSnapshot(snapshotId string, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.DeleteSnapshot", snapshotId, unused)
+	return s.rpcClient.Call("ControlPlane.DeleteSnapshot", snapshotId, unused, 0)
 }
 
 func (s *ControlClient) DeleteSnapshots(serviceId string, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.DeleteSnapshots", serviceId, unused)
+	return s.rpcClient.Call("ControlPlane.DeleteSnapshots", serviceId, unused, 0)
 }
 
 func (s *ControlClient) Rollback(request dao.RollbackRequest, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.Rollback", request, unused)
+	return s.rpcClient.Call("ControlPlane.Rollback", request, unused, 0)
 }
 
 func (s *ControlClient) Snapshot(request dao.SnapshotRequest, label *string) error {
-	return s.rpcClient.Call("ControlPlane.Snapshot", request, label)
+	return s.rpcClient.Call("ControlPlane.Snapshot", request, label, 0)
 }
 
 func (s *ControlClient) AsyncSnapshot(serviceId string, label *string) error {
-	return s.rpcClient.Call("ControlPlane.AsyncSnapshot", serviceId, label)
+	return s.rpcClient.Call("ControlPlane.AsyncSnapshot", serviceId, label, 0)
 }
 
 func (s *ControlClient) ListSnapshots(serviceId string, snapshots *[]dao.SnapshotInfo) error {
-	return s.rpcClient.Call("ControlPlane.ListSnapshots", serviceId, snapshots)
+	return s.rpcClient.Call("ControlPlane.ListSnapshots", serviceId, snapshots, 0)
 }
 
 func (s *ControlClient) Commit(containerId string, label *string) error {
-	return s.rpcClient.Call("ControlPlane.Commit", containerId, label)
+	return s.rpcClient.Call("ControlPlane.Commit", containerId, label, 0)
 }
 
 func (s *ControlClient) ReadyDFS(unused bool, unusedint *int) error {
-	return s.rpcClient.Call("ControlPlane.ReadyDFS", unused, unusedint)
+	return s.rpcClient.Call("ControlPlane.ReadyDFS", unused, unusedint, 0)
 }
 
 func (s *ControlClient) ListBackups(backupDirectory string, backupFiles *[]dao.BackupFile) error {
-	return s.rpcClient.Call("ControlPlane.ListBackups", backupDirectory, backupFiles)
+	return s.rpcClient.Call("ControlPlane.ListBackups", backupDirectory, backupFiles, 0)
 }
 
 func (s *ControlClient) Backup(backupDirectory string, backupFilePath *string) error {
-	return s.rpcClient.Call("ControlPlane.Backup", backupDirectory, backupFilePath)
+	return s.rpcClient.Call("ControlPlane.Backup", backupDirectory, backupFilePath, 0)
 }
 
 func (s *ControlClient) AsyncBackup(backupDirectory string, backupFilePath *string) error {
-	return s.rpcClient.Call("ControlPlane.AsyncBackup", backupDirectory, backupFilePath)
+	return s.rpcClient.Call("ControlPlane.AsyncBackup", backupDirectory, backupFilePath, 0)
 }
 
 func (s *ControlClient) Restore(backupFilePath string, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.Restore", backupFilePath, unused)
+	return s.rpcClient.Call("ControlPlane.Restore", backupFilePath, unused, 0)
 }
 
 func (s *ControlClient) AsyncRestore(backupFilePath string, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.AsyncRestore", backupFilePath, unused)
+	return s.rpcClient.Call("ControlPlane.AsyncRestore", backupFilePath, unused, 0)
 }
 
 func (s *ControlClient) BackupStatus(notUsed int, backupStatus *string) error {
-	return s.rpcClient.Call("ControlPlane.BackupStatus", notUsed, backupStatus)
+	return s.rpcClient.Call("ControlPlane.BackupStatus", notUsed, backupStatus, 0)
 }
 
 func (s *ControlClient) ImageLayerCount(imageUUID string, layers *int) error {
-	return s.rpcClient.Call("ControlPlane.ImageLayerCount", imageUUID, layers)
+	return s.rpcClient.Call("ControlPlane.ImageLayerCount", imageUUID, layers, 0)
 }
 
 func (s *ControlClient) ValidateCredentials(user user.User, result *bool) error {
-	return s.rpcClient.Call("ControlPlane.ValidateCredentials", user, result)
+	return s.rpcClient.Call("ControlPlane.ValidateCredentials", user, result, 0)
 }
 
 func (s *ControlClient) GetSystemUser(unused int, user *user.User) error {
-	return s.rpcClient.Call("ControlPlane.GetSystemUser", unused, user)
+	return s.rpcClient.Call("ControlPlane.GetSystemUser", unused, user, 0)
 }
 
 func (s *ControlClient) Action(req dao.AttachRequest, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.Action", req, unused)
+	return s.rpcClient.Call("ControlPlane.Action", req, unused, 0)
 }
 
 func (s *ControlClient) GetHostMemoryStats(req dao.MetricRequest, stats *metrics.MemoryUsageStats) error {
-	return s.rpcClient.Call("ControlPlane.GetHostMemoryStats", req, stats)
+	return s.rpcClient.Call("ControlPlane.GetHostMemoryStats", req, stats, 0)
 }
 
 func (s *ControlClient) GetServiceMemoryStats(req dao.MetricRequest, stats *metrics.MemoryUsageStats) error {
-	return s.rpcClient.Call("ControlPlane.GetServiceMemoryStats", req, stats)
+	return s.rpcClient.Call("ControlPlane.GetServiceMemoryStats", req, stats, 0)
 }
 
 func (s *ControlClient) GetInstanceMemoryStats(req dao.MetricRequest, stats *[]metrics.MemoryUsageStats) error {
-	return s.rpcClient.Call("ControlPlane.GetInstanceMemoryStats", req, stats)
+	return s.rpcClient.Call("ControlPlane.GetInstanceMemoryStats", req, stats, 0)
 }
 
 func (s *ControlClient) LogHealthCheck(result domain.HealthCheckResult, unused *int) error {
-	return s.rpcClient.Call("ControlPlane.LogHealthCheck", result, unused)
+	return s.rpcClient.Call("ControlPlane.LogHealthCheck", result, unused, 0)
 }
 
 func (s *ControlClient) ServicedHealthCheck(IServiceNames []string, results *[]dao.IServiceHealthResult) error {
-	return s.rpcClient.Call("ControlPlane.ServicedHealthCheck", IServiceNames, results)
+	return s.rpcClient.Call("ControlPlane.ServicedHealthCheck", IServiceNames, results, 0)
 }

--- a/node/lbClient.go
+++ b/node/lbClient.go
@@ -51,78 +51,78 @@ func (a *LBClient) Close() error {
 // Ping waits for the specified time then returns the server time
 func (a *LBClient) Ping(waitFor time.Duration, timestamp *time.Time) error {
 	glog.V(4).Infof("ControlPlaneAgent.Ping()")
-	return a.rpcClient.Call("ControlPlaneAgent.Ping", waitFor, timestamp)
+	return a.rpcClient.Call("ControlPlaneAgent.Ping", waitFor, timestamp, 0)
 }
 
 // SendLogMessage simply outputs the ServiceLogInfo on the serviced master
 func (a *LBClient) SendLogMessage(serviceLogInfo ServiceLogInfo, _ *struct{}) error {
 	glog.V(4).Infof("ControlPlaneAgent.SendLogMessage()")
-	return a.rpcClient.Call("ControlPlaneAgent.SendLogMessage", serviceLogInfo, nil)
+	return a.rpcClient.Call("ControlPlaneAgent.SendLogMessage", serviceLogInfo, nil, 0)
 }
 
 // GetServiceEndpoints returns a list of endpoints for the given service endpoint request.
 func (a *LBClient) GetServiceEndpoints(serviceId string, endpoints *map[string][]dao.ApplicationEndpoint) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetServiceEndpoints()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetServiceEndpoints", serviceId, endpoints)
+	return a.rpcClient.Call("ControlPlaneAgent.GetServiceEndpoints", serviceId, endpoints, 0)
 }
 
 // GetService returns a service for the given service id request.
 func (a *LBClient) GetService(serviceId string, service *service.Service) error {
 	glog.V(0).Infof("ControlPlaneAgent.GetService()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetService", serviceId, service)
+	return a.rpcClient.Call("ControlPlaneAgent.GetService", serviceId, service, 0)
 }
 
 // GetServiceInstance returns a service for the given service id request.
 func (a *LBClient) GetServiceInstance(req ServiceInstanceRequest, service *service.Service) error {
 	glog.V(0).Infof("ControlPlaneAgent.GetServiceInstance()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetServiceInstance", req, service)
+	return a.rpcClient.Call("ControlPlaneAgent.GetServiceInstance", req, service, 0)
 }
 
 // GetProxySnapshotQuiece blocks until there is a snapshot request to the service
 func (a *LBClient) GetProxySnapshotQuiece(serviceId string, snapshotId *string) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetProxySnapshotQuiece()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetProxySnapshotQuiece", serviceId, snapshotId)
+	return a.rpcClient.Call("ControlPlaneAgent.GetProxySnapshotQuiece", serviceId, snapshotId, 0)
 }
 
 // AckProxySnapshotQuiece is called by clients when the snapshot command has
 // shown the service is quieced; the agent returns a response when the snapshot is complete
 func (a *LBClient) AckProxySnapshotQuiece(snapshotId string, unused *interface{}) error {
 	glog.V(4).Infof("ControlPlaneAgent.AckProxySnapshotQuiece()")
-	return a.rpcClient.Call("ControlPlaneAgent.AckProxySnapshotQuiece", snapshotId, unused)
+	return a.rpcClient.Call("ControlPlaneAgent.AckProxySnapshotQuiece", snapshotId, unused, 0)
 }
 
 // GetTenantId return's the service's tenant id
 func (a *LBClient) GetTenantId(serviceId string, tenantId *string) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetTenantId()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetTenantId", serviceId, tenantId)
+	return a.rpcClient.Call("ControlPlaneAgent.GetTenantId", serviceId, tenantId, 0)
 }
 
 // LogHealthCheck stores a health check result.
 func (a *LBClient) LogHealthCheck(result domain.HealthCheckResult, unused *int) error {
 	glog.V(4).Infof("ControlPlaneAgent.LogHealthCheck()")
-	return a.rpcClient.Call("ControlPlaneAgent.LogHealthCheck", result, unused)
+	return a.rpcClient.Call("ControlPlaneAgent.LogHealthCheck", result, unused, 0)
 }
 
 // GetHealthCheck returns the health check configuration for a service, if it exists
 func (a *LBClient) GetHealthCheck(req HealthCheckRequest, healthChecks *map[string]domain.HealthCheck) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetHealthCheck()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetHealthCheck", req, healthChecks)
+	return a.rpcClient.Call("ControlPlaneAgent.GetHealthCheck", req, healthChecks, 0)
 }
 
 // GetHostID returns the agent's host id
 func (a *LBClient) GetHostID(hostID *string) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetHostID()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetHostID", "na", hostID)
+	return a.rpcClient.Call("ControlPlaneAgent.GetHostID", "na", hostID, 0)
 }
 
 // GetZkInfo returns the agent's zookeeper connection string
 func (a *LBClient) GetZkInfo(zkInfo *ZkInfo) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetZkInfo()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetZkInfo", "na", zkInfo)
+	return a.rpcClient.Call("ControlPlaneAgent.GetZkInfo", "na", zkInfo, 0)
 }
 
 // GetServiceBindMounts returns the service
 func (a *LBClient) GetServiceBindMounts(serviceID string, bindmounts *map[string]string) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetServiceBindMounts(serviceID:%s)", serviceID)
-	return a.rpcClient.Call("ControlPlaneAgent.GetServiceBindMounts", serviceID, bindmounts)
+	return a.rpcClient.Call("ControlPlaneAgent.GetServiceBindMounts", serviceID, bindmounts, 0)
 }

--- a/node/lbClient.go
+++ b/node/lbClient.go
@@ -51,78 +51,78 @@ func (a *LBClient) Close() error {
 // Ping waits for the specified time then returns the server time
 func (a *LBClient) Ping(waitFor time.Duration, timestamp *time.Time) error {
 	glog.V(4).Infof("ControlPlaneAgent.Ping()")
-	return a.rpcClient.Call("ControlPlaneAgent.Ping", waitFor, timestamp, 0)
+	return a.rpcClient.Call("ControlPlaneAgent.Ping", waitFor, timestamp, 0, true)
 }
 
 // SendLogMessage simply outputs the ServiceLogInfo on the serviced master
 func (a *LBClient) SendLogMessage(serviceLogInfo ServiceLogInfo, _ *struct{}) error {
 	glog.V(4).Infof("ControlPlaneAgent.SendLogMessage()")
-	return a.rpcClient.Call("ControlPlaneAgent.SendLogMessage", serviceLogInfo, nil, 0)
+	return a.rpcClient.Call("ControlPlaneAgent.SendLogMessage", serviceLogInfo, nil, 0, true)
 }
 
 // GetServiceEndpoints returns a list of endpoints for the given service endpoint request.
 func (a *LBClient) GetServiceEndpoints(serviceId string, endpoints *map[string][]dao.ApplicationEndpoint) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetServiceEndpoints()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetServiceEndpoints", serviceId, endpoints, 0)
+	return a.rpcClient.Call("ControlPlaneAgent.GetServiceEndpoints", serviceId, endpoints, 0, true)
 }
 
 // GetService returns a service for the given service id request.
 func (a *LBClient) GetService(serviceId string, service *service.Service) error {
 	glog.V(0).Infof("ControlPlaneAgent.GetService()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetService", serviceId, service, 0)
+	return a.rpcClient.Call("ControlPlaneAgent.GetService", serviceId, service, 0, true)
 }
 
 // GetServiceInstance returns a service for the given service id request.
 func (a *LBClient) GetServiceInstance(req ServiceInstanceRequest, service *service.Service) error {
 	glog.V(0).Infof("ControlPlaneAgent.GetServiceInstance()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetServiceInstance", req, service, 0)
+	return a.rpcClient.Call("ControlPlaneAgent.GetServiceInstance", req, service, 0, true)
 }
 
 // GetProxySnapshotQuiece blocks until there is a snapshot request to the service
 func (a *LBClient) GetProxySnapshotQuiece(serviceId string, snapshotId *string) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetProxySnapshotQuiece()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetProxySnapshotQuiece", serviceId, snapshotId, 0)
+	return a.rpcClient.Call("ControlPlaneAgent.GetProxySnapshotQuiece", serviceId, snapshotId, 0, true)
 }
 
 // AckProxySnapshotQuiece is called by clients when the snapshot command has
 // shown the service is quieced; the agent returns a response when the snapshot is complete
 func (a *LBClient) AckProxySnapshotQuiece(snapshotId string, unused *interface{}) error {
 	glog.V(4).Infof("ControlPlaneAgent.AckProxySnapshotQuiece()")
-	return a.rpcClient.Call("ControlPlaneAgent.AckProxySnapshotQuiece", snapshotId, unused, 0)
+	return a.rpcClient.Call("ControlPlaneAgent.AckProxySnapshotQuiece", snapshotId, unused, 0, true)
 }
 
 // GetTenantId return's the service's tenant id
 func (a *LBClient) GetTenantId(serviceId string, tenantId *string) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetTenantId()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetTenantId", serviceId, tenantId, 0)
+	return a.rpcClient.Call("ControlPlaneAgent.GetTenantId", serviceId, tenantId, 0, true)
 }
 
 // LogHealthCheck stores a health check result.
 func (a *LBClient) LogHealthCheck(result domain.HealthCheckResult, unused *int) error {
 	glog.V(4).Infof("ControlPlaneAgent.LogHealthCheck()")
-	return a.rpcClient.Call("ControlPlaneAgent.LogHealthCheck", result, unused, 0)
+	return a.rpcClient.Call("ControlPlaneAgent.LogHealthCheck", result, unused, 0, true)
 }
 
 // GetHealthCheck returns the health check configuration for a service, if it exists
 func (a *LBClient) GetHealthCheck(req HealthCheckRequest, healthChecks *map[string]domain.HealthCheck) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetHealthCheck()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetHealthCheck", req, healthChecks, 0)
+	return a.rpcClient.Call("ControlPlaneAgent.GetHealthCheck", req, healthChecks, 0, true)
 }
 
 // GetHostID returns the agent's host id
 func (a *LBClient) GetHostID(hostID *string) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetHostID()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetHostID", "na", hostID, 0)
+	return a.rpcClient.Call("ControlPlaneAgent.GetHostID", "na", hostID, 0, true)
 }
 
 // GetZkInfo returns the agent's zookeeper connection string
 func (a *LBClient) GetZkInfo(zkInfo *ZkInfo) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetZkInfo()")
-	return a.rpcClient.Call("ControlPlaneAgent.GetZkInfo", "na", zkInfo, 0)
+	return a.rpcClient.Call("ControlPlaneAgent.GetZkInfo", "na", zkInfo, 0, true)
 }
 
 // GetServiceBindMounts returns the service
 func (a *LBClient) GetServiceBindMounts(serviceID string, bindmounts *map[string]string) error {
 	glog.V(4).Infof("ControlPlaneAgent.GetServiceBindMounts(serviceID:%s)", serviceID)
-	return a.rpcClient.Call("ControlPlaneAgent.GetServiceBindMounts", serviceID, bindmounts, 0)
+	return a.rpcClient.Call("ControlPlaneAgent.GetServiceBindMounts", serviceID, bindmounts, 0, true)
 }

--- a/rpc/agent/agent_client.go
+++ b/rpc/agent/agent_client.go
@@ -44,7 +44,7 @@ func (c *Client) Close() (err error) {
 // BuildHost creates a Host object from the current host.
 func (c *Client) BuildHost(request BuildHostRequest) (*host.Host, error) {
 	hostResponse := host.New()
-	if err := c.rpcClient.Call("Agent.BuildHost", request, hostResponse); err != nil {
+	if err := c.rpcClient.Call("Agent.BuildHost", request, hostResponse, 0); err != nil {
 		return nil, err
 	}
 	return hostResponse, nil
@@ -53,6 +53,6 @@ func (c *Client) BuildHost(request BuildHostRequest) (*host.Host, error) {
 // GetDockerLogs returns the last 10k worth of logs from the docker container
 func (c *Client) GetDockerLogs(dockerID string) (string, error) {
 	var logs string
-	err := c.rpcClient.Call("Agent.GetDockerLogs", dockerID, &logs)
+	err := c.rpcClient.Call("Agent.GetDockerLogs", dockerID, &logs, 0)
 	return logs, err
 }

--- a/rpc/agent/agent_client.go
+++ b/rpc/agent/agent_client.go
@@ -44,7 +44,7 @@ func (c *Client) Close() (err error) {
 // BuildHost creates a Host object from the current host.
 func (c *Client) BuildHost(request BuildHostRequest) (*host.Host, error) {
 	hostResponse := host.New()
-	if err := c.rpcClient.Call("Agent.BuildHost", request, hostResponse, 0); err != nil {
+	if err := c.rpcClient.Call("Agent.BuildHost", request, hostResponse, 0, true); err != nil {
 		return nil, err
 	}
 	return hostResponse, nil
@@ -53,6 +53,6 @@ func (c *Client) BuildHost(request BuildHostRequest) (*host.Host, error) {
 // GetDockerLogs returns the last 10k worth of logs from the docker container
 func (c *Client) GetDockerLogs(dockerID string) (string, error) {
 	var logs string
-	err := c.rpcClient.Call("Agent.GetDockerLogs", dockerID, &logs, 0)
+	err := c.rpcClient.Call("Agent.GetDockerLogs", dockerID, &logs, 0, true)
 	return logs, err
 }

--- a/rpc/master/client.go
+++ b/rpc/master/client.go
@@ -40,7 +40,7 @@ func NewClient(addr string) (*Client, error) {
 }
 
 func (c *Client) call(name string, request interface{}, response interface{}) error {
-	return c.rpcClient.Call("Master."+name, request, response)
+	return c.rpcClient.Call("Master."+name, request, response, 0)
 }
 
 // Close closes rpc client

--- a/rpc/master/client.go
+++ b/rpc/master/client.go
@@ -40,7 +40,7 @@ func NewClient(addr string) (*Client, error) {
 }
 
 func (c *Client) call(name string, request interface{}, response interface{}) error {
-	return c.rpcClient.Call("Master."+name, request, response, 0)
+	return c.rpcClient.Call("Master."+name, request, response, 0, true)
 }
 
 // Close closes rpc client

--- a/rpc/rpcutils/clientlist_test.go
+++ b/rpc/rpcutils/clientlist_test.go
@@ -17,7 +17,7 @@ func (tc *testClient) Close() error {
 	return nil
 }
 
-func (tc *testClient) Call(serviceMethod string, args interface{}, reply interface{}, timeout int64, timewarn bool) error {
+func (tc *testClient) Call(serviceMethod string, args interface{}, reply interface{}, timeout uint64, timewarn bool) error {
 	return nil
 }
 

--- a/rpc/rpcutils/clientlist_test.go
+++ b/rpc/rpcutils/clientlist_test.go
@@ -20,7 +20,7 @@ func (tc *testClient) Close() error {
 	return nil
 }
 
-func (tc *testClient) Call(serviceMethod string, args interface{}, reply interface{}) error {
+func (tc *testClient) Call(serviceMethod string, args interface{}, reply interface{}, timeout int64) error {
 	return nil
 }
 

--- a/rpc/rpcutils/clientlist_test.go
+++ b/rpc/rpcutils/clientlist_test.go
@@ -4,10 +4,7 @@
 
 package rpcutils
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
 var count = 0
 
@@ -26,7 +23,6 @@ func (tc *testClient) Call(serviceMethod string, args interface{}, reply interfa
 
 func factory(addr string) (Client, error) {
 	count = count + 1
-	fmt.Printf("creating %d\n", count)
 	return &testClient{addr, count}, nil
 }
 

--- a/rpc/rpcutils/clientlist_test.go
+++ b/rpc/rpcutils/clientlist_test.go
@@ -17,7 +17,7 @@ func (tc *testClient) Close() error {
 	return nil
 }
 
-func (tc *testClient) Call(serviceMethod string, args interface{}, reply interface{}, timeout int64) error {
+func (tc *testClient) Call(serviceMethod string, args interface{}, reply interface{}, timeout int64, timewarn bool) error {
 	return nil
 }
 

--- a/rpc/rpcutils/clients.go
+++ b/rpc/rpcutils/clients.go
@@ -23,7 +23,7 @@ func SetDialTimeout(timeout int) {
 
 type Client interface {
 	Close() error
-	Call(serviceMethod string, args interface{}, reply interface{}, timeout int64) error
+	Call(serviceMethod string, args interface{}, reply interface{}, timeout int64, timewarn bool) error
 }
 
 // NewReconnectingClient creates a client that reuses the same connection and does not close the underlying connection unless an error occurs.
@@ -61,7 +61,7 @@ func (rc *reconnectingClient) Close() error {
 	return nil
 }
 
-func (rc *reconnectingClient) Call(serviceMethod string, args interface{}, reply interface{}, timeout int64) error {
+func (rc *reconnectingClient) Call(serviceMethod string, args interface{}, reply interface{}, timeout int64, timewarn bool) error {
 	// WARNING: Printing to stdout/err here can cause issues with zendev, e.g., your service
 	//          template may not deploy. This problem will go away once we move to using exit codes.
 	rc.RLock()
@@ -81,19 +81,27 @@ func (rc *reconnectingClient) Call(serviceMethod string, args interface{}, reply
 		//get read lock again
 		rc.RLock()
 	}
-	if timeout != 0 {
-		c := make(chan error, 1)
-		go func() {
-			c <- rpcClient.Call(serviceMethod, args, reply)
-		}()
+	if timeout == 0 {
+		timeout = 3153600000 // One hundred years in seconds.
+	}
+	c := make(chan error, 1)
+	go func() {
+		c <- rpcClient.Call(serviceMethod, args, reply)
+	}()
+	start := time.Now()
+Loop:
+	for {
 		select {
 		case err = <-c:
-			// do nothing, keep the error.
+			break Loop
 		case <-time.After(time.Duration(timeout) * time.Second):
 			err = fmt.Errorf("RPC call to %s timed out after %d seconds.", serviceMethod, timeout)
+			break Loop
+		case <-time.After(10 * time.Second):
+			if timewarn {
+				glog.Warningf("RPC call to %s has taken more than %ds.", serviceMethod, int(time.Since(start).Seconds()))
+			}
 		}
-	} else {
-		err = rpcClient.Call(serviceMethod, args, reply)
 	}
 	rc.RUnlock()
 	if err != nil {

--- a/rpc/rpcutils/clients.go
+++ b/rpc/rpcutils/clients.go
@@ -23,7 +23,7 @@ func SetDialTimeout(timeout int) {
 
 type Client interface {
 	Close() error
-	Call(serviceMethod string, args interface{}, reply interface{}, timeout int64, timewarn bool) error
+	Call(serviceMethod string, args interface{}, reply interface{}, timeout uint64, timewarn bool) error
 }
 
 // NewReconnectingClient creates a client that reuses the same connection and does not close the underlying connection unless an error occurs.
@@ -61,7 +61,7 @@ func (rc *reconnectingClient) Close() error {
 	return nil
 }
 
-func (rc *reconnectingClient) Call(serviceMethod string, args interface{}, reply interface{}, timeout int64, timewarn bool) error {
+func (rc *reconnectingClient) Call(serviceMethod string, args interface{}, reply interface{}, timeout uint64, timewarn bool) error {
 	// WARNING: Printing to stdout/err here can cause issues with zendev, e.g., your service
 	//          template may not deploy. This problem will go away once we move to using exit codes.
 	rc.RLock()
@@ -93,6 +93,9 @@ Loop:
 	for {
 		select {
 		case err = <-c:
+			if err == nil {
+				glog.V(2).Infof("RPC call %s finished after %ds.", serviceMethod, int(time.Since(start).Seconds()))
+			}
 			break Loop
 		case <-time.After(time.Duration(timeout) * time.Second):
 			err = fmt.Errorf("RPC call to %s timed out after %d seconds.", serviceMethod, timeout)

--- a/rpc/rpcutils/clients_test.go
+++ b/rpc/rpcutils/clients_test.go
@@ -1,0 +1,62 @@
+package rpcutils
+
+import (
+	"fmt"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"testing"
+	"time"
+)
+
+type RPCTestType int
+
+func (rtt *RPCTestType) Sleep(seconds *int, reply *int) error {
+	time.Sleep(time.Duration(*seconds) * time.Second)
+	return nil
+}
+
+func TestTimeout(t *testing.T) {
+	rtt := new(RPCTestType)
+	rpc.Register(rtt)
+	rpc.HandleHTTP()
+	listener, err := net.Listen("tcp", ":32111")
+	if err != nil {
+		t.Errorf("listen error: %s", err)
+	}
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			defer conn.Close()
+			if err != nil {
+				t.Errorf("Error accepting connections: %s", err)
+			}
+			go rpc.ServeCodec(jsonrpc.NewServerCodec(conn))
+		}
+	}()
+
+	client, err := NewReconnectingClient("localhost:32111")
+
+	var reply, seconds int
+
+	// Sleep for one second, timeout after two. Shouldn't error.
+	seconds = 1
+	err = client.Call("RPCTestType.Sleep", &seconds, &reply, 2)
+	if err != nil {
+		t.Errorf("RPCTestType.Sleep error: %s", err)
+	}
+
+	// Sleep for one second, never timeout. Shouldn't error.
+	seconds = 1
+	err = client.Call("RPCTestType.Sleep", &seconds, &reply, 0)
+	if err != nil {
+		t.Errorf("RPCTestType.Sleep error: %s", err)
+	}
+
+	// Sleep for two seconds, timeout after one. Should error.
+	seconds = 2
+	err = client.Call("RPCTestType.Sleep", &seconds, &reply, 1)
+	if fmt.Sprintf("%s", err) != "RPC call to RPCTestType.Sleep timed out after 1 seconds." {
+		t.Error("Should have timed out, but didn't.")
+	}
+}

--- a/rpc/rpcutils/clients_test.go
+++ b/rpc/rpcutils/clients_test.go
@@ -41,21 +41,21 @@ func TestTimeout(t *testing.T) {
 
 	// Sleep for one second, timeout after two. Shouldn't error.
 	seconds = 1
-	err = client.Call("RPCTestType.Sleep", &seconds, &reply, 2)
+	err = client.Call("RPCTestType.Sleep", &seconds, &reply, 2, false)
 	if err != nil {
 		t.Errorf("RPCTestType.Sleep error: %s", err)
 	}
 
 	// Sleep for one second, never timeout. Shouldn't error.
 	seconds = 1
-	err = client.Call("RPCTestType.Sleep", &seconds, &reply, 0)
+	err = client.Call("RPCTestType.Sleep", &seconds, &reply, 0, true)
 	if err != nil {
 		t.Errorf("RPCTestType.Sleep error: %s", err)
 	}
 
 	// Sleep for two seconds, timeout after one. Should error.
 	seconds = 2
-	err = client.Call("RPCTestType.Sleep", &seconds, &reply, 1)
+	err = client.Call("RPCTestType.Sleep", &seconds, &reply, 1, false)
 	if fmt.Sprintf("%s", err) != "RPC call to RPCTestType.Sleep timed out after 1 seconds." {
 		t.Error("Should have timed out, but didn't.")
 	}


### PR DESCRIPTION
By default, most RPC calls are set to no timeout. We'll need to nail down proper timeouts for all the things. To help identify RPC calls that are unexpectedly slow, a warning is printed every 10 seconds for outstanding RPC calls indicating how long they've been outstanding.