### PR TITLE
Feature/cc 1347

### DIFF
--- a/commons/docker/api.go
+++ b/commons/docker/api.go
@@ -293,7 +293,11 @@ func (c *Container) Delete(volumes bool) error {
 	if err != nil {
 		return err
 	}
-	return dc.RemoveContainer(dockerclient.RemoveContainerOptions{ID: c.ID, RemoveVolumes: volumes})
+	err = dc.RemoveContainer(dockerclient.RemoveContainerOptions{ID: c.ID, RemoveVolumes: volumes})
+	if _, ok := err.(*dockerclient.NoSuchContainer); ok {
+		return ErrNoSuchContainer
+	}
+	return err
 }
 
 // Export writes the contents of the container's filesystem as a tar archive to outfile.

--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -119,6 +119,7 @@ type IServiceDefinition struct {
 	Configuration map[string]interface{}             // service specific configuration
 	Notify        func(*IService, interface{}) error // A function to run when notified of a data event
 	PostStart     func(*IService) error              // A function to run after the initial start of the service
+	Recover       func(path string) error            // A recovery step if the service fails to start
 	HostNetwork   bool                               // enables host network in the container
 	Links         []string                           // List of links to other containers in the form of <name>:<alias>
 	StartGroup    uint16                             // Start up group number
@@ -433,7 +434,7 @@ func (svc *IService) remove(notify chan<- int) {
 	defer func() { notify <- rc }()
 
 	// delete the container
-	if err := ctr.Delete(true); err != nil {
+	if err := ctr.Delete(true); err != nil && err != docker.ErrNoSuchContainer {
 		glog.Errorf("Could not remove isvc %s: %s", ctr.Name, err)
 	}
 }
@@ -481,7 +482,16 @@ func (svc *IService) run() {
 					continue
 				}
 
-				if svc.exited, err = svc.start(); err != nil {
+				svc.exited, err = svc.start()
+				if err != nil && svc.Recover != nil {
+					glog.Warningf("ISVC %s failed to start; attempting recovery", svc.name())
+					if e := svc.Recover(svc.getResourcePath("")); e != nil {
+						glog.Errorf("Could not recover service %s: %s", svc.name(), e)
+					} else {
+						svc.exited, err = svc.start()
+					}
+				}
+				if err != nil {
 					req.response <- err
 					continue
 				}

--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -640,11 +640,11 @@ func (svc *IService) startupHealthcheck() <-chan error {
 				svc.setHealthStatus(result, currentTime.Unix())
 				elapsed := time.Since(startCheck)
 				if result == nil {
-					glog.Infof("Verified health status of %s after %s seconds", svc.Name, elapsed)
+					glog.Infof("Verified health status of %s after %s", svc.Name, elapsed)
 					break
 				} else if elapsed.Seconds() > svc.StartupTimeout.Seconds() {
-					glog.Error("Could not verified health status of %s after %s seconds. Last health check returned %#v",
-						svc.Name, WAIT_FOR_INITIAL_HEALTHCHECK, result)
+					glog.Errorf("Could not verified health status of %s after %s. Last health check returned %#v",
+						svc.Name, svc.StartupTimeout, result)
 					break
 				}
 

--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -19,22 +19,59 @@
 package isvcs
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+
+	"github.com/control-center/serviced/volume"
 	"github.com/zenoss/elastigo/cluster"
 	"github.com/zenoss/glog"
 
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"time"
 )
+
+const (
+	ESRed ESHealth = iota
+	ESYellow
+	ESGreen
+)
+
+type ESHealth int
+
+func GetHealth(health string) ESHealth {
+	switch health {
+	case "red":
+		return ESRed
+	case "yellow":
+		return ESYellow
+	case "green":
+		return ESGreen
+	}
+	return ESHealth(-1)
+}
+
+func (health ESHealth) String() string {
+	switch health {
+	case ESRed:
+		return "red"
+	case ESYellow:
+		return "yellow"
+	case ESGreen:
+		return "green"
+	}
+	return "unknown"
+}
 
 var elasticsearch_logstash *IService
 var elasticsearch_serviced *IService
 
 const (
-	MIN_ES_STARTUP_TIMEOUT_SECONDS = 30
-	DEFAULT_ES_STARTUP_TIMEOUT_SECONDS = 240	// 4 minutes
+	MIN_ES_STARTUP_TIMEOUT_SECONDS     = 30
+	DEFAULT_ES_STARTUP_TIMEOUT_SECONDS = 240 // 4 minutes
 )
 
 func init() {
@@ -50,7 +87,7 @@ func init() {
 	}
 
 	defaultHealthCheck := healthCheckDefinition{
-		healthCheck: elasticsearchHealthCheck(9200),
+		healthCheck: esHealthCheck(9200, ESYellow),
 		Interval:    DEFAULT_HEALTHCHECK_INTERVAL,
 		Timeout:     DEFAULT_HEALTHCHECK_TIMEOUT,
 	}
@@ -68,7 +105,6 @@ func init() {
 			Volumes:        map[string]string{"data": "/opt/elasticsearch-0.90.9/data"},
 			Configuration:  make(map[string]interface{}),
 			HealthChecks:   healthChecks,
-			HostNetwork:    false,
 			StartupTimeout: time.Duration(DEFAULT_ES_STARTUP_TIMEOUT_SECONDS * time.Second),
 		},
 	)
@@ -84,16 +120,15 @@ func init() {
 	}
 
 	serviceName = "elasticsearch-logstash"
+	logStashHealthCheck := defaultHealthCheck
+	logStashHealthCheck.healthCheck = esHealthCheck(9100, ESYellow)
+	healthChecks = map[string]healthCheckDefinition{
+		DEFAULT_HEALTHCHECK_NAME: logStashHealthCheck,
+	}
 	elasticsearch_logstashPortBinding := portBinding{
 		HostIp:         "127.0.0.1",
 		HostIpOverride: "SERVICED_ISVC_ELASTICSEARCH_LOGSTASH_PORT_9100_HOSTIP",
 		HostPort:       9100,
-	}
-
-	logStashHealthCheck := defaultHealthCheck
-	logStashHealthCheck.healthCheck = elasticsearchHealthCheck(9100)
-	healthChecks = map[string]healthCheckDefinition{
-		DEFAULT_HEALTHCHECK_NAME: logStashHealthCheck,
 	}
 
 	elasticsearch_logstash, err = NewIService(
@@ -106,7 +141,7 @@ func init() {
 			Volumes:        map[string]string{"data": "/opt/elasticsearch-1.3.1/data"},
 			Configuration:  make(map[string]interface{}),
 			HealthChecks:   healthChecks,
-			HostNetwork:    false,
+			Recover:        recoverES,
 			StartupTimeout: time.Duration(DEFAULT_ES_STARTUP_TIMEOUT_SECONDS * time.Second),
 		},
 	)
@@ -123,70 +158,93 @@ func init() {
 	}
 }
 
-// elasticsearchHealthCheck() determines if elasticsearch is healthy
-func elasticsearchHealthCheck(port int) HealthCheckFunction {
-	return func(halt <-chan struct{}) error {
-		lastError := time.Now()
-		minUptime := time.Second * 2
-		baseUrl := fmt.Sprintf("http://localhost:%d", port)
-
-		for {
-			healthResponse, err := getElasticHealth(baseUrl)
-			if err == nil && (healthResponse.Status == "green" || healthResponse.Status == "yellow") {
-				break
-			} else {
-				lastError = time.Now()
-				glog.V(1).Infof("Still trying to connect to elasticsearch at %s: %v: %s", baseUrl, err, healthResponse.Status)
-			}
-
-			if time.Since(lastError) > minUptime {
-				break
-			}
-
-			select {
-			case <-halt:
-				if err != nil {
-					glog.Infof("Quit healthcheck for elasticsearch at %s: last error: %#v", baseUrl, err)
-				} else {
-					glog.Infof("Quit healthcheck for elasticsearch at %s: last response: %#v", baseUrl, healthResponse)
-				}
-				return nil
-			default:
-				time.Sleep(time.Second)
-			}
+func recoverES(path string) error {
+	if err := func() error {
+		file, err := os.Create(path + "-backup.tgz")
+		if err != nil {
+			glog.Errorf("Could not create backup for %s: %s", path, err)
+			return err
 		}
-		glog.V(1).Infof("elasticsearch running browser at %s/_plugin/head/", baseUrl)
+		defer file.Close()
+		gz := gzip.NewWriter(file)
+		defer gz.Close()
+		tarfile := tar.NewWriter(gz)
+		defer tarfile.Close()
+		if err := volume.ExportDirectory(tarfile, path, filepath.Base(path)); err != nil {
+			glog.Errorf("Could not backup %s: %s", path, err)
+			return err
+		}
+		if err := volume.ExportFile(tarfile, path+".clustername", filepath.Base(path)+".clustername"); err != nil {
+			return err
+		}
 		return nil
+	}(); err != nil {
+		return err
 	}
+	if err := os.RemoveAll(path); err != nil {
+		glog.Errorf("Could not remove %s: %s", path, err)
+		return err
+	}
+	return nil
 }
 
-func getElasticHealth(baseUrl string) (cluster.ClusterHealthResponse, error) {
-	healthUrl := fmt.Sprintf("%s/_cluster/health?pretty=true", baseUrl)
-	healthResponse := cluster.ClusterHealthResponse{}
-	healthResponse.Status = "unknown"
-	response, err := http.Get(healthUrl)
-	if err != nil {
-		return healthResponse, err
-	}
+type esres struct {
+	url      string
+	response *cluster.ClusterHealthResponse
+	err      error
+}
 
-	defer response.Body.Close()
-	if response.StatusCode != 200 {
-		err = fmt.Errorf("Failed to HTTP GET for %s, return code = %d", healthUrl, response.StatusCode)
-		return healthResponse, err
-	}
+func getESHealth(url string) <-chan esres {
+	esresC := make(chan esres, 1)
+	go func() {
+		resp, err := http.Get(url)
+		if err != nil {
+			esresC <- esres{url, nil, err}
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			esresC <- esres{url, nil, fmt.Errorf("received %d status code", resp.StatusCode)}
+			return
+		}
+		var health cluster.ClusterHealthResponse
+		if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+			esresC <- esres{url, nil, err}
+			return
+		}
+		esresC <- esres{url, &health, nil}
 
-	body, readErr := ioutil.ReadAll(response.Body)
-	if readErr != nil {
-		err = fmt.Errorf("Failed to read HTTP response from %s: %s", healthUrl, readErr)
-		return healthResponse, err
-	}
+	}()
+	return esresC
+}
 
-	jsonErr := json.Unmarshal(body, &healthResponse)
-	if jsonErr != nil {
-		err = fmt.Errorf("Failed to unmarshall response to healthcheck from %s: %s", healthUrl, jsonErr)
+func esHealthCheck(port int, minHealth ESHealth) HealthCheckFunction {
+	return func(cancel <-chan struct{}) error {
+		url := fmt.Sprintf("http://localhost:%d/_cluster/health", port)
+		var r esres
+		for {
+			select {
+			case r = <-getESHealth(url):
+				if r.err != nil {
+					glog.Warningf("Problem looking up %s: %s", r.url, r.err)
+					break
+				}
+				if status := GetHealth(r.response.Status); status < minHealth {
+					glog.Warningf("Received health status {%+v} at %s", r.response, r.url)
+					break
+				}
+				return nil
+			case <-cancel:
+				if r.err != nil {
+					glog.Infof("Cancel healthcheck for elasticsearch at %s: last error: %#v", url, r.err)
+				} else {
+					glog.Infof("Cancel healthcheck for elasticsearch at %s: last response: %#v", url, r.response)
+				}
+				return nil
+			}
+			time.Sleep(time.Second)
+		}
 	}
-
-	return healthResponse, err
 }
 
 func PurgeLogstashIndices(days int, gb int) {

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -29,7 +29,7 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO = "zenoss/serviced-isvcs"
-	IMAGE_TAG  = "v27.1"
+	IMAGE_TAG  = "v27.2"
 )
 
 func Init(esStartupTimeoutInSeconds int) {

--- a/volume/exportfs.go
+++ b/volume/exportfs.go
@@ -1,0 +1,181 @@
+// Copyright 2015 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package volume
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/zenoss/glog"
+)
+
+// ExportDirectory recursively writes its contents into a tar Writer.
+func ExportDirectory(tarfile *tar.Writer, path, name string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		glog.Errorf("Could not open %s: %s", path, err)
+		return err
+	}
+	defer dir.Close()
+	fstat, err := dir.Stat()
+	if err != nil {
+		glog.Errorf("Could not stat %s: %s", path, err)
+		return err
+	}
+	header, err := getHeader(name, "", fstat)
+	if err != nil {
+		return err
+	}
+	if err := tarfile.WriteHeader(header); err != nil {
+		glog.Errorf("Could not write header for directory %s: %s", path, err)
+		return err
+	}
+	files, err := dir.Readdir(0)
+	if err != nil {
+		glog.Errorf("Could not list directory for %s: %s", path, err)
+		return err
+	}
+	for _, finfo := range files {
+		fullpath, relpath := filepath.Join(path, finfo.Name()), filepath.Join(name, finfo.Name())
+		if finfo.IsDir() {
+			if err := ExportDirectory(tarfile, fullpath, relpath); err != nil {
+				return err
+			}
+		} else {
+			if err := ExportFile(tarfile, fullpath, relpath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ExportFile writes a file into a tar Writer.
+func ExportFile(tarfile *tar.Writer, path, name string) error {
+	finfo, _ := os.Stat(path)
+	if isSocket := finfo.Mode() & os.ModeSocket; isSocket == os.ModeSocket {
+		glog.Warningf("Cannot export Unix domain socket %s", path)
+		return nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		glog.Errorf("Could not open %s: %s", path, err)
+		return err
+	}
+	defer file.Close()
+	fstat, err := file.Stat()
+	if err != nil {
+		glog.Errorf("Could not stat %s: %s", path, err)
+		return err
+	}
+
+	link, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		glog.Errorf("Could not check link for %s: %s", path, err)
+		return err
+	}
+	header, err := getHeader(name, link, fstat)
+	if err != nil {
+		glog.Errorf("Could not create file header %s: %s", path, err)
+		return err
+	}
+	if err := tarfile.WriteHeader(header); err != nil {
+		glog.Errorf("Could not write file header %s: %s", path, err)
+		return err
+	}
+	if link == path {
+		if _, err := io.Copy(tarfile, file); err != nil {
+			glog.Errorf("Could not write file %s: %s", path, err)
+			return err
+		}
+	}
+	return nil
+}
+
+// ImportArchive reads from a tar Reader and writes the contents into a path
+// preserving file permissions and ownership.
+func ImportArchive(tarfile *tar.Reader, path string) error {
+	for {
+		header, err := tarfile.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			glog.Errorf("Could not import archive to %s: %s", path, err)
+			return err
+		}
+		if err := ImportArchiveHeader(header, tarfile, path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ImportArchiveHeader imports a tarfile header to a particular path
+func ImportArchiveHeader(header *tar.Header, reader io.Reader, path string) error {
+	filename := filepath.Join(path, header.Name)
+	switch header.Typeflag {
+	case tar.TypeDir:
+		if err := os.MkdirAll(filename, 0755); err != nil {
+			glog.Errorf("Could not create directory at %s: %s", filename, err)
+			return err
+		}
+	case tar.TypeSymlink:
+		if err := os.Symlink(filename, header.Linkname); err != nil {
+			glog.Errorf("Could not create symlink at %s: %s", filename, err)
+			return err
+		}
+	case tar.TypeReg:
+		err := func() error {
+			writer, err := os.Create(filename)
+			if err != nil {
+				glog.Errorf("Could not create file at %s: %s", filename, err)
+				return err
+			}
+			defer writer.Close()
+			if _, err := io.Copy(writer, reader); err != nil {
+				glog.Errorf("Could not copy file %s: %s", filename, err)
+				return err
+			}
+			return nil
+		}()
+		if err != nil {
+			return err
+		}
+	default:
+		glog.Errorf("Found unxepected file type %b: will not import %s", header.Typeflag, filename)
+		return nil
+	}
+	if err := os.Chown(filename, header.Uid, header.Gid); err != nil {
+		glog.Warningf("Could not change file ownership for %s: %s", filename, err)
+	}
+	if err := os.Chmod(filename, header.FileInfo().Mode()); err != nil {
+		glog.Warningf("Could not set permissions for file %s: %s", filename, err)
+	}
+	return nil
+}
+
+func getHeader(name, link string, fstat os.FileInfo) (*tar.Header, error) {
+	header, err := tar.FileInfoHeader(fstat, link)
+	if err != nil {
+		return nil, err
+	}
+	header.Name = name
+	header.Uid = int(fstat.Sys().(*syscall.Stat_t).Uid)
+	header.Gid = int(fstat.Sys().(*syscall.Stat_t).Gid)
+	header.ModTime = fstat.ModTime()
+	return header, nil
+}


### PR DESCRIPTION
Fixes CC-1347

This PR backports the changes for https://jira.zenoss.com/browse/CC-1164 which backup the ES-logstash directory if the startup healthchecks fail.  It also uses v27.2 of the iservices image (created yesterday) which uses a difference configuration for shards and replicas in new ES installations for 1.0.x