### PR TITLE
Manually backport changes from CC-672 and increase ES startup time to…

### DIFF
--- a/cli/api/api.go
+++ b/cli/api/api.go
@@ -81,12 +81,6 @@ func LoadOptions(ops Options) {
 
 	// Set verbosity
 	glog.SetVerbosity(options.Verbosity)
-
-	// Check option boundaries
-	if options.ESStartupTimeout < minTimeout {
-		glog.V(0).Infof("overriding elastic search startup timeout with minimum %d", minTimeout)
-		options.ESStartupTimeout = minTimeout
-	}
 }
 
 // GetOptionsEndpoint returns the serviced RPC endpoint from options

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -133,7 +133,7 @@ func (d *daemon) getEsClusterName(Type string) string {
 }
 
 func (d *daemon) startISVCS() {
-	isvcs.Init()
+	isvcs.Init(options.ESStartupTimeout)
 	isvcs.Mgr.SetVolumesDir(path.Join(options.VarPath, "isvcs"))
 	if err := isvcs.Mgr.SetConfigurationOption("elasticsearch-serviced", "cluster", d.getEsClusterName("elasticsearch-serviced")); err != nil {
 		glog.Fatalf("Could not set es-serviced option: %s", err)

--- a/cli/api/utils.go
+++ b/cli/api/utils.go
@@ -19,7 +19,6 @@ import (
 	"os/exec"
 	"os/user"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -28,8 +27,6 @@ import (
 )
 
 const (
-	minTimeout            = 30
-	defaultTimeout        = 600
 	networkAccessDelay    = 1
 	networkAccessAttempts = 90
 )
@@ -79,27 +76,6 @@ func GetVarPath() string {
 		return path.Join(os.TempDir(), "serviced-"+user.Username, "var")
 	}
 	return path.Join(os.TempDir(), "serviced")
-}
-
-// GetESStartupTimeout returns the Elastic Search Startup Timeout
-func GetESStartupTimeout() int {
-	var timeout int
-
-	if t := options.ESStartupTimeout; t > 0 {
-		timeout = options.ESStartupTimeout
-	} else if t := os.Getenv("ES_STARTUP_TIMEOUT"); t != "" {
-		if res, err := strconv.Atoi(t); err != nil {
-			timeout = res
-		}
-	}
-
-	if timeout == 0 {
-		timeout = defaultTimeout
-	} else if timeout < minTimeout {
-		timeout = minTimeout
-	}
-
-	return timeout
 }
 
 // GetGateway returns the default gateway

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -104,7 +104,7 @@ func New(driver api.API) *ServicedCli {
 		rpcPort          = configInt("RPC_PORT", defaultRPCPort)
 		agentEndpoint    = getLocalAgentEndpoint(rpcPort)
 		varPath          = api.GetVarPath()
-		esStartupTimeout = api.GetESStartupTimeout()
+		esStartupTimeout = configInt("ES_STARTUP_TIMEOUT", isvcs.DEFAULT_ES_STARTUP_TIMEOUT_SECONDS)
 		dockerDNS        = cli.StringSlice(api.GetDockerDNS())
 	)
 
@@ -183,7 +183,7 @@ func New(driver api.API) *ServicedCli {
 		cli.StringSliceFlag{"mount", &cli.StringSlice{}, "bind mount: DOCKER_IMAGE,HOST_PATH[,CONTAINER_PATH]"},
 		cli.StringFlag{"fstype", configEnv("FS_TYPE", "rsync"), "driver for underlying file system"},
 		cli.StringSliceFlag{"alias", &aliases, "list of aliases for this host, e.g., localhost"},
-		cli.IntFlag{"es-startup-timeout", esStartupTimeout, "time to wait on elasticsearch startup before bailing"},
+		cli.IntFlag{"es-startup-timeout", esStartupTimeout, "time (in seconds) to wait on elasticsearch startup before bailing"},
 		cli.IntFlag{"max-container-age", configInt("MAX_CONTAINER_AGE", 60*60*24), "maximum age (seconds) of a stopped container before removing"},
 		cli.IntFlag{"max-dfs-timeout", configInt("MAX_DFS_TIMEOUT", 60*5), "max timeout to perform a dfs snapshot"},
 		cli.StringFlag{"virtual-address-subnet", configEnv("VIRTUAL_ADDRESS_SUBNET", "10.3"), "/16 subnet for virtual addresses"},

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -100,7 +100,7 @@ func (dt *DaoTest) SetUpSuite(c *C) {
 	docker.SetUseRegistry(true)
 
 	dt.Port = 9202
-	isvcs.Init()
+	isvcs.Init(isvcs.DEFAULT_ES_STARTUP_TIMEOUT_SECONDS)
 	isvcs.Mgr.SetVolumesDir("/tmp/serviced-test")
 	esServicedClusterName, _ := utils.NewUUID36()
 	if err := isvcs.Mgr.SetConfigurationOption("elasticsearch-serviced", "cluster", esServicedClusterName); err != nil {


### PR DESCRIPTION
Fixes CC-1353

Includes manual backport of changes for CC-672 (make --es-startup-timeout work), as well as increasing the default startup time for ES isvcs to 4 minutes 