### PR TITLE
'serviced service status' output is staggered

### DIFF
--- a/cli/api/service.go
+++ b/cli/api/service.go
@@ -128,7 +128,11 @@ func (a *api) GetServiceStatus(serviceID string) (map[string]map[string]interfac
 			row := make(map[string]interface{})
 			row["ServiceID"] = svc.ID
 			row["Name"] = svc.Name
-			row["ParentID"] = svc.ParentServiceID
+			if svc.ParentServiceID != "" {
+				row["ParentID"] = fmt.Sprintf("%s/%d", svc.ParentServiceID, 0) //make this match the rowmap key
+			} else {
+				row["ParentID"] = ""
+			}
 			row["RAM"] = bytefmt.ByteSize(svc.RAMCommitment.Value)
 
 			if svc.Instances > 0 {
@@ -141,13 +145,17 @@ func (a *api) GetServiceStatus(serviceID string) (map[string]map[string]interfac
 					row["Status"] = dao.Stopped.String()
 				}
 			}
-			rowmap[svc.ID] = row
+			rowmap[fmt.Sprintf("%s/%d", svc.ID, 0)] = row
 		} else {
 			for _, stat := range status {
 				metricReq.Instances = append(metricReq.Instances, metrics.ServiceInstance{svc.ID, stat.State.InstanceID})
 				row := make(map[string]interface{})
 				row["ServiceID"] = svc.ID
-				row["ParentID"] = svc.ParentServiceID
+				if svc.ParentServiceID != "" {
+					row["ParentID"] = fmt.Sprintf("%s/%d", svc.ParentServiceID, 0) //make this match the rowmap key
+				} else {
+					row["ParentID"] = ""
+				}
 				row["RAM"] = bytefmt.ByteSize(svc.RAMCommitment.Value)
 				row["Status"] = stat.Status.String()
 				row["Hostname"] = hostmap[stat.State.HostID]
@@ -174,11 +182,7 @@ func (a *api) GetServiceStatus(serviceID string) (map[string]map[string]interfac
 
 					for hcName, hcResult := range stat.HealthCheckStatuses {
 						newrow := make(map[string]interface{})
-						if svc.Instances > 1 {
-							newrow["ParentID"] = fmt.Sprintf("%s/%d", svc.ID, stat.State.InstanceID)
-						} else {
-							newrow["ParentID"] = svc.ID
-						}
+						newrow["ParentID"] = fmt.Sprintf("%s/%d", svc.ID, stat.State.InstanceID) //make this match the rowmap key
 						newrow["Healthcheck"] = hcName
 						newrow["Healthcheck Status"] = hcResult.Status
 

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -473,17 +473,12 @@ func (c *ServicedCli) cmdServiceStatus(ctx *cli.Context) {
 			defer t.DedentRow()
 			for _, rowid := range childmap[root] {
 				row := states[rowid]
-
 				if _, ok := row["Healthcheck"]; !ok || showIndividualHealthChecks { //if this is a healthcheck row, only include it if showIndividualHealthChecks is true
 					t.AddRow(row)
-					nextRoot := fmt.Sprintf("%v", row["ServiceID"])
-
-					if _, ok := childmap[rowid]; ok {
-						nextRoot = rowid //if rowid exists in our childmap, use it instead of ServiceID
-					}
-
-					addRows(nextRoot)
 				}
+
+				nextRoot := rowid
+				addRows(nextRoot)
 			}
 		}
 	}


### PR DESCRIPTION
CC-1309

Fixed an issue where Parent service refs were incorrect.

Also fixed an issue in the table formatter that would not allow more than one level of indentation difference between two consecutive rows.