### PR TITLE
Feature/cc 1243 2

### DIFF
--- a/web/ui/src/Services/ServiceDetailsController.js
+++ b/web/ui/src/Services/ServiceDetailsController.js
@@ -10,9 +10,11 @@
     ["$scope", "$q", "$routeParams", "$location", "resourcesFactory",
     "authService", "$modalService", "$translate", "$notification",
     "$timeout", "servicesFactory", "miscUtils", "hostsFactory",
+    "CCUIState", "$cookies",
     function($scope, $q, $routeParams, $location, resourcesFactory,
     authService, $modalService, $translate, $notification,
-    $timeout, servicesFactory, utils, hostsFactory){
+    $timeout, servicesFactory, utils, hostsFactory,
+    CCUIState, $cookies){
 
         // Ensure logged in
         authService.checkLogin($scope);
@@ -616,6 +618,9 @@
                 // setup breadcrumbs
                 $scope.breadcrumbs = makeCrumbs($scope.services.current);
 
+                // update serviceTreeState
+                $scope.serviceTreeState = CCUIState.get($cookies.ZUsername, "serviceTreeState");
+
                 // create an entry in tree state for the
                 // current service
                 if(!($scope.services.current.id in $scope.serviceTreeState)){
@@ -631,10 +636,10 @@
                             collapsed: false
                         };
                     });
-
-                    // property for view to bind for tree state
-                    $scope.services.currentTreeState = treeState;
                 }
+
+                // property for view to bind for tree state
+                $scope.services.currentTreeState = $scope.serviceTreeState[$scope.services.current.id];
             }
 
             servicesFactory.updateHealth();
@@ -665,10 +670,21 @@
         };
 
         // expand/collapse state of service tree nodes
