### PR TITLE
Backport change from code-review comments for CC-1340

### DIFF
--- a/commons/subprocess/instance.go
+++ b/commons/subprocess/instance.go
@@ -55,8 +55,6 @@ func (s *Instance) Notify(sig os.Signal) {
 	select {
 	case s.signalChan <- sig:
 		glog.V(1).Infof("Notify: sending signal %v", sig)
-	default:
-		glog.Warningf("Notify: unable to send signal %v, because signalChan is full", sig)
 	}
 }
 
@@ -111,8 +109,6 @@ func (s *Instance) loop() {
 			glog.V(1).Infof("loop: process exited with error %v", exitError)
 			select {
 			case s.commandExit <- exitError: // tell our the parent controller that the command has exited
-			default:
-				glog.Warningf("Received child exit = %#v but the commandExit channel is full", exitError)
 			}
 			return
 


### PR DESCRIPTION
During code-review of CC-1340 (which backported changes for CC-1335 to support/1.0.x), Summer suggested a refinement to make the code more defensive in the case that channel is full. This PR implements those changes on the develop branch.