### PR TITLE
Cleanup before, during, and after different test runs

### DIFF
--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -1,26 +1,52 @@
 #!/bin/bash
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
 set -e
 set -x
-docker ps -a -q | xargs --no-run-if-empty docker rm -fv
+
+cleanup() {
+	sudo umount /exports/serviced_var || true
+	sudo umount /exports/serviced_var_volumes || true
+	sudo rm /tmp/serviced-root/var/isvcs/* -Rf
+	sudo rm /tmp/serviced-test -Rf
+	sudo rm /tmp/serviced* -Rf
+	docker ps -a -q | xargs --no-run-if-empty docker rm -fv
+}
+
+#
+# Run cleanup first in case a previous build left anything behind
+#
+cleanup
+
+#
+# Setup
+#
 unset EDITOR # so we don't fail a cli test :\
 gvm use go1.4.2
 go version
 docker version
+docker images | egrep 'zenoss/ubuntu[ ]+wget' || docker pull zenoss/ubuntu:wget
 export GOPATH=$WORKSPACE/gopath
 export PATH=$GOPATH/bin:$PATH
-sudo umount /exports/serviced_var || true
-sudo umount /exports/serviced_var_volumes || true
-sudo rm /tmp/serviced-root/var/isvcs/* -Rf
-sudo rm /tmp/serviced-test -Rf
-docker ps -a -q | xargs --no-run-if-empty docker rm -fv
-docker images | egrep 'zenoss/ubuntu[ ]+wget' || docker pull zenoss/ubuntu:wget
 go get github.com/tools/godep
 cd $GOPATH/src/github.com/control-center/serviced
-BUILD_TAGS="$(sudo bash ${DIR}/build-tags.sh)"
+
+#
+# First, run the tests that require root
+#
+BUILD_TAGS="$(sudo bash ${DIR}/build-tags.sh) integration"
 sudo su - root -c "source /home/jenkins/.gvm/scripts/gvm; gvm use go1.4.2; cd $PWD/volume; GOPATH=$GOPATH godep go test -tags=\"${BUILD_TAGS}\" ./..."
+
+#
+# Second, run the regular battery of tests
+#
+cleanup
 make clean test DOCKERCFG=""
-docker ps -a -q | xargs --no-run-if-empty docker rm -fv
-sudo rm /tmp/serviced* -Rf
-make
+
+#
+# Lastly, run the smoke tests
+#
+cleanup
 make smoketest DOCKERCFG=""
+
+cleanup


### PR DESCRIPTION
This change is intended to fix the recurring build problems we see where the setup for dao/elasticsearch/controlplanedao_test fails with errors like:
```
E0812 13:27:19.532070 10871 container.go:318] could not create /tmp/serviced-jenkins/var/isvcs/opentsdb/hbase on host: mkdir /tmp/serviced-jenkins/var/isvcs/opentsdb: permission denied
``` 
We haven't been able to reproduce this problem, but suspect that a previous build exited without cleaning up anything, leaving potential problems like the permission-denied errors for subsequent builds.   The fact that rebooting the build slave clears the errors supports that theory.  

Note that if a build fails, it's actually advantageous to NOT cleanup in case someone needs to inspect the machine for a detailed post mortem.