### PR TITLE
CC-1354: Increase test case timeout

### DIFF
--- a/zzk/service/service_test.go
+++ b/zzk/service/service_test.go
@@ -67,7 +67,7 @@ func (t *ZZKTest) TestServiceListener_NoHostState(c *C) {
 
 	// get the instance id
 	getInstances := func(svc *service.Service) []string {
-		timeout := time.After(time.Minute)
+		timeout := time.After(3 * time.Minute)
 		for {
 			var instanceIDs []string
 			stateIDs, ev, err := conn.ChildrenW(servicepath(svc.ID))


### PR DESCRIPTION
Test seems to run slower on Jenkins slave, so increase the timeout
before giving up on the test.