### PR TITLE
CC-1564: don't care so much if services don't get deleted from zookeeper

### DIFF
--- a/facade/service.go
+++ b/facade/service.go
@@ -454,9 +454,9 @@ func (f *Facade) removeService(ctx datastore.Context, id string) error {
 			endpoint.RemoveAssignment()
 		}
 
+		// Stale services in zookeeper will eventually get cleaned up by the syncer
 		if err := f.zzk.RemoveService(svc); err != nil {
-			glog.Errorf("Could not remove service %s (%s) from zookeeper: %s", svc.Name, svc.ID, err)
-			return err
+			glog.Warningf("Could not remove service %s (%s) from zookeeper: %s", svc.Name, svc.ID, err)
 		}
 
 		if err := store.Delete(ctx, svc.ID); err != nil {


### PR DESCRIPTION
Here is why we don't care if we are unable to delete a service from zookeeper:
* Services have to be stopped before deleting, so you don't need to worry about a rogue service getting scheduled even if it doesn't exist
* Once the service is deleted in ES, there is no way for the user to directly manipulate the service
* Stale services eventually get cleaned up by the syncer
* Even if the service is restored from backup and the stale node is in zookeeper, the code is implemented in such a way that we will create the node if it doesn't exist or we will overwrite the existing node.