### PR TITLE
CC-1196: Part I - Changing default paths

### DIFF
--- a/cli/api/api.go
+++ b/cli/api/api.go
@@ -44,10 +44,11 @@ type Options struct {
 	TLS                  bool
 	KeyPEMFile           string
 	CertPEMFile          string
-	VarPath              string
+	VolumesPath          string
+	IsvcsPath            string
+	BackupsPath          string
 	ResourcePath         string
 	Zookeepers           []string
-	RemoteZookeepers     []string
 	ReportStats          bool
 	HostStats            string
 	StatsPeriod          int
@@ -77,6 +78,7 @@ type Options struct {
 	StorageArgs          []string          // command-line arguments for storage options
 	StorageOptions       map[string]string // environment arguments for storage options
 	ControllerBinary     string            // Path to the container controller binary
+	StartISVCS           []string          // ISVCS to start when running as an agent
 }
 
 // LoadOptions overwrites the existing server options

--- a/cli/api/utils.go
+++ b/cli/api/utils.go
@@ -16,8 +16,6 @@ package api
 import (
 	"fmt"
 	"os"
-	"os/user"
-	"path"
 	"strconv"
 	"strings"
 
@@ -55,18 +53,6 @@ func GetDockerDNS() []string {
 
 	dockerdns := os.Getenv("SERVICED_DOCKER_DNS")
 	return strings.Split(dockerdns, ",")
-}
-
-// GetVarPath returns the serviced varpath
-func GetVarPath() string {
-	if options.VarPath != "" {
-		return options.VarPath
-	} else if home := os.Getenv("SERVICED_HOME"); home != "" {
-		return path.Join(home, "var")
-	} else if user, err := user.Current(); err == nil {
-		return path.Join(os.TempDir(), "serviced-"+user.Username, "var")
-	}
-	return path.Join(os.TempDir(), "serviced")
 }
 
 // GetESStartupTimeout returns the Elastic Search Startup Timeout

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -70,12 +70,12 @@ func New(driver api.API, config utils.ConfigReader) *ServicedCli {
 		cli.BoolFlag{"master", "run in master mode, i.e., the control center service"},
 		cli.BoolFlag{"agent", "run in agent mode, i.e., a host in a resource pool"},
 		cli.IntFlag{"mux", defaultOps.MuxPort, "multiplexing port"},
-		cli.StringFlag{"var", defaultOps.VarPath, "path to store serviced data"},
+		cli.StringFlag{"volumes-path", defaultOps.VolumesPath, "path where application data is stored"},
+		cli.StringFlag{"isvcs-path", defaultOps.IsvcsPath, "path where internal application data is stored"},
+		cli.StringFlag{"backups-path", defaultOps.BackupsPath, "default path where backups are stored"},
 		cli.StringFlag{"keyfile", defaultOps.KeyPEMFile, "path to private key file (defaults to compiled in private key)"},
 		cli.StringFlag{"certfile", defaultOps.CertPEMFile, "path to public certificate file (defaults to compiled in public cert)"},
 		cli.StringSliceFlag{"zk", convertToStringSlice(defaultOps.Zookeepers), "Specify a zookeeper instance to connect to (e.g. -zk localhost:2181)"},
-		// TODO: 1.1
-		// cli.StringSliceFlag{"remote-zk", &remotezks, "Specify a zookeeper instance to connect to (e.g. -remote-zk remote:2181)"},
 		cli.StringSliceFlag{"mount", convertToStringSlice(defaultOps.Mount), "bind mount: DOCKER_IMAGE,HOST_PATH[,CONTAINER_PATH]"},
 		cli.StringFlag{"fstype", string(defaultOps.FSType), "driver for underlying file system"},
 		cli.StringSliceFlag{"alias", convertToStringSlice(defaultOps.HostAliases), "list of aliases for this host, e.g., localhost"},
@@ -86,6 +86,7 @@ func New(driver api.API, config utils.ConfigReader) *ServicedCli {
 		cli.StringFlag{"master-pool-id", defaultOps.MasterPoolID, "master's pool ID"},
 		cli.StringFlag{"admin-group", defaultOps.AdminGroup, "system group that can log in to control center"},
 		cli.StringSliceFlag{"storage-opts", convertToStringSlice(defaultOps.StorageArgs), "storage args to initialize filesystem"},
+		cli.StringSliceFlag{"isvcs-start", convertToStringSlice(defaultOps.StartISVCS), "isvcs to start on agent"},
 
 		cli.BoolTFlag{"report-stats", "report container statistics"},
 		cli.StringFlag{"host-stats", defaultOps.HostStats, "container statistics for host:port"},
@@ -154,11 +155,12 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 		Agent:                ctx.GlobalBool("agent"),
 		MuxPort:              ctx.GlobalInt("mux"),
 		TLS:                  true,
-		VarPath:              ctx.GlobalString("var"),
+		VolumesPath:          ctx.GlobalString("volumes-path"),
+		IsvcsPath:            ctx.GlobalString("isvcs-path"),
+		BackupsPath:          ctx.GlobalString("backups-path"),
 		KeyPEMFile:           ctx.GlobalString("keyfile"),
 		CertPEMFile:          ctx.GlobalString("certfile"),
 		Zookeepers:           ctx.GlobalStringSlice("zk"),
-		RemoteZookeepers:     ctx.GlobalStringSlice("remote-zk"),
 		Mount:                ctx.GlobalStringSlice("mount"),
 		HostAliases:          ctx.GlobalStringSlice("alias"),
 		ESStartupTimeout:     ctx.GlobalInt("es-startup-timeout"),
@@ -184,6 +186,7 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 		SnapshotTTL:          ctx.GlobalInt("snapshot-ttl"),
 		StorageArgs:          ctx.GlobalStringSlice("storage-opts"),
 		ControllerBinary:     ctx.GlobalString("controller-binary"),
+		StartISVCS:           ctx.GlobalStringSlice("isvcs-start"),
 	}
 	if os.Getenv("SERVICED_MASTER") == "1" {
 		options.Master = true

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -44,7 +44,6 @@ func getDefaultOptions(config utils.ConfigReader) api.Options {
 		KeyPEMFile:           config.StringVal("KEY_FILE", ""),
 		CertPEMFile:          config.StringVal("CERT_FILE", ""),
 		Zookeepers:           config.StringSlice("ZK", []string{}),
-		RemoteZookeepers:     []string{},
 		HostStats:            config.StringVal("STATS_PORT", fmt.Sprintf("%s:8443", masterIP)),
 		StatsPeriod:          config.IntVal("STATS_PERIOD", 10),
 		MCUsername:           "scott",
@@ -67,6 +66,7 @@ func getDefaultOptions(config utils.ConfigReader) api.Options {
 		MaxRPCClients:        config.IntVal("MAX_RPC_CLIENTS", 3),
 		RPCDialTimeout:       config.IntVal("RPC_DIAL_TIMEOUT", 30),
 		SnapshotTTL:          config.IntVal("SNAPSHOT_TTL", 12),
+		StartISVCS:           config.StringSlice("ISVCS_START", []string{}),
 	}
 
 	options.Endpoint = config.StringVal("ENDPOINT", getDefaultEndpoint(options.OutboundIP, options.RPCPort))
@@ -80,11 +80,16 @@ func getDefaultOptions(config utils.ConfigReader) api.Options {
 	defaultControllerBinary := filepath.Join(dir, "serviced-controller")
 	options.ControllerBinary = config.StringVal("CONTROLLER_BINARY", defaultControllerBinary)
 
-	// Set the varpath to /tmp if running serviced as just an agent
+	// Set the volumePath to /tmp if running serviced as just an agent
+	varpath := getDefaultVarPath(config.StringVal("HOME", ""))
 	if options.Master {
-		options.VarPath = config.StringVal("VARPATH", getDefaultVarPath(config.StringVal("HOME", "")))
+		options.IsvcsPath = config.StringVal("ISVCS_PATH", filepath.Join(varpath, "isvcs"))
+		options.VolumesPath = config.StringVal("VOLUMES_PATH", filepath.Join(varpath, "volumes"))
+		options.BackupsPath = config.StringVal("BACKUPS_PATH", filepath.Join(varpath, "backups"))
 	} else {
-		options.VarPath = config.StringVal("VARPATH", getDefaultVarPath(""))
+		tmpvarpath := getDefaultVarPath("")
+		options.IsvcsPath = filepath.Join(varpath, "isvcs")
+		options.VolumesPath = filepath.Join(tmpvarpath, "volumes")
 	}
 	return options
 }

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -22,10 +22,10 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/control-center/serviced/cli/api"
 	"github.com/control-center/serviced/commons/docker"
+	"github.com/control-center/serviced/isvcs"
 	"github.com/control-center/serviced/node"
 	"github.com/control-center/serviced/utils"
 	"github.com/control-center/serviced/volume"
-	"github.com/control-center/serviced/isvcs"
 	"github.com/zenoss/glog"
 )
 
@@ -81,7 +81,8 @@ func getDefaultOptions(config utils.ConfigReader) api.Options {
 	options.ControllerBinary = config.StringVal("CONTROLLER_BINARY", defaultControllerBinary)
 
 	// Set the volumePath to /tmp if running serviced as just an agent
-	varpath := getDefaultVarPath(config.StringVal("HOME", ""))
+	homepath := config.StringVal("HOME", "")
+	varpath := getDefaultVarPath(config.StringVal("VARPATH", homepath))
 	if options.Master {
 		options.IsvcsPath = config.StringVal("ISVCS_PATH", filepath.Join(varpath, "isvcs"))
 		options.VolumesPath = config.StringVal("VOLUMES_PATH", filepath.Join(varpath, "volumes"))

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -82,7 +82,7 @@ func getDefaultOptions(config utils.ConfigReader) api.Options {
 
 	// Set the volumePath to /tmp if running serviced as just an agent
 	homepath := config.StringVal("HOME", "")
-	varpath := getDefaultVarPath(config.StringVal("VARPATH", homepath))
+	varpath := config.StringVal("VARPATH", getDefaultVarPath(homepath))
 	if options.Master {
 		options.IsvcsPath = config.StringVal("ISVCS_PATH", filepath.Join(varpath, "isvcs"))
 		options.VolumesPath = config.StringVal("VOLUMES_PATH", filepath.Join(varpath, "volumes"))

--- a/dao/elasticsearch/controlplanedao.go
+++ b/dao/elasticsearch/controlplanedao.go
@@ -49,7 +49,7 @@ type ControlPlaneDao struct {
 	hostName       string
 	port           int
 	rpcPort        int
-	varpath        string
+	volumesPath    string
 	fsType         volume.DriverType
 	dfs            *dfs.DistributedFilesystem
 	facade         *facade.Facade
@@ -133,7 +133,7 @@ func NewControlPlaneDao(hostName string, port int, rpcPort int) (*ControlPlaneDa
 	return dao, nil
 }
 
-func NewControlSvc(hostName string, port int, facade *facade.Facade, varpath string, fsType volume.DriverType, rpcPort int, maxdfstimeout time.Duration, dockerRegistry string, networkDriver storage.StorageDriver) (*ControlPlaneDao, error) {
+func NewControlSvc(hostName string, port int, facade *facade.Facade, volumesPath, backupsPath string, fsType volume.DriverType, rpcPort int, maxdfstimeout time.Duration, dockerRegistry string, networkDriver storage.StorageDriver) (*ControlPlaneDao, error) {
 	glog.V(2).Info("calling NewControlSvc()")
 	defer glog.V(2).Info("leaving NewControlSvc()")
 
@@ -145,7 +145,7 @@ func NewControlSvc(hostName string, port int, facade *facade.Facade, varpath str
 	//Used to bridge old to new
 	s.facade = facade
 
-	s.varpath = varpath
+	s.volumesPath = volumesPath
 	s.fsType = fsType
 
 	// create the account credentials
@@ -153,7 +153,7 @@ func NewControlSvc(hostName string, port int, facade *facade.Facade, varpath str
 		return nil, err
 	}
 
-	dfs, err := dfs.NewDistributedFilesystem(fsType, varpath, dockerRegistry, facade, maxdfstimeout, networkDriver)
+	dfs, err := dfs.NewDistributedFilesystem(fsType, volumesPath, backupsPath, dockerRegistry, facade, maxdfstimeout, networkDriver)
 	if err != nil {
 		return nil, err
 	}

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -18,7 +18,6 @@ package elasticsearch
 import (
 	"fmt"
 	"os"
-	"path"
 	"strconv"
 	"strings"
 	"testing"
@@ -139,10 +138,10 @@ func (dt *DaoTest) SetUpSuite(c *C) {
 	}
 
 	tmpdir := c.MkDir()
-	err = volume.InitDriver(volume.DriverTypeRsync, path.Join(tmpdir, "volumes"), []string{})
+	err = volume.InitDriver(volume.DriverTypeRsync, tmpdir, []string{})
 	c.Assert(err, IsNil)
 
-	dt.Dao, err = NewControlSvc("localhost", int(dt.Port), dt.Facade, tmpdir, volume.DriverTypeRsync, 4979, time.Minute*5, "localhost:5000", MockStorageDriver{})
+	dt.Dao, err = NewControlSvc("localhost", int(dt.Port), dt.Facade, tmpdir, "", volume.DriverTypeRsync, 4979, time.Minute*5, "localhost:5000", MockStorageDriver{})
 	if err != nil {
 		glog.Fatalf("Could not start es container: %s", err)
 	} else {

--- a/dao/elasticsearch/servicetemplate.go
+++ b/dao/elasticsearch/servicetemplate.go
@@ -50,7 +50,7 @@ func (this *ControlPlaneDao) DeployTemplate(request dao.ServiceTemplateDeploymen
 
 	// Create the tenant volume
 	for _, tenantID := range *tenantIDs {
-		if _, err := this.dfs.GetVolume(tenantID); err != nil {
+		if err := this.dfs.CreateVolume(tenantID); err != nil {
 			glog.Warningf("Could not create volume for tenant %s: %s", tenantID, err)
 		}
 	}

--- a/dfs/backup.go
+++ b/dfs/backup.go
@@ -59,7 +59,7 @@ func (dfs *DistributedFilesystem) ListBackups(dirpath string) ([]dao.BackupFile,
 	backups := make([]dao.BackupFile, 0)
 
 	if dirpath = strings.TrimSpace(dirpath); dirpath == "" {
-		dirpath = utils.BackupDir(dfs.varpath)
+		dirpath = dfs.backupsPath
 	} else {
 		dirpath = filepath.Clean(dirpath)
 	}
@@ -129,7 +129,7 @@ func (dfs *DistributedFilesystem) Backup(dirpath string, last int) (string, erro
 	// get the full path of the backup
 	name := time.Now().Format("backup-2006-01-02-150405")
 	if dirpath = strings.TrimSpace(dirpath); dirpath == "" {
-		dirpath = utils.BackupDir(dfs.varpath)
+		dirpath = dfs.backupsPath
 	}
 	filename := filepath.Join(dirpath, fmt.Sprintf("%s.tgz", name))
 	dirpath = filepath.Join(dirpath, name)
@@ -292,7 +292,7 @@ func (dfs *DistributedFilesystem) Restore(filename string) error {
 		}
 	}()
 
-	dirpath := filepath.Join(utils.BackupDir(dfs.varpath), "restore")
+	dirpath := filepath.Join(dfs.backupsPath, "restore")
 	if err := os.RemoveAll(dirpath); err != nil {
 		glog.Errorf("Could not remove %s: %s", dirpath, err)
 		return err

--- a/dfs/dfs.go
+++ b/dfs/dfs.go
@@ -32,11 +32,12 @@ import (
 
 type DatastoreGetter func() datastore.Context
 
-type ServiceVolumeGetter func(fsType volume.DriverType, varpath, serviceID string) (volume.Volume, error)
+type ServiceVolumeGetter func(fsType volume.DriverType, volumesPath, serviceID string) (volume.Volume, error)
 
 type DistributedFilesystem struct {
 	fsType           volume.DriverType
-	varpath          string
+	volumesPath      string
+	backupsPath      string
 	dockerHost       string
 	dockerPort       int
 	datastoreGet     DatastoreGetter
@@ -53,7 +54,7 @@ type DistributedFilesystem struct {
 	logger *logger
 }
 
-func NewDistributedFilesystem(fsType volume.DriverType, varpath, dockerRegistry string, facade facade.FacadeInterface, timeout time.Duration, networkDriver storage.StorageDriver) (*DistributedFilesystem, error) {
+func NewDistributedFilesystem(fsType volume.DriverType, volumesPath, backupsPath, dockerRegistry string, facade facade.FacadeInterface, timeout time.Duration, networkDriver storage.StorageDriver) (*DistributedFilesystem, error) {
 	host, port, err := parseRegistry(dockerRegistry)
 	if err != nil {
 		return nil, err
@@ -67,7 +68,8 @@ func NewDistributedFilesystem(fsType volume.DriverType, varpath, dockerRegistry 
 
 	return &DistributedFilesystem{
 		fsType:           fsType,
-		varpath:          varpath,
+		volumesPath:      volumesPath,
+		backupsPath:      backupsPath,
 		dockerHost:       host,
 		dockerPort:       port,
 		facade:           facade,

--- a/dfs/snapshot_test.go
+++ b/dfs/snapshot_test.go
@@ -77,7 +77,7 @@ func (st *snapshotTest) SetUpTest(c *C) {
 	// st.dfs.facade = st.mockFacade
 	st.dfs = &DistributedFilesystem{
 		fsType:           volume.DriverTypeRsync,
-		varpath:          st.tmpDir,
+		volumesPath:      st.tmpDir,
 		dockerHost:       "localhost",
 		dockerPort:       5000,
 		facade:           st.mockFacade,

--- a/dfs/volume.go
+++ b/dfs/volume.go
@@ -14,32 +14,19 @@
 package dfs
 
 import (
-	"errors"
-	"path/filepath"
-
 	"github.com/control-center/serviced/volume"
 	"github.com/zenoss/glog"
 )
 
 func (dfs *DistributedFilesystem) GetVolume(serviceID string) (volume.Volume, error) {
-	return dfs.getServiceVolume(dfs.fsType, dfs.varpath, serviceID)
+	return dfs.getServiceVolume(dfs.fsType, dfs.volumesPath, serviceID)
 }
 
-// GetSubvolume gets the path of the *local* volume on the host
-func GetSubvolume(fsType volume.DriverType, varpath, serviceID string) (volume.Volume, error) {
-	glog.Infof("Mounting tenantID: %v; baseDir: %v", serviceID, varpath)
-	return volume.FindMount(filepath.Join(varpath, "volumes", serviceID))
-}
-
-func serviceVolumeGet(fsType volume.DriverType, varpath, serviceID string) (volume.Volume, error) {
-	v, err := GetSubvolume(fsType, varpath, serviceID)
+func serviceVolumeGet(fsType volume.DriverType, root, serviceID string) (volume.Volume, error) {
+	drv, err := volume.GetDriver(root)
 	if err != nil {
-		glog.Errorf("Could not acquire subvolume for service %s: %s", serviceID, err)
-		return nil, err
-	} else if v == nil {
-		err := errors.New("volume is nil")
-		glog.Errorf("Could not get volume for service %s: %s", serviceID, err)
+		glog.Errorf("Could not find driver at root %s: %s", root, err)
 		return nil, err
 	}
-	return v, nil
+	return drv.Get(serviceID)
 }

--- a/dfs/volume.go
+++ b/dfs/volume.go
@@ -22,6 +22,16 @@ func (dfs *DistributedFilesystem) GetVolume(serviceID string) (volume.Volume, er
 	return dfs.getServiceVolume(dfs.fsType, dfs.volumesPath, serviceID)
 }
 
+func (dfs *DistributedFilesystem) CreateVolume(serviceID string) error {
+	drv, err := volume.GetDriver(dfs.volumesPath)
+	if err != nil {
+		glog.Errorf("Could not find driver at root %s: %s", dfs.volumesPath, err)
+		return err
+	}
+	_, err = drv.Create(serviceID)
+	return err
+}
+
 func serviceVolumeGet(fsType volume.DriverType, root, serviceID string) (volume.Volume, error) {
 	drv, err := volume.GetDriver(root)
 	if err != nil {

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -60,3 +60,15 @@ func Init(esStartupTimeoutInSeconds int) {
 		glog.Fatalf("%s", err)
 	}
 }
+
+func InitServices(isvcNames []string) {
+	Mgr = NewManager(utils.LocalDir("images"), utils.TempDir("var/isvcs"))
+	for _, isvcName := range isvcNames {
+		switch isvcName {
+		case "zookeeper":
+			if err := Mgr.Register(zookeeper); err != nil {
+				glog.Fatalf("%s", err)
+			}
+		}
+	}
+}

--- a/node/agent.go
+++ b/node/agent.go
@@ -26,7 +26,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -43,7 +42,6 @@ import (
 	coordclient "github.com/control-center/serviced/coordinator/client"
 	coordzk "github.com/control-center/serviced/coordinator/client/zookeeper"
 	"github.com/control-center/serviced/dao"
-	"github.com/control-center/serviced/dfs"
 	"github.com/control-center/serviced/domain"
 	"github.com/control-center/serviced/domain/addressassignment"
 	"github.com/control-center/serviced/domain/pool"
@@ -81,9 +79,8 @@ type HostAgent struct {
 	rpcport              string               // the rpc port to serviced (default is 4979)
 	hostID               string               // the hostID of the current host
 	dockerDNS            []string             // docker dns addresses
-	varPath              string               // directory to store serviced	 data
+	storage              volume.Driver        // driver supporting the application data
 	mount                []string             // each element is in the form: dockerImage,hostPath,containerPath
-	fsType               volume.DriverType    // driver for container volumes
 	currentServices      map[string]*exec.Cmd // the current running services
 	mux                  *proxy.TCPMux
 	useTLS               bool // Whether the mux uses TLS
@@ -120,7 +117,7 @@ type AgentOptions struct {
 	UIPort               string
 	RPCPort              string
 	DockerDNS            []string
-	VarPath              string
+	VolumesPath          string
 	Mount                []string
 	FSType               volume.DriverType
 	Zookeepers           []string
@@ -142,9 +139,7 @@ func NewHostAgent(options AgentOptions) (*HostAgent, error) {
 	agent.uiport = options.UIPort
 	agent.rpcport = options.RPCPort
 	agent.dockerDNS = options.DockerDNS
-	agent.varPath = options.VarPath
 	agent.mount = options.Mount
-	agent.fsType = volume.DriverTypeNFS
 	agent.mux = options.Mux
 	agent.useTLS = options.UseTLS
 	agent.maxContainerAge = options.MaxContainerAge
@@ -152,43 +147,21 @@ func NewHostAgent(options AgentOptions) (*HostAgent, error) {
 	agent.servicedChain = iptables.NewChain("SERVICED")
 	agent.controllerBinary = options.ControllerBinary
 
+	var err error
 	dsn := getZkDSN(options.Zookeepers)
-	basePath := ""
-	zkClient, err := coordclient.New("zookeeper", dsn, basePath, nil)
-	if err != nil {
+	if agent.zkClient, err = coordclient.New("zookeeper", dsn, "", nil); err != nil {
 		return nil, err
 	}
-	agent.zkClient = zkClient
-
-	hostID, err := utils.HostID()
-	if err != nil {
+	if agent.storage, err = volume.GetDriver(options.VolumesPath); err != nil {
+		glog.Errorf("Could not load storage driver at %s: %s", options.VolumesPath, err)
+		return nil, err
+	}
+	if agent.hostID, err = utils.HostID(); err != nil {
 		panic("Could not get hostid")
 	}
-	agent.hostID = hostID
 	agent.currentServices = make(map[string]*exec.Cmd)
-
 	agent.proxyRegistry = proxy.NewDefaultProxyRegistry()
 	return agent, err
-
-	/* FIXME: this should work here
-
-	addr, err := net.ResolveTCPAddr("tcp", processForwarderAddr)
-	if err != nil {
-		return nil, err
-	}
-	listener, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return nil, err
-	}
-
-	sio := shell.NewProcessForwarderServer(proxyOptions.servicedEndpoint)
-	sio.Handle("/", http.FileServer(http.Dir("/serviced/www/")))
-	go http.Serve(listener, sio)
-	c := &ControllerP{
-		processForwarderListener: listener,
-	}
-	*/
-
 }
 
 // Use the Context field of the given template to fill in all the templates in
@@ -743,12 +716,11 @@ func configureContainer(a *HostAgent, client *ControlClient,
 // setupVolume
 func (a *HostAgent) setupVolume(tenantID string, service *service.Service, volume servicedefinition.Volume) (string, error) {
 	glog.V(4).Infof("setupVolume for service Name:%s ID:%s", service.Name, service.ID)
-	sv, err := dfs.GetSubvolume(a.fsType, a.varPath, tenantID)
+	vol, err := a.storage.Get(tenantID)
 	if err != nil {
-		return "", fmt.Errorf("Could not create subvolume: %s", err)
+		return "", fmt.Errorf("could not get subvolume %s: %s", tenantID, err)
 	}
-
-	resourcePath := path.Join(sv.Path(), volume.ResourcePath)
+	resourcePath := filepath.Join(vol.Path(), volume.ResourcePath)
 	if err = os.MkdirAll(resourcePath, 0770); err != nil {
 		return "", fmt.Errorf("Could not create resource path: %s, %s", resourcePath, err)
 	}

--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -39,11 +39,15 @@
 # Set the mux port to listen on
 # SERVICED_MUX_PORT=22250
 
-# Set the VOLUMES path for serviced application data
-# SERVICED_VOLUMES_PATH=/opt/serviced/var/volumes
+# DEPRECATED: Set the var path for serviced. Use options below to specify paths
+# to the isvcs, volumes, and backups directories.
+# SERVICED_VARPATH=/opt/serviced/var
 
 # Set the ISVCS path for serviced internal data
 # SERVICED_ISVCS_PATH=/opt/serviced/var/isvcs
+
+# Set the VOLUMES path for serviced application data
+# SERVICED_VOLUMES_PATH=/opt/serviced/var/volumes
 
 # Set the BACKUPS path for serviced backups
 # SERVICED_BACKUPS_PATH=/opt/serviced/var/backups

--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -12,9 +12,6 @@
 # Set enable/disable the master role, set to 1/0, respectively
 # SERVICED_MASTER=0
 
-# Set the pool id for the master role
-# SERVICED_MASTER_POOLID=default
-
 # Set the the zookeeper ensemble, multiple masters should be comma separated
 # SERVICED_ZK={{SERVICED_MASTER_IP}}:2181
 
@@ -42,8 +39,14 @@
 # Set the mux port to listen on
 # SERVICED_MUX_PORT=22250
 
-# Set the VAR path for serviced
-# SERVICED_VARPATH=/opt/serviced/var
+# Set the VOLUMES path for serviced application data
+# SERVICED_VOLUMES_PATH=/opt/serviced/var/volumes
+
+# Set the ISVCS path for serviced internal data
+# SERVICED_ISVCS_PATH=/opt/serviced/var/isvcs
+
+# Set the BACKUPS path for serviced backups
+# SERVICED_BACKUPS_PATH=/opt/serviced/var/backups
 
 # Set the TLS keyfile
 # SERVICED_KEY_FILE=/etc/....
@@ -130,6 +133,9 @@
 
 # Overrides the default for the service migration image.
 # SERVICED_SERVICE_MIGRATION_TAG=1.0.2
+
+# Enables the following isvcs to run on the host (if not the master)
+# SERVICED_ISVCS_START=celery,elasticsearch,logstash,opentsdb,docker-registry,zookeeper
 
 # Arbitrary serviced daemon args
 # SERVICED_OPTS=

--- a/smoke.sh
+++ b/smoke.sh
@@ -52,7 +52,7 @@ trap cleanup EXIT
 
 start_serviced() {
     echo "Starting serviced..."
-    sudo GOPATH=${GOPATH} PATH=${PATH} SERVICED_NOREGISTRY="true" ${SERVICED} -master -agent server &
+    sudo GOPATH=${GOPATH} PATH=${PATH} ${SERVICED} -master -agent server &
     echo "Waiting 120 seconds for serviced to become the leader..."
     retry 180 wget --no-check-certificate http://${HOSTNAME}:443 -O- &>/dev/null
     return $?


### PR DESCRIPTION
* TODO: fix zendev
* TODO: need doc update for changes to default file
* Replaced SERVICED_VARPATH with ISVCS_PATH VOLUMES_PATH and BACKUPS_PATH
* Can customize what services to start with the isvcs-manager (if running as an agent)
* DFS changes for updated paths
* Created new option SERVICED_ISVCS_START, that takes a comma delimited string to specify which isvcs can run on the agent-only system.