### PR TITLE
CC-1480: Fix default registry key value

### DIFF
--- a/dfs/docker/docker.go
+++ b/dfs/docker/docker.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	DefaultSocket   = "unix:///var/run/docker.sock"
-	DefaultRegistry = "https://index.docker.io/v1"
+	DefaultRegistry = "https://index.docker.io/v1/"
 	Latest          = "latest"
 	MaxLayers       = 127 - 2
 )


### PR DESCRIPTION
This value is a string used to look up our credentials from Docker's
creds file, so must match exactly what Docker uses.