### PR TITLE
serviced service status -h (but not really)

### DIFF
--- a/cli/api/service.go
+++ b/cli/api/service.go
@@ -167,6 +167,34 @@ func (a *api) GetServiceStatus(serviceID string) (map[string]map[string]interfac
 				row["Cur/Max/Avg"] = fmt.Sprintf("--")
 
 				rowmap[fmt.Sprintf("%s/%d", svc.ID, stat.State.InstanceID)] = row
+
+				if(stat.Status == dao.Running && len(stat.HealthCheckStatuses) > 0){ 
+				
+					explicitFailure := false
+
+					for hcName, hcResult := range stat.HealthCheckStatuses{
+						newrow := make(map[string]interface{})
+						if svc.Instances > 1 {
+							newrow["ParentID"] = fmt.Sprintf("%s/%d", svc.ID, stat.State.InstanceID)
+						} else {
+							newrow["ParentID"] = svc.ID
+						}
+						newrow["Healthcheck"] = hcName
+						newrow["Healthcheck Status"] = hcResult.Status
+
+						if(hcResult.Status == "failed"){
+							explicitFailure = true
+						}
+
+						rowmap[fmt.Sprintf("%s/%d-%v", svc.ID, stat.State.InstanceID, hcName)] = newrow
+					}
+					
+					//go back and add the healthcheck field for the parent row
+					if explicitFailure{
+						row["HC Fail"] = "X"	
+					}
+				}
+
 			}
 		}
 	}

