### PR TITLE
Update pkg dependencies to dockerproject.org.

### DIFF
--- a/pkg/makefile
+++ b/pkg/makefile
@@ -161,10 +161,10 @@ deb: stage_deb
 		-s dir \
 		-d nfs-kernel-server \
 		-d net-tools \
-		-d libdevmapper \
-		-d libdevmapper-event \
+		-d libdevmapper1.02.1 \
+		-d libdevmapper-event1.02.1 \
 		-d nfs-common \
-		-d 'lxc-docker-1.7.1' \
+		-d 'docker-engine (= 1.7.1-0~trusty)' \
 		-d logrotate \
 		-t deb \
 		-a x86_64 \
@@ -197,7 +197,7 @@ rpm: stage_rpm
 		-d device-mapper-event \
 		-d device-mapper-event-libs \
 		-d device-mapper-libs \
-		-d 'zenoss-docker = 1.7.1' \
+		-d 'docker-engine = 1.7.1' \
 		-d logrotate \
 		-t rpm \
 		-a x86_64 \


### PR DESCRIPTION
Demo updating 1.0.5 to 1.1.0 on Centos 7, uninstalling zenoss-docker without removing serviced: https://gist.githubusercontent.com/wwwtyro/a51cf7cacd12b0badff9/raw/3592d22422ea4b9c313272e5b096705034477938/gistfile1.txt

Demo updating 1.0.5 to 1.1.0 on Ubuntu 14.04, uninstalling zenoss-docker without removing serviced: https://gist.githubusercontent.com/wwwtyro/e401962dadb52d335a78/raw/a3bd6f4bfc50047accd128c139122d03463135d8/gistfile1.txt