### PR TITLE
Merge pull request #2217 from control-center/feature/US14125

### DIFF
--- a/dfs/dfs.go
+++ b/dfs/dfs.go
@@ -65,7 +65,7 @@ type DFS interface {
 	GetSnapshotWithTag(tenantID string, tagName string) (string, error)
 	// UpgradeRegistry loads images for each service
 	// into the docker registry index
-	UpgradeRegistry(svcs []service.Service, tenantID string) error
+	UpgradeRegistry(svcs []service.Service, tenantID, registryHost string) error
 }
 
 var _ = DFS(&DistributedFilesystem{})

--- a/dfs/dfs_test.go
+++ b/dfs/dfs_test.go
@@ -37,6 +37,7 @@ var (
 	ErrTestNoCommit                = errors.New("container not committed")
 	ErrTestNoPush                  = errors.New("image not pushed")
 	ErrTestNoPull                  = errors.New("could not pull image")
+	ErrTestNoTag                   = errors.New("could not tag image")
 	ErrTestImageNotInRegistry      = errors.New("image not in registry")
 	ErrTestImageNotRemoved         = errors.New("could not remove image")
 	ErrTestVolumeNotRemoved        = errors.New("could not remove volume")

--- a/dfs/mocks/DFS.go
+++ b/dfs/mocks/DFS.go
@@ -310,12 +310,12 @@ func (_m *DFS) GetSnapshotWithTag(tenantID string, tagName string) (string, erro
 	return r0, r1
 }
 
-func (_m *DFS) UpgradeRegistry(svcs []service.Service, tenantID string) error {
-	ret := _m.Called(svcs, tenantID)
+func (_m *DFS) UpgradeRegistry(svcs []service.Service, tenantID, registryHost string) error {
+	ret := _m.Called(svcs, tenantID, registryHost)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func([]service.Service, string) error); ok {
-		r0 = rf(svcs, tenantID)
+	if rf, ok := ret.Get(0).(func([]service.Service, string, string) error); ok {
+		r0 = rf(svcs, tenantID, registryHost)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/facade/dfs.go
+++ b/facade/dfs.go
@@ -267,7 +267,7 @@ func (f *Facade) RepairRegistry(ctx datastore.Context) error {
 
 // UpgradeRegistry adds the images to the registry index so that they will be
 // pushed into the registry.
-func (f *Facade) UpgradeRegistry(ctx datastore.Context) error {
+func (f *Facade) UpgradeRegistry(ctx datastore.Context, registryHost string) error {
 	tenantIDs, err := f.getTenantIDs(ctx)
 	if err != nil {
 		return err
@@ -277,7 +277,7 @@ func (f *Facade) UpgradeRegistry(ctx datastore.Context) error {
 		if err != nil {
 			return err
 		}
-		if err := f.dfs.UpgradeRegistry(svcs, tenantID); err != nil {
+		if err := f.dfs.UpgradeRegistry(svcs, tenantID, registryHost); err != nil {
 			glog.Warningf("Could not upgrade registry for tenant %s: %s", tenantID, err)
 		}
 	}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -164,7 +164,7 @@ func (s *scheduler) mainloop(conn coordclient.Connection) {
 
 	// perform v1 to v2 registry upgrade if necessary
 	glog.Infof("Checking service images")
-	if err := s.facade.UpgradeRegistry(datastore.Get()); err != nil {
+	if err := s.facade.UpgradeRegistry(datastore.Get(), ""); err != nil {
 		glog.Errorf("Could not upgrade registry: %s", err)
 		return
 	}


### PR DESCRIPTION
UpgradeRegistry can now move images from old docker registry