### PR TITLE
Changes to work with Jenkins slaves

### DIFF
--- a/acceptance/runUIAcceptance.sh
+++ b/acceptance/runUIAcceptance.sh
@@ -138,9 +138,13 @@ parse_host() {
 
 TARGET_HOST=`parse_host ${APPLICATION_URL}`
 
-# Don't depend on 'hostname -i' because some machines (like our Jenkins slaves)
-#   map hostname to 127.0.0.1
-HOST_IP=$(/sbin/ifconfig docker0 | grep 'inet addr:' | cut -d: -f2 | awk {'print $1'})
+HOST_IP=`hostname -i`
+if [[ $HOST_IP == 127* ]]; then
+    # serviced won't allow us to add a loopback address, so use docker's as an alternative
+    echo "Overriding default HOST_IP ($HOST_IP)"
+    HOST_IP=$(/sbin/ifconfig docker0 | grep 'inet addr:' | cut -d: -f2 | awk {'print $1'})
+fi
+echo "Using HOST_IP=$HOST_IP"
 
 cp -u `pwd`/../serviced `pwd`/ui
 

--- a/acceptance/startMockAgents.sh
+++ b/acceptance/startMockAgents.sh
@@ -31,6 +31,11 @@ if [ ! -d ${DIR}/ui/features/data/${DATASET} ]; then
 fi
 
 HOST_IP=`hostname -i`
+if [[ $HOST_IP == 127* ]]; then
+    echo "Overriding default HOST_IP ($HOST_IP)"
+    HOST_IP=$(/sbin/ifconfig docker0 | grep 'inet addr:' | cut -d: -f2 | awk {'print $1'})
+fi
+echo "Using HOST_IP=$HOST_IP"
 
 set -e
 

--- a/acceptance/ui/features/data/default/hosts.json
+++ b/acceptance/ui/features/data/default/hosts.json
@@ -2,7 +2,7 @@
   "hosts":
   {
     "defaultHost": {
-      "nameAndPort": "%{target_host}:4981",
+      "nameAndPort": "%{local_ip}:4981",
       "name": "defaultHost",
       "rpcPort": 4981,
       "hostID": 4981,
@@ -15,11 +15,11 @@
       "ccRelease": "Default CC Release Test",
       "pool": "default",
       "commitment": "75%",
-      "outboundIP": "%{target_host}"
+      "outboundIP": "%{local_ip}"
     },
 
     "host2": {
-      "nameAndPort": "%{target_host}:4982",
+      "nameAndPort": "%{local_ip}:4982",
       "name": "secondHost",
       "rpcPort": 4982,
       "hostID": 4982,
@@ -32,11 +32,11 @@
       "ccRelease": "CC Release test 2",
       "pool": "default",
       "commitment": "5737418240",
-      "outboundIP": "%{target_host}"
+      "outboundIP": "%{local_ip}"
     },
 
     "host3": {
-      "nameAndPort": "%{target_host}:4983",
+      "nameAndPort": "%{local_ip}:4983",
       "name": "thirdHost",
       "rpcPort": 4983,
       "hostID": 4983,
@@ -49,11 +49,11 @@
       "ccRelease": "Third Test CC Release",
       "pool": "testPool2",
       "commitment": "20%",
-      "outboundIP": "%{target_host}"
+      "outboundIP": "%{local_ip}"
     },
 
     "host4": {
-      "nameAndPort": "%{target_host}:4984",
+      "nameAndPort": "%{local_ip}:4984",
       "name": "fourthHost",
       "rpcPort": 4984,
       "hostID": 4984,
@@ -66,11 +66,11 @@
       "ccRelease": "v4",
       "pool": "testPool3",
       "commitment": "100%",
-      "outboundIP": "%{target_host}"
+      "outboundIP": "%{local_ip}"
     },
 
     "host5": {
-      "nameAndPort": "%{target_host}:4985",
+      "nameAndPort": "%{local_ip}:4985",
       "name": "fifthHost",
       "rpcPort": 4985,
       "hostID": 4985,
@@ -83,7 +83,7 @@
       "ccRelease": "#5",
       "pool": "testPool4",
       "commitment": "75%",
-      "outboundIP": "%{target_host}"
+      "outboundIP": "%{local_ip}"
     }
   }
 }


### PR DESCRIPTION
Previous round of acceptance refactoring broke tests on Jenkins because the Jenkins slave machines have their hostnames bound to 127.0.1.1 and serviced does not allow hosts to be added to a loopback address