### PR TITLE
Add acceptance.sh to start serviced and run acceptance tests in Jenkins

### DIFF
--- a/acceptance.sh
+++ b/acceptance.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#######################################################
+#
+# Control Center Acceptance Test
+#
+# You must define the serviced login credentials by setting
+# the environment variables APPLICATION_USERID
+# and APPLICATION_PASSWORD before running this script.
+#
+#######################################################
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+SERVICED=${DIR}/serviced
+IP=$(/sbin/ifconfig docker0 | grep 'inet addr:' | cut -d: -f2 | awk {'print $1'})
+HOSTNAME=$(hostname)
+
+succeed() {
+    echo ===== SUCCESS =====
+    echo $@
+    echo ===================
+}
+
+fail() {
+    echo ====== FAIL ======
+    echo $@
+    echo ==================
+    exit 1
+}
+
+# install prereqs
+install_prereqs() {
+    local wget_image="zenoss/ubuntu:wget"
+    if ! docker inspect "${wget_image}" >/dev/null; then
+        docker pull "${wget_image}"
+       if ! docker inspect "${wget_image}" >/dev/null; then
+            fail "ERROR: docker image "${wget_image}" is not available - wget tests will fail"
+       fi
+    fi
+}
+
+# Add the vhost to /etc/hosts so we can resolve it for the test
+add_to_etc_hosts() {
+    if [ -z "$(grep -e "^${IP} websvc.${HOSTNAME}" /etc/hosts)" ]; then
+        sudo /bin/bash -c "echo ${IP} websvc.${HOSTNAME} >> /etc/hosts"
+    fi
+}
+
+start_serviced() {
+    echo "Starting serviced..."
+    sudo GOPATH=${GOPATH} PATH=${PATH} SERVICED_NOREGISTRY="true" ${SERVICED} -master -agent server &
+
+    echo "Waiting 180 seconds for serviced to become the leader..."
+    retry 180 wget --no-check-certificate http://${HOSTNAME}:443 -O- &>/dev/null
+    return $?
+}
+
+retry() {
+    TIMEOUT=$1
+    shift
+    COMMAND="$@"
+    DURATION=0
+    until [ ${DURATION} -ge ${TIMEOUT} ]; do
+        TRY_COUNTDOWN=$[${TIMEOUT} - ${DURATION}]
+        ${COMMAND}; RESULT=$?; [ ${RESULT} = 0 ] && break
+        DURATION=$[$DURATION+1]
+        sleep 1
+    done
+    return ${RESULT}
+}
+
+# Add a host
+add_host() {
+    HOST_ID=$(${SERVICED} host add "${IP}:4979" default)
+    sleep 1
+    [ -z "$(${SERVICED} host list ${HOST_ID} 2>/dev/null)" ] && return 1
+    return 0
+}
+
+cleanup() {
+    echo "Stopping serviced and mockAgent"
+    sudo pkill -9 serviced
+    sudo pkill -9 mockAgent
+    sudo pkill -9 startMockAgent
+
+    echo "Removing all docker containers"
+    docker ps -a -q | xargs --no-run-if-empty docker rm -fv
+
+    sudo rm -rf /tmp/serviced-root/var
+}
+trap cleanup EXIT
+
+
+# Force a clean environment
+cleanup
+
+# Setup
+install_prereqs
+add_to_etc_hosts
+
+start_serviced             && succeed "Serviced became leader within timeout"    || fail "serviced failed to become the leader within 120 seconds."
+retry 20 add_host          && succeed "Added host successfully"                  || fail "Unable to add host"
+
+# build/start mock agents
+make mockAgent
+cd ${DIR}/acceptance
+sudo GOPATH=${GOPATH} PATH=${PATH} ./startMockAgents.sh --no-wait
+
+# launch cucumber/capybara
+./runUIAcceptance.sh -a https://${HOSTNAME}
+
+# "trap cleanup EXIT", above, will handle cleanup

--- a/acceptance/startMockAgents.sh
+++ b/acceptance/startMockAgents.sh
@@ -1,7 +1,28 @@
 #!/bin/bash
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+wait_forever=true
+
+while (( "$#" )); do
+    if [ "$1" == "--no-wait" ]; then
+         wait_forever=false
+        shift 1
+    else
+        if [ "$1" != "-h" ]; then
+            echo "ERROR: invalid argument '$1'"
+        fi
+        echo "USAGE: startMockAgents.sh [--no-wait]"
+        echo ""
+        echo "where"
+        echo "    --no-wait    do not wait"
+        exit 1
+    fi
+
+done
 
 set -e
 
+cd ${DIR}
 echo `mockAgent/mockAgent --config-file ui/features/data/default/hosts.json --host defaultHost` &
 echo `mockAgent/mockAgent --config-file ui/features/data/default/hosts.json --host host2` &
 echo `mockAgent/mockAgent --config-file ui/features/data/default/hosts.json --host host3` &
@@ -15,7 +36,7 @@ while [ $WAIT -lt 5 ]; do
   let WAIT=WAIT+1
 done
 
-if jobs -l | grep -q "Done"; 
+if jobs -l | grep -q "Done";
   then
     jobs 1>&2
     echo "Mock agent(s) failed, closing" 1>&2
@@ -25,6 +46,6 @@ fi
 
 echo "Mock agents up, test suite may be run"
 
-while true; 
+while $wait_forever ;
   do sleep 5m;
 done


### PR DESCRIPTION
Add acceptance.sh to start serviced and run acceptance tests in Jenkins

WIP - needs to be validated on another local dev box. After it's merged, we can try adding to Jenkins build. Once it's running in Jenkins with proper reporting, then we can update the script (and possibly the tests) to use a well-known application template.

To test locally, run as
```
$ cdz serviced
$ make clean build
$ APPLICATION_USERID=yourUserID APPLICATION_PASSWORD=yourPassword CUCUMBER_OPTS="--tags @login" ./acceptance.sh
```

Note that until we resolve the issue with Application Template, it's sufficient just to run a limited set of tests like `@login`

Also, the current runCucumber.sh script is not returning non-zero values for failed tests. We'll need to fix that also.