### PR TITLE
Feature/ta25730

### DIFF
--- a/cli/api/docker.go
+++ b/cli/api/docker.go
@@ -13,22 +13,30 @@
 
 package api
 
-import "github.com/control-center/serviced/dao"
-
 // ResetRegistry moves all relevant images into the new docker registry
 func (a *api) ResetRegistry() error {
-	client, err := a.connectDAO()
+	client, err := a.connectMaster()
 	if err != nil {
 		return err
 	}
-	return client.RepairRegistry(dao.NullRequest{}, new(int))
+	return client.ResetRegistry()
 }
 
-// RegistrySync walks the service tree and syncs all images from docker to local registry
-func (a *api) RegistrySync() (err error) {
-	client, err := a.connectDAO()
+// SyncRegistry walks the service tree and syncs all images from docker to local
+// registry.
+func (a *api) RegistrySync() error {
+	client, err := a.connectMaster()
 	if err != nil {
 		return err
 	}
-	return client.ResetRegistry(dao.NullRequest{}, new(int))
+	return client.SyncRegistry()
+}
+
+// UpgradeRegistry migrates images from an older or remote docker registry.
+func (a *api) UpgradeRegistry(endpoint string, override bool) error {
+	client, err := a.connectMaster()
+	if err != nil {
+		return err
+	}
+	return client.UpgradeRegistry(endpoint, override)
 }

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -106,6 +106,7 @@ type API interface {
 	// Docker
 	ResetRegistry() error
 	RegistrySync() error
+	UpgradeRegistry(endpoint string, override bool) error
 
 	// Logs
 	ExportLogs(config ExportLogsConfig) error

--- a/cli/api/service_test.go
+++ b/cli/api/service_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/rpc/master/mocks"
 
+	"github.com/control-center/serviced/domain/applicationendpoint"
 	"github.com/stretchr/testify/mock"
 	. "gopkg.in/check.v1"
-	"github.com/control-center/serviced/domain/applicationendpoint"
 )
 
 var tGlobal *testing.T
@@ -183,7 +183,7 @@ func (st *serviceAPITest) TestGetEndpoints_fails(c *C) {
 	serviceID := "test-service"
 
 	st.mockMasterClient.
-		On("GetServiceEndpoints", []string{serviceID}, true).
+		On("GetServiceEndpoints", []string{serviceID}, true, true, true).
 		Return(nil, errorStub)
 
 	actual, err := st.api.GetEndpoints(serviceID, true, true, true)
@@ -196,7 +196,7 @@ func (st *serviceAPITest) TestGetEndpoints_works(c *C) {
 	serviceID := "test-service"
 
 	st.mockMasterClient.
-		On("GetServiceEndpoints", []string{serviceID}, true).
+		On("GetServiceEndpoints", []string{serviceID}, true, true, true).
 		Return([]applicationendpoint.EndpointReport{}, nil)
 
 	actual, err := st.api.GetEndpoints(serviceID, true, true, true)

--- a/cli/cmd/docker.go
+++ b/cli/cmd/docker.go
@@ -38,7 +38,7 @@ func (c *ServicedCli) initDocker() {
 			}, {
 				Name:        "migrate-registry",
 				Usage:       "service docker migrate-registry",
-				Description: "Pull images from the provided docker registry and updates the index",
+				Description: "Upgrades the docker registry from an older or remote registry",
 				Action:      c.cmdMigrateRegistry,
 				Flags: []cli.Flag{
 					cli.StringFlag{"registry", "", "host:port where the registry is running"},

--- a/cli/cmd/docker.go
+++ b/cli/cmd/docker.go
@@ -30,15 +30,20 @@ func (c *ServicedCli) initDocker() {
 				Usage:       "serviced docker sync",
 				Description: "sync pushes all images to local registry - allows single host to easily be made master for multi-host",
 				Action:      c.cmdRegistrySync,
-				Flags: []cli.Flag{
-					cli.StringFlag{"endpoint", "unix:///var/run/docker.sock", "docker endpoint"},
-				},
-			},
-			{
+			}, {
 				Name:        "reset-registry",
 				Usage:       "serviced docker reset-registry",
-				Description: "Migrates all the docker images into the new registry",
+				Description: "Pulls images from the docker registry and updates the index",
 				Action:      c.cmdResetRegistry,
+			}, {
+				Name:        "migrate-registry",
+				Usage:       "service docker migrate-registry",
+				Description: "Pull images from the provided docker registry and updates the index",
+				Action:      c.cmdMigrateRegistry,
+				Flags: []cli.Flag{
+					cli.StringFlag{"registry", "", "host:port where the registry is running"},
+					cli.BoolFlag{"override, f", "overrides all existing image records"},
+				},
 			},
 		},
 	})
@@ -46,15 +51,24 @@ func (c *ServicedCli) initDocker() {
 
 // serviced docker sync
 func (c *ServicedCli) cmdRegistrySync(ctx *cli.Context) {
-
 	err := c.driver.RegistrySync()
 	if err != nil {
 		glog.Fatalf("error syncing docker images to local registry: %s", err)
 	}
 }
 
+// serviced reset-registry
 func (c *ServicedCli) cmdResetRegistry(ctx *cli.Context) {
 	if err := c.driver.ResetRegistry(); err != nil {
 		glog.Fatalf("error while resetting the registry: %s", err)
+	}
+}
+
+// serviced migrate-registry
+func (c *ServicedCli) cmdMigrateRegistry(ctx *cli.Context) {
+	endpoint := ctx.String("registry")
+	override := ctx.Bool("override")
+	if err := c.driver.UpgradeRegistry(endpoint, override); err != nil {
+		glog.Fatalf("error while upgrading the registry: %s", err)
 	}
 }

--- a/dfs/dfs.go
+++ b/dfs/dfs.go
@@ -65,7 +65,7 @@ type DFS interface {
 	GetSnapshotWithTag(tenantID string, tagName string) (string, error)
 	// UpgradeRegistry loads images for each service
 	// into the docker registry index
-	UpgradeRegistry(svcs []service.Service, tenantID, registryHost string) error
+	UpgradeRegistry(svcs []service.Service, tenantID, registryHost string, override bool) error
 }
 
 var _ = DFS(&DistributedFilesystem{})

--- a/dfs/mocks/DFS.go
+++ b/dfs/mocks/DFS.go
@@ -310,12 +310,12 @@ func (_m *DFS) GetSnapshotWithTag(tenantID string, tagName string) (string, erro
 	return r0, r1
 }
 
-func (_m *DFS) UpgradeRegistry(svcs []service.Service, tenantID, registryHost string) error {
-	ret := _m.Called(svcs, tenantID, registryHost)
+func (_m *DFS) UpgradeRegistry(svcs []service.Service, tenantID, registryHost string, override bool) error {
+	ret := _m.Called(svcs, tenantID, registryHost, override)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func([]service.Service, string, string) error); ok {
-		r0 = rf(svcs, tenantID, registryHost)
+	if rf, ok := ret.Get(0).(func([]service.Service, string, string, bool) error); ok {
+		r0 = rf(svcs, tenantID, registryHost, override)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/dfs/upgraderegistry.go
+++ b/dfs/upgraderegistry.go
@@ -24,7 +24,7 @@ import (
 // UpgradeRegistry loads images for each service into the docker registry
 // index.  Also migrates images from a previous (or V1) registry at
 // registryHost (host:port).
-func (dfs *DistributedFilesystem) UpgradeRegistry(svcs []service.Service, tenantID, registryHost string) error {
+func (dfs *DistributedFilesystem) UpgradeRegistry(svcs []service.Service, tenantID, registryHost string, override bool) error {
 	imageIDs := make(map[string]struct{})
 	for _, svc := range svcs {
 		if svc.ImageID == "" {
@@ -37,17 +37,19 @@ func (dfs *DistributedFilesystem) UpgradeRegistry(svcs []service.Service, tenant
 			continue
 		}
 		imageIDs[image] = struct{}{}
-		// is image in registry?
-		rImage, err := dfs.findImage(image, tenantID)
-		if err != nil {
-			return err
-		} else if rImage != "" {
-			// image is already in the registry
-			glog.V(2).Infof("Image %s for service %s (%s) already present in docker registry", rImage, svc.Name, svc.ID)
-			continue
+		if !override {
+			// is image in registry?
+			rImage, err := dfs.findImage(image, tenantID)
+			if err != nil {
+				return err
+			} else if rImage != "" {
+				// image is already in the registry
+				glog.V(2).Infof("Image %s for service %s (%s) already present in docker registry", rImage, svc.Name, svc.ID)
+				continue
+			}
 		}
 		// get registry image tag from image name
-		rImage, err = dfs.parseRegistryImage(image, tenantID)
+		rImage, err := dfs.parseRegistryImage(image, tenantID)
 		if err != nil {
 			glog.Warningf("Cannot parse image name %s under service %s (%s)", image, svc.Name, svc.ID)
 			continue

--- a/dfs/upgraderegistry_test.go
+++ b/dfs/upgraderegistry_test.go
@@ -34,7 +34,7 @@ func (s *DFSTestSuite) TestUpgradeRegistry_FindImageFail(c *C) {
 		},
 	}
 	s.index.On("FindImage", "unknown/repo").Return(nil, ErrTestGeneric)
-	err := s.dfs.UpgradeRegistry(svcs, "test_tenantID", "")
+	err := s.dfs.UpgradeRegistry(svcs, "test_tenantID", "", false)
 	c.Assert(err, Equals, ErrTestGeneric)
 }
 
@@ -55,7 +55,51 @@ func (s *DFSTestSuite) TestUpgradeRegistry_FindImageSuccess(c *C) {
 		UUID:    "testuuid",
 	}
 	s.index.On("FindImage", imageName).Return(rImage, nil)
-	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "")
+	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "", false)
+	c.Assert(err, IsNil)
+}
+
+// image in registry and override enabled
+func (s *DFSTestSuite) TestUpgradeRegistry_OverrideImageFound(c *C) {
+	imageName := "localhost:5000/tenantid/reponame"
+	svcs := []service.Service{
+		{
+			Name:    "service",
+			ID:      "service_id",
+			ImageID: imageName,
+		},
+	}
+	rImage := &registry.Image{
+		Library: "tenantid",
+		Repo:    "reponame",
+		Tag:     "latest",
+		UUID:    "uuidvalue",
+	}
+	s.index.On("FindImage", imageName).Return(rImage, nil)
+	image := &dockerclient.Image{ID: "xyzabc123"}
+	s.docker.On("GetImageHash", image.ID).Return("hashvalue", nil)
+	s.docker.On("FindImage", imageName).Return(image, nil)
+	s.index.On("PushImage", "tenantid/reponame:latest", "xyzabc123", "hashvalue").Return(nil)
+	err := s.dfs.UpgradeRegistry(svcs, "tenantid", "", true)
+	c.Assert(err, IsNil)
+}
+
+// image not in registry and override enabled
+func (s *DFSTestSuite) TestUpgradeRegistry_OverrideImageNotFound(c *C) {
+	imageName := "localhost:5000/tenantid/reponame"
+	svcs := []service.Service{
+		{
+			Name:    "service",
+			ID:      "service_id",
+			ImageID: imageName,
+		},
+	}
+	s.index.On("FindImage", imageName).Return(nil, index.ErrImageNotFound)
+	image := &dockerclient.Image{ID: "xyzabc123"}
+	s.docker.On("GetImageHash", image.ID).Return("hashvalue", nil)
+	s.docker.On("FindImage", imageName).Return(image, nil)
+	s.index.On("PushImage", "tenantid/reponame:latest", "xyzabc123", "hashvalue").Return(nil)
+	err := s.dfs.UpgradeRegistry(svcs, "tenantid", "", true)
 	c.Assert(err, IsNil)
 }
 
@@ -71,7 +115,7 @@ func (s *DFSTestSuite) TestUpgradeRegistry_DockerImageNotFound(c *C) {
 	}
 	s.index.On("FindImage", imageName).Return(nil, index.ErrImageNotFound)
 	s.docker.On("FindImage", imageName).Return(nil, dockerclient.ErrNoSuchImage)
-	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "")
+	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "", false)
 	c.Assert(err, IsNil)
 }
 
@@ -87,7 +131,7 @@ func (s *DFSTestSuite) TestUpgradeRegistry_DockerFindImageFail(c *C) {
 	}
 	s.index.On("FindImage", imageName).Return(nil, index.ErrImageNotFound)
 	s.docker.On("FindImage", imageName).Return(nil, ErrTestGeneric)
-	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "")
+	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "", false)
 	c.Assert(err, Equals, ErrTestGeneric)
 }
 
@@ -105,7 +149,7 @@ func (s *DFSTestSuite) TestUpgradeRegistry_PushImageNoHash(c *C) {
 	image := &dockerclient.Image{ID: "youyoueyedee"}
 	s.docker.On("FindImage", imageName).Return(image, nil)
 	s.docker.On("GetImageHash", image.ID).Return("", ErrTestNoHash)
-	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "")
+	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "", false)
 	c.Assert(err, Equals, ErrTestNoHash)
 }
 
