### PR TITLE
Replace ipconfig with 'ip addr' for improved portability

### DIFF
--- a/acceptance.sh
+++ b/acceptance.sh
@@ -14,7 +14,7 @@
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 SERVICED=${DIR}/serviced
-IP=$(/sbin/ifconfig docker0 | grep 'inet addr:' | cut -d: -f2 | awk {'print $1'})
+IP=$(ip addr show docker0 | grep -w inet | awk {'print $2'} | cut -d/ -f1)
 HOSTNAME=$(hostname)
 
 #

--- a/acceptance/runUIAcceptance.sh
+++ b/acceptance/runUIAcceptance.sh
@@ -142,7 +142,7 @@ HOST_IP=`hostname -i`
 if [[ $HOST_IP == 127* ]]; then
     # serviced won't allow us to add a loopback address, so use docker's as an alternative
     echo "Overriding default HOST_IP ($HOST_IP)"
-    HOST_IP=$(/sbin/ifconfig docker0 | grep 'inet addr:' | cut -d: -f2 | awk {'print $1'})
+    HOST_IP=$(ip addr show docker0 | grep -w inet | awk {'print $2'} | cut -d/ -f1)
 fi
 echo "Using HOST_IP=$HOST_IP"
 

--- a/acceptance/startMockAgents.sh
+++ b/acceptance/startMockAgents.sh
@@ -33,7 +33,7 @@ fi
 HOST_IP=`hostname -i`
 if [[ $HOST_IP == 127* ]]; then
     echo "Overriding default HOST_IP ($HOST_IP)"
-    HOST_IP=$(/sbin/ifconfig docker0 | grep 'inet addr:' | cut -d: -f2 | awk {'print $1'})
+    HOST_IP=$(ip addr show docker0 | grep -w inet | awk {'print $2'} | cut -d/ -f1)
 fi
 echo "Using HOST_IP=$HOST_IP"
 

--- a/smoke.sh
+++ b/smoke.sh
@@ -8,7 +8,7 @@
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 SERVICED=$(which serviced)
-IP=$(/sbin/ifconfig docker0 | grep 'inet addr:' | cut -d: -f2 | awk {'print $1'})
+IP=$(ip addr show docker0 | grep -w inet | awk {'print $2'} | cut -d/ -f1)
 HOSTNAME=$(hostname)
 
 succeed() {


### PR DESCRIPTION
In changing over to RHEL agents, we found portability problems with the way several tests scripts parse the output from ifconfig.  These changes replace ifconfig with `ip addr` which has a consistent output format across Ubuntu and RHEL