### PR TITLE
CC-691: Add recursion to SVC_WAIT

### DIFF
--- a/dao/elasticsearch/service.go
+++ b/dao/elasticsearch/service.go
@@ -157,7 +157,7 @@ func (this *ControlPlaneDao) StopService(request dao.ScheduleServiceRequest, aff
 
 // WaitService waits for the given service IDs to reach a particular state
 func (this *ControlPlaneDao) WaitService(request dao.WaitServiceRequest, _ *int) (err error) {
-	return this.facade.WaitService(datastore.Get(), request.DesiredState, request.Timeout, request.ServiceIDs...)
+	return this.facade.WaitService(datastore.Get(), request.DesiredState, request.Timeout, request.Recursive, request.ServiceIDs...)
 }
 
 // assign an IP address to a service (and all its child services) containing non default AddressResourceConfig

--- a/dao/interface.go
+++ b/dao/interface.go
@@ -81,6 +81,7 @@ type WaitServiceRequest struct {
 	ServiceIDs   []string             // List of service IDs to monitor
 	DesiredState service.DesiredState // State which to monitor for
 	Timeout      time.Duration        // Time to wait before cancelling the subprocess
+	Recursive    bool                 // Recursively wait for the desired state
 }
 
 type HostServiceRequest struct {

--- a/facade/dfs.go
+++ b/facade/dfs.go
@@ -467,7 +467,7 @@ func (f *Facade) Rollback(ctx datastore.Context, snapshotID string, force bool) 
 		}
 		serviceids[i] = svc.ID
 	}
-	if err := f.WaitService(ctx, service.SVCStop, f.dfs.Timeout(), serviceids...); err != nil {
+	if err := f.WaitService(ctx, service.SVCStop, f.dfs.Timeout(), false, serviceids...); err != nil {
 		glog.Errorf("Could not wait for services to %s during rollback of snapshot %s: %s", service.SVCStop, snapshotID, err)
 		return err
 	}
@@ -522,7 +522,7 @@ func (f *Facade) Snapshot(ctx datastore.Context, serviceID, message string, tags
 			}
 		}
 	}
