### PR TITLE
Avoid accessing uninitialized endpoint variable

### DIFF
--- a/container/controller.go
+++ b/container/controller.go
@@ -964,7 +964,11 @@ func (c *Controller) handleControlCenterImports(rpcdead chan struct{}) error {
 		}
 
 		// set proxy addresses
-		c.setProxyAddresses(key, endpointList, endpointList[0].VirtualAddress, cc_endpoint_purpose)
+		endpointMap := make(map[int]applicationendpoint.ApplicationEndpoint)
+		for i, ep := range endpointList {
+			endpointMap[i] = ep
+		}
+		c.setProxyAddresses(key, endpointMap, endpointList[0].VirtualAddress, cc_endpoint_purpose)
 
 		// add/replace entries in importedEndpoints
 		instanceIDStr := fmt.Sprintf("%d", endpointList[0].InstanceID)

--- a/container/endpoint.go
+++ b/container/endpoint.go
@@ -512,7 +512,7 @@ func (c *Controller) setProxyAddresses(tenantEndpointID string, endpoints map[in
 	} else if purpose == "import_all" {
 		// Need to create a proxy per instance of the service whose endpoint is
 		// being imported
-		for ii, instance := range endpoints {
+		for key, instance := range endpoints {
 			// Port for this instance is base port + instanceID
 			proxyPort := instance.ProxyPort + uint16(instance.InstanceID)
 			if _, conflict := exported[proxyPort]; conflict {
@@ -521,7 +521,7 @@ func (c *Controller) setProxyAddresses(tenantEndpointID string, endpoints map[in
 			}
 			proxyKeys[instance.InstanceID] = fmt.Sprintf("%s_%d", tenantEndpointID, instance.InstanceID)
 			instance.ProxyPort = proxyPort
-			endpoints[ii] = instance
+			endpoints[key] = instance
 		}
 	}
 

--- a/container/endpoint.go
+++ b/container/endpoint.go
@@ -433,7 +433,7 @@ func (c *Controller) processTenantEndpoint(conn coordclient.Connection, parentPa
 	tenantEndpointID := parts[len(parts)-1]
 
 	if ep := c.getMatchingEndpoint(tenantEndpointID); ep != nil {
-		endpoints := make([]applicationendpoint.ApplicationEndpoint, len(hostContainerIDs))
+		endpoints := make(map[int]applicationendpoint.ApplicationEndpoint, len(hostContainerIDs))
 		for ii, hostContainerID := range hostContainerIDs {
 			path := fmt.Sprintf("%s/%s", parentPath, hostContainerID)
 			endpointNode, err := endpointRegistry.GetItem(conn, path)
@@ -441,21 +441,22 @@ func (c *Controller) processTenantEndpoint(conn coordclient.Connection, parentPa
 				glog.Errorf("error getting endpoint node at %s: %v", path, err)
 				continue
 			}
-			endpoints[ii] = endpointNode.ApplicationEndpoint
+			endpoint := endpointNode.ApplicationEndpoint
 			if ep.port != 0 {
 				glog.V(2).Infof("overriding ProxyPort with imported port:%v for endpoint: %+v", ep.port, endpointNode)
-				endpoints[ii].ProxyPort = ep.port
+				endpoint.ProxyPort = ep.port
 			} else {
 				glog.V(2).Infof("not overriding ProxyPort with imported port:%v for endpoint: %+v", ep.port, endpointNode)
-				endpoints[ii].ProxyPort = endpoints[ii].ContainerPort
+				endpoint.ProxyPort = endpoint.ContainerPort
 			}
+			endpoints[ii] = endpoint
 		}
 		c.setProxyAddresses(tenantEndpointID, endpoints, ep.virtualAddress, ep.purpose)
 	}
 }
 
 // setProxyAddresses tells the proxies to update with addresses
-func (c *Controller) setProxyAddresses(tenantEndpointID string, endpoints []applicationendpoint.ApplicationEndpoint, importVirtualAddress, purpose string) {
+func (c *Controller) setProxyAddresses(tenantEndpointID string, endpoints map[int]applicationendpoint.ApplicationEndpoint, importVirtualAddress, purpose string) {
 	glog.V(1).Info("starting setProxyAddresses(tenantEndpointID: %s, purpose: %s)", tenantEndpointID, purpose)
 	proxiesLock.Lock()
 	defer proxiesLock.Unlock()
@@ -519,7 +520,8 @@ func (c *Controller) setProxyAddresses(tenantEndpointID string, endpoints []appl
 				continue
 			}
 			proxyKeys[instance.InstanceID] = fmt.Sprintf("%s_%d", tenantEndpointID, instance.InstanceID)
-			endpoints[ii].ProxyPort = proxyPort
+			instance.ProxyPort = proxyPort
+			endpoints[ii] = instance
 		}
 	}
 


### PR DESCRIPTION
Changed _endpoints_ list variable from a slice to a map[int], allowing it to be sparse in the case that the endpoint is not in the registry.

Previously, the [continue statement](https://github.com/control-center/serviced/blob/1f80c4938aa575e188b30c35884c834a481a31a7/container/endpoint.go#L442) would cause the _endpoints_ list to have default data.  This would cause the [check for conflicts between exported and imported endpoints](https://github.com/control-center/serviced/blob/1f80c4938aa575e188b30c35884c834a481a31a7/container/endpoint.go#L517) to return a false negative, which resulted in an erroneous endpoint being imported.  Serviced would then open the port (as an imported endpoint), preventing the service process from doing so.

Fixes [CC-1625](https://jira.zenoss.com/browse/CC-1625)