### PR TITLE
Fix race in test teardown

### DIFF
--- a/datastore/elastic/testutils.go
+++ b/datastore/elastic/testutils.go
@@ -197,8 +197,15 @@ cluster.name: %v`, rand.Int())
 			return
 		}
 		tc.cmdLock.Unlock()
+
 		err = cmd.Wait()
-		if err != nil && !tc.shutdown {
+		if err == nil {
+			return
+		}
+
+		tc.cmdLock.Lock()
+		defer tc.cmdLock.Unlock()
+		if !tc.shutdown {
 			log.Printf("Error running elastic: %s\n", err)
 			if data, err := ioutil.ReadAll(stdout); err == nil {
 				log.Printf("Stdout: %s\n", string(data))


### PR DESCRIPTION
Fixes a data race in the teardown code for elastic search.
Here's an example of the race that failed http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/199
```
2015/12/18 17:20:09 ElasticTest TearDownSuite called
2015/12/18 17:20:09 Stop called, killing elastic search
==================
WARNING: DATA RACE
Read by goroutine 14:
  github.com/control-center/serviced/datastore/elastic.func·002()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/datastore/elastic/testutils.go:201 +0x3eb

Previous write by goroutine 43:
  github.com/control-center/serviced/datastore/elastic.(*testCluster).Stop()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/datastore/elastic/testutils.go:155 +0xad
  github.com/control-center/serviced/datastore/elastic.(*ElasticTest).stop()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/datastore/elastic/testutils.go:139 +0x7c
  github.com/control-center/serviced/datastore/elastic.(*ElasticTest).TearDownSuite()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/datastore/elastic/testutils.go:121 +0x10d
  github.com/control-center/serviced/datastore/elastic_test.(*S).TearDownSuite()
      <autogenerated>:4 +0x5c
  runtime.call16()
      /home/jenkins/.gvm/gos/go1.4.2/src/runtime/asm_amd64.s:401 +0x44
  reflect.Value.Call()
      /home/jenkins/.gvm/gos/go1.4.2/src/reflect/value.go:296 +0xd8
  gopkg.in/check%2ev1.func·002()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/Godeps/_workspace/src/gopkg.in/check.v1/check.go:703 +0x1cf
  gopkg.in/check%2ev1.func·001()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/Godeps/_workspace/src/gopkg.in/check.v1/check.go:648 +0xf7

Goroutine 14 (running) created at:
  github.com/control-center/serviced/datastore/elastic.newTestCluster()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/datastore/elastic/testutils.go:210 +0x9af
  github.com/control-center/serviced/datastore/elastic.(*ElasticTest).SetUpSuite()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/datastore/elastic/testutils.go:86 +0x264
  github.com/control-center/serviced/datastore/elastic_test.(*S).SetUpSuite()
      <autogenerated>:2 +0x5c
  runtime.call16()
      /home/jenkins/.gvm/gos/go1.4.2/src/runtime/asm_amd64.s:401 +0x44
  reflect.Value.Call()
      /home/jenkins/.gvm/gos/go1.4.2/src/reflect/value.go:296 +0xd8
  gopkg.in/check%2ev1.func·002()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/Godeps/_workspace/src/gopkg.in/check.v1/check.go:703 +0x1cf
  gopkg.in/check%2ev1.func·001()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/Godeps/_workspace/src/gopkg.in/check.v1/check.go:648 +0xf7

Goroutine 43 (finished) created at:
  gopkg.in/check%2ev1.(*suiteRunner).forkCall()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/Godeps/_workspace/src/gopkg.in/check.v1/check.go:649 +0x5db
  gopkg.in/check%2ev1.(*suiteRunner).runFunc()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/Godeps/_workspace/src/gopkg.in/check.v1/check.go:655 +0x5d
  gopkg.in/check%2ev1.(*suiteRunner).runFixture()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/Godeps/_workspace/src/gopkg.in/check.v1/check.go:704 +0x65
  gopkg.in/check%2ev1.(*suiteRunner).run()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/Godeps/_workspace/src/gopkg.in/check.v1/check.go:610 +0x1d3
  gopkg.in/check%2ev1.Run()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/Godeps/_workspace/src/gopkg.in/check.v1/run.go:90 +0x57
  gopkg.in/check%2ev1.RunAll()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/Godeps/_workspace/src/gopkg.in/check.v1/run.go:82 +0x132
  gopkg.in/check%2ev1.TestingT()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/Godeps/_workspace/src/gopkg.in/check.v1/run.go:70 +0x47c
  github.com/control-center/serviced/datastore/elastic_test.Test()
      /workspace/workspace/serviced-develop-pullrequests-integration/gopath/src/github.com/control-center/serviced/datastore/elastic/connection_test.go:32 +0x35
  testing.tRunner()
      /home/jenkins/.gvm/gos/go1.4.2/src/testing/testing.go:447 +0x133
==================
FAIL	github.com/control-center/serviced/datastore/elastic	13.129s
```