### PR TITLE
Fix CC-1486: negative WaitGroup counter

### DIFF
--- a/commons/docker/api.go
+++ b/commons/docker/api.go
@@ -371,15 +371,16 @@ func (c *Container) Restart(timeout time.Duration) error {
 }
 
 // Start uses the information provided in the container definition cd to start a new Docker
-// container. If a container can't be started before the timeout expires an error is returned.
-func (c *Container) Start(timeout time.Duration) error {
+// container. If a container can't be completely started an error is returned. The bool returned
+// specifies whether the caller should expect a events (Start, Die, ...) from the Docker subsystem.
+func (c *Container) Start() (bool, error) {
 	if c.State.Running != false {
-		return nil
+		return false, nil
 	}
 
 	dc, err := getDockerClient()
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	args := struct {
@@ -391,29 +392,29 @@ func (c *Container) Start(timeout time.Duration) error {
 	ctr, err := dc.InspectContainer(args.id)
 	if err != nil {
 		glog.V(1).Infof("unable to inspect container %s prior to starting it: %v", args.id, err)
-		return err
+		return false, err
 	}
 
 	if ctr.State.Running {
-		return ErrAlreadyStarted
+		return false, ErrAlreadyStarted
 	}
 
 	glog.V(2).Infof("starting container %s: %+v", args.id, args.hostConfig)
 	err = dc.StartContainer(args.id, args.hostConfig)
 	if err != nil {
 		glog.V(2).Infof("unable to start %s: %v", args.id, err)
-		return err
+		return false, err
 	}
 
 	glog.V(2).Infof("update container %s state post start", args.id)
 	ctr, err = dc.InspectContainer(args.id)
 	if err != nil {
 		glog.V(2).Infof("failed to update container %s state post start: %v", args.id, err)
-		return err
+		return true, err
 	}
 	c.Container = ctr
 
-	return nil
+	return true, nil
 }
 
 // Stop stops the container specified by the id. If the container can't be stopped before the timeout

--- a/commons/docker/container_test.go
+++ b/commons/docker/container_test.go
@@ -53,7 +53,7 @@ func TestContainerCommit(t *testing.T) {
 		sc <- struct{}{}
 	})
 
-	err = ctr.Start(30 * time.Second)
+	_, err = ctr.Start()
 	if err != nil {
 		t.Fatal("can't start container: ", err)
 	}
@@ -98,7 +98,7 @@ func TestOnContainerStart(t *testing.T) {
 		sc <- struct{}{}
 	})
 
-	err = ctr.Start(30 * time.Second)
+	_, err = ctr.Start()
 	if err != nil {
 		t.Fatal("can't start container: ", err)
 	}
@@ -182,7 +182,7 @@ func TestCancelOnEvent(t *testing.T) {
 
 	ctr.CancelOnEvent(Start)
 
-	ctr.Start(1 * time.Second)
+	ctr.Start()
 
 	select {
 	case <-ec:
@@ -368,7 +368,7 @@ func TestInspectContainer(t *testing.T) {
 		sc <- struct{}{}
 	})
 
-	if err := ctr.Start(1 * time.Second); err != nil {
+	if _, err := ctr.Start(); err != nil {
 		t.Fatal("can't start container: ", err)
 	}
 
@@ -415,7 +415,7 @@ func TestRepeatedStart(t *testing.T) {
 		sc <- struct{}{}
 	})
 
-	if err := ctr.Start(1 * time.Second); err != nil {
+	if _, err := ctr.Start(); err != nil {
 		t.Fatal("can't start container: ", err)
 	}
 
@@ -426,7 +426,7 @@ func TestRepeatedStart(t *testing.T) {
 		t.Fatal("timed out waiting for container to start")
 	}
 
-	if err := ctr.Start(1 * time.Second); err == nil {
+	if _, err := ctr.Start(); err == nil {
 		t.Fatal("expecting ErrAlreadyStarted")
 	}
 

--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -385,7 +385,7 @@ func (svc *IService) start() (<-chan int, error) {
 	ctr.OnEvent(docker.Die, func(cid string) { svc.remove(notify) })
 
 	// start the container
-	if err := ctr.Start(10 * time.Second); err != nil && err != docker.ErrAlreadyStarted {
+	if _, err := ctr.Start(); err != nil && err != docker.ErrAlreadyStarted {
 		svc.setStoppedHealthStatus(fmt.Errorf("could not start service: %s", err))
 		return nil, err
 	}

--- a/isvcs/manager.go
+++ b/isvcs/manager.go
@@ -214,7 +214,8 @@ func (m *Manager) wipe() error {
 		ctr.Delete(true)
 	})
 
-	return ctr.Start(10 * time.Second)
+	_, err = ctr.Start()
+	return err
 }
 
 // loadImages() loads all the images defined in the registered services

--- a/node/agent.go
+++ b/node/agent.go
@@ -315,6 +315,13 @@ func chownConfFile(filename, owner, permissions string, dockerImage string) erro
 
 // StartService starts a new instance of the specified service and updates the control center state accordingly.
 func (a *HostAgent) StartService(svc *service.Service, state *servicestate.ServiceState, exited func(string)) error {
+	handlerInstalled := false
+	defer func() {
+		if !handlerInstalled {
+			exited(state.ID)
+		}
+	}()
+
 	glog.V(2).Infof("About to start service %s with name %s", svc.ID, svc.Name)
 	client, err := NewControlClient(a.master)
 	if err != nil {
@@ -376,12 +383,17 @@ func (a *HostAgent) StartService(svc *service.Service, state *servicestate.Servi
 		a.removeInstance(state.ID, ctr)
 	})
 
-	if err := ctr.Start(time.Hour); err != nil {
+	if expectDockerEvents, err := ctr.Start(); err != nil {
 		glog.Errorf("Could not start service state %s (%s) for service %s (%s): %s", state.ID, ctr.ID, svc.Name, svc.ID, err)
-		started.Done()
-		a.removeInstance(state.ID, ctr)
+		if !expectDockerEvents {
+			// The Docker event handlers we just registered won't get called, so perform those cleanup steps here
+			glog.Infof("Cleaning up after start failure for service state %s (%s) for service %s (%s)", state.ID, ctr.ID, svc.Name, svc.ID)
+			started.Done()
+			a.removeInstance(state.ID, ctr)
+		}
 		return err
 	}
+	handlerInstalled = true
 
 	started.Wait()
 	if err := updateInstance(state, ctr); err != nil {

--- a/zzk/service/host.go
+++ b/zzk/service/host.go
@@ -277,10 +277,8 @@ func (l *HostStateListener) terminateInstance(locker sync.Locker, done chan<- st
 func (l *HostStateListener) startInstance(locker sync.Locker, svc *service.Service, state *servicestate.ServiceState) (<-chan struct{}, error) {
 	done := make(chan struct{})
 	locker.Lock()
-	onExitFunction := l.terminateInstance(locker, done)
-	if err := l.handler.StartService(svc, state, onExitFunction); err != nil {
+	if err := l.handler.StartService(svc, state, l.terminateInstance(locker, done)); err != nil {
 		glog.Errorf("Error trying to start service instance %s for service %s (%s): %s", state.ID, svc.Name, svc.ID, err)
-		onExitFunction(state.ID)
 		return nil, err
 	}
 	return done, UpdateServiceState(l.conn, state)


### PR DESCRIPTION
Some of our wrappers around the Docker APIs fail after the call to
Docker was successful, so we were getting an error from our wrapper,
cleaning up, then having the cleanup occur again when we got the
event (Start, Die, etc.) from Docker.  Now we're watching for those
cases and only cleaning up once.

Also, removed the unused 'timeout' parameter from the Container.Start()
method.