### PR TITLE
tweak modal action button colors

### DIFF
--- a/web/ui/src/common/modalService.js
+++ b/web/ui/src/common/modalService.js
@@ -27,7 +27,7 @@
                 "cancel": {
                     label: "Cancel",
                     icon: "glyphicon-remove",
-                    classes: "btn-link",
+                    classes: "btn-link minor",
                     action: function(){
                         this.close();
                     }
@@ -135,14 +135,14 @@
                         $buttonClone,
                         buttonContent, startWidth, endWidth;
 
-                    // button wasnt found 
+                    // button wasnt found
                     if(!$button.length){
                         return;
                     }
 
                     // explicitly set width so it can be animated
                     startWidth = $button.width();
-                    
+
                     // clone the button and set the ending text so the
                     // explicit width can be calculated
                     $buttonClone = $button.clone().width("auto").text(disabledText).appendTo("body");
@@ -166,7 +166,7 @@
                     };
                 }
             };
-            
+
 
 
 
@@ -195,7 +195,7 @@
                 // TODO - default config object
                 config.actions = config.actions || [];
                 config.onShow = config.onShow || function(){};
-                config.onHide = config.onHide || function(){}; 
+                config.onHide = config.onHide || function(){};
                 var model = config.model || {};
 
                 // if the template was provided, use that

--- a/web/ui/static/css/main.css
+++ b/web/ui/static/css/main.css
@@ -336,7 +336,7 @@ table .btn,
 }
 
 .btn-primary{
-    background-color: #6b6b6b;
+    background-color: #325385;
     border-color: #555;
 }
 .btn-primary[disabled],
@@ -350,8 +350,8 @@ table .btn,
 .btn-primary:active,
 .btn-primary.active,
 .open .dropdown-toggle.btn-primary {
-    background-color: #8b8b8b;
-    border-color: #555;
+    border-color: #0084DB;
+    background-color: #4F83D1;
 }
 
 .details {
@@ -1021,6 +1021,9 @@ input.startup {
 }
 .btn-link:hover {
     color: #4F83D1;
+}
+.btn-link.minor {
+    color: #888;
 }
 
 .btn-danger {


### PR DESCRIPTION
Makes modal action button blue, and minor action button (usually cancel) gray. This emphasizes the primary action more than other secondary stuff.

![oldcolors](https://cloud.githubusercontent.com/assets/1927558/11632650/968fb9a6-9ccd-11e5-9dce-036f215e9e99.png)

![newcolors](https://cloud.githubusercontent.com/assets/1927558/11632651/9691d1f0-9ccd-11e5-83b8-0b3a38f408cb.png)
