### PR TITLE
Helps CC-1248 Panic when no network configured

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -506,7 +506,7 @@ func (d *daemon) startAgent() error {
 	rpcPort := strings.TrimLeft(options.Listen, ":")
 	thisHost, err := host.Build(agentIP, rpcPort, "unknown", "", options.StaticIPs...)
 	if err != nil {
-		panic(err)
+		glog.Fatalf("Failed to acquire all host info: %s", err)
 	}
 
 	myHostID, err := utils.HostID()

--- a/cli/api/utils.go
+++ b/cli/api/utils.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/control-center/serviced/utils"
+	"github.com/zenoss/glog"
 )
 
 const (
@@ -41,7 +42,7 @@ func GetAgentIP(defaultRPCPort int) string {
 	}
 	agentIP, err := utils.GetIPAddress()
 	if err != nil {
-		panic(err)
+		glog.Fatalf("Failed to get IP address: %s", err)
 	}
 	return agentIP + fmt.Sprintf(":%d", defaultRPCPort)
 }

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -42,7 +42,7 @@ type ServicedCli struct {
 // New instantiates a new command-line client
 func New(driver api.API, config utils.ConfigReader) *ServicedCli {
 	if config == nil {
-		panic("Missing configuration data!")
+		glog.Fatal("Missing configuration data!")
 	}
 	defaultOps := getDefaultOptions(config)
 	masterIP := config.StringVal("MASTER_IP", "127.0.0.1")

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -100,7 +100,6 @@ func getDefaultEndpoint(ip, port string) string {
 	if ip == "" {
 		var err error
 		if ip, err = utils.GetIPAddress(); err != nil {
-			//fmt.Fprintf(os.Stderr, "ERROR: Unable to get default endpoint: %s\n", err)
 			return ""
 		}
 	}

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -100,7 +100,8 @@ func getDefaultEndpoint(ip, port string) string {
 	if ip == "" {
 		var err error
 		if ip, err = utils.GetIPAddress(); err != nil {
-			panic(err)
+			//fmt.Fprintf(os.Stderr, "ERROR: Unable to get default endpoint: %s\n", err)
+			return ""
 		}
 	}
 	return fmt.Sprintf("%s:%s", ip, port)

--- a/cli/cmd/server.go
+++ b/cli/cmd/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/control-center/serviced/cli/api"
 	"github.com/control-center/serviced/rpc/rpcutils"
+	"github.com/zenoss/glog"
 )
 
 // Initializer for serviced server
@@ -49,5 +50,7 @@ func (c *ServicedCli) cmdServer(ctx *cli.Context) {
 
 	// Start server mode
 	rpcutils.RPC_CLIENT_SIZE = api.GetOptionsMaxRPCClients()
-	c.driver.StartServer()
+	if err := c.driver.StartServer(); err != nil {
+		glog.Fatalf("Could not start server: %s", err)
+	}
 }

--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/zenoss/glog"
+
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -35,7 +37,7 @@ func remove(index int, list ...interface{}) []interface{} {
 
 	switch {
 	case index < 0 || index > len(list):
-		panic("index out of bounds")
+		glog.Warning("index out of bounds")
 	case index+1 < len(list):
 		right = list[index+1:]
 		fallthrough

--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -24,29 +24,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/zenoss/glog"
-
 	"golang.org/x/crypto/ssh/terminal"
 )
-
-func remove(index int, list ...interface{}) []interface{} {
-	var (
-		left  []interface{}
-		right []interface{}
-	)
-
-	switch {
-	case index < 0 || index > len(list):
-		glog.Warning("index out of bounds")
-	case index+1 < len(list):
-		right = list[index+1:]
-		fallthrough
-	default:
-		left = list[:index]
-	}
-
-	return append(left, right...)
-}
 
 var editors = []string{"vim", "vi", "nano"}
 


### PR DESCRIPTION
There were several panics in the cli code, and some were early enough to
prevent simple subcommands (like 'help' and 'version') from running. I
changed them to log instead (often Fatal, so serviced would shut down)
so we don't have the stack traces, which are bothersome to customers
(and they didn't seem like they would be helpful for the problems that
were being detected anyway).

I also found that starting the server ignored some errors that were
returned--we now log those as Fatal errors (so we shut down).