@@ -124,7 +168,7 @@ func (s *DFSTestSuite) TestUpgradeRegistry_PushImageSuccess(c *C) {
 	s.docker.On("FindImage", imageName).Return(image, nil)
 	s.docker.On("GetImageHash", image.ID).Return("hashvalue", nil)
 	s.index.On("PushImage", "goodtenant/repo:latest", "youyoueyedee", "hashvalue").Return(nil)
-	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "")
+	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "", false)
 	c.Assert(err, IsNil)
 }
 
@@ -143,7 +187,7 @@ func (s *DFSTestSuite) TestUpgradeRegistry_PushImageFail(c *C) {
 	s.docker.On("FindImage", imageName).Return(image, nil)
 	s.docker.On("GetImageHash", image.ID).Return("hashvalue", nil)
 	s.index.On("PushImage", "goodtenant/repo:latest", "youyoueyedee", "hashvalue").Return(ErrTestNoPush)
-	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "")
+	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "", false)
 	c.Assert(err, Equals, ErrTestNoPush)
 }
 
@@ -166,7 +210,7 @@ func (s *DFSTestSuite) TestUpgradeRegistry_NoDupes(c *C) {
 	s.docker.On("FindImage", imageName).Return(image, nil).Once()
 	s.docker.On("GetImageHash", image.ID).Return("hashvalue", nil)
 	s.index.On("PushImage", "goodtenant/repo:latest", "youyoueyedee", "hashvalue").Return(nil).Once()
-	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "")
+	err := s.dfs.UpgradeRegistry(svcs, "goodtenant", "", false)
 	c.Assert(err, IsNil)
 }
 
