### PR TITLE
CC-1251: Moving restore functions

### DIFF
--- a/facade/host.go
+++ b/facade/host.go
@@ -118,6 +118,42 @@ func (f *Facade) UpdateHost(ctx datastore.Context, entity *host.Host) error {
 	return err
 }
 
+// RestoreHosts restores a list of hosts, typically from a backup
+func (f *Facade) RestoreHosts(ctx datastore.Context, hosts []host.Host) error {
+	var exists bool
+	var err error
+
+	for _, host := range hosts {
+		host.DatabaseVersion = 0
+		// check all the static ips on this host
+		for _, ip := range host.IPs {
+			if exists, err = f.HasIP(ctx, host.PoolID, ip.IPAddress); err != nil {
+				glog.Errorf("Could no check ip %s in pool %s while restoring host %s: %s", ip.IPAddress, host.PoolID, ip.HostID, err)
+				return err
+			} else if exists {
+				glog.Warningf("Could not restore host %s (%s): ip already exists", ip.HostID, ip.IPAddress)
+				break
+			}
+		}
+		if !exists {
+			// check the primary ip on this host
+			if exists, err := f.HasIP(ctx, host.PoolID, host.IPAddr); err != nil {
+				glog.Errorf("Could not check ip %s in pool %s while restoring host %s: %s", host.IPAddr, host.PoolID, host.ID, err)
+				return err
+			} else if !exists {
+				if err := f.AddHost(ctx, &host); err != nil {
+					glog.Errorf("Could not add host %s to pool: %s", host.ID, host.PoolID, err)
+					return err
+				}
+				glog.Infof("Restored host %s (%s) to pool %s", host.ID, host.IPAddr, host.PoolID)
+			} else {
+				glog.Warningf("Could not restore host %s (%s): ip already exists", host.ID, host.IPAddr)
+			}
+		}
+	}
+	return nil
+}
+
 // RemoveHost removes a Host from serviced
 func (f *Facade) RemoveHost(ctx datastore.Context, hostID string) (err error) {
 	glog.V(2).Infof("Facade.RemoveHost: %s", hostID)

--- a/facade/host.go
+++ b/facade/host.go
@@ -142,7 +142,7 @@ func (f *Facade) RestoreHosts(ctx datastore.Context, hosts []host.Host) error {
 				return err
 			} else if !exists {
 				if err := f.AddHost(ctx, &host); err != nil {
-					glog.Errorf("Could not add host %s to pool: %s", host.ID, host.PoolID, err)
+					glog.Errorf("Could not add host %s to pool %s: %s", host.ID, host.PoolID, err)
 					return err
 				}
 				glog.Infof("Restored host %s (%s) to pool %s", host.ID, host.IPAddr, host.PoolID)

--- a/facade/host_test.go
+++ b/facade/host_test.go
@@ -119,6 +119,7 @@ func (s *FacadeTest) TestRestoreHosts(c *C) {
 			UpdatedAt: time.Time{},
 		},
 	}
+	defer s.Facade.RemoveHost(s.CTX, "deadb11f")
 	err := s.Facade.RestoreHosts(s.CTX, hosts1)
 	c.Assert(err, IsNil)
 	actual, err := s.Facade.GetHosts(s.CTX)
@@ -129,7 +130,6 @@ func (s *FacadeTest) TestRestoreHosts(c *C) {
 		actual[i].UpdatedAt = time.Time{}
 	}
 	c.Assert(actual, DeepEquals, hosts1)
-	defer s.Facade.RemoveHost(s.CTX, "deadb11f")
 
 	// different host with the same ip
 	hosts2 := []host.Host{
@@ -153,6 +153,7 @@ func (s *FacadeTest) TestRestoreHosts(c *C) {
 		},
 	}
 	err = s.Facade.RestoreHosts(s.CTX, hosts2)
+	c.Assert(err, IsNil)
 	hosts2[0].DatabaseVersion++
 	actual, err = s.Facade.GetHosts(s.CTX)
 	c.Assert(err, IsNil)

--- a/facade/pool_test.go
+++ b/facade/pool_test.go
@@ -140,6 +140,79 @@ func (ft *FacadeTest) Test_RemoveResourcePool(t *C) {
 	fmt.Println(" ##### Test_RemoveResourcePool: PASSED")
 }
 
+func (ft *FacadeTest) TestRestoreResourcePools(c *C) {
+	pools1 := []pool.ResourcePool{
+		{
+			ID:    "testpool-1",
+			Realm: "default",
+			VirtualIPs: []pool.VirtualIP{
+				{
+					PoolID:        "testpool-1",
+					IP:            "122.34.56.7",
+					Netmask:       "255.255.255.0",
+					BindInterface: "eth0",
+				},
+			},
+			CreatedAt: time.Time{},
+			UpdatedAt: time.Time{},
+		},
+	}
+	err := ft.Facade.RestoreResourcePools(ft.CTX, pools1)
+	c.Assert(err, IsNil)
+	actual, err := ft.Facade.GetResourcePools(ft.CTX)
+	c.Assert(err, IsNil)
+	for i := range actual {
+		actual[i].DatabaseVersion = 0
+		actual[i].CreatedAt = time.Time{}
+		actual[i].UpdatedAt = time.Time{}
+	}
+	c.Assert(actual, DeepEquals, pools1)
+	defer ft.Facade.RemoveResourcePool(ft.CTX, "testpool-1")
+
+	pools2 := []pool.ResourcePool{
+		{
+			ID:    "testpool-1",
+			Realm: "default",
+			VirtualIPs: []pool.VirtualIP{
+				{
+					PoolID:        "testpool-1",
+					IP:            "122.34.56.8",
+					Netmask:       "255.255.255.1",
+					BindInterface: "eth1",
+				},
+			},
+			CoreLimit:   1,
+			MemoryLimit: 1,
+			CreatedAt:   time.Time{},
+			UpdatedAt:   time.Time{},
+		}, {
+			ID:    "testpool-2",
+			Realm: "default",
+			VirtualIPs: []pool.VirtualIP{
+				{
+					PoolID:        "testpool-2",
+					IP:            "122.34.56.7",
+					Netmask:       "255.255.255.0",
+					BindInterface: "eth0",
+				},
+			},
+			CreatedAt: time.Time{},
+			UpdatedAt: time.Time{},
+		},
+	}
+	err = ft.Facade.RestoreResourcePools(ft.CTX, pools2)
+	c.Assert(err, IsNil)
+	actual, err = ft.Facade.GetResourcePools(ft.CTX)
+	c.Assert(err, IsNil)
+	for i := range actual {
+		actual[i].DatabaseVersion = 0
+		actual[i].CreatedAt = time.Time{}
+		actual[i].UpdatedAt = time.Time{}
+	}
+	c.Assert(actual, DeepEquals, pools2)
+	defer ft.Facade.RemoveResourcePool(ft.CTX, "testpool-2")
+}
+
 func (ft *FacadeTest) Test_GetResourcePools(t *C) {
 	result, err := ft.Facade.GetResourcePools(ft.CTX)
 	if err != nil {

--- a/facade/pool_test.go
+++ b/facade/pool_test.go
@@ -157,6 +157,7 @@ func (ft *FacadeTest) TestRestoreResourcePools(c *C) {
 			UpdatedAt: time.Time{},
 		},
 	}
+	defer ft.Facade.RemoveResourcePool(ft.CTX, "testpool-1")
 	err := ft.Facade.RestoreResourcePools(ft.CTX, pools1)
 	c.Assert(err, IsNil)
 	actual, err := ft.Facade.GetResourcePools(ft.CTX)
@@ -167,7 +168,6 @@ func (ft *FacadeTest) TestRestoreResourcePools(c *C) {
 		actual[i].UpdatedAt = time.Time{}
 	}
 	c.Assert(actual, DeepEquals, pools1)
-	defer ft.Facade.RemoveResourcePool(ft.CTX, "testpool-1")
 
 	pools2 := []pool.ResourcePool{
 		{
@@ -200,6 +200,7 @@ func (ft *FacadeTest) TestRestoreResourcePools(c *C) {
 			UpdatedAt: time.Time{},
 		},
 	}
+	defer ft.Facade.RemoveResourcePool(ft.CTX, "testpool-2")
 	err = ft.Facade.RestoreResourcePools(ft.CTX, pools2)
 	c.Assert(err, IsNil)
 	actual, err = ft.Facade.GetResourcePools(ft.CTX)
@@ -210,7 +211,6 @@ func (ft *FacadeTest) TestRestoreResourcePools(c *C) {
 		actual[i].UpdatedAt = time.Time{}
 	}
 	c.Assert(actual, DeepEquals, pools2)
-	defer ft.Facade.RemoveResourcePool(ft.CTX, "testpool-2")
 }
 
 func (ft *FacadeTest) Test_GetResourcePools(t *C) {

--- a/facade/servicetemplate.go
+++ b/facade/servicetemplate.go
@@ -86,6 +86,31 @@ func (f *Facade) RemoveServiceTemplate(ctx datastore.Context, id string) error {
 	return nil
 }
 
+// RestoreServiceTemplates restores a service template, typically from a backup
+func (f *Facade) RestoreServiceTemplates(ctx datastore.Context, templates []servicetemplate.ServiceTemplate) error {
+	curtemplates, err := f.GetServiceTemplates(ctx)
+	if err != nil {
+		glog.Errorf("Could not look up service templates: %s", err)
+		return err
+	}
+
+	for _, template := range templates {
+		if _, ok := curtemplates[template.ID]; ok {
+			if err := f.UpdateServiceTemplate(ctx, template); err != nil {
+				glog.Errorf("Could not update service template %s: %s", template.ID, err)
+				return err
+			}
+		} else {
+			template.ID = ""
+			if _, err := f.AddServiceTemplate(ctx, template); err != nil {
+				glog.Errorf("Could not add service template %s: %s", template.ID, err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func (f *Facade) GetServiceTemplates(ctx datastore.Context) (map[string]servicetemplate.ServiceTemplate, error) {
 	glog.V(2).Infof("Facade.GetServiceTemplates")
 	results, err := f.templateStore.GetServiceTemplates(ctx)

--- a/facade/servicetemplate.go
+++ b/facade/servicetemplate.go
@@ -95,6 +95,7 @@ func (f *Facade) RestoreServiceTemplates(ctx datastore.Context, templates []serv
 	}
 
 	for _, template := range templates {
+		template.DatabaseVersion = 0
 		if _, ok := curtemplates[template.ID]; ok {
 			if err := f.UpdateServiceTemplate(ctx, template); err != nil {
 				glog.Errorf("Could not update service template %s: %s", template.ID, err)


### PR DESCRIPTION
Originally, this was performed in the DFS--the idea here is to do this exclusively in the facade and either offer an interface to the dfs that calls these restores, or just leave this piece in the facade. (limiting the number of facade calls from the dfs)