### PR TITLE
Output from 'serviced service status' is super wide

### DIFF
--- a/cli/api/service.go
+++ b/cli/api/service.go
@@ -156,11 +156,20 @@ func (a *api) GetServiceStatus(serviceID string) (map[string]map[string]interfac
 				} else {
 					row["ParentID"] = ""
 				}
+
+				//round to uptime to nearest second
+				uptime := stat.State.Uptime()
+				remainder := uptime % time.Second
+				uptime = uptime - remainder
+				if remainder/time.Millisecond >= 500 {
+					uptime += 1 * time.Second
+				}
+
 				row["RAM"] = bytefmt.ByteSize(svc.RAMCommitment.Value)
 				row["Status"] = stat.Status.String()
 				row["Hostname"] = hostmap[stat.State.HostID]
 				row["DockerID"] = fmt.Sprintf("%.12s", stat.State.DockerID)
-				row["Uptime"] = stat.State.Uptime().String()
+				row["Uptime"] = uptime.String()
 
 				if stat.State.InSync {
 					row["InSync"] = "Y"

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -483,7 +483,7 @@ func (c *ServicedCli) cmdServiceStatus(ctx *cli.Context) {
 		}
 	}
 	addRows("")
-	t.Padding = 6
+	t.Padding = 3
 	t.Print()
 	return
 }

--- a/cli/cmd/table.go
+++ b/cli/cmd/table.go
@@ -200,7 +200,7 @@ func (t *Table) getIndents(field string) (int, []string) {
 			}
 		}
 		// compute the max width of the column
-		if width := len(rows[i]); width > maxWidth {
+		if width := len([]rune(rows[i])); width > maxWidth { //count runes, not bytes
 			maxWidth = width
 		}
 	}


### PR DESCRIPTION
CC-1310

https://jira.zenoss.com/browse/CC-1310

Applied the following changes:

1.) Cut padding between columngs in half (6 down to 3)
2.) Fixed a bug in the table that was miscalculating column width
3.) Rounding uptime to the nearest second