### PR TITLE
Adds more verbose help function to service run

### DIFF
--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -896,7 +896,9 @@ func ExampleServicedCLI_CmdServiceRun_exec() {
 	InitServiceAPITest("serviced", "service", "run", "-i", "test-service-1", "hello", "-i")
 
 	// Output:
-	// echo hello world -i
+	// Command "hello" not available.
+	// Available commands for Zenoss:
+	//     No commands available.
 }
 
 /*

--- a/domain/common.go
+++ b/domain/common.go
@@ -25,6 +25,7 @@ type MinMax struct {
 
 type Command struct {
 	Command         string
+	Description     string
 	CommitOnSuccess bool
 }
 


### PR DESCRIPTION
"serviced service run <svc> help" displays commands available to that service.

Additionally, if a Command has a Description defined, the help message will
display that in the "Available commands" listing.

Closes CC-1102