### PR TITLE
CC-1642 Use devicemapper as default storage driver

### DIFF
--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -48,7 +48,7 @@ func getDefaultOptions(config utils.ConfigReader) api.Options {
 		StatsPeriod:          config.IntVal("STATS_PERIOD", 10),
 		MCUsername:           "scott",
 		MCPasswd:             "tiger",
-		FSType:               volume.DriverType(config.StringVal("FS_TYPE", "rsync")),
+		FSType:               volume.DriverType(config.StringVal("FS_TYPE", "devicemapper")),
 		ESStartupTimeout:     getDefaultESStartupTimeout(config.IntVal("ES_STARTUP_TIMEOUT", isvcs.DEFAULT_ES_STARTUP_TIMEOUT_SECONDS)),
 		HostAliases:          config.StringSlice("VHOST_ALIASES", []string{}),
 		Verbosity:            config.IntVal("LOG_LEVEL", 0),

--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -63,7 +63,7 @@
 # SERVICED_CERT_FILE=/etc/....
 
 # Set the driver type on the master for the distributed file system (rsync/btrfs/devicemapper)
-# SERVICED_FS_TYPE=rsync
+# SERVICED_FS_TYPE=devicemapper
 
 # Set the aliases for this host (use in vhost muxing)
 # SERVICED_VHOST_ALIASES=foobar.com,example.com


### PR DESCRIPTION
Updates the default configs to use devicemapper
instead of rsync.