-        // NOTE - keys are the current page's service (the current
-        // context service)
-        // TODO - use CCUIState service
-        $scope.serviceTreeState = {};
+        $scope.serviceTreeState = CCUIState.get($cookies.ZUsername, "serviceTreeState");
+        // servicedTreeState is a collection of objects
+        // describing if nodes in a service tree are hidden or collapsed.
+        // It is first keyed by the id of the current service context (the
+        // service who's name is at the top of the page), then keyed by
+        // the service in question. eg:
+        //
+        // current service id
+        //      -> child service id
+        //          -> hidden
+        //          -> collapsed
+        //      -> child service id
+        //          -> hidden
+        //          -> collapsed
+        //      ...
 
         $scope.toggleChildren = function(service){
             if(!$scope.services.current){

--- a/web/ui/src/Services/view-subservices.html
+++ b/web/ui/src/Services/view-subservices.html
@@ -133,10 +133,10 @@
                   <th style="width: 210px;" ng-if="!services.current.isIsvc()" translate>running_tbl_actions</th>
                 </tr>
             </thead>
-            <tr ng-repeat="app in $data" data-id="{{app.model.ID}}">
+            <tr ng-repeat="app in $data" data-id="{{app.model.ID}}" ng-hide="services.currentTreeState[app.id].hidden">
               <td data-title="'label_service'|translate" style="overflow: hidden; white-space: nowrap;">
                 <span ng-style="calculateIndent(app)"></span>
-                <span ng-if="app.children.length" ng-click="toggleChildren($event, app)" class="table-collapse glyphicon glyphicon-chevron-down"></span>
+                <span ng-if="app.children.length" ng-click="toggleChildren(app)" class="table-collapse glyphicon" ng-class="services.currentTreeState[app.id].collapsed ? 'glyphicon-chevron-right' : 'glyphicon-chevron-down'"></span>
                 <span ng-if="!app.children.length" ng-style="indent(1)"></span>
                 <a href="#/services/{{app.model.ID}}" ng-click="routeToService(app.model.ID, $event)" class="link">
                     {{app.model.Name}}

--- a/web/ui/src/app.js
+++ b/web/ui/src/app.js
@@ -26,7 +26,7 @@ var controlplane = angular.module('controlplane', [
     'modalService', 'angular-data.DSCacheFactory', 'ui.codemirror',
     'sticky', 'graphPanel', 'servicesFactory', 'healthIcon',
     'authService', 'miscUtils', 'hostsFactory', 'poolsFactory', 'instancesFactory', 'baseFactory',
-    'ngTable', 'jellyTable', 'ngLocationUpdate'
+    'ngTable', 'jellyTable', 'ngLocationUpdate', 'CCUIState'
 ]);
 
 controlplane.

--- a/web/ui/src/common/CCUIState.js
+++ b/web/ui/src/common/CCUIState.js
@@ -1,0 +1,45 @@
+/* CCUIState.js
+ * preserve state through ui navigations
+ */
+(function(){
+    "use strict";
+
+    // TODO - persist to local storage
+    class CCUIState {
+        constructor(){
+            // -> user name
+            //    -> store name
+            //       -> stored object
+            this.store = {};
+        }
+
+        get(userName, storeName){
+            var userStore = this.getUserStore(userName);
+
+            // if the store doesnt exist for this user,
+            // create it
+            if(!userStore[storeName]){
+                // TODO - formalize creation of this object
+                userStore[storeName] = {};
+            }
+
+            return userStore[storeName];
+        }
+
+        // creates and returns a user store for the specified
+        // user, or returns existing user store for the user
+        getUserStore(name){
+            var users = Object.keys(this.store);
+
+            // if this user doesn't have a store,
+            // create one
+            if(users.indexOf(name) === -1){
+                this.store[name] = {};
+            }
+
+            return this.store[name];
+        }
+    }
+
+    angular.module("CCUIState", []).service("CCUIState", [CCUIState]);
+})();

--- a/web/ui/test/common/CCUIStateMock.js
+++ b/web/ui/test/common/CCUIStateMock.js
@@ -1,0 +1,13 @@
+// An Angular factory that returns a mock implementation of the CCUIState
+//
+// Call 'beforeEach(module(CCUIStateMock))' to inject this factory into a test case, and
+// Angular will then inject an instance of the spy created by this factory.
+var CCUIStateMock = function($provide) {
+    $provide.factory('CCUIState', function() {
+        var mock = jasmine.createSpyObj('CCUIState', [
+            "get"
+        ]);
+
+        return mock;
+    });
+};

--- a/web/ui/test/common/CCUIStateSpec.js
+++ b/web/ui/test/common/CCUIStateSpec.js
@@ -1,0 +1,45 @@
+/* global jasmine: true, spyOn: true, beforeEach: true, DEBUG: true, expect: true, inject: true, module: true */
+
+describe('CCUIState', function() {
+
+    var $scope = null;
+    var CCUIState = null;
+
+    beforeEach(module('controlplaneTest'));
+    beforeEach(module('CCUIState'));
+
+    beforeEach(inject(function($injector) {
+        $scope = $injector.get('$rootScope').$new();
+        CCUIState = $injector.get('CCUIState');
+    }));
+
+    it('Creates a userstore if the user doesnt exist', function() {
+        var user = "themckrakken";
+        CCUIState.get(user, "testStore");
+        expect(CCUIState.store[user]).toBeDefined();
+    });
+
+    it('Modifies an existing user store, rather than overwriting it', function() {
+        var user = "themckrakken";
+        CCUIState.get(user, "testStore");
+        var userStore = CCUIState.store[user];
+        CCUIState.get(user, "testStore");
+        expect(CCUIState.store[user]).toBe(userStore);
+    });
+
+    it('Returns a new store', function() {
+        var user = "themckrakken";
+        var storeName = "groceryStore";
+        var store = CCUIState.get(user, storeName);
+        expect(store).toBeDefined();
+    });
+
+    it('Passes a store by reference', function() {
+        var user = "themckrakken";
+        var storeName = "groceryStore";
+        var store = CCUIState.get(user, storeName);
+        store.jellyfish = "wiggle wiggle wiggle, yeah";
+        var storeAgain = CCUIState.get(user, storeName);
+        expect(storeAgain.jellyfish).toBe(store.jellyfish);
+    });
+});


### PR DESCRIPTION
Preserves state of service tree during navigation, so services that are collapsed stay collapsed. The newly created CCUIState service can be used in the future to store other state stuff like graph settings.

Note that state is not persisted to disk. A page refresh will clear it, but angularjs route navigations (almost all links in the UI are route navigation) will retain state.