### PR TITLE
Fixes CC-922: Wait for network for outbound IP

### DIFF
--- a/cli/api/api.go
+++ b/cli/api/api.go
@@ -97,9 +97,14 @@ func LoadOptions(ops Options) {
 	}
 }
 
-// GetOptionsEndpoint returns the serviced RPC endpoint from options
+// GetOptionsRPCEndpoint returns the serviced RPC endpoint from options
 func GetOptionsRPCEndpoint() string {
 	return options.Endpoint
+}
+
+// SetOptionsRPCEndpoint sets the serviced RPC endpoint in the options
+func SetOptionsRPCEndpoint(endpoint string) {
+	options.Endpoint = endpoint
 }
 
 // GetOptionsRPCPort returns the serviced RPC port from options

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -79,7 +79,7 @@ func (t APITest) StartServer() error {
 
 func ExampleServicedCLI_CmdInit_logging() {
 	InitAPITest("serviced", "--logtostderr", "--alsologtostderr", "--master", "server")
-	InitAPITest("serviced", "--logstashurl", "127.0.0.1", "-v", "4", "--agent", "server")
+	InitAPITest("serviced", "--logstashurl", "127.0.0.1", "-v", "4", "--agent", "--endpoint", "1.2.3.4:4979", "server")
 	InitAPITest("serviced", "--stderrthreshold", "2", "--vmodule", "a=1,b=2,c=3", "--master", "--agent", "server")
 	InitAPITest("serviced", "--log_backtrace_at", "file.go:123", "--master", "--agent", "server")
 
@@ -95,7 +95,7 @@ func ExampleServicedCLI_CmdInit_logging() {
 
 func ExampleServicedCLI_CmdInit_logerr() {
 	InitAPITest("serviced", "--master", "--stderrthreshold", "abc", "server")
-	InitAPITest("serviced", "--agent", "--vmodule", "abc", "server")
+	InitAPITest("serviced", "--agent", "--endpoint", "5.6.7.8:4979", "--vmodule", "abc", "server")
 	InitAPITest("serviced", "--master", "--log_backtrace_at", "abc", "server")
 
 	// Output:

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -71,7 +71,7 @@ func getDefaultOptions(config utils.ConfigReader) api.Options {
 		IsvcsZKQuorum:        config.StringSlice("ISVCS_ZOOKEEPER_QUORUM", []string{}),
 	}
 
-	options.Endpoint = config.StringVal("ENDPOINT", getDefaultEndpoint(options))
+	options.Endpoint = config.StringVal("ENDPOINT", "")
 
 	// Set the path to the controller binary
 	dir, _, err := node.ExecPath()
@@ -103,30 +103,6 @@ func getDefaultDockerRegistry() string {
 	} else {
 		return fmt.Sprintf("%s:5000", hostname)
 	}
-}
-
-// getDefaultEndpoint gets the endpoint to use if the user did not specify one.
-// Takes other configuration options into account while determining the default.
-func getDefaultEndpoint(options api.Options) string {
-	defaultEndpoint := ""
-
-	switch {
-	case options.Master:
-		// Master has multiple backup sources: OUTBOUND_IP or query network configuration
-		if len(options.OutboundIP) > 0 {
-			defaultEndpoint = fmt.Sprintf("%s:%s", options.OutboundIP, options.RPCPort)
-		} else if ip, err := utils.GetIPAddress(); err == nil {
-			defaultEndpoint = fmt.Sprintf("%s:%s", ip, options.RPCPort)
-		} else {
-			defaultEndpoint = ""
-		}
-	default:
-		// On all other hosts (including pure Agent), ENDPOINT is required to know where Master is
-		// (We can't guess where)
-		defaultEndpoint = ""
-	}
-
-	return defaultEndpoint
 }
 
 func getDefaultVarPath(home string) string {

--- a/cli/cmd/server.go
+++ b/cli/cmd/server.go
@@ -59,7 +59,6 @@ func (c *ServicedCli) cmdServer(ctx *cli.Context) {
 				glog.Fatal(err)
 			}
 			endpoint := fmt.Sprintf("%s:%s", outboundIP, api.GetOptionsRPCPort())
-			glog.Infof("Using %s for endpoint", endpoint)
 			api.SetOptionsRPCEndpoint(endpoint)
 		} else {
 			glog.Fatal("No endpoint to master has been configured")

--- a/cli/cmd/server.go
+++ b/cli/cmd/server.go
@@ -16,11 +16,18 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/codegangsta/cli"
 	"github.com/control-center/serviced/cli/api"
 	"github.com/control-center/serviced/rpc/rpcutils"
+	"github.com/control-center/serviced/utils"
 	"github.com/zenoss/glog"
+)
+
+const (
+	outboundIPRetryDelay = 1
+	outboundIPMaxWait    = 90
 )
 
 // Initializer for serviced server
@@ -44,6 +51,21 @@ func (c *ServicedCli) cmdServer(ctx *cli.Context) {
 		return
 	}
 
+	// Make sure we have an endpoint to work with
+	if endpoint := api.GetOptionsRPCEndpoint(); len(endpoint) == 0 {
+		if master {
+			outboundIP, err := getOutboundIP()
+			if err != nil {
+				glog.Fatal(err)
+			}
+			endpoint := fmt.Sprintf("%s:%s", outboundIP, api.GetOptionsRPCPort())
+			glog.Infof("Using %s for endpoint", endpoint)
+			api.SetOptionsRPCEndpoint(endpoint)
+		} else {
+			glog.Fatal("No endpoint to master has been configured")
+		}
+	}
+
 	if master {
 		fmt.Println("This master has been configured to be in pool: " + api.GetOptionsMasterPoolID())
 	}
@@ -52,5 +74,29 @@ func (c *ServicedCli) cmdServer(ctx *cli.Context) {
 	rpcutils.RPC_CLIENT_SIZE = api.GetOptionsMaxRPCClients()
 	if err := c.driver.StartServer(); err != nil {
 		glog.Fatalf("Could not start server: %s", err)
+	}
+}
+
+// getOutboundIP queries the network configuration for an IP address suitable for reaching the outside world.
+// Will retry for a while if a path to the outside world is not yet available.
+func getOutboundIP() (string, error) {
+	var outboundIP string
+	var err error
+	timeout := time.After(outboundIPMaxWait * time.Second)
+	for {
+		if outboundIP, err = utils.GetIPAddress(); err == nil {
+			// Success
+			return outboundIP, nil
+		} else {
+			select {
+			case <-timeout:
+				// Give up
+				return "", fmt.Errorf("Gave up waiting for network (to determine our outbound IP address): %s", err)
+			default:
+				// Retry
+				glog.Info("Waiting for network initialization...")
+				time.Sleep(outboundIPRetryDelay * time.Second)
+			}
+		}
 	}
 }

--- a/cli/cmd/server_test.go
+++ b/cli/cmd/server_test.go
@@ -39,7 +39,7 @@ func InitServerAPITest(args ...string) {
 
 func ExampleSerivcedCLI_CmdServer_good() {
 	InitServerAPITest("serviced", "--master", "server")
-	InitServerAPITest("serviced", "--agent", "server")
+	InitServerAPITest("serviced", "--agent", "--endpoint", "10.20.30.40", "server")
 	InitServerAPITest("serviced", "--agent", "--master", "server")
 
 	// Output:

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -26,7 +26,7 @@ BUILD_TAGS="$(bash ${DIR}/build-tags.sh)"
 
 echo "Running unit tests ..."
 START_TIME=`date --utc +%s`
-godep go test -tags="${BUILD_TAGS} unit -v" $GOTEST ./...
+godep go test -tags="${BUILD_TAGS} unit" $GOTEST ./...
 UNIT_TEST_RESULT=$?
 END_TIME=`date --utc +%s`
 echo "Unit tests finished in $(($END_TIME - $START_TIME)) seconds"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -26,7 +26,7 @@ BUILD_TAGS="$(bash ${DIR}/build-tags.sh)"
 
 echo "Running unit tests ..."
 START_TIME=`date --utc +%s`
-godep go test -tags="${BUILD_TAGS} unit" $GOTEST ./...
+godep go test -tags="${BUILD_TAGS} unit -v" $GOTEST ./...
 UNIT_TEST_RESULT=$?
 END_TIME=`date --utc +%s`
 echo "Unit tests finished in $(($END_TIME - $START_TIME)) seconds"


### PR DESCRIPTION
When our appliances (possibly other hosts?) are rebooted, serviced often
starts running before IP addresses have been assigned to all interfaces.
So wait (up to 90 seconds) for one of the interfaces of the type we need
to become available.

Also noticed some confusion between the definition and use of ENDPOINT
and OUTBOUND_IP, so straightened those out.  (For Master, ENDPOINT is
optional and can fall back to OUTBOUND_IP or dynamic.  For Agent,
ENDPOINT is required.  When just parsing options, don't report any
error.  Wait to enforce the rules when we actually go to start the
daemon.)