### PR TITLE
CC-1354: Retry sync() if resuming instances fails

### DIFF
--- a/zzk/service/service.go
+++ b/zzk/service/service.go
@@ -267,6 +267,7 @@ func (l *ServiceListener) sync(svc *service.Service, rss []dao.RunningService) b
 		// resumeInstance updates the service state ONLY if it has a PAUSED DesiredState
 		if err := resumeInstance(l.conn, state.HostID, state.ID); err != nil {
 			glog.Warningf("Could not resume paused service instance %s (%s) for service %s on host %s: %s", state.ID, state.Name, state.ServiceID, state.HostID, err)
+			return false
 		}
 	}
 

--- a/zzk/service/service_test.go
+++ b/zzk/service/service_test.go
@@ -67,7 +67,7 @@ func (t *ZZKTest) TestServiceListener_NoHostState(c *C) {
 
 	// get the instance id
 	getInstances := func(svc *service.Service) []string {
-		timeout := time.After(3 * time.Minute)
+		timeout := time.After(time.Minute)
 		for {
 			var instanceIDs []string
 			stateIDs, ev, err := conn.ChildrenW(servicepath(svc.ID))


### PR DESCRIPTION
sync() was not returning false in this case, so the caller was not
setting the retry timer.  Which led to the test case timing out.