### PR TITLE
CC-249: Validate virtual ip interface

### DIFF
--- a/domain/addressassignment/addressassignmentstore.go
+++ b/domain/addressassignment/addressassignmentstore.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain"
 	"github.com/zenoss/elastigo/search"
 )
 
@@ -60,9 +61,9 @@ func (s *Store) GetServiceAddressAssignmentsByPort(ctx datastore.Context, port u
 
 func (s *Store) FindAssignmentByServiceEndpoint(ctx datastore.Context, serviceID, endpointName string) (*AddressAssignment, error) {
 	if serviceID = strings.TrimSpace(serviceID); serviceID == "" {
-		return nil, fmt.Errorf("service ID cannot be empty")
+		return nil, domain.EmptyFieldNotAllowed("serviceID")
 	} else if endpointName = strings.TrimSpace(endpointName); endpointName == "" {
-		return nil, fmt.Errorf("endpoint name cannot be empty")
+		return nil, domain.EmptyFieldNotAllowed("endpointName")
 	}
 
 	search := search.Search("controlplane").Type(kind).Filter(
@@ -84,7 +85,7 @@ func (s *Store) FindAssignmentByServiceEndpoint(ctx datastore.Context, serviceID
 
 func (s *Store) FindAssignmentByHostPort(ctx datastore.Context, ipAddr string, port uint16) (*AddressAssignment, error) {
 	if ipAddr = strings.TrimSpace(ipAddr); ipAddr == "" {
-		return nil, fmt.Errorf("hostIP cannot be empty")
+		return nil, domain.EmptyFieldNotAllowed("IPAddress")
 	} else if port == 0 {
 		return nil, fmt.Errorf("port must be greater than 0")
 	}

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -1,0 +1,24 @@
+// Copyright 2015 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package domain
+
+import "fmt"
+
+// EmptyFieldNotAllowed is an error type used in validating input for
+// parameters entered while making a request to the database.
+type EmptyFieldNotAllowed string
+
+func (fieldName EmptyFieldNotAllowed) Error() string {
+	return fmt.Sprintf("empty %s not allowed", fieldName)
+}

--- a/domain/pool/poolstore.go
+++ b/domain/pool/poolstore.go
@@ -14,10 +14,10 @@
 package pool
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain"
 	"github.com/zenoss/elastigo/search"
 	"github.com/zenoss/glog"
 )
@@ -43,7 +43,7 @@ func (s *Store) GetResourcePoolsByRealm(ctx datastore.Context, realm string) ([]
 	glog.V(3).Infof("Pool Store.GetResourcePoolsByRealm")
 	id := strings.TrimSpace(realm)
 	if id == "" {
-		return nil, errors.New("empty realm not allowed")
+		return nil, domain.EmptyFieldNotAllowed("realm")
 	}
 	q := datastore.NewQuery(ctx)
 	query := search.Query().Term("Realm", id)
@@ -58,9 +58,9 @@ func (s *Store) GetResourcePoolsByRealm(ctx datastore.Context, realm string) ([]
 // HasVirtualIP returns true if there is a virtual ip found for the given pool
 func (s *Store) HasVirtualIP(ctx datastore.Context, poolID, virtualIP string) (bool, error) {
 	if poolID = strings.TrimSpace(poolID); poolID == "" {
-		return false, errors.New("empty pool id not allowed")
+		return false, domain.EmptyFieldNotAllowed("poolID")
 	} else if virtualIP = strings.TrimSpace(virtualIP); virtualIP == "" {
-		return false, errors.New("empty virtual ip not allowed")
+		return false, domain.EmptyFieldNotAllowed("virtualIP")
 	}
 
 	search := search.Search("controlplane").Type(kind).Filter(

--- a/domain/registry/store.go
+++ b/domain/registry/store.go
@@ -14,10 +14,10 @@
 package registry
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain"
 	"github.com/zenoss/elastigo/search"
 )
 
@@ -65,9 +65,9 @@ func (s *ImageRegistryStore) GetImages(ctx datastore.Context) ([]Image, error) {
 // SearchLibraryByTag looks for repos that are registered under a library and tag
 func (s *ImageRegistryStore) SearchLibraryByTag(ctx datastore.Context, library, tag string) ([]Image, error) {
 	if library = strings.TrimSpace(library); library == "" {
-		return nil, errors.New("empty library not allowed")
+		return nil, domain.EmptyFieldNotAllowed("library")
 	} else if tag = strings.TrimSpace(tag); tag == "" {
-		return nil, errors.New("empty tag not allowed")
+		return nil, domain.EmptyFieldNotAllowed("tag")
 	}
 	search := search.Search("controlplane").Type(kind).Size("50000").Filter(
 		"and",

--- a/domain/service/servicestore.go
+++ b/domain/service/servicestore.go
@@ -15,10 +15,10 @@ package service
 
 import (
 	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain"
 	"github.com/control-center/serviced/domain/servicedefinition"
 	"github.com/zenoss/elastigo/search"
 
-	"errors"
 	"strings"
 	"time"
 )
@@ -80,7 +80,7 @@ func (s *Store) GetUpdatedServices(ctx datastore.Context, since time.Duration) (
 //GetTaggedServices returns services with the given tags
 func (s *Store) GetTaggedServices(ctx datastore.Context, tags ...string) ([]Service, error) {
 	if len(tags) == 0 {
-		return nil, errors.New("empty tags not allowed")
+		return nil, domain.EmptyFieldNotAllowed("tags")
 	}
 	qs := strings.Join(tags, " AND ")
 	return query(ctx, qs)
@@ -88,12 +88,11 @@ func (s *Store) GetTaggedServices(ctx datastore.Context, tags ...string) ([]Serv
 
 //GetServicesByPool returns services with the given pool id
 func (s *Store) GetServicesByPool(ctx datastore.Context, poolID string) ([]Service, error) {
-	id := strings.TrimSpace(poolID)
-	if id == "" {
-		return nil, errors.New("empty poolID not allowed")
+	if poolID = strings.TrimSpace(poolID); poolID == "" {
+		return nil, domain.EmptyFieldNotAllowed("poolID")
 	}
 	q := datastore.NewQuery(ctx)
-	query := search.Query().Term("PoolID", id)
+	query := search.Query().Term("PoolID", poolID)
 	search := search.Search("controlplane").Type(kind).Size("50000").Query(query)
 	results, err := q.Execute(search)
 	if err != nil {
@@ -104,12 +103,11 @@ func (s *Store) GetServicesByPool(ctx datastore.Context, poolID string) ([]Servi
 
 //GetServicesByDeployment returns services with the given deployment id
 func (s *Store) GetServicesByDeployment(ctx datastore.Context, deploymentID string) ([]Service, error) {
-	id := strings.TrimSpace(deploymentID)
-	if id == "" {
-		return nil, errors.New("empty deploymentID not allowed")
+	if deploymentID = strings.TrimSpace(deploymentID); deploymentID != "" {
+		return nil, domain.EmptyFieldNotAllowed("deploymentID")
 	}
 	q := datastore.NewQuery(ctx)
-	query := search.Query().Term("DeploymentID", id)
+	query := search.Query().Term("DeploymentID", deploymentID)
 	search := search.Search("controlplane").Type(kind).Size("50000").Query(query)
 	results, err := q.Execute(search)
 	if err != nil {
@@ -120,12 +118,11 @@ func (s *Store) GetServicesByDeployment(ctx datastore.Context, deploymentID stri
 
 //GetChildServices returns services that are children of the given parent service id
 func (s *Store) GetChildServices(ctx datastore.Context, parentID string) ([]Service, error) {
-	id := strings.TrimSpace(parentID)
-	if id == "" {
-		return nil, errors.New("empty parent service id not allowed")
+	if parentID = strings.TrimSpace(parentID); parentID != "" {
+		return nil, domain.EmptyFieldNotAllowed("parentID")
 	}
 	q := datastore.NewQuery(ctx)
-	query := search.Query().Term("ParentServiceID", id)
+	query := search.Query().Term("ParentServiceID", parentID)
 	search := search.Search("controlplane").Type(kind).Size("50000").Query(query)
 	results, err := q.Execute(search)
 	if err != nil {
@@ -138,9 +135,9 @@ func (s *Store) FindChildService(ctx datastore.Context, deploymentID, parentID, 
 	parentID = strings.TrimSpace(parentID)
 
 	if deploymentID = strings.TrimSpace(deploymentID); deploymentID == "" {
-		return nil, errors.New("empty deployment ID not allowed")
+		return nil, domain.EmptyFieldNotAllowed("deploymentID")
 	} else if serviceName = strings.TrimSpace(serviceName); serviceName == "" {
-		return nil, errors.New("empty service name not allowed")
+		return nil, domain.EmptyFieldNotAllowed("serviceName")
 	}
 
 	search := search.Search("controlplane").Type(kind).Filter(
@@ -169,9 +166,9 @@ func (s *Store) FindChildService(ctx datastore.Context, deploymentID, parentID, 
 // and service name
 func (s *Store) FindTenantByDeploymentID(ctx datastore.Context, deploymentID, name string) (*Service, error) {
 	if deploymentID = strings.TrimSpace(deploymentID); deploymentID == "" {
-		return nil, errors.New("empty deployment ID not allowed")
+		return nil, domain.EmptyFieldNotAllowed("deploymentID")
 	} else if name = strings.TrimSpace(name); name == "" {
-		return nil, errors.New("empty service name not allowed")
+		return nil, domain.EmptyFieldNotAllowed("serviceName")
 	}
 
 	search := search.Search("controlplane").Type(kind).Filter(


### PR DESCRIPTION
TODO: need to update the virtual ip listener to only bind to a hosts provided static ips

Before adding a new virtual ip, there is additional validation against whether any of the hosts in the given resource pool actually has a host that allows an ip to bind to the given interface.