@@ -186,7 +230,7 @@ func (s *DFSTestSuite) TestUpgradeRegistry_MigrateNoImage(c *C) {
 	s.docker.On("FindImage", imageName).Return(image, nil)
 	s.docker.On("GetImageHash", image.ID).Return("hashvalue", nil)
 	s.index.On("PushImage", "tenantid/reponame:latest", "uuidvalue", "hashvalue").Return(nil)
-	err := s.dfs.UpgradeRegistry(svcs, "tenantid", "old-server:5001")
+	err := s.dfs.UpgradeRegistry(svcs, "tenantid", "old-server:5001", false)
 	c.Assert(err, IsNil)
 }
 
@@ -203,7 +247,7 @@ func (s *DFSTestSuite) TestUpgradeRegistry_MigrateTagFail(c *C) {
 	s.index.On("FindImage", imageName).Return(nil, index.ErrImageNotFound)
 	s.docker.On("PullImage", "old-server:5001/tenantid/reponame:latest").Return(nil)
 	s.docker.On("TagImage", "old-server:5001/tenantid/reponame:latest", "test-server:5000/tenantid/reponame").Return(ErrTestNoTag)
-	err := s.dfs.UpgradeRegistry(svcs, "tenantid", "old-server:5001")
+	err := s.dfs.UpgradeRegistry(svcs, "tenantid", "old-server:5001", false)
 	c.Assert(err, Equals, ErrTestNoTag)
 }
 
