### PR TITLE
fix typo in pam library ImportPath

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -301,7 +301,7 @@
 			"Rev": "1dfe7915deaf3f80b962c163b918868d8a6d8974"
 		},
 		{
-			"ImportPath": "golang.org/msteinert/pam",
+			"ImportPath": "github.com/msteinert/pam",
 			"Rev": "6534f23b3984c4b8f517feba04a7d65b4da3ca57"
 		}
 	]


### PR DESCRIPTION
Fix typo in ImportPath for msteinert/pam library - was golang.org, should be github.com