### PR TITLE
Add back the remove-app-instance scenario

### DIFF
--- a/acceptance/ui/features/applications.feature
+++ b/acceptance/ui/features/applications.feature
@@ -172,7 +172,7 @@ Feature: Application Management
 
   @clean_hosts
   Scenario: Remove an instance of the default template
-    Given PENDING only the default host is added
+    Given only the default host is added
       And that the "table://applications/defaultApp/template" application with the "table://applications/defaultApp/id" Deployment ID is added
     When I remove "table://applications/defaultApp/template" from the Applications list
     Then I should see "Remove Application"


### PR DESCRIPTION
Now that #1869 has been merged, we can restore the test for remove application instance.