### PR TITLE
'--es-startup-timeout' CLI flag not respected

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -142,7 +142,7 @@ func (d *daemon) getEsClusterName(Type string) string {
 }
 
 func (d *daemon) startISVCS() {
-	isvcs.Init()
+	isvcs.Init(options.ESStartupTimeout)
 	isvcs.Mgr.SetVolumesDir(path.Join(options.VarPath, "isvcs"))
 	if err := isvcs.Mgr.SetConfigurationOption("elasticsearch-serviced", "cluster", d.getEsClusterName("elasticsearch-serviced")); err != nil {
 		glog.Fatalf("Could not set es-serviced option: %s", err)

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -79,7 +79,7 @@ func New(driver api.API, config utils.ConfigReader) *ServicedCli {
 		cli.StringSliceFlag{"mount", convertToStringSlice(defaultOps.Mount), "bind mount: DOCKER_IMAGE,HOST_PATH[,CONTAINER_PATH]"},
 		cli.StringFlag{"fstype", string(defaultOps.FSType), "driver for underlying file system"},
 		cli.StringSliceFlag{"alias", convertToStringSlice(defaultOps.HostAliases), "list of aliases for this host, e.g., localhost"},
-		cli.IntFlag{"es-startup-timeout", defaultOps.ESStartupTimeout, "time to wait on elasticsearch startup before bailing"},
+		cli.IntFlag{"es-startup-timeout", defaultOps.ESStartupTimeout, "time (in seconds) to wait on elasticsearch startup before bailing"},
 		cli.IntFlag{"max-container-age", defaultOps.MaxContainerAge, "maximum age (seconds) of a stopped container before removing"},
 		cli.IntFlag{"max-dfs-timeout", defaultOps.MaxDFSTimeout, "max timeout to perform a dfs snapshot"},
 		cli.StringFlag{"virtual-address-subnet", defaultOps.VirtualAddressSubnet, "/16 subnet for virtual addresses"},

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"time"
 
 	"github.com/codegangsta/cli"
 	"github.com/control-center/serviced/cli/api"
@@ -51,7 +50,7 @@ func getDefaultOptions(config utils.ConfigReader) api.Options {
 		MCUsername:           "scott",
 		MCPasswd:             "tiger",
 		FSType:               volume.DriverType(config.StringVal("FS_TYPE", "rsync")),
-		ESStartupTimeout:     getDefaultESStartupTimeout(config.IntVal("ES_STARTUP_TIMEOUT", int(isvcs.DEFAULT_ES_STARTUP_TIMEOUT / time.Second))),
+		ESStartupTimeout:     getDefaultESStartupTimeout(config.IntVal("ES_STARTUP_TIMEOUT", isvcs.DEFAULT_ES_STARTUP_TIMEOUT_SECONDS)),
 		HostAliases:          config.StringSlice("VHOST_ALIASES", []string{}),
 		Verbosity:            config.IntVal("LOG_LEVEL", 0),
 		StaticIPs:            config.StringSlice("STATIC_IPS", []string{}),
@@ -121,7 +120,7 @@ func getDefaultVarPath(home string) string {
 }
 
 func getDefaultESStartupTimeout(timeout int) int {
-	minTimeout := int(isvcs.MIN_ES_STARTUP_TIMEOUT / time.Second)
+	minTimeout := isvcs.MIN_ES_STARTUP_TIMEOUT_SECONDS
 	if timeout < minTimeout {
 		timeout = minTimeout
 	}

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"time"
 
 	"github.com/codegangsta/cli"
 	"github.com/control-center/serviced/cli/api"
@@ -25,6 +26,7 @@ import (
 	"github.com/control-center/serviced/node"
 	"github.com/control-center/serviced/utils"
 	"github.com/control-center/serviced/volume"
+	"github.com/control-center/serviced/isvcs"
 	"github.com/zenoss/glog"
 )
 
@@ -49,7 +51,7 @@ func getDefaultOptions(config utils.ConfigReader) api.Options {
 		MCUsername:           "scott",
 		MCPasswd:             "tiger",
 		FSType:               volume.DriverType(config.StringVal("FS_TYPE", "rsync")),
-		ESStartupTimeout:     getDefaultESStartupTimeout(config.IntVal("ES_STARTUP_TIMEOUT", 600)),
+		ESStartupTimeout:     getDefaultESStartupTimeout(config.IntVal("ES_STARTUP_TIMEOUT", int(isvcs.DEFAULT_ES_STARTUP_TIMEOUT / time.Second))),
 		HostAliases:          config.StringSlice("VHOST_ALIASES", []string{}),
 		Verbosity:            config.IntVal("LOG_LEVEL", 0),
 		StaticIPs:            config.StringSlice("STATIC_IPS", []string{}),
@@ -119,7 +121,7 @@ func getDefaultVarPath(home string) string {
 }
 
 func getDefaultESStartupTimeout(timeout int) int {
-	const minTimeout = 30
+	minTimeout := int(isvcs.MIN_ES_STARTUP_TIMEOUT / time.Second)
 	if timeout < minTimeout {
 		timeout = minTimeout
 	}

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -107,7 +107,7 @@ type DaoTest struct {
 //SetUpSuite is run before the tests to ensure elastic, zookeeper etc. are running.
 func (dt *DaoTest) SetUpSuite(c *C) {
 	dt.Port = 9202
-	isvcs.Init(int(isvcs.DEFAULT_ES_STARTUP_TIMEOUT / time.Second))
+	isvcs.Init(isvcs.DEFAULT_ES_STARTUP_TIMEOUT_SECONDS)
 	isvcs.Mgr.SetVolumesDir("/tmp/serviced-test")
 	esServicedClusterName, _ := utils.NewUUID36()
 	if err := isvcs.Mgr.SetConfigurationOption("elasticsearch-serviced", "cluster", esServicedClusterName); err != nil {

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -107,7 +107,7 @@ type DaoTest struct {
 //SetUpSuite is run before the tests to ensure elastic, zookeeper etc. are running.
 func (dt *DaoTest) SetUpSuite(c *C) {
 	dt.Port = 9202
-	isvcs.Init()
+	isvcs.Init(int(isvcs.DEFAULT_ES_STARTUP_TIMEOUT / time.Second))
 	isvcs.Mgr.SetVolumesDir("/tmp/serviced-test")
 	esServicedClusterName, _ := utils.NewUUID36()
 	if err := isvcs.Mgr.SetConfigurationOption("elasticsearch-serviced", "cluster", esServicedClusterName); err != nil {

--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -152,7 +152,7 @@ func NewIService(sd IServiceDefinition) (*IService, error) {
 		sd.Configuration = make(map[string]interface{})
 	}
 
-	if sd.StartupTimeout <= 0 {
+	if sd.StartupTimeout == 0 { //Initialize startup timeout to Default for all IServices if not specified
 		sd.StartupTimeout = WAIT_FOR_INITIAL_HEALTHCHECK
 	}
 

--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -30,6 +30,9 @@ import (
 	"time"
 )
 
+const DEFAULT_ES_STARTUP_TIMEOUT = WAIT_FOR_INITIAL_HEALTHCHECK	//default startup timeout (same as all other iservices)
+const MIN_ES_STARTUP_TIMEOUT = time.Duration(30) * time.Second	 	//minimum startup timeout
+
 var elasticsearch_logstash *IService
 var elasticsearch_serviced *IService
 
@@ -55,14 +58,15 @@ func init() {
 
 	elasticsearch_serviced, err = NewIService(
 		IServiceDefinition{
-			Name:          serviceName,
-			Repo:          IMAGE_REPO,
-			Tag:           IMAGE_TAG,
-			Command:       func() string { return "" },
-			PortBindings:  []portBinding{elasticsearch_servicedPortBinding},
-			Volumes:       map[string]string{"data": "/opt/elasticsearch-0.90.9/data"},
-			Configuration: make(map[string]interface{}),
-			HealthChecks:  healthChecks,
+			Name:          	serviceName,
+			Repo:          	IMAGE_REPO,
+			Tag:           	IMAGE_TAG,
+			Command:       	func() string { return "" },
+			PortBindings:  	[]portBinding{elasticsearch_servicedPortBinding},
+			Volumes:       	map[string]string{"data": "/opt/elasticsearch-0.90.9/data"},
+			Configuration: 	make(map[string]interface{}),
+			HealthChecks:	healthChecks,
+			StartupTimeout:	DEFAULT_ES_STARTUP_TIMEOUT,
 		},
 	)
 	if err != nil {
@@ -90,14 +94,15 @@ func init() {
 
 	elasticsearch_logstash, err = NewIService(
 		IServiceDefinition{
-			Name:          serviceName,
-			Repo:          IMAGE_REPO,
-			Tag:           IMAGE_TAG,
-			Command:       func() string { return "" },
-			PortBindings:  []portBinding{elasticsearch_logstashPortBinding},
-			Volumes:       map[string]string{"data": "/opt/elasticsearch-1.3.1/data"},
-			Configuration: make(map[string]interface{}),
-			HealthChecks:  healthChecks,
+			Name:          	serviceName,
+			Repo:          	IMAGE_REPO,
+			Tag:           	IMAGE_TAG,
+			Command:       	func() string { return "" },
+			PortBindings:  	[]portBinding{elasticsearch_logstashPortBinding},
+			Volumes:       	map[string]string{"data": "/opt/elasticsearch-1.3.1/data"},
+			Configuration: 	make(map[string]interface{}),
+			HealthChecks:  	healthChecks,
+			StartupTimeout:	DEFAULT_ES_STARTUP_TIMEOUT,
 		},
 	)
 	if err != nil {

--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -30,8 +30,8 @@ import (
 	"time"
 )
 
-const DEFAULT_ES_STARTUP_TIMEOUT = WAIT_FOR_INITIAL_HEALTHCHECK	//default startup timeout (same as all other iservices)
-const MIN_ES_STARTUP_TIMEOUT = time.Duration(30) * time.Second	 	//minimum startup timeout
+const DEFAULT_ES_STARTUP_TIMEOUT_SECONDS = int(WAIT_FOR_INITIAL_HEALTHCHECK/time.Second)	//default startup timeout in seconds (same as all other iservices)
+const MIN_ES_STARTUP_TIMEOUT_SECONDS = 30	 	//minimum startup timeout in seconds
 
 var elasticsearch_logstash *IService
 var elasticsearch_serviced *IService
@@ -66,7 +66,7 @@ func init() {
 			Volumes:       	map[string]string{"data": "/opt/elasticsearch-0.90.9/data"},
 			Configuration: 	make(map[string]interface{}),
 			HealthChecks:	healthChecks,
-			StartupTimeout:	DEFAULT_ES_STARTUP_TIMEOUT,
+			StartupTimeout:	time.Duration(DEFAULT_ES_STARTUP_TIMEOUT_SECONDS)*time.Second,
 		},
 	)
 	if err != nil {
@@ -102,7 +102,7 @@ func init() {
 			Volumes:       	map[string]string{"data": "/opt/elasticsearch-1.3.1/data"},
 			Configuration: 	make(map[string]interface{}),
 			HealthChecks:  	healthChecks,
-			StartupTimeout:	DEFAULT_ES_STARTUP_TIMEOUT,
+			StartupTimeout:	time.Duration(DEFAULT_ES_STARTUP_TIMEOUT_SECONDS)*time.Second,
 		},
 	)
 	if err != nil {

--- a/isvcs/es_test.go
+++ b/isvcs/es_test.go
@@ -17,11 +17,10 @@ package isvcs
 
 import (
 	"testing"
-	"time"
 )
 
 func TestPurge(t *testing.T) {
-	Init(int(DEFAULT_ES_STARTUP_TIMEOUT / time.Second))
+	Init(DEFAULT_ES_STARTUP_TIMEOUT_SECONDS)
 	Mgr.Start()
 	PurgeLogstashIndices(10, 10)
 	Mgr.Stop()

--- a/isvcs/es_test.go
+++ b/isvcs/es_test.go
@@ -17,10 +17,11 @@ package isvcs
 
 import (
 	"testing"
+	"time"
 )
 
 func TestPurge(t *testing.T) {
-	Init()
+	Init(int(DEFAULT_ES_STARTUP_TIMEOUT / time.Second))
 	Mgr.Start()
 	PurgeLogstashIndices(10, 10)
 	Mgr.Stop()

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -21,6 +21,8 @@ package isvcs
 import (
 	"github.com/control-center/serviced/utils"
 	"github.com/zenoss/glog"
+
+	"time"
 )
 
 var Mgr *Manager
@@ -30,7 +32,10 @@ const (
 	IMAGE_TAG  = "v32"
 )
 
-func Init() {
+func Init(esStartupTimeoutInSeconds int) {
+	elasticsearch_serviced.StartupTimeout = time.Duration(esStartupTimeoutInSeconds) * time.Second
+	elasticsearch_logstash.StartupTimeout = time.Duration(esStartupTimeoutInSeconds) * time.Second
+
 	Mgr = NewManager(utils.LocalDir("images"), utils.TempDir("var/isvcs"))
 
 	if err := Mgr.Register(elasticsearch_serviced); err != nil {


### PR DESCRIPTION
Fixes CC-672:
https://jira.zenoss.com/browse/CC-672

Added StartupTimeout member to IServiceDefinition that defaults to the WAIT_FOR_INITIAL_HEALTHCHECK constant.

Modified isvc initialization to apply the ESStartupTimeout option to both the elasticsearch_logstash and elasticsearch_serviced services.