### PR TITLE
Feature/fix rhel unit tests

### DIFF
--- a/node/utils_test.go
+++ b/node/utils_test.go
@@ -111,7 +111,7 @@ func (ts *ZZKTest) TestCreateVolumeDir(t *C) {
 	}
 	v := volumeSpec{
 		hostPath:      path.Join(tmpPath, "actual_share_doc"),
-		containerPath: "/usr/share/vim", // do not use a dir with symlinks that point outside the path
+		containerPath: "/usr/share/dpkg", // do not use a dir with symlinks that point outside the path
 		image:         "ubuntu:latest",
 		user:          "games:games",
 		perm:          "755",


### PR DESCRIPTION
Fix a couple of problems found while trying to standup up new Jenkins build slaves on CentOS:
 * PAM tests on RHEL rely on the 'wheel' group which is set in the variable `adminGroup`, but only AFTER init() has run (i.e. can't rely on `adminGroup` for static variable initialization).
 * TestCreateVolumeDir was copying symlinks from ubuntu to RHEL, which failed the comparison test because the symlinks were pointing to non-existent files on RHEL.