### PR TITLE
Fixes CC-1285: Leaking file descriptors over time

### DIFF
--- a/datastore/elastic/driver.go
+++ b/datastore/elastic/driver.go
@@ -14,9 +14,9 @@
 package elastic
 
 import (
+	"github.com/control-center/serviced/datastore"
 	"github.com/zenoss/elastigo/api"
 	"github.com/zenoss/glog"
-	"github.com/control-center/serviced/datastore"
 
 	"bytes"
 	"encoding/json"
@@ -178,11 +178,11 @@ func (ed *elasticDriver) getHealth() (map[string]interface{}, error) {
 	if err != nil {
 		return health, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		return health, fmt.Errorf("http status: %v", resp.StatusCode)
 	}
 
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		glog.Errorf("error reading elastic health: %v", err)

--- a/isvcs/docker_registry.go
+++ b/isvcs/docker_registry.go
@@ -62,7 +62,8 @@ func init() {
 func registryHealthCheck(halt <-chan struct{}) error {
 	url := fmt.Sprintf("http://localhost:%d/", registryPort)
 	for {
-		if _, err := http.Get(url); err == nil {
+		if resp, err := http.Get(url); err == nil {
+			resp.Body.Close()
 			break
 		} else {
 			glog.V(1).Infof("Still trying to connect to docker registry at %s: %v", url, err)

--- a/isvcs/opentsdb.go
+++ b/isvcs/opentsdb.go
@@ -86,7 +86,8 @@ func (c *OpenTsdbISvc) Run() error {
 	start := time.Now()
 	timeout := time.Second * 30
 	for {
-		if _, err := http.Get("http://localhost:4242/version"); err == nil {
+		if resp, err := http.Get("http://localhost:4242/version"); err == nil {
+			resp.Body.Close()
 			break
 		} else {
 			if time.Since(start) > timeout && time.Since(start) < (timeout/4) {


### PR DESCRIPTION
Per the documentation for net/http.Get():
  When err is nil, resp always contains a non-nil resp.Body.
  Caller should close resp.Body when done reading from it.
We weren't always doing that.