@@ -224,6 +268,6 @@ func (s *DFSTestSuite) TestUpgradeRegistry_MigrateSuccess(c *C) {
 	s.docker.On("FindImage", imageName).Return(image, nil)
 	s.docker.On("GetImageHash", image.ID).Return("hashvalue", nil)
 	s.index.On("PushImage", "tenantid/reponame:latest", "uuidvalue", "hashvalue").Return(nil)
-	err := s.dfs.UpgradeRegistry(svcs, "tenantid", "old-server:5001")
+	err := s.dfs.UpgradeRegistry(svcs, "tenantid", "old-server:5001", false)
 	c.Assert(err, IsNil)
 }

--- a/facade/dfs_test.go
+++ b/facade/dfs_test.go
@@ -227,8 +227,8 @@ func (fdrt *FacadeDfsRegistryTest) addServices(c *gocheck.C) {
 }
 
 // Must be called before calling Facade.UpgradeRegistry()
-func (fdrt *FacadeDfsRegistryTest) verifyAllImagesUpgraded(c *gocheck.C, endpoint string) {
-	fdrt.dfs.On("UpgradeRegistry", mock.AnythingOfType("[]service.Service"), dfsRegistrySvcDefs[0].ID, endpoint).Return(nil).Run(func(args mock.Arguments) {
+func (fdrt *FacadeDfsRegistryTest) verifyAllImagesUpgraded(c *gocheck.C, endpoint string, force bool) {
+	fdrt.dfs.On("UpgradeRegistry", mock.AnythingOfType("[]service.Service"), dfsRegistrySvcDefs[0].ID, endpoint, force).Return(nil).Run(func(args mock.Arguments) {
 		svcs := args.Get(0).([]service.Service)
 		c.Assert(len(svcs), gocheck.Equals, 1)
 		c.Assert(svcs[0].ID, gocheck.Equals, dfsRegistrySvcDefs[0].ID)
@@ -237,7 +237,7 @@ func (fdrt *FacadeDfsRegistryTest) verifyAllImagesUpgraded(c *gocheck.C, endpoin
 		c.Assert(svcs[0].ImageID, gocheck.Equals, dfsRegistrySvcDefs[0].ImageID)
 		c.Assert(svcs[0].PoolID, gocheck.Equals, dfsRegistrySvcDefs[0].PoolID)
 	})
-	fdrt.dfs.On("UpgradeRegistry", mock.AnythingOfType("[]service.Service"), dfsRegistrySvcDefs[1].ID, endpoint).Return(nil).Run(func(args mock.Arguments) {
+	fdrt.dfs.On("UpgradeRegistry", mock.AnythingOfType("[]service.Service"), dfsRegistrySvcDefs[1].ID, endpoint, force).Return(nil).Run(func(args mock.Arguments) {
 		svcs := args.Get(0).([]service.Service)
 		c.Assert(len(svcs), gocheck.Equals, 1)
 		c.Assert(svcs[0].ID, gocheck.Equals, dfsRegistrySvcDefs[1].ID)
@@ -267,7 +267,7 @@ func getOldRegistryEndpoint() string {
 // Test Cases
 
 func (fdrt *FacadeDfsRegistryTest) TestUpgradeRegistry_UpgradeLocal(c *gocheck.C) {
-	fdrt.verifyAllImagesUpgraded(c, getOldRegistryEndpoint())
+	fdrt.verifyAllImagesUpgraded(c, getOldRegistryEndpoint(), false)
 
 	err := fdrt.Facade.UpgradeRegistry(fdrt.CTX, "", false)
 
@@ -288,7 +288,7 @@ func (fdrt *FacadeDfsRegistryTest) TestUpgradeRegistry_SkipUpgradedLocal(c *goch
 func (fdrt *FacadeDfsRegistryTest) TestUpgradeRegistry_ForceLocal(c *gocheck.C) {
 	fdrt.markOldRegistryUpgraded(c)
 
-	fdrt.verifyAllImagesUpgraded(c, getOldRegistryEndpoint())
+	fdrt.verifyAllImagesUpgraded(c, getOldRegistryEndpoint(), true)
 
 	err := fdrt.Facade.UpgradeRegistry(fdrt.CTX, "", true)
 
@@ -301,13 +301,13 @@ func (fdrt *FacadeDfsRegistryTest) TestUpgradeRegistry_ForceLocalButNoRegistry(c
 
 	err := fdrt.Facade.UpgradeRegistry(fdrt.CTX, "", true)
 
-	c.Assert(err, gocheck.NotNil) // Should report there was no registry to upgrade
+	c.Assert(err, gocheck.IsNil) // Should report there was no registry to upgrade
 	fdrt.verifyNoImagesUpgraded(c)
 	fdrt.verifyOldRegistryContainerExists(c, false)
 }
 
 func (fdrt *FacadeDfsRegistryTest) TestUpgradeRegistry_UpgradeRemote(c *gocheck.C) {
-	fdrt.verifyAllImagesUpgraded(c, remoteRegistryEndpoint)
+	fdrt.verifyAllImagesUpgraded(c, remoteRegistryEndpoint, false)
 
 	err := fdrt.Facade.UpgradeRegistry(fdrt.CTX, remoteRegistryEndpoint, false)
 
@@ -316,7 +316,7 @@ func (fdrt *FacadeDfsRegistryTest) TestUpgradeRegistry_UpgradeRemote(c *gocheck.
 }
 
 func (fdrt *FacadeDfsRegistryTest) TestUpgradeRegistry_UpgradeRemoteForce(c *gocheck.C) {
-	fdrt.verifyAllImagesUpgraded(c, remoteRegistryEndpoint)
+	fdrt.verifyAllImagesUpgraded(c, remoteRegistryEndpoint, true)
 
 	err := fdrt.Facade.UpgradeRegistry(fdrt.CTX, remoteRegistryEndpoint, true)
 

--- a/rpc/master/docker_client.go
+++ b/rpc/master/docker_client.go
@@ -1,0 +1,39 @@
+// Copyright 2015 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package master
+
+// UpgradeDockerRequest are options for upgrading/migrating the docker registry.
+type UpgradeDockerRequest struct {
+	Endpoint string
+	Override bool
+}
+
+// ResetRegistry pulls latest from the running docker registry and updates the
+// index.
+func (c *Client) ResetRegistry() error {
+	return c.call("ResetRegistry", struct{}{}, new(int))
+}
+
+// SyncRegistry sends a signal to the master to repush all images into the
+// docker registry.
+func (c *Client) SyncRegistry() error {
+	return c.call("SyncRegistry", struct{}{}, new(int))
+}
+
+// UpgradeRegistry migrates images from an older or remote docker registry and
+// updates the index.
+func (c *Client) UpgradeRegistry(endpoint string, override bool) error {
+	req := UpgradeDockerRequest{endpoint, override}
+	return c.call("UpgradeRegistry", req, new(int))
+}

--- a/rpc/master/docker_server.go
+++ b/rpc/master/docker_server.go
@@ -1,0 +1,32 @@
+// Copyright 2015 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package master
+
+// ResetRegistry pulls from the configured docker registry and updates the
+// index.
+func (s *Server) ResetRegistry(req struct{}, reply *int) error {
+	return s.f.RepairRegistry(s.context())
+}
+
+// SyncRegistry prompts the master to repush all images in the index into the
+// docker registry.
+func (s *Server) SyncRegistry(req struct{}, reply *int) error {
+	return s.f.SyncRegistryImages(s.context(), true)
+}
+
+// UpgradeRegistry migrates docker registry images from an older or remote
+// docker registry.
+func (s *Server) UpgradeRegistry(req UpgradeDockerRequest, reply *int) error {
+	return s.f.UpgradeRegistry(s.context(), req.Endpoint, req.Override)
+}

--- a/rpc/master/interface.go
+++ b/rpc/master/interface.go
@@ -96,4 +96,18 @@ type ClientInterface interface {
 
 	// GetServiceEndpoints gets the endpoints for one or more services
 	GetServiceEndpoints(serviceIDs []string, reportImports, reportExports bool, validate bool) ([]applicationendpoint.EndpointReport, error)
+
+	//--------------------------------------------------------------------------
+	// Docker Registry Management Functions
+
+	// ResetRegistry pulls images from the docker registry and updates the
+	// index.
+	ResetRegistry() error
+
+	// SyncRegistry prompts the master to push its images into the docker
+	// registry.
+	SyncRegistry() error
+
+	// UpgradeRegistry migrates images from an older or remote docker registry.
+	UpgradeRegistry(endpoint string, override bool) error
 }

--- a/rpc/master/mocks/ClientInterface.go
+++ b/rpc/master/mocks/ClientInterface.go
@@ -87,24 +87,24 @@ func (_m *ClientInterface) GetActiveHostIDs() ([]string, error) {
 
 	return r0, r1
 }
-func (_m *ClientInterface) AddHost(host host.Host) error {
-	ret := _m.Called(host)
+func (_m *ClientInterface) AddHost(targetHost host.Host) error {
+	ret := _m.Called(targetHost)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(host.Host) error); ok {
-		r0 = rf(host)
+		r0 = rf(targetHost)
 	} else {
 		r0 = ret.Error(0)
 	}
 
 	return r0
 }
-func (_m *ClientInterface) UpdateHost(host host.Host) error {
-	ret := _m.Called(host)
+func (_m *ClientInterface) UpdateHost(targetHost host.Host) error {
+	ret := _m.Called(targetHost)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(host.Host) error); ok {
-		r0 = rf(host)
+		r0 = rf(targetHost)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/rpc/master/mocks/ClientInterface.go
+++ b/rpc/master/mocks/ClientInterface.go
@@ -186,24 +186,24 @@ func (_m *ClientInterface) GetResourcePools() ([]pool.ResourcePool, error) {
 
 	return r0, r1
 }
-func (_m *ClientInterface) AddResourcePool(pool pool.ResourcePool) error {
-	ret := _m.Called(pool)
+func (_m *ClientInterface) AddResourcePool(targetPool pool.ResourcePool) error {
+	ret := _m.Called(targetPool)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(pool.ResourcePool) error); ok {
-		r0 = rf(pool)
+		r0 = rf(targetPool)
 	} else {
 		r0 = ret.Error(0)
 	}
 
 	return r0
 }
-func (_m *ClientInterface) UpdateResourcePool(pool pool.ResourcePool) error {
-	ret := _m.Called(pool)
+func (_m *ClientInterface) UpdateResourcePool(targetPool pool.ResourcePool) error {
+	ret := _m.Called(targetPool)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(pool.ResourcePool) error); ok {
-		r0 = rf(pool)
+		r0 = rf(targetPool)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/rpc/master/mocks/ClientInterface.go
+++ b/rpc/master/mocks/ClientInterface.go
@@ -16,11 +16,12 @@ func (_m *ClientInterface) Close() error {
 	ret := _m.Called()
 
 	var r0 error
-	if rf, ok := ret.Get(1).(func() error); ok {
+	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Error(1)
+		r0 = ret.Error(0)
 	}
+
 	return r0
 }
 func (_m *ClientInterface) GetHost(hostID string) (*host.Host, error) {
@@ -86,24 +87,24 @@ func (_m *ClientInterface) GetActiveHostIDs() ([]string, error) {
 
 	return r0, r1
 }
-func (_m *ClientInterface) AddHost(newHost host.Host) error {
-	ret := _m.Called(newHost)
+func (_m *ClientInterface) AddHost(host host.Host) error {
+	ret := _m.Called(host)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(host.Host) error); ok {
-		r0 = rf(newHost)
+		r0 = rf(host)
 	} else {
 		r0 = ret.Error(0)
 	}
 
 	return r0
 }
-func (_m *ClientInterface) UpdateHost(targetHost host.Host) error {
-	ret := _m.Called(targetHost)
+func (_m *ClientInterface) UpdateHost(host host.Host) error {
+	ret := _m.Called(host)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(host.Host) error); ok {
-		r0 = rf(targetHost)
+		r0 = rf(host)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -185,24 +186,24 @@ func (_m *ClientInterface) GetResourcePools() ([]pool.ResourcePool, error) {
 
 	return r0, r1
 }
-func (_m *ClientInterface) AddResourcePool(newPool pool.ResourcePool) error {
-	ret := _m.Called(newPool)
+func (_m *ClientInterface) AddResourcePool(pool pool.ResourcePool) error {
+	ret := _m.Called(pool)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(pool.ResourcePool) error); ok {
-		r0 = rf(newPool)
+		r0 = rf(pool)
 	} else {
 		r0 = ret.Error(0)
 	}
 
 	return r0
 }
-func (_m *ClientInterface) UpdateResourcePool(targetPool pool.ResourcePool) error {
-	ret := _m.Called(targetPool)
+func (_m *ClientInterface) UpdateResourcePool(pool pool.ResourcePool) error {
+	ret := _m.Called(pool)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(pool.ResourcePool) error); ok {
-		r0 = rf(targetPool)
+		r0 = rf(pool)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -267,20 +268,18 @@ func (_m *ClientInterface) RemoveVirtualIP(requestVirtualIP pool.VirtualIP) erro
 	return r0
 }
 func (_m *ClientInterface) ServiceUse(serviceID string, imageID string, registry string, replaceImgs []string, noOp bool) (string, error) {
-	ret := _m.Called()
+	ret := _m.Called(serviceID, imageID, registry, replaceImgs, noOp)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(string, string, string, []string, bool) string); ok {
+		r0 = rf(serviceID, imageID, registry, replaceImgs, noOp)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(string)
-		}
+		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(string, string, string, []string, bool) error); ok {
+		r1 = rf(serviceID, imageID, registry, replaceImgs, noOp)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -308,12 +307,12 @@ func (_m *ClientInterface) GetVolumeStatus() (*volume.Statuses, error) {
 
 	return r0, r1
 }
-func (_m *ClientInterface) GetServiceEndpoints(serviceIDs []string, reportImports, reportExports, validate bool) ([]applicationendpoint.EndpointReport, error) {
-	ret := _m.Called(serviceIDs, validate)
+func (_m *ClientInterface) GetServiceEndpoints(serviceIDs []string, reportImports bool, reportExports bool, validate bool) ([]applicationendpoint.EndpointReport, error) {
+	ret := _m.Called(serviceIDs, reportImports, reportExports, validate)
 
 	var r0 []applicationendpoint.EndpointReport
-	if rf, ok := ret.Get(0).(func([]string, bool) []applicationendpoint.EndpointReport); ok {
-		r0 = rf(serviceIDs, validate)
+	if rf, ok := ret.Get(0).(func([]string, bool, bool, bool) []applicationendpoint.EndpointReport); ok {
+		r0 = rf(serviceIDs, reportImports, reportExports, validate)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]applicationendpoint.EndpointReport)
@@ -321,11 +320,47 @@ func (_m *ClientInterface) GetServiceEndpoints(serviceIDs []string, reportImport
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func([]string, bool) error); ok {
-		r1 = rf(serviceIDs, validate)
+	if rf, ok := ret.Get(1).(func([]string, bool, bool, bool) error); ok {
+		r1 = rf(serviceIDs, reportImports, reportExports, validate)
 	} else {
 		r1 = ret.Error(1)
 	}
 
 	return r0, r1
+}
+func (_m *ClientInterface) ResetRegistry() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *ClientInterface) SyncRegistry() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *ClientInterface) UpgradeRegistry(endpoint string, override bool) error {
+	ret := _m.Called(endpoint, override)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, bool) error); ok {
+		r0 = rf(endpoint, override)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }


### PR DESCRIPTION
New CLI command:
serviced docker migrate-registry [--endpoint HOST:PORT] [--override]
* endpoint (string, optional): is the endpoint to a remote docker registry
* override (bool, optional): overrides existing images that may have already been written to the current docker registry

MigrateRegistry moves images from an older or remote docker registry, specifically used in the v1=>v2 registry migration. See https://rally1.rallydev.com/#/46743532340d/detail/userstory/47069032153 for more details.