### PR TITLE
ZEN-19471: Decode cookie values

### DIFF
--- a/web/session.go
+++ b/web/session.go
@@ -24,6 +24,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -109,9 +110,14 @@ func loginOK(r *rest.Request) bool {
 
 	sessionsLock.Lock()
 	defer sessionsLock.Unlock()
-	session, err := findsessionT(cookie.Value)
+	value, err := url.QueryUnescape(cookie.Value)
 	if err != nil {
-		glog.V(1).Info("Unable to find session ", cookie.Value)
+		glog.Warning("Unable to decode session ", cookie.Value)
+		return false
+	}
+	session, err := findsessionT(value)
+	if err != nil {
+		glog.Info("Unable to find session ", value)
 		return false
 	}
 	session.access = time.Now()


### PR DESCRIPTION
This is necessary to facilitate https://github.com/zenoss/zenoss-prodbin/pull/1069.

ZPublisher URL-encodes the values of cookies it sends back to the browser.
https://fossies.org/dox/Zope2-2.13.22/ZPublisher_2HTTPResponse_8py_source.html#l00885