### PR TITLE
Fix false negatives in tests for sorting behavior

### DIFF
--- a/acceptance/ui/features/steps/generic_steps.rb
+++ b/acceptance/ui/features/steps/generic_steps.rb
@@ -225,15 +225,17 @@ def closeDialog()
 end
 
 def sortColumn(category, sortOrder)
-    categoryLink = page.find("[class^='header  sortable']", :text => /\A#{category}\z/)
     if sortOrder == "ascending"
         order = 'header  sortable sort-asc'
     else
         order = 'header  sortable sort-desc'
     end
+
     # click until column header shows ascending/descending
+    categoryLink = page.find("[class^='header  sortable']", :text => /\A#{category}\z/)
     while categoryLink[:class] != order do
         categoryLink.click()
+        categoryLink = page.find("[class^='header  sortable']", :text => /\A#{category}\z/)
     end
 end
 


### PR DESCRIPTION
The previous tests went into a hard-loop clicking an element and testing if it's CSS class had changed, this worked most of the time, but not all of the time.  Examples of failed builds due to test bugs:
 * http://jenkins.zendev.org/job/serviced-develop/1035/
 * http://jenkins.zendev.org/job/serviced-develop/1030/

Also, in looking at past test history, there are several examples where the When step to click on the sortable column took 10-20 seconds which indicates some kind of problem with that loop.  My best guess is that it is a bad coding practice to use an element reference after interactions with the element.  So I changed the code to retrieve the element reference after the header click.