### PR TITLE
Feature/cc 1222

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -14,6 +14,7 @@
 package api
 
 import (
+	"github.com/control-center/serviced/commons/docker"
 	coordclient "github.com/control-center/serviced/coordinator/client"
 	coordzk "github.com/control-center/serviced/coordinator/client/zookeeper"
 	"github.com/control-center/serviced/coordinator/storage"
@@ -100,6 +101,10 @@ type daemon struct {
 	waitGroup        *sync.WaitGroup
 	rpcServer        *rpc.Server
 	networkDriver    storage.StorageDriver
+}
+
+func init() {
+	docker.StartKernel()
 }
 
 func newDaemon(servicedEndpoint string, staticIPs []string, masterPoolID string) (*daemon, error) {

--- a/commons/docker/container_test.go
+++ b/commons/docker/container_test.go
@@ -25,6 +25,12 @@ import (
 	dockerclient "github.com/fsouza/go-dockerclient"
 )
 
+func TestMain(m *testing.M) {
+	StartKernel()
+	defer func() { done <- struct{}{} }()
+	os.Exit(m.Run())
+}
+
 func TestContainerCommit(t *testing.T) {
 	cd := &ContainerDefinition{
 		dockerclient.CreateContainerOptions{

--- a/commons/docker/kernel.go
+++ b/commons/docker/kernel.go
@@ -96,14 +96,13 @@ var (
 	done = make(chan struct{})
 )
 
-// init starts up the kernel loop that is responsible for handling all the API calls
+// StartKernel starts up the kernel loop that is responsible for handling all the API calls
 // in a goroutine.
-func init() {
+func StartKernel() {
 	client, err := getDockerClient()
 	if err != nil {
 		panic(fmt.Sprintf("can't create Docker client: %v", err))
 	}
-
 	go kernel(client, done)
 }
 

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -17,6 +17,7 @@ package elasticsearch
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -24,6 +25,7 @@ import (
 	"time"
 
 	"github.com/control-center/serviced/commons"
+	"github.com/control-center/serviced/commons/docker"
 	coordclient "github.com/control-center/serviced/coordinator/client"
 	coordzk "github.com/control-center/serviced/coordinator/client/zookeeper"
 	"github.com/control-center/serviced/dao"
@@ -80,6 +82,11 @@ func (m MockStorageDriver) Restart() error {
 
 func (m MockStorageDriver) Stop() error {
 	return nil
+}
+
+func TestMain(m *testing.M) {
+	docker.StartKernel()
+	os.Exit(m.Run())
 }
 
 // This plumbs gocheck into testing

--- a/isvcs/manager_test.go
+++ b/isvcs/manager_test.go
@@ -21,11 +21,19 @@
 package isvcs
 
 import (
+	"os"
+
+	"github.com/control-center/serviced/commons/docker"
 	"github.com/control-center/serviced/utils"
 
 	"testing"
 	"time"
 )
+
+func TestMain(m *testing.M) {
+	docker.StartKernel()
+	os.Exit(m.Run())
+}
 
 func TestManager(t *testing.T) {
 	testManager := NewManager(utils.LocalDir("images"), "/tmp")

--- a/isvcs/testutils.go
+++ b/isvcs/testutils.go
@@ -16,6 +16,7 @@
 package isvcs
 
 import (
+	"github.com/control-center/serviced/commons/docker"
 	"github.com/control-center/serviced/utils"
 	. "gopkg.in/check.v1"
 )
@@ -33,6 +34,7 @@ type ManagerTestSuite struct {
 }
 
 func (t *ManagerTestSuite) SetUpSuite(c *C) {
+	docker.StartKernel()
 	t.manager = NewManager(utils.LocalDir("images"), "/tmp/serviced-test")
 	for _, testservice := range t.testservices {
 		svc := testservice.GetService(c)


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-1222
Do not start the docker kernel when running serviced as a container controller.