--- a/cli/api/service.go
+++ b/cli/api/service.go
@@ -168,11 +168,11 @@ func (a *api) GetServiceStatus(serviceID string) (map[string]map[string]interfac
 
 				rowmap[fmt.Sprintf("%s/%d", svc.ID, stat.State.InstanceID)] = row
 
-				if(stat.Status == dao.Running && len(stat.HealthCheckStatuses) > 0){ 
-				
+				if stat.Status == dao.Running && len(stat.HealthCheckStatuses) > 0 {
+
 					explicitFailure := false
 
-					for hcName, hcResult := range stat.HealthCheckStatuses{
+					for hcName, hcResult := range stat.HealthCheckStatuses {
 						newrow := make(map[string]interface{})
 						if svc.Instances > 1 {
 							newrow["ParentID"] = fmt.Sprintf("%s/%d", svc.ID, stat.State.InstanceID)
@@ -182,16 +182,16 @@ func (a *api) GetServiceStatus(serviceID string) (map[string]map[string]interfac
 						newrow["Healthcheck"] = hcName
 						newrow["Healthcheck Status"] = hcResult.Status
 
-						if(hcResult.Status == "failed"){
+						if hcResult.Status == "failed" {
 							explicitFailure = true
 						}
 
 						rowmap[fmt.Sprintf("%s/%d-%v", svc.ID, stat.State.InstanceID, hcName)] = newrow
 					}
-					
+
 					//go back and add the healthcheck field for the parent row
-					if explicitFailure{
-						row["HC Fail"] = "X"	
+					if explicitFailure {
+						row["HC Fail"] = "X"
 					}
 				}
 

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -410,16 +410,15 @@ func (c *ServicedCli) cmdServiceStatus(ctx *cli.Context) {
 	var states map[string]map[string]interface{}
 	var err error
 
-	
 	//Determine whether to show healthcheck fields and rows based on user input:
 	//   By default, we only show individual healthcheck rows if a specific service is requested
 	//   However, we will show them if the user explicitly requests the "Healthcheck" or "Healthcheck Status" fields
-	showIndividualHealthChecks := false //whether or not to add rows to the table for individual health checks.
+	showIndividualHealthChecks := false       //whether or not to add rows to the table for individual health checks.
 	fieldsToShow := ctx.String("show-fields") //we will modify this if not user-set
-	
-	if(!ctx.IsSet("show-fields")){
+
+	if !ctx.IsSet("show-fields") {
 		//only show the appropriate health fields based on arguments
-		if len(ctx.Args()) > 0{ //don't show "HC Fail"
+		if len(ctx.Args()) > 0 { //don't show "HC Fail"
 			fieldsToShow = strings.Replace(fieldsToShow, "HC Fail,", "", -1)
 			fieldsToShow = strings.Replace(fieldsToShow, ",HC Fail", "", -1) //in case it was last in the list
 		} else { //don't show "Healthcheck" or "Healthcheck Status"
@@ -474,9 +473,9 @@ func (c *ServicedCli) cmdServiceStatus(ctx *cli.Context) {
 			defer t.DedentRow()
 			for _, rowid := range childmap[root] {
 				row := states[rowid]
-				
+
 				if _, ok := row["Healthcheck"]; !ok || showIndividualHealthChecks { //if this is a healthcheck row, only include it if showIndividualHealthChecks is true
-					t.AddRow(row)	
+					t.AddRow(row)
 					nextRoot := fmt.Sprintf("%v", row["ServiceID"])
 
 					if _, ok := childmap[rowid]; ok {

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -66,7 +66,7 @@ func (c *ServicedCli) initService() {
 				Action:      c.cmdServiceStatus,
 				Flags: []cli.Flag{
 					cli.BoolFlag{"ascii, a", "use ascii characters for service tree (env SERVICED_TREE_ASCII=1 will default to ascii)"},
-					cli.StringFlag{"show-fields", "Name,ServiceID,Status,Uptime,RAM,Cur/Max/Avg,Hostname,InSync,DockerID", "Comma-delimited list describing which fields to display"},
+					cli.StringFlag{"show-fields", "Name,ServiceID,Status,HC Fail,Healthcheck,Healthcheck Status,Uptime,RAM,Cur/Max/Avg,Hostname,InSync,DockerID", "Comma-delimited list describing which fields to display"},
 				},
 			}, {
 				Name:        "add",
@@ -410,6 +410,31 @@ func (c *ServicedCli) cmdServiceStatus(ctx *cli.Context) {
 	var states map[string]map[string]interface{}
 	var err error
 
+	
+	//Determine whether to show healthcheck fields and rows based on user input:
+	//   By default, we only show individual healthcheck rows if a specific service is requested
+	//   However, we will show them if the user explicitly requests the "Healthcheck" or "Healthcheck Status" fields
+	showIndividualHealthChecks := false //whether or not to add rows to the table for individual health checks.
+	fieldsToShow := ctx.String("show-fields") //we will modify this if not user-set
+	
+	if(!ctx.IsSet("show-fields")){
+		//only show the appropriate health fields based on arguments
+		if len(ctx.Args()) > 0{ //don't show "HC Fail"
+			fieldsToShow = strings.Replace(fieldsToShow, "HC Fail,", "", -1)
+			fieldsToShow = strings.Replace(fieldsToShow, ",HC Fail", "", -1) //in case it was last in the list
+		} else { //don't show "Healthcheck" or "Healthcheck Status"
+
+			fieldsToShow = strings.Replace(fieldsToShow, "Healthcheck Status,", "", -1)
+			fieldsToShow = strings.Replace(fieldsToShow, ",Healthcheck Status", "", -1) //in case it was last in the list
+
+			fieldsToShow = strings.Replace(fieldsToShow, "Healthcheck,", "", -1)
+			fieldsToShow = strings.Replace(fieldsToShow, ",Healthcheck", "", -1) //in case it was last in the list
+		}
+	}
+
+	//set showIndividualHealthChecks based on the fields
+	showIndividualHealthChecks = strings.Contains(fieldsToShow, "Healthcheck") || strings.Contains(fieldsToShow, "Healthcheck Status")
+
 	if len(ctx.Args()) > 0 {
 		svc, err := c.searchForService(ctx.Args()[0])
 		if err != nil {
@@ -433,7 +458,7 @@ func (c *ServicedCli) cmdServiceStatus(ctx *cli.Context) {
 
 	cmdSetTreeCharset(ctx, c.config)
 
-	t := NewTable(ctx.String("show-fields"))
+	t := NewTable(fieldsToShow)
 	childmap := make(map[string][]string)
 	for id, state := range states {
 		parent := fmt.Sprintf("%v", state["ParentID"])
@@ -449,9 +474,17 @@ func (c *ServicedCli) cmdServiceStatus(ctx *cli.Context) {
 			defer t.DedentRow()
 			for _, rowid := range childmap[root] {
 				row := states[rowid]
-				t.AddRow(row)
-				nextRoot := fmt.Sprintf("%v", row["ServiceID"])
-				addRows(nextRoot)
+				
+				if _, ok := row["Healthcheck"]; !ok || showIndividualHealthChecks { //if this is a healthcheck row, only include it if showIndividualHealthChecks is true
+					t.AddRow(row)	
+					nextRoot := fmt.Sprintf("%v", row["ServiceID"])
+
+					if _, ok := childmap[rowid]; ok {
+						nextRoot = rowid //if rowid exists in our childmap, use it instead of ServiceID
+					}
+
+					addRows(nextRoot)
+				}
 			}
 		}
 	}

--- a/dao/elasticsearch/servicestate.go
+++ b/dao/elasticsearch/servicestate.go
@@ -16,6 +16,7 @@ package elasticsearch
 import (
 	//	"errors"
 
+	"fmt"
 	"github.com/control-center/serviced/coordinator/client"
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/datastore"
@@ -24,7 +25,6 @@ import (
 	"github.com/control-center/serviced/zzk"
 	zkservice "github.com/control-center/serviced/zzk/service"
 	"github.com/zenoss/glog"
-	"fmt"
 	"strconv"
 )
 
@@ -138,13 +138,13 @@ func (this *ControlPlaneDao) GetServiceStatus(serviceID string, status *map[stri
 
 	if st != nil {
 		//get all healthcheck statuses for this service
-		healthStatuses:= health.GetHealthStatusesForService(serviceID) //map[string]map[string]*domain.HealthCheckStatus
-		
+		healthStatuses := health.GetHealthStatusesForService(serviceID) //map[string]map[string]*domain.HealthCheckStatus
+
 		//merge st with healthcheck info into *status
 		*status = make(map[string]dao.ServiceStatus, len(st))
-		for stateID, instanceStatus := range st{
+		for stateID, instanceStatus := range st {
 			instanceID := strconv.Itoa(instanceStatus.State.InstanceID) //healthStatuses are mapped using a string for instanceID
-			instanceStatus.HealthCheckStatuses = healthStatuses[instanceID] 
+			instanceStatus.HealthCheckStatuses = healthStatuses[instanceID]
 
 			(*status)[stateID] = instanceStatus
 		}

--- a/dao/elasticsearch/servicestate.go
+++ b/dao/elasticsearch/servicestate.go
@@ -20,10 +20,12 @@ import (
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain/servicestate"
+	"github.com/control-center/serviced/health"
 	"github.com/control-center/serviced/zzk"
 	zkservice "github.com/control-center/serviced/zzk/service"
 	"github.com/zenoss/glog"
 	"fmt"
+	"strconv"
 )
 
 func (this *ControlPlaneDao) getPoolBasedConnection(serviceID string) (client.Connection, error) {
@@ -122,6 +124,7 @@ func (this *ControlPlaneDao) StopRunningInstance(request dao.HostServiceRequest,
 
 func (this *ControlPlaneDao) GetServiceStatus(serviceID string, status *map[string]dao.ServiceStatus) error {
 	*status = make(map[string]dao.ServiceStatus, 0)
+
 	poolBasedConn, err := this.getPoolBasedConnection(serviceID)
 	if err != nil {
 		return err
@@ -134,7 +137,17 @@ func (this *ControlPlaneDao) GetServiceStatus(serviceID string, status *map[stri
 	}
 
 	if st != nil {
-		*status = st
+		//get all healthcheck statuses for this service
+		healthStatuses:= health.GetHealthStatusesForService(serviceID) //map[string]map[string]*domain.HealthCheckStatus
+		
+		//merge st with healthcheck info into *status
+		*status = make(map[string]dao.ServiceStatus, len(st))
+		for stateID, instanceStatus := range st{
+			instanceID := strconv.Itoa(instanceStatus.State.InstanceID) //healthStatuses are mapped using a string for instanceID
+			instanceStatus.HealthCheckStatuses = healthStatuses[instanceID] 
+
+			(*status)[stateID] = instanceStatus
+		}
 	}
 
 	return nil

--- a/dao/model.go
+++ b/dao/model.go
@@ -117,8 +117,9 @@ var (
 )
 
 type ServiceStatus struct {
-	State  servicestate.ServiceState
-	Status Status
+	State  				servicestate.ServiceState
+	Status 				Status
+	HealthCheckStatuses	map[string]domain.HealthCheckStatus //map of healthcheck name --> healthcheck status
 }
 
 // BackupFile is the structure for backup file data

--- a/dao/model.go
+++ b/dao/model.go
@@ -117,9 +117,9 @@ var (
 )
 
 type ServiceStatus struct {
-	State  				servicestate.ServiceState
-	Status 				Status
-	HealthCheckStatuses	map[string]domain.HealthCheckStatus //map of healthcheck name --> healthcheck status
+	State               servicestate.ServiceState
+	Status              Status
+	HealthCheckStatuses map[string]domain.HealthCheckStatus //map of healthcheck name --> healthcheck status
 }
 
 // BackupFile is the structure for backup file data

--- a/health/health.go
+++ b/health/health.go
@@ -41,6 +41,23 @@ var runningServices []dao.RunningService
 var exitChannel = make(chan bool)
 var lock = &sync.RWMutex{}
 
+
+// Returns Map of InstanceID -> HealthCheckName -> healthStatus for a given serviceID.  
+func GetHealthStatusesForService(serviceID string) map[string]map[string]domain.HealthCheckStatus {
+	lock.RLock()
+	defer lock.RUnlock()
+
+	//make a copy of healthStatuses[serviceID] and store the HealthCheckStatus values instead of pointers
+	result := make(map[string]map[string]domain.HealthCheckStatus, len(healthStatuses[serviceID]))
+	for instanceID, healthChecks := range(healthStatuses[serviceID]){
+		result[instanceID]= make(map[string]domain.HealthCheckStatus, len(healthChecks))
+		for hcName, hcStatus := range(healthChecks){
+			result[instanceID][hcName] = *hcStatus
+		}
+	}
+	return result
+}
+
 func init() {
 	foreverHealthy := &domain.HealthCheckStatus{
 		Status:    "passed",

--- a/health/health.go
+++ b/health/health.go
@@ -41,17 +41,16 @@ var runningServices []dao.RunningService
 var exitChannel = make(chan bool)
 var lock = &sync.RWMutex{}
 
-
-// Returns Map of InstanceID -> HealthCheckName -> healthStatus for a given serviceID.  
+// Returns Map of InstanceID -> HealthCheckName -> healthStatus for a given serviceID.
 func GetHealthStatusesForService(serviceID string) map[string]map[string]domain.HealthCheckStatus {
 	lock.RLock()
 	defer lock.RUnlock()
 
 	//make a copy of healthStatuses[serviceID] and store the HealthCheckStatus values instead of pointers
 	result := make(map[string]map[string]domain.HealthCheckStatus, len(healthStatuses[serviceID]))
-	for instanceID, healthChecks := range(healthStatuses[serviceID]){
-		result[instanceID]= make(map[string]domain.HealthCheckStatus, len(healthChecks))
-		for hcName, hcStatus := range(healthChecks){
+	for instanceID, healthChecks := range healthStatuses[serviceID] {
+		result[instanceID] = make(map[string]domain.HealthCheckStatus, len(healthChecks))
+		for hcName, hcStatus := range healthChecks {
 			result[instanceID][hcName] = *hcStatus
 		}
 	}

--- a/zzk/service/servicestate.go
+++ b/zzk/service/servicestate.go
@@ -102,6 +102,7 @@ func wait(shutdown <-chan interface{}, conn client.Connection, serviceID, stateI
 }
 
 // GetServiceStatus creates a map of service states to their corresponding status
+// The ServiceStatus objects returned will NOT include healthcheck info
 func GetServiceStatus(conn client.Connection, serviceID string) (map[string]dao.ServiceStatus, error) {
 	states, err := GetServiceStates(conn, serviceID)
 	if err != nil {

--- a/zzk/service/servicestate_test.go
+++ b/zzk/service/servicestate_test.go
@@ -101,9 +101,9 @@ func (t *ZZKTest) TestGetServiceStatus(c *C) {
 	statusmap, err = GetServiceStatus(conn, svc.ID)
 	c.Assert(err, IsNil)
 	c.Assert(statusmap, DeepEquals, map[string]dao.ServiceStatus{
-		stateIDs[0]: dao.ServiceStatus{states[stateIDs[0]], dao.Running},
-		stateIDs[1]: dao.ServiceStatus{states[stateIDs[1]], dao.Resuming},
-		stateIDs[2]: dao.ServiceStatus{states[stateIDs[2]], dao.Starting},
+		stateIDs[0]: dao.ServiceStatus{states[stateIDs[0]], dao.Running, nil},
+		stateIDs[1]: dao.ServiceStatus{states[stateIDs[1]], dao.Resuming, nil},
+		stateIDs[2]: dao.ServiceStatus{states[stateIDs[2]], dao.Starting, nil},
 	})
 
 	c.Log("Desired state is PAUSE")
@@ -114,9 +114,9 @@ func (t *ZZKTest) TestGetServiceStatus(c *C) {
 	statusmap, err = GetServiceStatus(conn, svc.ID)
 	c.Assert(err, IsNil)
 	c.Assert(statusmap, DeepEquals, map[string]dao.ServiceStatus{
-		stateIDs[0]: dao.ServiceStatus{states[stateIDs[0]], dao.Pausing},
-		stateIDs[1]: dao.ServiceStatus{states[stateIDs[1]], dao.Paused},
-		stateIDs[2]: dao.ServiceStatus{states[stateIDs[2]], dao.Stopped},
+		stateIDs[0]: dao.ServiceStatus{states[stateIDs[0]], dao.Pausing, nil},
+		stateIDs[1]: dao.ServiceStatus{states[stateIDs[1]], dao.Paused, nil},
+		stateIDs[2]: dao.ServiceStatus{states[stateIDs[2]], dao.Stopped, nil},
 	})
 
 	c.Log("Desired state is STOP")
@@ -127,8 +127,8 @@ func (t *ZZKTest) TestGetServiceStatus(c *C) {
 	statusmap, err = GetServiceStatus(conn, svc.ID)
 	c.Assert(err, IsNil)
 	c.Assert(statusmap, DeepEquals, map[string]dao.ServiceStatus{
-		stateIDs[0]: dao.ServiceStatus{states[stateIDs[0]], dao.Stopping},
-		stateIDs[1]: dao.ServiceStatus{states[stateIDs[1]], dao.Stopping},
-		stateIDs[2]: dao.ServiceStatus{states[stateIDs[2]], dao.Stopped},
+		stateIDs[0]: dao.ServiceStatus{states[stateIDs[0]], dao.Stopping, nil},
+		stateIDs[1]: dao.ServiceStatus{states[stateIDs[1]], dao.Stopping, nil},
+		stateIDs[2]: dao.ServiceStatus{states[stateIDs[2]], dao.Stopped, nil},
 	})
 }


### PR DESCRIPTION
Addresses CC-107

https://jira.zenoss.com/browse/CC-107

Serviced service status will now include healthcheck info by default.  No additional flag needed.  With no service specified, new field "HC Fail" will have an X for a service that has at least one failing healthcheck.  When a service is specified, two new fields, "Healthcheck" and "Healthcheck Status" will show the status of every healthcheck for the service.