### PR TITLE
Fixes CC-1568: serviced returns success when adding an invalid host

### DIFF
--- a/acceptance/ui/features/hosts.feature
+++ b/acceptance/ui/features/hosts.feature
@@ -52,7 +52,7 @@ Feature: Host Management
       And I fill in the RAM Commitment field with "table://hosts/defaultHost/commitment"
       And I click "Add Host"
     Then I should see "Error"
-      And I should see "Internal Server Error: dial tcp 172.17.42.1:9999"
+      And I should see "Bad Request: dial tcp 172.17.42.1:9999: connection refused"
       And I should see an empty Hosts page
 
   Scenario: Add an invalid host with an invalid Resource Pool field

--- a/commons/pool/pool.go
+++ b/commons/pool/pool.go
@@ -96,7 +96,8 @@ func (p *itemPool) BorrowWait(timeout time.Duration) (*Item, error) {
 			return
 		}
 		if !found {
-			newItem, err := p.newItem()
+			var newItem *Item
+			newItem, err = p.newItem()
 			if err != nil && err != ErrItemUnavailable {
 				return
 			} else if err == nil {

--- a/commons/pool/pool_test.go
+++ b/commons/pool/pool_test.go
@@ -46,6 +46,16 @@ func Factory(maxCreate int) ItemFactory {
 
 }
 
+func (s *MySuite) TestBorrowReturnsFactoryFailure(c *C) {
+	// Setup a factory that fails on every borrow attempt
+	p, err := NewPool(1, Factory(0))
+	c.Assert(err, IsNil)
+
+	item, err := p.Borrow()
+	c.Assert(item, IsNil)
+	c.Assert(err, ErrorMatches, "Tried to create.*")
+}
+
 func (s *MySuite) TestBorrowReturnRemove(c *C) {
 
 	capacity := 1


### PR DESCRIPTION
Fix scoping bug that prevented newItem() errors from being returned to the caller