-	if err := f.WaitService(ctx, service.SVCPause, f.dfs.Timeout(), serviceids...); err != nil {
+	if err := f.WaitService(ctx, service.SVCPause, f.dfs.Timeout(), false, serviceids...); err != nil {
 		glog.Errorf("Could not wait for services to %s during snapshot of %s: %s", service.SVCStop, tenantID, err)
 		return "", err
 	}

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -53,7 +53,7 @@ type FacadeInterface interface {
 
 	UpdateService(ctx datastore.Context, svc service.Service) error
 
-	WaitService(ctx datastore.Context, dstate service.DesiredState, timeout time.Duration, serviceIDs ...string) error
+	WaitService(ctx datastore.Context, dstate service.DesiredState, timeout time.Duration, recursive bool, serviceIDs ...string) error
 
 	GetServiceTemplates(ctx datastore.Context) (map[string]servicetemplate.ServiceTemplate, error)
 

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -131,8 +131,8 @@ func (m *FacadeInterface) UpdateService(ctx datastore.Context, svc service.Servi
 
 	return r0
 }
-func (m *FacadeInterface) WaitService(ctx datastore.Context, dstate service.DesiredState, timeout time.Duration, serviceIDs ...string) error {
-	ret := m.Called(ctx, dstate, timeout, serviceIDs)
+func (m *FacadeInterface) WaitService(ctx datastore.Context, dstate service.DesiredState, timeout time.Duration, recursive bool, serviceIDs ...string) error {
+	ret := m.Called(ctx, dstate, timeout, recursive, serviceIDs)
 
 	r0 := ret.Error(0)
 

--- a/rpc/master/interface.go
+++ b/rpc/master/interface.go
@@ -17,8 +17,10 @@ import (
 	"github.com/control-center/serviced/domain/applicationendpoint"
 	"github.com/control-center/serviced/domain/host"
 	"github.com/control-center/serviced/domain/pool"
+	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/facade"
 	"github.com/control-center/serviced/volume"
+	"time"
 )
 
 // The RPC interface is the API for a serviced master.
@@ -84,6 +86,9 @@ type ClientInterface interface {
 
 	// ServiceUse will use a new image for a given service - this will pull the image and tag it
 	ServiceUse(serviceID string, imageID string, registry string, replaceImgs []string, noOp bool) (string, error)
+
+	// WaitService will wait for the specified services to reach the specified state, within the given timeout
+	WaitService(serviceIDs []string, state service.DesiredState, timeout time.Duration, recursive bool) error
 
 	//--------------------------------------------------------------------------
 	// Volume Management Functions

--- a/rpc/master/mocks/ClientInterface.go
+++ b/rpc/master/mocks/ClientInterface.go
@@ -1,10 +1,13 @@
 package mocks
 
+import "time"
+
 import "github.com/stretchr/testify/mock"
 
 import "github.com/control-center/serviced/domain/applicationendpoint"
 import "github.com/control-center/serviced/domain/host"
 import "github.com/control-center/serviced/domain/pool"
+import "github.com/control-center/serviced/domain/service"
 import "github.com/control-center/serviced/facade"
 import "github.com/control-center/serviced/volume"
 
@@ -285,6 +288,18 @@ func (_m *ClientInterface) ServiceUse(serviceID string, imageID string, registry
 	}
 
 	return r0, r1
+}
+func (_m *ClientInterface) WaitService(serviceIDs []string, state service.DesiredState, timeout time.Duration, recursive bool) error {
+	ret := _m.Called(serviceIDs, state, timeout, recursive)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]string, service.DesiredState, time.Duration, bool) error); ok {
+		r0 = rf(serviceIDs, state, timeout, recursive)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 func (_m *ClientInterface) GetVolumeStatus() (*volume.Statuses, error) {
 	ret := _m.Called()

--- a/rpc/master/service_client.go
+++ b/rpc/master/service_client.go
@@ -14,7 +14,9 @@
 package master
 
 import (
+	"github.com/control-center/serviced/domain/service"
 	"github.com/zenoss/glog"
+	"time"
 )
 
 type ServiceUseRequest struct {
@@ -23,6 +25,13 @@ type ServiceUseRequest struct {
 	ReplaceImgs []string
 	Registry    string
 	NoOp        bool
+}
+
+type WaitServiceRequest struct {
+	ServiceIDs []string
+	State      service.DesiredState
+	Timeout    time.Duration
+	Recursive  bool
 }
 
 // ServiceUse will use a new image for a given service - this will pull the image and tag it
@@ -35,4 +44,18 @@ func (c *Client) ServiceUse(serviceID string, imageID string, registry string, r
 		return "", err
 	}
 	return result, nil
+}
+
+// WaitService will wait for the specified services to reach the specified
+// state, within the given timeout
+func (c *Client) WaitService(serviceIDs []string, state service.DesiredState, timeout time.Duration, recursive bool) error {
+	waitSvcRequest := &WaitServiceRequest{
+		ServiceIDs: serviceIDs,
+		State:      state,
+		Timeout:    timeout,
+		Recursive:  recursive,
+	}
+	throwaway := ""
+	err := c.call("WaitService", waitSvcRequest, &throwaway)
+	return err
 }

--- a/rpc/master/service_server.go
+++ b/rpc/master/service_server.go
@@ -23,3 +23,9 @@ func (s *Server) ServiceUse(request *ServiceUseRequest, response *string) error 
 	*response = ""
 	return nil
 }
+
+// Wait on specified services to be in the given state
+func (s *Server) WaitService(request *WaitServiceRequest, throwaway *string) error {
+	err := s.f.WaitService(s.context(), request.State, request.Timeout, request.Recursive, request.ServiceIDs...)
+	return err
+}

--- a/script/descriptor_test.txt
+++ b/script/descriptor_test.txt
@@ -23,3 +23,5 @@ SVC_RUN  Zenoss.core/Zope upgrade
 SVC_RUN  Zenoss.core/HBase/RegionServer upgrade arg1 arg2
 SVC_EXEC COMMIT Zenoss.core/Zope command1
 SVC_EXEC NO_COMMIT Zenoss.core/zenhub command2 with args
+SVC_START Zenoss.core
+SVC_WAIT Zenoss.core started recursive

--- a/script/eval.go
+++ b/script/eval.go
@@ -96,7 +96,7 @@ func evalSvcWait(r *runner, n node) error {
 	}
 
 	var svcIDs []string
-	var stateIdx = -1
+	var stateIdx int
 	for i, arg := range n.args {
 		if arg == "started" || arg == "stopped" || arg == "paused" {
 			stateIdx = i
@@ -116,15 +116,26 @@ func evalSvcWait(r *runner, n node) error {
 	state := ServiceState(n.args[stateIdx])
 
 	timeout := uint32(0)
-	hasTimeout := len(n.args) == stateIdx+2
-	if hasTimeout {
-		var timeout64 uint64
-		var err error
-		lastArg := n.args[len(n.args)-1]
-		if timeout64, err = strconv.ParseUint(lastArg, 10, 32); err != nil {
-			return fmt.Errorf("Unable to parse timeout value %s: %s", lastArg, err)
+	recursive := false
+
+	if len(n.args) > stateIdx+1 {
+		// check optional first arg
+		if n.args[stateIdx+1] == "recursive" {
+			recursive = true
+		} else {
+			var timeout64 uint64
+			var err error
+			lastArg := n.args[len(n.args)-1]
+			if timeout64, err = strconv.ParseUint(n.args[stateIdx+1], 10, 32); err != nil {
+				return fmt.Errorf("Unable to parse timeout value %s: %s", lastArg, err)
+			}
+			timeout = uint32(timeout64)
 		}
-		timeout = uint32(timeout64)
+		// check optional second arg (data should be sanitized prior to here)
+		if len(n.args) == stateIdx+3 {
+			recursive = true
+		}
+
 	}
 
 	plural := ""
@@ -132,7 +143,7 @@ func evalSvcWait(r *runner, n node) error {
 		plural = "s"
 	}
 	glog.Infof("waiting %d for service%s %s to be %s", timeout, plural, strings.Join(n.args[:stateIdx], ", "), state)
-	if err := r.svcWait(svcIDs, state, timeout); err != nil {
+	if err := r.svcWait(svcIDs, state, timeout, recursive); err != nil {
 		return err
 	}
 

--- a/script/nodes_test.go
+++ b/script/nodes_test.go
@@ -216,6 +216,22 @@ func (vs *ScriptSuite) Test_svcWait(t *C) {
 	cmd, err = nodeFactories[SVC_WAIT](ctx, SVC_WAIT, []string{"zope", "started", "4", "extra"})
 	t.Assert(err, NotNil)
 
+	ctx.line = "SVC_WAIT zope started 4 recursive"
+	cmd, err = nodeFactories[SVC_WAIT](ctx, SVC_WAIT, []string{"zope", "started", "4", "recursive"})
+	t.Assert(err, IsNil)
+
+	ctx.line = "SVC_WAIT zope started recursive"
+	cmd, err = nodeFactories[SVC_WAIT](ctx, SVC_WAIT, []string{"zope", "started", "recursive"})
+	t.Assert(err, IsNil)
+
+	ctx.line = "SVC_WAIT zope started recursive 5"
+	cmd, err = nodeFactories[SVC_WAIT](ctx, SVC_WAIT, []string{"zope", "started", "recursive", "5"})
+	t.Assert(err, NotNil)
+
+	ctx.line = "SVC_WAIT zope started 4 garbage"
+	cmd, err = nodeFactories[SVC_WAIT](ctx, SVC_WAIT, []string{"zope", "started", "4", "garbage"})
+	t.Assert(err, NotNil)
+
 	line = "SVC_WAIT zope mariadb started 0"
 	ctx.line = line
 	cmd, err = nodeFactories[SVC_WAIT](ctx, SVC_WAIT, strings.Split(line, " "))
@@ -230,6 +246,10 @@ func (vs *ScriptSuite) Test_svcWait(t *C) {
 
 	line = "SVC_WAIT zope mariadb started extra"
 	ctx.line = line
+	cmd, err = nodeFactories[SVC_WAIT](ctx, SVC_WAIT, strings.Split(line, " "))
+	t.Assert(err, NotNil)
+
+	ctx.line = "SVC_WAIT zope mariadb started extra recursive"
 	cmd, err = nodeFactories[SVC_WAIT](ctx, SVC_WAIT, strings.Split(line, " "))
 	t.Assert(err, NotNil)
 }

--- a/script/parser_test.go
+++ b/script/parser_test.go
@@ -75,6 +75,8 @@ func (vs *ScriptSuite) Test_parseFile(t *C) {
 		node{lineNum: 23, cmd: SVC_RUN, line: "SVC_RUN  Zenoss.core/HBase/RegionServer upgrade arg1 arg2", args: []string{"Zenoss.core/HBase/RegionServer", "upgrade", "arg1", "arg2"}},
 		node{lineNum: 24, cmd: SVC_EXEC, line: "SVC_EXEC COMMIT Zenoss.core/Zope command1", args: []string{"COMMIT", "Zenoss.core/Zope", "command1"}},
 		node{lineNum: 25, cmd: SVC_EXEC, line: "SVC_EXEC NO_COMMIT Zenoss.core/zenhub command2 with args", args: []string{"NO_COMMIT", "Zenoss.core/zenhub", "command2", "with", "args"}},
+		node{lineNum: 26, cmd: SVC_START, line: "SVC_START Zenoss.core", args: []string{"Zenoss.core"}},
+		node{lineNum: 27, cmd: SVC_WAIT, line: "SVC_WAIT Zenoss.core started recursive", args: []string{"Zenoss.core", "started", "recursive"}},
 	}
 	t.Assert(len(ctx.nodes), Equals, len(expected))
 


### PR DESCRIPTION
This change adds the ability to recursively `SVC_WAIT` for services in a
`serviced service script` script.  This means we can now wait for all
services under an organizer to start/stop, for example.