### PR TITLE
Please review branch feature/detect-upgrade-old-registry-11x

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -768,6 +768,7 @@ func (d *daemon) initFacade() *facade.Facade {
 	dfs := dfs.NewDistributedFilesystem(d.docker, index, d.reg, d.disk, d.net, time.Duration(options.MaxDFSTimeout)*time.Second)
 	dfs.SetTmp(os.Getenv("TMP"))
 	f.SetDFS(dfs)
+	f.SetIsvcsPath(options.IsvcsPath)
 	return f
 }
 

--- a/facade/dfs.go
+++ b/facade/dfs.go
@@ -17,16 +17,43 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
+	"github.com/control-center/serviced/commons/docker"
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/dfs"
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/volume"
+	dockerclient "github.com/fsouza/go-dockerclient"
 	"github.com/zenoss/glog"
 )
+
+var oldLocalRegistryPort = "5001"
+
+type registryVersionInfo struct {
+	version int
+	rootDir string
+	imageId string
+}
+
+var registryVersionInfos = map[int]registryVersionInfo{
+	1: registryVersionInfo{
+		1,
+		"registry",
+		"registry:0.9.1",
+	},
+	2: registryVersionInfo{
+		2,
+		"v2",
+		"registry:2.2.0", // This is the registry we currently use--may change in the future
+	},
+}
 
 // Backup takes a backup of all installed applications
 func (f *Facade) Backup(ctx datastore.Context, w io.Writer) error {
@@ -265,22 +292,115 @@ func (f *Facade) RepairRegistry(ctx datastore.Context) error {
 	return nil
 }
 
-// UpgradeRegistry adds the images to the registry index so that they will be
-// pushed into the registry.
-func (f *Facade) UpgradeRegistry(ctx datastore.Context, registryHost string) error {
+// UpgradeRegistry adds the images to the registry index so that they will be pushed into the registry.
+// If fromRegistryHost is not set, search for an old registry on the local host to upgrade.
+// If force is true for a local registry, upgrade again even if previous upgrade was successful.
+// (For a remote registry, the upgrade is always performed regardless of the value of the force parameter.)
+func (f *Facade) UpgradeRegistry(ctx datastore.Context, fromRegistryHost string, force bool) error {
+	var err error
+	var oldExists bool
+	var oldUpgraded bool
+	var oldRegistryVersionInfo registryVersionInfo
+
+	// If no remote registry is specified, upgrade from an older local registry.
+	if len(fromRegistryHost) == 0 {
+		// Currently, we only have two registry versions to worry about: v2 (current) and v1 (previous),
+		// so it's easy to figure out what to upgrade from. In the future, we may have to expand this logic...
+		if oldExists, oldUpgraded, oldRegistryVersionInfo, err = f.LocalDockerRegistryExists(1); err != nil {
+			glog.Errorf("Could not determine whether previous Docker registry exists: %s", err)
+			return err
+		}
+
+		if !oldExists {
+			if force {
+				glog.Errorf("No previous version of the Docker registry exists on this host")
+				return err
+			} else {
+				return nil
+			}
+		}
+
+		// If older registry has already been upgraded and caller did not specify force, there's nothing to do here
+		if oldUpgraded && !force {
+			return nil
+		}
+
+		// At this point, an older version was found and either is not upgraded or force == true
+		glog.Infof("Found older Docker registry (v%d) to upgrade...", oldRegistryVersionInfo.version)
+		var localContainer *docker.Container
+		if localContainer, err = oldRegistryVersionInfo.start(f.isvcsPath, oldLocalRegistryPort); err != nil {
+			glog.Errorf("Could not start Docker registry v%d: %s", oldRegistryVersionInfo.version, err)
+			return err
+		}
+		defer func() {
+			glog.Infof("Stopping Docker registry v%d container %s", oldRegistryVersionInfo.version, localContainer.Name)
+			if err := localContainer.Stop(5 * time.Minute); err != nil {
+				glog.Errorf("Could not stop Docker registry v%d container %s: %s",
+					oldRegistryVersionInfo.version, localContainer.Name, err)
+			}
+		}()
+
+		fromRegistryHost = fmt.Sprintf("localhost:%s", oldLocalRegistryPort)
+	}
+
+	successful := true
 	tenantIDs, err := f.getTenantIDs(ctx)
 	if err != nil {
 		return err
 	}
 	for _, tenantID := range tenantIDs {
+
 		svcs, err := f.GetServices(ctx, dao.ServiceRequest{TenantID: tenantID})
 		if err != nil {
 			return err
 		}
-		if err := f.dfs.UpgradeRegistry(svcs, tenantID, registryHost); err != nil {
+		if err := f.dfs.UpgradeRegistry(svcs, tenantID, fromRegistryHost); err != nil {
+			successful = false
 			glog.Warningf("Could not upgrade registry for tenant %s: %s", tenantID, err)
 		}
 	}
+
+	if oldExists && successful {
+		f.markLocalDockerRegistryUpgraded(oldRegistryVersionInfo)
+	}
+
+	return nil
+}
+
+// LocalDockerRegistryExists checks whether the Docker registry of the requested version appears
+// to exist on this host. If so, the info about this registry version is returned. 'upgraded' is true if
+// it appears we have already migrated this registry's images to another registry.
+func (f *Facade) LocalDockerRegistryExists(version int) (exists bool, upgraded bool, versionInfo registryVersionInfo, err error) {
+	var tempVersionInfo registryVersionInfo
+	var ok bool
+	if tempVersionInfo, ok = registryVersionInfos[version]; !ok {
+		err = errors.New(fmt.Sprintf("Unrecognized Docker registry version: %d", version))
+		return
+	}
+
+	registryPath := tempVersionInfo.getStoragePath(f.isvcsPath)
+	if _, err := os.Stat(registryPath); err == nil {
+		exists = true
+		versionInfo = tempVersionInfo
+	}
+
+	markerFilePath := tempVersionInfo.getUpgradedMarkerPath(f.isvcsPath)
+	if _, err := os.Stat(markerFilePath); err == nil {
+		upgraded = true
+	} else {
+		glog.V(2).Infof("Marker file %s not found: %s", markerFilePath, err)
+	}
+
+	return
+}
+
+func (f *Facade) markLocalDockerRegistryUpgraded(versionInfo registryVersionInfo) error {
+	markerFilePath := versionInfo.getUpgradedMarkerPath(f.isvcsPath)
+	if err := ioutil.WriteFile(markerFilePath, []byte{}, 0); err != nil {
+		glog.Errorf("Could not write marker file %s: %s", markerFilePath, err)
+		return err
+	}
+
 	return nil
 }
 
@@ -430,4 +550,94 @@ func (f *Facade) Snapshot(ctx datastore.Context, serviceID, message string, tags
 	}
 	glog.Infof("Successfully captured application data from tenant %s and created snapshot %s", tenantID, snapshotID)
 	return snapshotID, nil
+}
+
+func (info *registryVersionInfo) getStoragePath(isvcsRoot string) string {
+	return filepath.Join(isvcsRoot, "docker-registry", info.rootDir)
+}
+
+func (info *registryVersionInfo) getUpgradedMarkerPath(isvcsRoot string) string {
+	return filepath.Join(info.getStoragePath(isvcsRoot), "cc-upgraded")
+}
+
+func (info *registryVersionInfo) start(isvcsRoot string, hostPort string) (*docker.Container, error) {
+	var err error
+
+	containerName := fmt.Sprintf("cc-temp-registry-v%d", info.version)
+	storagePath := info.getStoragePath(isvcsRoot)
+	bindMount := fmt.Sprintf("%s:/tmp/registry", storagePath)
+	portBindings := make(map[dockerclient.Port][]dockerclient.PortBinding)
+	portBindings["5000/tcp"] = []dockerclient.PortBinding{dockerclient.PortBinding{HostPort: hostPort}}
+	url := fmt.Sprintf("http://localhost:%s/", hostPort)
+
+	// See if container for old registry already exists
+	container, err := docker.FindContainer(containerName)
+	if err != nil {
+		if err != docker.ErrNoSuchContainer {
+			glog.Errorf("Could not look up container %s: %s", containerName, err)
+			return nil, err
+		}
+
+		// Not found, so make a new one
+		containerDefinition := &docker.ContainerDefinition{
+			dockerclient.CreateContainerOptions{
+				Name: containerName,
+				Config: &dockerclient.Config{
+					User:       "root",
+					WorkingDir: "/tmp/registry",
+					Image:      info.imageId,
+					Env:        []string{"SETTINGS_FLAVOR=local"},
+				},
+				// HostConfig: &dockerclient.HostConfig{
+				// 	Binds:        []string{bindMount},
+				// 	PortBindings: portBindings,
+				// },
+			},
+			dockerclient.HostConfig{},
+		}
+
+		glog.Infof("Creating container %s from image %s", containerDefinition.Name, containerDefinition.Config.Image)
+		container, err = docker.NewContainer(containerDefinition, false, 0, nil, nil)
+		if err != nil {
+			glog.Errorf("Error trying to create container %s: %s", containerDefinition.Name, err)
+			return nil, err
+		}
+	}
+
+	os.MkdirAll(storagePath, 0755)
+
+	// Make sure container is running
+	container.HostConfig.Binds = []string{bindMount}
+	container.HostConfig.PortBindings = portBindings
+	glog.Infof("Starting container %s for Docker registry v%d at %s", container.Name, info.version, url)
+	if err = container.Start(); err != nil {
+		glog.Errorf("Could not start container %s: %s", container.Name, err)
+		return nil, err
+	}
+
+	// Make sure registry is up and running (accepting connections)
+	timeout := time.After(5 * time.Minute)
+	for {
+		resp, err := http.Get(url)
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+		if err == nil {
+			break
+		} else {
+			glog.V(1).Infof("Waiting for Docker registry v%d to accept connections...", info.version)
+		}
+
+		select {
+		case <-timeout:
+			glog.Warningf("Timed out waiting for Docker registry v%d to accept connections", info.version)
+			if err := container.Stop(5 * time.Minute); err != nil {
+				glog.Errorf("After timeout, could not stop Docker registry v%d container %s: %s", info.version, container.Name, err)
+			}
+			return nil, errors.New(fmt.Sprintf("Timed out waiting for Docker registry v%d to accept connections", info.version))
+		case <-time.After(time.Second):
+		}
+	}
+
+	return container, nil
 }

--- a/facade/dfs_test.go
+++ b/facade/dfs_test.go
@@ -1,0 +1,325 @@
+// Copyright 2015 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build integration
+
+package facade
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/datastore/elastic"
+	"github.com/control-center/serviced/domain/addressassignment"
+	"github.com/control-center/serviced/domain/host"
+	"github.com/control-center/serviced/domain/pool"
+	"github.com/control-center/serviced/domain/registry"
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/domain/serviceconfigfile"
+	"github.com/control-center/serviced/domain/servicetemplate"
+	"github.com/control-center/serviced/domain/user"
+
+	dfsmocks "github.com/control-center/serviced/dfs/mocks"
+	zzkmocks "github.com/control-center/serviced/facade/mocks"
+	"github.com/stretchr/testify/mock"
+	gocheck "gopkg.in/check.v1"
+)
+
+var (
+	testDataRootDir        = "/tmp/dfsregistrytest"
+	remoteRegistryEndpoint = "1.2.3.4:5000"
+)
+
+var dfsRegistrySvcDefs = [...]service.Service{
+	service.Service{
+		ID:           "dfsrgysvc1",
+		Name:         "TestDfsRegistry1",
+		DeploymentID: "testdfsdeployment",
+		ImageID:      "zenoss/testimage1",
+		PoolID:       "pool_id",
+		Launch:       "auto",
+	},
+	service.Service{
+		ID:           "dfsrgysvc2",
+		Name:         "TestDfsRegistry2",
+		DeploymentID: "testdfsdeployment",
+		ImageID:      "zenoss/testimage2",
+		PoolID:       "pool_id",
+		Launch:       "auto",
+	},
+}
+
+//-----------------------------------------------------------------------
+// FacadeDfsRegistryTest and other support functions
+
+var _ = gocheck.Suite(&FacadeDfsRegistryTest{})
+
+type FacadeDfsRegistryTest struct {
+	elastic.ElasticTest
+	CTX    datastore.Context
+	Facade *Facade
+	zzk    *zzkmocks.ZZK
+	dfs    *dfsmocks.DFS
+
+	registryVersionInfo registryVersionInfo
+	v1RegistryRootDir   string
+}
+
+func (fdrt *FacadeDfsRegistryTest) SetUpSuite(c *gocheck.C) {
+	//set up index and mappings before setting up elastic
+	fdrt.Index = "controlplane"
+	if fdrt.Mappings == nil {
+		fdrt.Mappings = make([]elastic.Mapping, 0)
+	}
+	fdrt.Mappings = append(fdrt.Mappings, host.MAPPING)
+	fdrt.Mappings = append(fdrt.Mappings, pool.MAPPING)
+	fdrt.Mappings = append(fdrt.Mappings, service.MAPPING)
+	fdrt.Mappings = append(fdrt.Mappings, servicetemplate.MAPPING)
+	fdrt.Mappings = append(fdrt.Mappings, addressassignment.MAPPING)
+	fdrt.Mappings = append(fdrt.Mappings, serviceconfigfile.MAPPING)
+	fdrt.Mappings = append(fdrt.Mappings, user.MAPPING)
+	fdrt.Mappings = append(fdrt.Mappings, registry.MAPPING)
+
+	fdrt.ElasticTest.SetUpSuite(c)
+	datastore.Register(fdrt.Driver())
+	fdrt.CTX = datastore.Get()
+
+	fdrt.Facade = New()
+
+	fdrt.registryVersionInfo = registryVersionInfos[1] // Currently, only old registry is v1
+	fdrt.cleanUpOldRegistry(c)                         // Just to be sure
+}
+
+func (fdrt *FacadeDfsRegistryTest) SetUpTest(c *gocheck.C) {
+	fdrt.ElasticTest.SetUpTest(c)
+	fdrt.zzk = &zzkmocks.ZZK{}
+	fdrt.Facade.SetZZK(fdrt.zzk)
+	fdrt.dfs = &dfsmocks.DFS{}
+	fdrt.Facade.SetDFS(fdrt.dfs)
+	fdrt.setupMockZZK()
+
+	fdrt.Facade.SetIsvcsPath(testDataRootDir)
+
+	fdrt.addServices(c)
+	fdrt.setupOldRegistry(c)
+}
+
+func (fdrt *FacadeDfsRegistryTest) TearDownTest(c *gocheck.C) {
+	fdrt.cleanUpOldRegistry(c)
+}
+
+func (fdrt *FacadeDfsRegistryTest) TearDownSuite(c *gocheck.C) {
+	if exists := fdrt.oldRegistryImageExists(c); exists {
+		cmd := exec.Command("docker", "rmi", "--force", fdrt.registryVersionInfo.imageId)
+		if err := cmd.Run(); err != nil {
+			c.Errorf("Could not delete image %s: %s", fdrt.registryVersionInfo.imageId, err)
+		}
+	}
+}
+
+func (fdrt *FacadeDfsRegistryTest) setupMockZZK() {
+	fdrt.zzk.On("AddResourcePool", mock.AnythingOfType("*pool.ResourcePool")).Return(nil)
+	fdrt.zzk.On("UpdateResourcePool", mock.AnythingOfType("*pool.ResourcePool")).Return(nil)
+	fdrt.zzk.On("RemoveResourcePool", mock.AnythingOfType("string")).Return(nil)
+	fdrt.zzk.On("AddVirtualIP", mock.AnythingOfType("*pool.VirtualIP")).Return(nil)
+	fdrt.zzk.On("RemoveVirtualIP", mock.AnythingOfType("*pool.VirtualIP")).Return(nil)
+	fdrt.zzk.On("AddHost", mock.AnythingOfType("*host.Host")).Return(nil)
+	fdrt.zzk.On("UpdateHost", mock.AnythingOfType("*host.Host")).Return(nil)
+	fdrt.zzk.On("RemoveHost", mock.AnythingOfType("*host.Host")).Return(nil)
+	fdrt.zzk.On("UpdateService", mock.AnythingOfType("*service.Service"), mock.AnythingOfType("bool")).Return(nil)
+	fdrt.zzk.On("RemoveService", mock.AnythingOfType("*service.Service")).Return(nil)
+	fdrt.zzk.On("SetRegistryImage", mock.AnythingOfType("*registry.Image")).Return(nil)
+	fdrt.zzk.On("DeleteRegistryImage", mock.AnythingOfType("string")).Return(nil)
+	fdrt.zzk.On("DeleteRegistryLibrary", mock.AnythingOfType("string")).Return(nil)
+	fdrt.zzk.On("LockServices", mock.AnythingOfType("[]service.Service")).Return(nil)
+	fdrt.zzk.On("UnlockServices", mock.AnythingOfType("[]service.Service")).Return(nil)
+}
+
+func (fdrt *FacadeDfsRegistryTest) getOldRegistryContainerName() string {
+	return fmt.Sprintf(oldLocalRegistryContainerNameBase, fdrt.registryVersionInfo.version)
+}
+
+func (fdrt *FacadeDfsRegistryTest) getRegistryPath(c *gocheck.C) string {
+	return filepath.Join(testDataRootDir, registryRootSubdir, fdrt.registryVersionInfo.rootDir)
+}
+
+func (fdrt *FacadeDfsRegistryTest) setupOldRegistry(c *gocheck.C) {
+	fdrt.v1RegistryRootDir = fdrt.getRegistryPath(c)
+	os.MkdirAll(fdrt.v1RegistryRootDir, 0755)
+}
+
+func (fdrt *FacadeDfsRegistryTest) oldRegistryContainerExists(c *gocheck.C) (found bool) {
+	return execGrep(c, "docker ps --all", fdrt.getOldRegistryContainerName())
+}
+
+func (fdrt *FacadeDfsRegistryTest) oldRegistryImageExists(c *gocheck.C) (found bool) {
+	return execGrep(c, "docker images", fdrt.registryVersionInfo.imageId)
+}
+
+func execGrep(c *gocheck.C, command string, stringToFind string) (found bool) {
+	found = false
+
+	commandAndArgs := strings.Split(command, " ")
+	cmd := exec.Command(commandAndArgs[0], commandAndArgs[1:]...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		c.Errorf("Could not read output from go exec.Command: %s", err)
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		c.Errorf("Could not start go exec.Command('docker ps --all'): %s", err)
+		return
+	}
+	defer cmd.Wait()
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), stringToFind) {
+			found = true
+			break
+		}
+	}
+
+	return
+}
+
+func (fdrt *FacadeDfsRegistryTest) cleanUpOldRegistry(c *gocheck.C) {
+	if exists := fdrt.oldRegistryContainerExists(c); exists {
+		cmd := exec.Command("docker", "rm", "--force", fdrt.getOldRegistryContainerName())
+		if err := cmd.Run(); err != nil {
+			c.Fatalf("Cleanup failed: Could not delete container %s: %s", fdrt.getOldRegistryContainerName(), err)
+		}
+	}
+
+	os.RemoveAll(fdrt.v1RegistryRootDir)
+}
+
+func (fdrt *FacadeDfsRegistryTest) verifyOldRegistryContainerExists(c *gocheck.C, exists bool) {
+	found := fdrt.oldRegistryContainerExists(c)
+	if exists != found {
+		c.Errorf("Expected old registry container exists == %t, but found == %t", exists, found)
+	}
+}
+
+func (fdrt *FacadeDfsRegistryTest) addServices(c *gocheck.C) {
+	for _, svc := range dfsRegistrySvcDefs {
+		if err := fdrt.Facade.AddService(fdrt.CTX, svc); err != nil {
+			c.Fatalf("Setup failed: Could not add service %s: %s", svc.ID, err)
+			return
+		}
+	}
+}
+
+// Must be called before calling Facade.UpgradeRegistry()
+func (fdrt *FacadeDfsRegistryTest) verifyAllImagesUpgraded(c *gocheck.C, endpoint string) {
+	fdrt.dfs.On("UpgradeRegistry", mock.AnythingOfType("[]service.Service"), dfsRegistrySvcDefs[0].ID, endpoint).Return(nil).Run(func(args mock.Arguments) {
+		svcs := args.Get(0).([]service.Service)
+		c.Assert(len(svcs), gocheck.Equals, 1)
+		c.Assert(svcs[0].ID, gocheck.Equals, dfsRegistrySvcDefs[0].ID)
+		c.Assert(svcs[0].Name, gocheck.Equals, dfsRegistrySvcDefs[0].Name)
+		c.Assert(svcs[0].DeploymentID, gocheck.Equals, dfsRegistrySvcDefs[0].DeploymentID)
+		c.Assert(svcs[0].ImageID, gocheck.Equals, dfsRegistrySvcDefs[0].ImageID)
+		c.Assert(svcs[0].PoolID, gocheck.Equals, dfsRegistrySvcDefs[0].PoolID)
+	})
+	fdrt.dfs.On("UpgradeRegistry", mock.AnythingOfType("[]service.Service"), dfsRegistrySvcDefs[1].ID, endpoint).Return(nil).Run(func(args mock.Arguments) {
+		svcs := args.Get(0).([]service.Service)
+		c.Assert(len(svcs), gocheck.Equals, 1)
+		c.Assert(svcs[0].ID, gocheck.Equals, dfsRegistrySvcDefs[1].ID)
+		c.Assert(svcs[0].Name, gocheck.Equals, dfsRegistrySvcDefs[1].Name)
+		c.Assert(svcs[0].DeploymentID, gocheck.Equals, dfsRegistrySvcDefs[1].DeploymentID)
+		c.Assert(svcs[0].ImageID, gocheck.Equals, dfsRegistrySvcDefs[1].ImageID)
+		c.Assert(svcs[0].PoolID, gocheck.Equals, dfsRegistrySvcDefs[1].PoolID)
+	})
+}
+
+func (fdrt *FacadeDfsRegistryTest) verifyNoImagesUpgraded(c *gocheck.C) {
+	fdrt.dfs.AssertNotCalled(c, "UpgradeRegistry", mock.AnythingOfType("[]service.Service"), mock.AnythingOfType("string"), mock.AnythingOfType("string"))
+}
+
+func (fdrt *FacadeDfsRegistryTest) markOldRegistryUpgraded(c *gocheck.C) {
+	markerFile := filepath.Join(fdrt.getRegistryPath(c), upgradedMarkerFile)
+	if err := ioutil.WriteFile(markerFile, []byte{}, 0644); err != nil {
+		c.Fatalf("Could not create 'upgraded' marker file %s: %s", markerFile, err)
+	}
+}
+
+func getOldRegistryEndpoint() string {
+	return fmt.Sprintf("localhost:%s", oldLocalRegistryPort)
+}
+
+//-----------------------------------------------------------------------
+// Test Cases
+
+func (fdrt *FacadeDfsRegistryTest) TestUpgradeRegistry_UpgradeLocal(c *gocheck.C) {
+	fdrt.verifyAllImagesUpgraded(c, getOldRegistryEndpoint())
+
+	err := fdrt.Facade.UpgradeRegistry(fdrt.CTX, "", false)
+
+	c.Assert(err, gocheck.IsNil)
+	fdrt.verifyOldRegistryContainerExists(c, true)
+}
+
+func (fdrt *FacadeDfsRegistryTest) TestUpgradeRegistry_SkipUpgradedLocal(c *gocheck.C) {
+	fdrt.markOldRegistryUpgraded(c)
+
+	err := fdrt.Facade.UpgradeRegistry(fdrt.CTX, "", false)
+
+	c.Assert(err, gocheck.IsNil)
+	fdrt.verifyNoImagesUpgraded(c)
+	fdrt.verifyOldRegistryContainerExists(c, false)
+}
+
+func (fdrt *FacadeDfsRegistryTest) TestUpgradeRegistry_ForceLocal(c *gocheck.C) {
+	fdrt.markOldRegistryUpgraded(c)
+
+	fdrt.verifyAllImagesUpgraded(c, getOldRegistryEndpoint())
+
+	err := fdrt.Facade.UpgradeRegistry(fdrt.CTX, "", true)
+
+	c.Assert(err, gocheck.IsNil)
+	fdrt.verifyOldRegistryContainerExists(c, true)
+}
+
+func (fdrt *FacadeDfsRegistryTest) TestUpgradeRegistry_ForceLocalButNoRegistry(c *gocheck.C) {
+	fdrt.cleanUpOldRegistry(c)
+
+	err := fdrt.Facade.UpgradeRegistry(fdrt.CTX, "", true)
+
+	c.Assert(err, gocheck.NotNil) // Should report there was no registry to upgrade
+	fdrt.verifyNoImagesUpgraded(c)
+	fdrt.verifyOldRegistryContainerExists(c, false)
+}
+
+func (fdrt *FacadeDfsRegistryTest) TestUpgradeRegistry_UpgradeRemote(c *gocheck.C) {
+	fdrt.verifyAllImagesUpgraded(c, remoteRegistryEndpoint)
+
+	err := fdrt.Facade.UpgradeRegistry(fdrt.CTX, remoteRegistryEndpoint, false)
+
+	c.Assert(err, gocheck.IsNil)
+	fdrt.verifyOldRegistryContainerExists(c, false)
+}
+
+func (fdrt *FacadeDfsRegistryTest) TestUpgradeRegistry_UpgradeRemoteForce(c *gocheck.C) {
+	fdrt.verifyAllImagesUpgraded(c, remoteRegistryEndpoint)
+
+	err := fdrt.Facade.UpgradeRegistry(fdrt.CTX, remoteRegistryEndpoint, true)
+
+	c.Assert(err, gocheck.IsNil)
+	fdrt.verifyOldRegistryContainerExists(c, false)
+}

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -46,8 +46,12 @@ type Facade struct {
 
 	zzk ZZK
 	dfs dfs.DFS
+
+	isvcsPath string
 }
 
 func (f *Facade) SetZZK(zzk ZZK) { f.zzk = zzk }
 
 func (f *Facade) SetDFS(dfs dfs.DFS) { f.dfs = dfs }
+
+func (f *Facade) SetIsvcsPath(path string) { f.isvcsPath = path }

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -207,3 +207,15 @@ func (m *FacadeInterface) GetHealthChecksForService(ctx datastore.Context, id st
 
 	return r0, r1
 }
+func (_m *FacadeInterface) UpgradeRegistry(ctx datastore.Context, fromRegistryHost string, force bool) error {
+	ret := _m.Called(ctx, fromRegistryHost, force)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, bool) error); ok {
+		r0 = rf(ctx, fromRegistryHost, force)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -164,7 +164,7 @@ func (s *scheduler) mainloop(conn coordclient.Connection) {
 
 	// perform v1 to v2 registry upgrade if necessary
 	glog.Infof("Checking service images")
-	if err := s.facade.UpgradeRegistry(datastore.Get(), ""); err != nil {
+	if err := s.facade.UpgradeRegistry(datastore.Get(), "", false); err != nil {
 		glog.Errorf("Could not upgrade registry: %s", err)
 		return
 	}


### PR DESCRIPTION
Cherry-picked 492320b
Cherry-picked f4a6285

Pull request created by zendev port

Detect older registry that needs to be upgraded.  And start the older version of the Docker registry so we can get the images out of it.

US14125 / TA27529
