### PR TITLE
Initialize storage drivers using a file rather than a directory

### DIFF
--- a/volume/btrfs/btrfs.go
+++ b/volume/btrfs/btrfs.go
@@ -97,6 +97,9 @@ func Init(root string, _ []string) (volume.Driver, error) {
 	if err := os.MkdirAll(driver.MetadataDir(), 0755); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
+	if err := volume.TouchFlagFile(driver.poolDir()); err != nil {
+		return nil, err
+	}
 	return driver, nil
 }
 

--- a/volume/detect.go
+++ b/volume/detect.go
@@ -24,7 +24,8 @@ import (
 func DetectDriverType(root string) (DriverType, error) {
 	// Check to see if the directory even exists. If not, no driver has been initialized.
 	glog.V(2).Infof("Detecting driver type under %s", root)
-	if _, err := os.Stat(root); err != nil {
+	flagfile := FlagFilePath(root)
+	if _, err := os.Stat(flagfile); err != nil {
 		if os.IsNotExist(err) {
 			glog.V(2).Infof("Root does not exist; no driver has been initialized")
 			return "", ErrDriverNotInit

--- a/volume/detect.go
+++ b/volume/detect.go
@@ -24,8 +24,7 @@ import (
 func DetectDriverType(root string) (DriverType, error) {
 	// Check to see if the directory even exists. If not, no driver has been initialized.
 	glog.V(2).Infof("Detecting driver type under %s", root)
-	flagfile := FlagFilePath(root)
-	if _, err := os.Stat(flagfile); err != nil {
+	if _, err := os.Stat(root); err != nil {
 		if os.IsNotExist(err) {
 			glog.V(2).Infof("Root does not exist; no driver has been initialized")
 			return "", ErrDriverNotInit
@@ -33,9 +32,10 @@ func DetectDriverType(root string) (DriverType, error) {
 		return "", err
 	}
 	for _, drivertype := range []DriverType{DriverTypeBtrFS, DriverTypeRsync, DriverTypeDeviceMapper} {
-		dirname := fmt.Sprintf(".%s", drivertype)
-		if fi, err := os.Stat(filepath.Join(root, dirname)); !os.IsNotExist(err) && fi != nil && fi.IsDir() {
-			glog.V(2).Infof("Found %s directory; returning %s", dirname, drivertype)
+		dirname := filepath.Join(root, fmt.Sprintf(".%s", drivertype))
+		flagfile := FlagFilePath(dirname)
+		if fi, err := os.Stat(flagfile); !os.IsNotExist(err) && fi != nil {
+			glog.V(2).Infof("Found %s file; returning %s", dirname, drivertype)
 			return drivertype, nil
 		}
 	}

--- a/volume/devicemapper/devicemapper.go
+++ b/volume/devicemapper/devicemapper.go
@@ -323,6 +323,9 @@ func (d *DeviceMapperDriver) ensureInitialized() error {
 	if err := os.MkdirAll(poolPath, 0755); err != nil && !os.IsExist(err) {
 		return err
 	}
+	if err := volume.TouchFlagFile(poolPath); err != nil {
+		return err
+	}
 	if d.DeviceSet == nil {
 		deviceSet, err := devmapper.NewDeviceSet(poolPath, true, d.options, nil, nil)
 		if err != nil {

--- a/volume/rsync/rsync.go
+++ b/volume/rsync/rsync.go
@@ -75,6 +75,9 @@ func Init(root string, _ []string) (volume.Driver, error) {
 	if err := os.MkdirAll(driver.MetadataDir(), 0755); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
+	if err := volume.TouchFlagFile(driver.poolDir()); err != nil {
+		return nil, err
+	}
 	return driver, nil
 }
 

--- a/volume/utils.go
+++ b/volume/utils.go
@@ -15,9 +15,11 @@ package volume
 
 import (
 	"errors"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
+	"path/filepath"
 	"sort"
 
 	"github.com/zenoss/glog"
@@ -27,6 +29,8 @@ var (
 	ErrNotADirectory = errors.New("not a directory")
 	ErrBtrfsCommand  = errors.New("error running btrfs command")
 )
+
+const FlagFileName = ".initialized"
 
 // IsDir() checks if the given dir is a directory. If any error is encoutered
 // it is returned and directory is set to false.
@@ -107,4 +111,17 @@ func RunBtrFSCmd(sudoer bool, args ...string) ([]byte, error) {
 func IsBtrfsFilesystem(path string) bool {
 	_, err := RunBtrFSCmd(false, "filesystem", "df", path)
 	return err == nil
+}
+
+func FlagFilePath(root string) string {
+	return filepath.Join(root, FlagFileName)
+}
+
+func TouchFlagFile(root string) error {
+	// Touch the file indicating that this dir has been initialized
+	initfile := FlagFilePath(root)
+	if _, err := os.Stat(initfile); os.IsNotExist(err) {
+		return ioutil.WriteFile(initfile, []byte{}, 0754)
+	}
+	return nil
 }


### PR DESCRIPTION
This allows (for example) HA systems to use the storage driver metadata directory as a mount point to be synced between masters. Otherwise, where mere existence of the directory indicates driver initialization, no driver ever gets dealt with on the secondary master, because the mount point always exists.