### PR TITLE
Use docker logging options for isvcs containers

### DIFF
--- a/cli/api/api.go
+++ b/cli/api/api.go
@@ -83,7 +83,7 @@ type Options struct {
 	IsvcsZKID            int               // Zookeeper server id when running as a quorum
 	IsvcsZKQuorum        []string          // Members of the zookeeper quorum
 	DockerLogDriver      string            // Which log driver to use with containers
-	DockerLogConfig      []string          // List of key=value options for docker logging
+	DockerLogConfigList  []string          // List of comma-separated key=value options for docker logging
 }
 
 // LoadOptions overwrites the existing server options

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -152,7 +152,7 @@ func (d *daemon) getEsClusterName(name string) string {
 }
 
 func (d *daemon) startISVCS() {
-	isvcs.Init(options.ESStartupTimeout)
+	isvcs.Init(options.ESStartupTimeout, options.DockerLogDriver)
 	isvcs.Mgr.SetVolumesDir(options.IsvcsPath)
 	if err := isvcs.Mgr.SetConfigurationOption("elasticsearch-serviced", "cluster", d.getEsClusterName("elasticsearch-serviced")); err != nil {
 		glog.Fatalf("Could not set es-serviced option: %s", err)
@@ -167,7 +167,7 @@ func (d *daemon) startISVCS() {
 }
 
 func (d *daemon) startAgentISVCS(serviceNames []string) {
-	isvcs.InitServices(serviceNames)
+	isvcs.InitServices(serviceNames, options.DockerLogDriver)
 	isvcs.Mgr.SetVolumesDir(options.IsvcsPath)
 	if err := isvcs.Mgr.Start(); err != nil {
 		glog.Fatalf("Could not start isvcs: %s", err)
@@ -672,7 +672,7 @@ func (d *daemon) startAgent() error {
 			ControllerBinary:     options.ControllerBinary,
 			LogstashURL:          options.LogstashURL,
 			DockerLogDriver:      options.DockerLogDriver,
-			DockerLogConfig:      options.DockerLogConfig,
+			DockerLogConfig:      convertStringSliceToMap(options.DockerLogConfigList),
 		}
 		// creates a zClient that is not pool based!
 		hostAgent, err := node.NewHostAgent(agentOptions, d.reg)

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -152,7 +152,7 @@ func (d *daemon) getEsClusterName(name string) string {
 }
 
 func (d *daemon) startISVCS() {
-	isvcs.Init(options.ESStartupTimeout, options.DockerLogDriver)
+	isvcs.Init(options.ESStartupTimeout, options.DockerLogDriver, convertStringSliceToMap(options.DockerLogConfigList))
 	isvcs.Mgr.SetVolumesDir(options.IsvcsPath)
 	if err := isvcs.Mgr.SetConfigurationOption("elasticsearch-serviced", "cluster", d.getEsClusterName("elasticsearch-serviced")); err != nil {
 		glog.Fatalf("Could not set es-serviced option: %s", err)
@@ -167,7 +167,7 @@ func (d *daemon) startISVCS() {
 }
 
 func (d *daemon) startAgentISVCS(serviceNames []string) {
-	isvcs.InitServices(serviceNames, options.DockerLogDriver)
+	isvcs.InitServices(serviceNames, options.DockerLogDriver, convertStringSliceToMap(options.DockerLogConfigList))
 	isvcs.Mgr.SetVolumesDir(options.IsvcsPath)
 	if err := isvcs.Mgr.Start(); err != nil {
 		glog.Fatalf("Could not start isvcs: %s", err)

--- a/cli/api/utils.go
+++ b/cli/api/utils.go
@@ -104,3 +104,20 @@ func (a version) Compare(b version) int {
 		return 0
 	}
 }
+
+func convertStringSliceToMap(list []string) map[string]string {
+	mapValues := make(map[string]string)
+	for i, keyValuePair := range list {
+		if keyValuePair == "" {
+			glog.Warningf("Skipping empty key=value pair at index %d from list %v", i, list)
+			continue
+		}
+		keyValue := strings.SplitN(keyValuePair, "=", 2)
+		if len(keyValue) != 2 || keyValue[0] == "" {
+			glog.Warningf("Skipping invalid key=value pair %q at index %d from list %v", keyValuePair, i, list)
+			continue
+		}
+		mapValues[keyValue[0]] = keyValue[1]
+	}
+	return mapValues
+}

--- a/cli/api/utils_test.go
+++ b/cli/api/utils_test.go
@@ -1,0 +1,65 @@
+// Copyright 2015 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package api
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+func (st *serviceAPITest) TestEnvironConfigReader_StringMap_Empty(c *C) {
+	listValue := []string{""}
+	expected := map[string]string{}
+
+	result := convertStringSliceToMap(listValue)
+
+	c.Assert(result, DeepEquals, expected)
+}
+
+func (st *serviceAPITest) TestEnvironConfigReader_StringMap_Simple(c *C) {
+	listValue := []string{"keySimple=valueSimple"}
+	expected := map[string]string{"keySimple": "valueSimple"}
+
+	result := convertStringSliceToMap(listValue)
+
+	c.Assert(result, DeepEquals, expected)
+}
+
+func (st *serviceAPITest) TestEnvironConfigReader_StringMap_Multiple(c *C) {
+	listValue := []string{"key1=value1", "key2=value2", "key3=value3"}
+	expected := map[string]string{"key1": "value1", "key2": "value2", "key3": "value3"}
+
+	result := convertStringSliceToMap(listValue)
+
+	c.Assert(result, DeepEquals, expected)
+}
+
+func (st *serviceAPITest) TestEnvironConfigReader_StringMap_EmptyPair(c *C) {
+	listValue := []string{"key1=value1", "", "key2=value2", ""}
+	expected := map[string]string{"key1": "value1", "key2": "value2"}
+
+	result := convertStringSliceToMap(listValue)
+
+	c.Assert(result, DeepEquals, expected)
+}
+
+func (st *serviceAPITest) TestEnvironConfigReader_StringMap_InvalidPair(c *C) {
+	listValue := []string{"key1=value1", "key2=", "=value3", "foo"}
+	expected := map[string]string{"key1": "value1", "key2": ""}
+
+	result := convertStringSliceToMap(listValue)
+
+	c.Assert(result, DeepEquals, expected)
+}

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -104,7 +104,7 @@ func New(driver api.API, config utils.ConfigReader) *ServicedCli {
 		cli.IntFlag{"snapshot-ttl", defaultOps.SnapshotTTL, "snapshot TTL in hours, 0 to disable"},
 		cli.StringFlag{"controller-binary", defaultOps.ControllerBinary, "path to the container controller binary"},
 		cli.StringFlag{"log-driver", defaultOps.DockerLogDriver, "log driver for docker containers"},
-		cli.StringSliceFlag{"log-config", convertToStringSlice(defaultOps.DockerLogConfig), "comma-separated list of key=value settings for docker log driver"},
+		cli.StringSliceFlag{"log-config", convertToStringSlice(defaultOps.DockerLogConfigList), "comma-separated list of key=value settings for docker log driver"},
 
 		// Reimplementing GLOG flags :(
 		cli.BoolTFlag{"logtostderr", "log to standard error instead of files"},
@@ -196,7 +196,7 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 		IsvcsZKID:            ctx.GlobalInt("isvcs-zk-id"),
 		IsvcsZKQuorum:        ctx.GlobalStringSlice("isvcs-zk-quorum"),
 		DockerLogDriver:      ctx.GlobalString("log-driver"),
-		DockerLogConfig:      ctx.GlobalStringSlice("log-config"),
+		DockerLogConfigList:  ctx.GlobalStringSlice("log-config"),
 	}
 	if os.Getenv("SERVICED_MASTER") == "1" {
 		options.Master = true

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -70,7 +70,7 @@ func getDefaultOptions(config utils.ConfigReader) api.Options {
 		IsvcsZKID:            config.IntVal("ISVCS_ZOOKEEPER_ID", 0),
 		IsvcsZKQuorum:        config.StringSlice("ISVCS_ZOOKEEPER_QUORUM", []string{}),
 		DockerLogDriver:      config.StringVal("DOCKER_LOG_DRIVER", "json-file"),
-		DockerLogConfig:      config.StringSlice("DOCKER_LOG_CONFIG", []string{"max-file=5", "max-size=10m"}),
+		DockerLogConfigList:  config.StringSlice("DOCKER_LOG_CONFIG", []string{"max-file=5", "max-size=10m"}),
 	}
 
 	options.Endpoint = config.StringVal("ENDPOINT", "")

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -106,7 +106,7 @@ type DaoTest struct {
 //SetUpSuite is run before the tests to ensure elastic, zookeeper etc. are running.
 func (dt *DaoTest) SetUpSuite(c *C) {
 	dt.Port = 9202
-	isvcs.Init(isvcs.DEFAULT_ES_STARTUP_TIMEOUT_SECONDS)
+	isvcs.Init(isvcs.DEFAULT_ES_STARTUP_TIMEOUT_SECONDS, "json-file", map[string]string{"max-file": "5", "max-size": "10m"})
 	isvcs.Mgr.SetVolumesDir("/tmp/serviced-test")
 	esServicedClusterName, _ := utils.NewUUID36()
 	if err := isvcs.Mgr.SetConfigurationOption("elasticsearch-serviced", "cluster", esServicedClusterName); err != nil {

--- a/isvcs/es_test.go
+++ b/isvcs/es_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestPurge(t *testing.T) {
-	Init(DEFAULT_ES_STARTUP_TIMEOUT_SECONDS)
+	Init(DEFAULT_ES_STARTUP_TIMEOUT_SECONDS, defaultTestDockerLogDriver, defaultTestDockerLogOptions)
 	Mgr.Start()
 	PurgeLogstashIndices(10, 10)
 	Mgr.Stop()

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -29,11 +29,11 @@ const (
 	ZK_IMAGE_TAG  = "v2"
 )
 
-func Init(esStartupTimeoutInSeconds int) {
+func Init(esStartupTimeoutInSeconds int, dockerLogDriver string, dockerLogConfig map[string]string) {
 	elasticsearch_serviced.StartupTimeout = time.Duration(esStartupTimeoutInSeconds) * time.Second
 	elasticsearch_logstash.StartupTimeout = time.Duration(esStartupTimeoutInSeconds) * time.Second
 
-	Mgr = NewManager(utils.LocalDir("images"), utils.TempDir("var/isvcs"))
+	Mgr = NewManager(utils.LocalDir("images"), utils.TempDir("var/isvcs"), dockerLogDriver, dockerLogConfig)
 
 	if err := Mgr.Register(elasticsearch_serviced); err != nil {
 		glog.Fatalf("%s", err)
@@ -58,8 +58,8 @@ func Init(esStartupTimeoutInSeconds int) {
 	}
 }
 
-func InitServices(isvcNames []string) {
-	Mgr = NewManager(utils.LocalDir("images"), utils.TempDir("var/isvcs"))
+func InitServices(isvcNames []string, dockerLogDriver string, dockerLogConfig map[string]string) {
+	Mgr = NewManager(utils.LocalDir("images"), utils.TempDir("var/isvcs"), dockerLogDriver, dockerLogConfig)
 	for _, isvcName := range isvcNames {
 		switch isvcName {
 		case "zookeeper":

--- a/isvcs/manager_test.go
+++ b/isvcs/manager_test.go
@@ -25,13 +25,14 @@ import (
 	"time"
 )
 
+
 func TestMain(m *testing.M) {
 	docker.StartKernel()
 	os.Exit(m.Run())
 }
 
 func TestManager(t *testing.T) {
-	testManager := NewManager(utils.LocalDir("images"), "/tmp")
+	testManager := NewManager(utils.LocalDir("images"), "/tmp", defaultTestDockerLogDriver, defaultTestDockerLogOptions)
 
 	if err := testManager.Start(); err != nil {
 		t.Logf("expected no error got %s", err)

--- a/isvcs/testutils.go
+++ b/isvcs/testutils.go
@@ -21,6 +21,12 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+
+var (
+	defaultTestDockerLogDriver = "json-file"
+	defaultTestDockerLogOptions = map[string]string{"max-file": "5", "max-size": "10m"}
+)
+
 type IServiceTest interface {
 	GetService(c *C) *IService
 	Create(c *C)
@@ -35,7 +41,7 @@ type ManagerTestSuite struct {
 
 func (t *ManagerTestSuite) SetUpSuite(c *C) {
 	docker.StartKernel()
-	t.manager = NewManager(utils.LocalDir("images"), "/tmp/serviced-test")
+	t.manager = NewManager(utils.LocalDir("images"), "/tmp/serviced-test", defaultTestDockerLogDriver, defaultTestDockerLogOptions)
 	for _, testservice := range t.testservices {
 		svc := testservice.GetService(c)
 		if err := t.manager.Register(svc); err != nil {

--- a/node/agent.go
+++ b/node/agent.go
@@ -92,7 +92,7 @@ type HostAgent struct {
 	controllerBinary     string          // Path to the controller binary
 	logstashURL          string
 	dockerLogDriver      string
-	dockerLogConfig      []string
+	dockerLogConfig      map[string]string
 	pullreg              registry.Registry
 }
 
@@ -125,7 +125,7 @@ type AgentOptions struct {
 	ControllerBinary     string
 	LogstashURL          string
 	DockerLogDriver      string
-	DockerLogConfig      []string
+	DockerLogConfig      map[string]string
 }
 
 // NewHostAgent creates a new HostAgent given a connection string
@@ -744,11 +744,7 @@ func configureContainer(a *HostAgent, client dao.ControlPlane,
 	}
 
 	hcfg.LogConfig.Type = a.dockerLogDriver
-	hcfg.LogConfig.Config = make(map[string]string)
-	for _, kv := range a.dockerLogConfig {
-		keyvalue := strings.SplitN(kv, "=", 2)
-		hcfg.LogConfig.Config[keyvalue[0]] = keyvalue[1]
-	}
+	hcfg.LogConfig.Config = a.dockerLogConfig
 
 	return cfg, hcfg, nil
 }

--- a/node/agent_test.go
+++ b/node/agent_test.go
@@ -127,7 +127,7 @@ func TestConfigureContainer_DockerLog(t *testing.T) {
 	// Create a fake HostAgent
 	fakeHostAgent := &HostAgent{
 		dockerLogDriver:      "fakejson-log",
-		dockerLogConfig:      []string{"alpha=one", "bravo=two", "charlie=three"},
+		dockerLogConfig:      map[string]string{"alpha": "one", "bravo": "two", "charlie": "three"},
 		virtualAddressSubnet: "0.0.0.0",
 		pullreg:              fakeRegistry,
 	}


### PR DESCRIPTION
Fixes CC-1665
Demo:

On Centos/RHEL machines. add the following to `/etc/default/serviced` to route docker output to journald instead of the default docker logging (`json-file`):
```
SERVICED_DOCKER_LOG_DRIVER=journald
SERVICED_DOCKER_LOG_CONFIG=,
```
Note that the single comma for SERVICED_DOCKER_LOG_CONFIG is required since serviced hard-codes default options for `json-file` logging which are invalid for `journald` logging. The single comma ultimately produces an empty map of key/value pairs.

After restarting serviced, use the following to inspect zookeeper logs:
```
journalctl CONTAINER_NAME=serviced-isvcs_zookeeper --since=today
```
