### PR TITLE
CC-1370: Incorporated the idea of snapshot tags on the volume

### DIFF
--- a/volume/drivertest/drivertest.go
+++ b/volume/drivertest/drivertest.go
@@ -85,9 +85,13 @@ func arrayContains(array []string, element string) bool {
 }
 
 // filter out the lost+found directory created on ext4 filesystems
-func filterLostAndFound(fis []os.FileInfo) (filtered []os.FileInfo) {
+// filter out the .SNAPSHOTINFO file that gets created when a new snapshot is
+// taken
+func filterExtraFiles(fis []os.FileInfo) (filtered []os.FileInfo) {
 	for _, fi := range fis {
-		if !fi.IsDir() || fi.Name() != "lost+found" {
+		switch fi.Name() {
+		case "lost+found", ".SNAPSHOTINFO":
+		default:
 			filtered = append(filtered, fi)
 		}
 	}
@@ -113,7 +117,7 @@ func DriverTestCreateEmpty(c *C, drivername volume.DriverType, root string, args
 	verifyFile(c, vol.Path(), 0755|os.ModeDir, uint32(os.Getuid()), uint32(os.Getgid()))
 	fis, err := ioutil.ReadDir(vol.Path())
 	c.Assert(err, IsNil)
-	fis = filterLostAndFound(fis)
+	fis = filterExtraFiles(fis)
 	c.Assert(fis, HasLen, 0)
 
 	driver.Release(volumeName)
@@ -164,7 +168,7 @@ func verifyBase(c *C, driver *Driver, vol volume.Volume) {
 	checkBase(c, driver, vol)
 	fis, err := ioutil.ReadDir(vol.Path())
 	c.Assert(err, IsNil)
-	fis = filterLostAndFound(fis)
+	fis = filterExtraFiles(fis)
 	c.Assert(fis, HasLen, 2)
 }
 
@@ -176,7 +180,7 @@ func verifyBaseWithExtra(c *C, driver *Driver, vol volume.Volume) {
 
 	fis, err := ioutil.ReadDir(vol.Path())
 	c.Assert(err, IsNil)
-	fis = filterLostAndFound(fis)
+	fis = filterExtraFiles(fis)
 	c.Assert(fis, HasLen, 3)
 }
 
@@ -218,18 +222,27 @@ func DriverTestSnapshots(c *C, drivername volume.DriverType, root string, args [
 	c.Assert(err, IsNil)
 
 	// Snapshot with the verified base
-	err = vol.Snapshot("Snap")
+	err = vol.Snapshot("Snap", "snapshot-message-0", []string{"tagA"})
 	c.Assert(err, IsNil)
 
 	snaps, err := vol.Snapshots()
 	c.Assert(err, IsNil)
 	c.Assert(arrayContains(snaps, "Base_Snap"), Equals, true)
 
+	info, err := vol.SnapshotInfo("Base_Snap")
+	c.Assert(err, IsNil)
+	c.Assert(info, NotNil)
+	c.Check(info.Name, Equals, "Base_Snap")
+	c.Check(info.Label, Equals, "Snap")
+	c.Check(info.TenantID, Equals, "Base")
+	c.Check(info.Message, Equals, "snapshot-message-0")
+	c.Check(info.Tags, DeepEquals, []string{"tagA"})
+
 	// Write another file
 	writeExtra(c, driver, vol)
 
 	// Re-snapshot with the extra file
-	err = vol.Snapshot("Snap2")
+	err = vol.Snapshot("Snap2", "snapshot-message-1", []string{"tag1", "tag2", "tag3"})
 	c.Assert(err, IsNil)
 
 	// Make sure the metadata path exists for the snapshot
@@ -261,11 +274,11 @@ func DriverTestSnapshots(c *C, drivername volume.DriverType, root string, args [
 	c.Assert(arrayContains(snaps, "Base_Snap2"), Equals, true)
 
 	// Snapshot using an existing label and make sure it errors properly
-	err = vol.Snapshot("Snap")
+	err = vol.Snapshot("Snap", "snapshot-message-2", []string{"tag4"})
 	c.Assert(err, ErrorMatches, volume.ErrSnapshotExists.Error())
 
 	// Resnapshot using the raw label and make sure it is equivalent
-	err = vol.Snapshot("Base_Snap")
+	err = vol.Snapshot("Base_Snap", "snapshot-message-3", []string{"tag5", "tag6"})
 	c.Assert(err, ErrorMatches, volume.ErrSnapshotExists.Error())
 
 	c.Assert(driver.Remove("Base"), IsNil)
@@ -296,7 +309,7 @@ func DriverTestExportImport(c *C, drivername volume.DriverType, exportfs, import
 	c.Assert(err, IsNil)
 
 	// Export the snapshot
-	c.Assert(vol.Snapshot("Backup"), IsNil)
+	c.Assert(vol.Snapshot("Backup", "", []string{}), IsNil)
 	err = vol.Export("Base_Backup", "", buffer)
 	c.Assert(err, IsNil)
 

--- a/volume/mocks/Volume.go
+++ b/volume/mocks/Volume.go
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build integration
-
 package mocks
 
 import "github.com/control-center/serviced/volume"

--- a/volume/mocks/Volume.go
+++ b/volume/mocks/Volume.go
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -11,106 +11,204 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build integration
+
 package mocks
 
-import (
-	"io"
-
-	"github.com/control-center/serviced/volume"
-)
+import "github.com/control-center/serviced/volume"
 import "github.com/stretchr/testify/mock"
+
+import "io"
 
 type Volume struct {
 	mock.Mock
 }
 
-func (m *Volume) Name() string {
-	ret := m.Called()
+func (_m *Volume) Name() string {
+	ret := _m.Called()
 
-	r0 := ret.Get(0).(string)
-
-	return r0
-}
-func (m *Volume) Path() string {
-	ret := m.Called()
-
-	r0 := ret.Get(0).(string)
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
 
 	return r0
 }
-func (m *Volume) Driver() volume.Driver {
-	ret := m.Called()
+func (_m *Volume) Path() string {
+	ret := _m.Called()
 
-	r0 := ret.Get(0).(volume.Driver)
-
-	return r0
-}
-func (m *Volume) Snapshot(label string) error {
-	ret := m.Called(label)
-
-	r0 := ret.Error(0)
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
 
 	return r0
 }
-func (m *Volume) WriteMetadata(label, name string) (io.WriteCloser, error) {
-	ret := m.Called(label, name)
+func (_m *Volume) Driver() volume.Driver {
+	ret := _m.Called()
 
-	r0 := ret.Get(0).(io.WriteCloser)
-	r1 := ret.Error(1)
+	var r0 volume.Driver
+	if rf, ok := ret.Get(0).(func() volume.Driver); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(volume.Driver)
+	}
+
+	return r0
+}
+func (_m *Volume) Snapshot(label string, message string, tags []string) error {
+	ret := _m.Called(label, message, tags)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, []string) error); ok {
+		r0 = rf(label, message, tags)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Volume) SnapshotInfo(label string) (*volume.SnapshotInfo, error) {
+	ret := _m.Called(label)
+
+	var r0 *volume.SnapshotInfo
+	if rf, ok := ret.Get(0).(func(string) *volume.SnapshotInfo); ok {
+		r0 = rf(label)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*volume.SnapshotInfo)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(label)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
-func (m *Volume) ReadMetadata(label, name string) (io.ReadCloser, error) {
-	ret := m.Called(label, name)
+func (_m *Volume) WriteMetadata(label string, name string) (io.WriteCloser, error) {
+	ret := _m.Called(label, name)
 
-	r0 := ret.Get(0).(io.ReadCloser)
-	r1 := ret.Error(1)
+	var r0 io.WriteCloser
+	if rf, ok := ret.Get(0).(func(string, string) io.WriteCloser); ok {
+		r0 = rf(label, name)
+	} else {
+		r0 = ret.Get(0).(io.WriteCloser)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(label, name)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
-func (m *Volume) Snapshots() ([]string, error) {
-	ret := m.Called()
+func (_m *Volume) ReadMetadata(label string, name string) (io.ReadCloser, error) {
+	ret := _m.Called(label, name)
+
+	var r0 io.ReadCloser
+	if rf, ok := ret.Get(0).(func(string, string) io.ReadCloser); ok {
+		r0 = rf(label, name)
+	} else {
+		r0 = ret.Get(0).(io.ReadCloser)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(label, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Volume) Snapshots() ([]string, error) {
+	ret := _m.Called()
 
 	var r0 []string
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]string)
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
 	}
-	r1 := ret.Error(1)
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
-func (m *Volume) RemoveSnapshot(label string) error {
-	ret := m.Called(label)
+func (_m *Volume) RemoveSnapshot(label string) error {
+	ret := _m.Called(label)
 
-	r0 := ret.Error(0)
-
-	return r0
-}
-func (m *Volume) Rollback(label string) error {
-	ret := m.Called(label)
-
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(label)
+	} else {
+		r0 = ret.Error(0)
+	}
 
 	return r0
 }
-func (m *Volume) Export(label string, parent string, writer io.Writer) error {
-	ret := m.Called(label, parent, writer)
+func (_m *Volume) Rollback(label string) error {
+	ret := _m.Called(label)
 
-	r0 := ret.Error(0)
-
-	return r0
-}
-func (m *Volume) Import(label string, reader io.Reader) error {
-	ret := m.Called(label, reader)
-
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(label)
+	} else {
+		r0 = ret.Error(0)
+	}
 
 	return r0
 }
-func (m *Volume) Tenant() string {
-	ret := m.Called()
+func (_m *Volume) Export(label string, parent string, writer io.Writer) error {
+	ret := _m.Called(label, parent, writer)
 
-	r0 := ret.Get(0).(string)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, io.Writer) error); ok {
+		r0 = rf(label, parent, writer)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Volume) Import(label string, reader io.Reader) error {
+	ret := _m.Called(label, reader)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, io.Reader) error); ok {
+		r0 = rf(label, reader)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Volume) Tenant() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
 
 	return r0
 }

--- a/volume/nfs/nfs.go
+++ b/volume/nfs/nfs.go
@@ -166,8 +166,13 @@ func (v *NFSVolume) ReadMetadata(label, name string) (io.ReadCloser, error) {
 }
 
 // Snapshot implements volume.Volume.Snapshot
-func (v *NFSVolume) Snapshot(label string) (err error) {
+func (v *NFSVolume) Snapshot(label, message string, tags []string) (err error) {
 	return ErrNotSupported
+}
+
+// SnapshotInfo implements volume.Volume.SnapshotInfo
+func (v *NFSVolume) SnapshotInfo(label string) (*volume.SnapshotInfo, error) {
+	return nil, ErrNotSupported
 }
 
 // Snapshots implements volume.Volume.Snapshots

--- a/volume/nfs/nfs_test.go
+++ b/volume/nfs/nfs_test.go
@@ -94,7 +94,11 @@ func (s *NFSSuite) TestNFSDriver(c *C) {
 	c.Assert(rc, IsNil)
 	c.Assert(err, Equals, ErrNotSupported)
 
-	c.Assert(vol.Snapshot(""), Equals, ErrNotSupported)
+	c.Assert(vol.Snapshot("", "", []string{}), Equals, ErrNotSupported)
+
+	info, err := vol.SnapshotInfo("")
+	c.Assert(info, IsNil)
+	c.Assert(err, Equals, ErrNotSupported)
 
 	snaps, err := vol.Snapshots()
 	c.Assert(snaps, IsNil)

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/zenoss/glog"
 )
@@ -45,6 +46,15 @@ type Status struct { // see Docker - look at their status struct and borrow heav
 
 type Statuses struct {
 	StatusMap map[string]Status
+}
+
+type SnapshotInfo struct {
+	Name     string
+	TenantID string
+	Label    string
+	Tags     []string
+	Message  string
+	Created  time.Time
 }
 
 const (
@@ -122,7 +132,9 @@ type Volume interface {
 	Driver() Driver
 	// Snapshot snapshots the current state of this volume and stores it
 	// using the name <label>
-	Snapshot(label string) (err error)
+	Snapshot(label, message string, tags []string) (err error)
+	// SnapshotInfo returns general information about a particular snapshot
+	SnapshotInfo(label string) (*SnapshotInfo, error)
 	// WriteMetadata returns a handle to write metadata to a snapshot
 	WriteMetadata(label, name string) (io.WriteCloser, error)
 	// ReadMetadata returns a handle to read metadata from a snapshot


### PR DESCRIPTION
This is the back half of the implementation.
Potentially you could do more, like add tags after creating a snapshot or removing a specific tag but preserving the volume, so I will leave that open-ended for now.  I am implementing this because I needed the SnapshotInfo bit for CC-1121 for better parsing of our snapshot labels.