### PR TITLE
Update serviced-isvcs image to include changes to zookeeper log purging.

### DIFF
--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -27,7 +27,7 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO = "zenoss/serviced-isvcs"
-	IMAGE_TAG  = "v30"
+	IMAGE_TAG  = "v31"
 )
 
 func Init() {

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -27,7 +27,7 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO = "zenoss/serviced-isvcs"
-	IMAGE_TAG  = "v31"
+	IMAGE_TAG  = "v32"
 )
 
 func Init() {

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -27,7 +27,7 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO = "zenoss/serviced-isvcs"
-	IMAGE_TAG  = "v32"
+	IMAGE_TAG  = "v31"
 )
 
 func Init() {


### PR DESCRIPTION
This PR involves a change to isvcs. 

/zookeeper-3.4.5/conf/zoo.cfg was altered to engage the autopurge system:

```
# The number of snapshots to retain in dataDir
autopurge.snapRetainCount=3
# Purge task interval in hours
# Set to "0" to disable auto purge feature
autopurge.purgeInterval=1
```