### PR TITLE
Store zookeeper logs in the isvcs container

### DIFF
--- a/isvcs/zk.go
+++ b/isvcs/zk.go
@@ -38,10 +38,12 @@ var exhibitorPortBinding = portBinding{
 }
 
 var Zookeeper = IServiceDefinition{
-	Name:         "zookeeper",
-	Repo:         IMAGE_REPO,
-	Tag:          IMAGE_TAG,
-	Command:      func() string { return "exec /opt/zookeeper-3.4.5/bin/zkServer.sh start-foreground" },
+	Name: "zookeeper",
+	Repo: IMAGE_REPO,
+	Tag:  IMAGE_TAG,
+	Command: func() string {
+		return "ZOO_LOG_DIR=/opt/zenoss/log ZOO_LOG4J_PROP=INFO,ROLLINGFILE exec /opt/zookeeper-3.4.5/bin/zkServer.sh start-foreground"
+	},
 	PortBindings: []portBinding{zookeeperPortBinding, exhibitorPortBinding},
 	Volumes:      map[string]string{"data": "/tmp"},
 }


### PR DESCRIPTION
This PR does NOT fix CC-1140. Before this PR, zookeeper log spamming was written to ZK's stdout which was collected by Docker and recorded in `/var/lib/docker`. So an out-of-control ZK could potentially fill up /var/lib/docker.  

With the changes in this PR, the ZK for isvcs will write it's logs to files inside the isvc container. The log4j.properties for ZK is already setup to keep ten 10MB log files, so the log spam will be constrained to no more than 100MB. This is consistent with the other isvcs.