### PR TITLE
Add build tags to separate unit and integration tests

### DIFF
--- a/cli/api/backup_test.go
+++ b/cli/api/backup_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package api
 
 import (

--- a/cli/api/host_test.go
+++ b/cli/api/host_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package api
 
 import (

--- a/cli/api/logs_test.go
+++ b/cli/api/logs_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package api
 
 import (

--- a/cli/api/pool_test.go
+++ b/cli/api/pool_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package api
 
 import (

--- a/cli/api/script_test.go
+++ b/cli/api/script_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a
 // license that can be found in the LICENSE file.
 
+// +build unit
+
 package api
 
 import (

--- a/cli/api/service_test.go
+++ b/cli/api/service_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package api
 
 import (

--- a/cli/api/snapshot_test.go
+++ b/cli/api/snapshot_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package api
 
 import (

--- a/cli/api/template_test.go
+++ b/cli/api/template_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package api
 
 import (

--- a/cli/cmd/backup_test.go
+++ b/cli/cmd/backup_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package cmd
 
 import (

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package cmd
 
 import (

--- a/cli/cmd/healthcheck_test.go
+++ b/cli/cmd/healthcheck_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package cmd
 
 import (

--- a/cli/cmd/host_test.go
+++ b/cli/cmd/host_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package cmd
 
 import (

--- a/cli/cmd/parser_test.go
+++ b/cli/cmd/parser_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package cmd
 
 import (

--- a/cli/cmd/pool_test.go
+++ b/cli/cmd/pool_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package cmd
 
 import (

--- a/cli/cmd/server_test.go
+++ b/cli/cmd/server_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package cmd
 
 import (

--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package cmd
 
 import (

--- a/cli/cmd/snapshot_test.go
+++ b/cli/cmd/snapshot_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package cmd
 
 import (

--- a/cli/cmd/template_test.go
+++ b/cli/cmd/template_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package cmd
 
 import (

--- a/commons/atomicfile/atomicfile_test.go
+++ b/commons/atomicfile/atomicfile_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package atomicfile
 
 import (

--- a/commons/circular/buffer_test.go
+++ b/commons/circular/buffer_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package circular
 
 import (

--- a/commons/docker/container_test.go
+++ b/commons/docker/container_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build unit
+// +build integration
 
 package docker
 

--- a/commons/docker/container_test.go
+++ b/commons/docker/container_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package docker
 
 import (

--- a/commons/docker/image_test.go
+++ b/commons/docker/image_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build unit
+// +build integration
 
 package docker
 

--- a/commons/docker/image_test.go
+++ b/commons/docker/image_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package docker
 
 import (

--- a/commons/imageid_test.go
+++ b/commons/imageid_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package commons
 
 import (

--- a/commons/layer/squash_test.go
+++ b/commons/layer/squash_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package layer
 
 import (

--- a/commons/proc/nfsd_test.go
+++ b/commons/proc/nfsd_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package proc
 
 import (

--- a/commons/proc/nfsfs_test.go
+++ b/commons/proc/nfsfs_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package proc
 
 import (

--- a/commons/proc/stat_test.go
+++ b/commons/proc/stat_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package proc
 
 import (

--- a/commons/subprocess/instance_test.go
+++ b/commons/subprocess/instance_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package subprocess
 
 import (

--- a/container/logstash_test.go
+++ b/container/logstash_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 // Package agent implements a service that runs on a serviced node. It is
 // responsible for ensuring that a particular node is running the correct services
 // and reporting the state and health of those services back to the master

--- a/container/metric_forwarder_test.go
+++ b/container/metric_forwarder_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 // Package agent implements a service that runs on a serviced node. It is
 // responsible for ensuring that a particular node is running the correct services
 // and reporting the state and health of those services back to the master

--- a/container/proxy_test.go
+++ b/container/proxy_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package container
 
 import (

--- a/container/stats_test.go
+++ b/container/stats_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package container
 
 import (

--- a/coordinator/client/retry/ntimes_test.go
+++ b/coordinator/client/retry/ntimes_test.go
@@ -10,6 +10,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// +build unit
+
 package retry
 
 import (

--- a/coordinator/client/zookeeper/connection_test.go
+++ b/coordinator/client/zookeeper/connection_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package zookeeper
 
 import (

--- a/coordinator/client/zookeeper/leader_test.go
+++ b/coordinator/client/zookeeper/leader_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package zookeeper
 
 import (

--- a/coordinator/client/zookeeper/lock_test.go
+++ b/coordinator/client/zookeeper/lock_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package zookeeper
 
 import (

--- a/coordinator/storage/client_test.go
+++ b/coordinator/storage/client_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package storage
 
 import (

--- a/coordinator/storage/monitor_test.go
+++ b/coordinator/storage/monitor_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package storage
 
 import (

--- a/coordinator/storage/server_test.go
+++ b/coordinator/storage/server_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package storage
 
 import (

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package elasticsearch
 
 import (

--- a/dao/elasticsearch/registry_test.go
+++ b/dao/elasticsearch/registry_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 //This test is an integration test and need zookeeper which is why it isn't in the zzk/registry package
 package elasticsearch
 

--- a/dao/logstash_test.go
+++ b/dao/logstash_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 // Package agent implements a service that runs on a serviced node. It is
 // responsible for ensuring that a particular node is running the correct services
 // and reporting the state and health of those services back to the master

--- a/datastore/context_test.go
+++ b/datastore/context_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package datastore
 
 import (

--- a/datastore/elastic/connection_test.go
+++ b/datastore/elastic/connection_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package elastic_test
 
 import (

--- a/datastore/elastic/mapping_test.go
+++ b/datastore/elastic/mapping_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package elastic_test
 
 import (

--- a/datastore/elastic/testutils.go
+++ b/datastore/elastic/testutils.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package elastic
 
 import (

--- a/datastore/integration_test/datastore_test.go
+++ b/datastore/integration_test/datastore_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package integration_test
 
 import (

--- a/dfs/backup_test.go
+++ b/dfs/backup_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package dfs
 
 import (

--- a/dfs/nfs/common_test.go
+++ b/dfs/nfs/common_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package nfs
 
 import (

--- a/dfs/nfs/mounts_test.go
+++ b/dfs/nfs/mounts_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package nfs
 
 import (
@@ -70,4 +72,3 @@ func TestParseMounts(t *testing.T) {
 		}
 	}
 }
-

--- a/dfs/nfs/server_test.go
+++ b/dfs/nfs/server_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package nfs
 
 import (

--- a/dfs/snapshot_test.go
+++ b/dfs/snapshot_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package dfs
 
 import (

--- a/dfs/snapshotttl_test.go
+++ b/dfs/snapshotttl_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package dfs
 
 import (

--- a/domain/addressassignment/store_test.go
+++ b/domain/addressassignment/store_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package addressassignment
 
 import (

--- a/domain/addressassignment/validation_test.go
+++ b/domain/addressassignment/validation_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package addressassignment
 
 import (

--- a/domain/graph_test.go
+++ b/domain/graph_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package domain
 
 import (

--- a/domain/health_test.go
+++ b/domain/health_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package domain
 
 import (

--- a/domain/host/host_test.go
+++ b/domain/host/host_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package host
 
 import (

--- a/domain/host/hoststore_test.go
+++ b/domain/host/hoststore_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package host
 
 import (

--- a/domain/host/testutils.go
+++ b/domain/host/testutils.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package host
 
 type errorf interface {

--- a/domain/metric_test.go
+++ b/domain/metric_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package domain
 
 import (

--- a/domain/monitor_test.go
+++ b/domain/monitor_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package domain
 
 import (

--- a/domain/pool/poolstore_test.go
+++ b/domain/pool/poolstore_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package pool
 
 import (

--- a/domain/service/evaluate_test.go
+++ b/domain/service/evaluate_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package service
 
 import "testing"

--- a/domain/service/service_test.go
+++ b/domain/service/service_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 // Package agent implements a service that runs on a serviced node. It is
 // responsible for ensuring that a particular node is running the correct services
 // and reporting the state and health of those services back to the master

--- a/domain/service/serviceeval_test.go
+++ b/domain/service/serviceeval_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 // Package agent implements a service that runs on a serviced node. It is
 // responsible for ensuring that a particular node is running the correct services
 // and reporting the state and health of those services back to the master

--- a/domain/service/servicestore_test.go
+++ b/domain/service/servicestore_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package service
 
 import (

--- a/domain/service/validation_test.go
+++ b/domain/service/validation_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package service
 
 import ()

--- a/domain/serviceconfigfile/store_test.go
+++ b/domain/serviceconfigfile/store_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package serviceconfigfile
 
 import (

--- a/domain/serviceconfigfile/validation_test.go
+++ b/domain/serviceconfigfile/validation_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package serviceconfigfile
 
 import (

--- a/domain/servicedefinition/template_test.go
+++ b/domain/servicedefinition/template_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package servicedefinition
 
 import (
@@ -37,7 +39,7 @@ func init() {
 				ImageID: "ubuntu",
 				ConfigFiles: map[string]ConfigFile{
 					"/loadavg.sh": ConfigFile{Owner: "root:root", Filename: "/loadavg.sh", Permissions: "0775", Content: `#!/bin/bash
- 
+
 interval=1
 
 
@@ -46,7 +48,7 @@ if [ ! -x /usr/bin/curl ]; then
 		echo "Could not install curl"
 		exit 1
 	fi
-	
+
 fi
 echo "posting loadavg at $interval second(s) interval"
 while :
@@ -54,14 +56,14 @@ while :
 	now=` + "`date +%s`" + `
 	value=` + "`cat /proc/loadavg | cut -d ' ' -f 1`" + `
 	data="{\"control\":{\"type\":null,\"value\":null},\"metrics\":[{\"metric\":\"loadavg\",\"timestamp\":$now,\"value\":$value,\"tags\":{\"name\":\"value\"}}]}"
- 
+
 	output=` + "`curl -s -XPOST -H \"Content-Type: application/json\" -d \"$data\" \"$CONTROLPLANE_CONSUMER_URL\"`" + `
- 
+
 	if ! [[ "$output" == *OK* ]]
 	then
 		echo "failure";
 	fi
- 
+
 	sleep $interval
 done
 `},

--- a/domain/servicedefinition/testsvc/postmetrics/-CONFIGS-/loadavg.sh
+++ b/domain/servicedefinition/testsvc/postmetrics/-CONFIGS-/loadavg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
- 
+
 interval=1
 
 
@@ -8,7 +8,7 @@ if [ ! -x /usr/bin/curl ]; then
 		echo "Could not install curl"
 		exit 1
 	fi
-	
+
 fi
 echo "posting loadavg at $interval second(s) interval"
 while :
@@ -16,13 +16,13 @@ while :
 	now=`date +%s`
 	value=`cat /proc/loadavg | cut -d ' ' -f 1`
 	data="{\"control\":{\"type\":null,\"value\":null},\"metrics\":[{\"metric\":\"loadavg\",\"timestamp\":$now,\"value\":$value,\"tags\":{\"name\":\"value\"}}]}"
- 
+
 	output=`curl -s -XPOST -H "Content-Type: application/json" -d "$data" "$CONTROLPLANE_CONSUMER_URL"`
- 
+
 	if ! [[ "$output" == *OK* ]]
 	then
 		echo "failure";
 	fi
- 
+
 	sleep $interval
 done

--- a/domain/servicedefinition/testutils/testdefinitions.go
+++ b/domain/servicedefinition/testutils/testdefinitions.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit integration
+
 package testutils
 
 import (

--- a/domain/servicedefinition/validation_test.go
+++ b/domain/servicedefinition/validation_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package servicedefinition_test
 
 import (

--- a/domain/servicetemplate/templatestore_test.go
+++ b/domain/servicetemplate/templatestore_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package servicetemplate
 
 import (

--- a/domain/servicetemplate/validation_test.go
+++ b/domain/servicetemplate/validation_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package servicetemplate
 
 import (

--- a/domain/test/test.go
+++ b/domain/test/test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package main
 
 import (

--- a/domain/threshold_test.go
+++ b/domain/threshold_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package domain
 
 import (

--- a/domain/validation_test.go
+++ b/domain/validation_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package domain
 
 import (

--- a/facade/facade_test.go
+++ b/facade/facade_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package facade
 
 import (

--- a/facade/host_test.go
+++ b/facade/host_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package facade
 
 import (

--- a/facade/pool_test.go
+++ b/facade/pool_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package facade
 
 import (

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package facade
 
 import (

--- a/facade/servicetemplate_test.go
+++ b/facade/servicetemplate_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package facade
 
 import (

--- a/facade/testutils.go
+++ b/facade/testutils.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package facade
 
 import (

--- a/isvcs/es_test.go
+++ b/isvcs/es_test.go
@@ -1,3 +1,18 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build integration
+
 package isvcs
 
 import (

--- a/isvcs/manager_test.go
+++ b/isvcs/manager_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 // Package agent implements a service that runs on a serviced node. It is
 // responsible for ensuring that a particular node is running the correct services
 // and reporting the state and health of those services back to the master

--- a/isvcs/testutils.go
+++ b/isvcs/testutils.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package isvcs
 
 import (

--- a/metrics/memoryusage_test.go
+++ b/metrics/memoryusage_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package metrics
 
 import (

--- a/node/agent_proxy_test.go
+++ b/node/agent_proxy_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 // Package agent implements a service that runs on a serviced node. It is
 // responsible for ensuring that a particular node is running the correct services
 // and reporting the state and health of those services back to the master

--- a/node/agent_test.go
+++ b/node/agent_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package node
 
 import (

--- a/node/utils_test.go
+++ b/node/utils_test.go
@@ -16,6 +16,8 @@
 // and reporting the state and health of those services back to the master
 // serviced.
 
+// +build integration
+
 package node
 
 import (

--- a/proxy/mux_test.go
+++ b/proxy/mux_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package proxy
 
 import (
@@ -18,8 +20,8 @@ import (
 	"io"
 	"net"
 	"strings"
-	"time"
 	"testing"
+	"time"
 )
 
 type echoListener struct {
@@ -53,7 +55,7 @@ func connectToListener(listener net.Listener) (net.Conn, error) {
 	return net.Dial("tcp", fmt.Sprintf("127.0.0.1:%s", port))
 }
 
-func (e *echoListener) Connect() (net.Conn) {
+func (e *echoListener) Connect() net.Conn {
 	conn, err := connectToListener(e.listener)
 	if err != nil {
 		e.t.Fatalf("could not connect to echo server: %s", err)

--- a/rpc/agent/agent_test.go
+++ b/rpc/agent/agent_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package agent
 
 import (

--- a/rpc/rpcutils/clientlist_test.go
+++ b/rpc/rpcutils/clientlist_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a
 // license that can be found in the LICENSE file.
 
+// +build unit
+
 package rpcutils
 
 import "testing"

--- a/rpc/rpcutils/clients_test.go
+++ b/rpc/rpcutils/clients_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package rpcutils
 
 import (

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -22,12 +22,14 @@ function stop_elastic {
 
 stop_elastic
 
+echo "Running unit tests ..."
 START_TIME=`date --utc +%s`
 godep go test -tags=unit $GOTEST ./...
 UNIT_TEST_RESULT=$?
 END_TIME=`date --utc +%s`
 echo "Unit tests finished in $(($END_TIME - $START_TIME)) seconds"
 
+echo "Running integration tests ..."
 START_TIME=`date --utc +%s`
 mkdir $ES_TMP
 if [ ! -e /tmp/elasticsearch-$ES_VER.tar.gz ]; then

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -22,9 +22,11 @@ function stop_elastic {
 
 stop_elastic
 
+BUILD_TAGS="$(bash ${DIR}/build-tags.sh)"
+
 echo "Running unit tests ..."
 START_TIME=`date --utc +%s`
-godep go test -tags=unit $GOTEST ./...
+godep go test -tags="${BUILD_TAGS} unit" $GOTEST ./...
 UNIT_TEST_RESULT=$?
 END_TIME=`date --utc +%s`
 echo "Unit tests finished in $(($END_TIME - $START_TIME)) seconds"
@@ -40,7 +42,6 @@ tar -xf /tmp/elasticsearch-$ES_VER.tar.gz -C $ES_TMP
 echo "cluster.name: zero" > $ES_DIR/config/elasticsearch.yml
 $ES_DIR/bin/elasticsearch -f -Des.http.port=9202 > $ES_TMP/elastic.log & echo $!>$ES_TMP/pid
 
-BUILD_TAGS="$(bash ${DIR}/build-tags.sh)"
 godep go test -tags="${BUILD_TAGS} integration" $GOTEST ./...
 INTEGRATION_TEST_RESULT=$?
 stop_elastic

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -22,6 +22,13 @@ function stop_elastic {
 
 stop_elastic
 
+START_TIME=`date --utc +%s`
+godep go test -tags=unit $GOTEST ./...
+UNIT_TEST_RESULT=$?
+END_TIME=`date --utc +%s`
+echo "Unit tests finished in $(($END_TIME - $START_TIME)) seconds"
+
+START_TIME=`date --utc +%s`
 mkdir $ES_TMP
 if [ ! -e /tmp/elasticsearch-$ES_VER.tar.gz ]; then
 	curl https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VER.tar.gz > /tmp/elasticsearch-$ES_VER.tar.gz;
@@ -32,9 +39,10 @@ echo "cluster.name: zero" > $ES_DIR/config/elasticsearch.yml
 $ES_DIR/bin/elasticsearch -f -Des.http.port=9202 > $ES_TMP/elastic.log & echo $!>$ES_TMP/pid
 
 BUILD_TAGS="$(bash ${DIR}/build-tags.sh)"
-godep go test -tags="${BUILD_TAGS}" $GOTEST ./...
-RESULT=$?
-
+godep go test -tags="${BUILD_TAGS} integration" $GOTEST ./...
+INTEGRATION_TEST_RESULT=$?
 stop_elastic
+END_TIME=`date --utc +%s`
+echo "Integration tests finished in $(($END_TIME - $START_TIME)) seconds"
 
-exit $RESULT
+exit $(($UNIT_TEST_RESULT + $INTEGRATION_TEST_RESULT))

--- a/scheduler/hostpolicy_test.go
+++ b/scheduler/hostpolicy_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package scheduler
 
 import (

--- a/script/eval_test.go
+++ b/script/eval_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a
 // license that can be found in the LICENSE file.
 
+// +build unit
+
 package script
 
 import (

--- a/script/nodes_test.go
+++ b/script/nodes_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a
 // license that can be found in the LICENSE file.
 
+// +build unit
+
 package script
 
 import (

--- a/script/parser_test.go
+++ b/script/parser_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a
 // license that can be found in the LICENSE file.
 
+// +build unit
+
 package script
 
 import (

--- a/script/runner_test.go
+++ b/script/runner_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a
 // license that can be found in the LICENSE file.
 
+// +build unit
+
 package script
 
 import (

--- a/servicedversion/servicedversion_test.go
+++ b/servicedversion/servicedversion_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package servicedversion
 
 import (

--- a/stats/cgroup/cgroup_test.go
+++ b/stats/cgroup/cgroup_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 // Package cgroup provides access to /sys/fs/cgroup metrics.
 
 package cgroup

--- a/utils/cmd_test.go
+++ b/utils/cmd_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package utils
 
 import (

--- a/utils/directory_test.go
+++ b/utils/directory_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 // Package agent implements a service that runs on a serviced node. It is
 // responsible for ensuring that a particular node is running the correct services
 // and reporting the state and health of those services back to the master

--- a/utils/engnotation_test.go
+++ b/utils/engnotation_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package utils
 
 import (

--- a/utils/filelock_test.go
+++ b/utils/filelock_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package utils
 
 import (

--- a/utils/strings_test.go
+++ b/utils/strings_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package utils
 
 import (

--- a/utils/ttl_test.go
+++ b/utils/ttl_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package utils
 
 import (

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 // Package agent implements a service that runs on a serviced node. It is
 // responsible for ensuring that a particular node is running the correct services
 // and reporting the state and health of those services back to the master

--- a/utils/uuid_test.go
+++ b/utils/uuid_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package utils
 
 import (

--- a/validation/validators_test.go
+++ b/validation/validators_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package validation
 
 import (

--- a/volume/btrfs/btrfs_test.go
+++ b/volume/btrfs/btrfs_test.go
@@ -1,5 +1,3 @@
-// +build root
-
 // Copyright 2014 The Serviced Authors.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build integration
+// +build root,integration
 
 package btrfs_test
 

--- a/volume/btrfs/btrfs_test.go
+++ b/volume/btrfs/btrfs_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package btrfs_test
 
 import (

--- a/volume/devicemapper/devicemapper_test.go
+++ b/volume/devicemapper/devicemapper_test.go
@@ -1,5 +1,3 @@
-// +build root
-
 // Copyright 2015 The Serviced Authors.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// +build root,integration
 
 package devicemapper_test
 

--- a/volume/drivertest/drivertest.go
+++ b/volume/drivertest/drivertest.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package drivertest
 
 import (

--- a/volume/rsync/rsync_test.go
+++ b/volume/rsync/rsync_test.go
@@ -1,5 +1,3 @@
-// +build root
-
 // Copyright 2015 The Serviced Authors.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build integration
+// +build root,integration
+
 package rsync_test
 
 import (

--- a/volume/rsync/rsync_test.go
+++ b/volume/rsync/rsync_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
 package rsync_test
 
 import (

--- a/volume/util_test.go
+++ b/volume/util_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package volume_test
 
 import (

--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package volume_test
 
 import (

--- a/web/gzip_test.go
+++ b/web/gzip_test.go
@@ -1,3 +1,18 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
 package web
 
 import (

--- a/web/hostresource_test.go
+++ b/web/hostresource_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package web
 
 import (

--- a/web/poolresource_test.go
+++ b/web/poolresource_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package web
 
 import (

--- a/zzk/docker/action_test.go
+++ b/zzk/docker/action_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// build +integration
+
 package docker
 
 import (

--- a/zzk/docker/action_test.go
+++ b/zzk/docker/action_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// build +integration
+// +build integration
 
 package docker
 

--- a/zzk/service/host_test.go
+++ b/zzk/service/host_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// build +integration
+// +build integration
 
 package service
 

--- a/zzk/service/host_test.go
+++ b/zzk/service/host_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// build +integration
+
 package service
 
 import (

--- a/zzk/service/hostregistry_test.go
+++ b/zzk/service/hostregistry_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// build +integration
+// +build integration
 
 package service
 

--- a/zzk/service/hostregistry_test.go
+++ b/zzk/service/hostregistry_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// build +integration
+
 package service
 
 import (

--- a/zzk/service/lock_test.go
+++ b/zzk/service/lock_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package service
 
 import (

--- a/zzk/service/running_test.go
+++ b/zzk/service/running_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// build +integration
+// +build integration
 
 package service
 

--- a/zzk/service/running_test.go
+++ b/zzk/service/running_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// build +integration
+
 package service
 
 import (

--- a/zzk/service/service_test.go
+++ b/zzk/service/service_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// build +integration
+// +build integration
 
 package service
 

--- a/zzk/service/service_test.go
+++ b/zzk/service/service_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// build +integration
+
 package service
 
 import (

--- a/zzk/service/servicestate_test.go
+++ b/zzk/service/servicestate_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// build +integration
+// +build integration
 
 package service
 

--- a/zzk/service/servicestate_test.go
+++ b/zzk/service/servicestate_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// build +integration
+
 package service
 
 import (

--- a/zzk/service/utils_test.go
+++ b/zzk/service/utils_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package service
 
 import (

--- a/zzk/snapshot/snapshot_test.go
+++ b/zzk/snapshot/snapshot_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// build +integration
+
 package snapshot
 
 import (

--- a/zzk/snapshot/snapshot_test.go
+++ b/zzk/snapshot/snapshot_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// build +integration
+// +build integration
 
 package snapshot
 

--- a/zzk/testutils.go
+++ b/zzk/testutils.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// build +integration
+// +build integration
 
 package zzk
 

--- a/zzk/testutils.go
+++ b/zzk/testutils.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// build +integration
+
 package zzk
 
 import (

--- a/zzk/virtualips/virtualips_test.go
+++ b/zzk/virtualips/virtualips_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// build +integration
+
 package virtualips
 
 import (

--- a/zzk/virtualips/virtualips_test.go
+++ b/zzk/virtualips/virtualips_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// build +integration
+// +build integration
 
 package virtualips
 

--- a/zzk/zzk_test.go
+++ b/zzk/zzk_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// build +integration
+// +build integration
 
 package zzk
 

--- a/zzk/zzk_test.go
+++ b/zzk/zzk_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// build +integration
+
 package zzk
 
 import (


### PR DESCRIPTION
The goal was to measure the time differential btwn the different tests.

Out of a total of 133 `*test*.go` files, I tagged 79 as unit tests, and 53 as integration tests.  On my workstation, all of the unit-tests complete in 48 seconds, and the integration tests take ~657 seconds to complete.  I defined "integration test" as anything that used Elastic, Zookeeper or Docker.