### PR TITLE
Fixes speedUpBuilds

### DIFF
--- a/jenkins_rc.sh
+++ b/jenkins_rc.sh
@@ -15,5 +15,5 @@ trap dochown EXIT
 
 . /home/jenkins/.gvm/scripts/gvm
 gvm use go1.4.2
-export GOPATH=$WORKSPACE/gopath:$GOPATH
+export GOPATH=$WORKSPACE/gopath
 export PATH=$WORKSPACE/gopath/bin:$PATH

--- a/jenkins_rc.sh
+++ b/jenkins_rc.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Jenkins resource file - this file is sourced by Jenkins build jobs to setup common environment
+# variables and functions for various jenkins builds
+#
+
+#
+# This is a fail-safe to make sure that any files accidentally created as root during a test
+# can be cleaned up by jenkins in the next execution of the build job
+#
+function dochown {
+    sudo chown -R jenkins:jenkins $WORKSPACE
+}
+trap dochown EXIT
+
+. /home/jenkins/.gvm/scripts/gvm
+gvm use go1.4.2
+export GOPATH=$WORKSPACE/gopath:$GOPATH
+export PATH=$WORKSPACE/gopath/bin:$PATH


### PR DESCRIPTION
These changes were originally made on support/1.1.x.  The goal of this PR is to remove copy/paste code from the Jenkins project definition and capture it in an rc file that can be reused by several different jobs.
The jenkins PR jobs for develop have already been updated to use jenkins_rc.sh
cherry-pick commit 04aa979e55e0535b8c7fe9375e83dce59c448622
(committed by "zendev port cherry-pick")