### PR TITLE
Reregister the host.

### DIFF
--- a/zzk/service/host.go
+++ b/zzk/service/host.go
@@ -81,13 +81,15 @@ type HostStateListener struct {
 	handler  HostStateHandler
 	hostID   string
 	registry string
+	nodelock sync.Mutex
 }
 
 // NewHostListener instantiates a HostListener object
 func NewHostStateListener(handler HostStateHandler, hostID string) *HostStateListener {
 	return &HostStateListener{
-		handler: handler,
-		hostID:  hostID,
+		handler:  handler,
+		hostID:   hostID,
+		nodelock: sync.Mutex{},
 	}
 }
 
@@ -101,6 +103,8 @@ func (l *HostStateListener) GetPath(nodes ...string) string {
 
 // Ready adds an ephemeral node to the host registry
 func (l *HostStateListener) Ready() error {
+	l.nodelock.Lock()
+	defer l.nodelock.Unlock()
 	// get the host node
 	var host host.Host
 	if err := l.conn.Get(hostpath(l.hostID), &HostNode{Host: &host}); err != nil {
@@ -153,6 +157,13 @@ func (l *HostStateListener) Spawn(shutdown <-chan interface{}, stateID string) {
 	defer l.stopInstance(&processLock, &ss)
 
 	for {
+		// Listen to the registry node
+		var h host.Host
+		hEvt, err := l.conn.GetW(l.registry, &HostNode{Host: &h})
+		if err != nil {
+			glog.Errorf("Failed to get ephemeral node for host %s: %s", l.hostID, err)
+			return
+		}
 		// Get the HostState instance
 		hsEvt, err := l.conn.GetW(hostpath(l.hostID, stateID), &hs)
 		if err != nil {
@@ -213,8 +224,16 @@ func (l *HostStateListener) Spawn(shutdown <-chan interface{}, stateID string) {
 
 		select {
 		case <-processDone:
-                       glog.Infof("Process ended for instance %s for service %s (%s)", stateID, svc.Name, svc.ID)
-                       processDone = nil // CC-1341 - once the process exits, don't read this channel again
+			glog.Infof("Process ended for instance %s for service %s (%s)", stateID, svc.Name, svc.ID)
+			processDone = nil // CC-1341 - once the process exits, don't read this channel again
+		case e := <-hEvt:
+			glog.V(3).Infof("Host %s received an event: %+v", l.hostID, e)
+			if e.Type == client.EventNodeDeleted {
+				if err := l.Ready(); err != nil {
+					glog.Errorf("Failed to add ephemeral node for host %s: %+v", l.hostID, err)
+					return
+				}
+			}
 		case e := <-hsEvt:
 			glog.V(3).Infof("Host instance %s for service %s (%s) received an event: %+v", stateID, svc.Name, svc.ID, e)
 			if e.Type == client.EventNodeDeleted {

--- a/zzk/service/host_test.go
+++ b/zzk/service/host_test.go
@@ -347,6 +347,7 @@ func (t *ZZKTest) TestHostStateListener_Spawn_StartAndStop(c *C) {
 	}
 
 	var node1, node2 ServiceStateNode
+	listener.Ready()
 	go func() {
 		listener.Spawn(shutdown, stateID)
 	}()


### PR DESCRIPTION
An inconsistency in zookeeper state can occur when an agent temporarily loses its connection to zookeeper and ephemeral node and later regains its connection. This change makes the agent watch its ephemeral node, and when dropped, recreates it.