### PR TITLE
Feature/cc 1633

### DIFF
--- a/coordinator/client/mocks/Connection.go
+++ b/coordinator/client/mocks/Connection.go
@@ -1,0 +1,272 @@
+package mocks
+
+import "github.com/control-center/serviced/coordinator/client"
+import (
+	"github.com/stretchr/testify/mock"
+	"github.com/zenoss/glog"
+)
+
+type Connection struct {
+	mock.Mock
+}
+
+func (_m *Connection) Close() {
+	glog.Infof("Close() START")
+	_m.Called()
+}
+func (_m *Connection) SetID(_a0 int) {
+	glog.Infof("SetID(%d) START", _a0)
+	_m.Called(_a0)
+}
+func (_m *Connection) ID() int {
+	glog.Infof("ID() START")
+	ret := _m.Called()
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func() int); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+func (_m *Connection) SetOnClose(_a0 func(int)) {
+	_m.Called(_a0)
+}
+func (_m *Connection) NewTransaction() client.Transaction {
+	glog.Infof("NewTransaction() START")
+	ret := _m.Called()
+
+	var r0 client.Transaction
+	if rf, ok := ret.Get(0).(func() client.Transaction); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(client.Transaction)
+	}
+
+	return r0
+}
+func (_m *Connection) Create(path string, node client.Node) error {
+	glog.Infof("Create(%s,%v) START", path, node)
+	ret := _m.Called(path, node)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, client.Node) error); ok {
+		r0 = rf(path, node)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Connection) CreateDir(path string) error {
+	glog.Infof("CreateDir(%s) START", path)
+	ret := _m.Called(path)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Connection) CreateEphemeral(path string, node client.Node) (string, error) {
+	glog.Infof("CreateEphemeral(%s,%v) START", path, node)
+	ret := _m.Called(path, node)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, client.Node) string); ok {
+		r0 = rf(path, node)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, client.Node) error); ok {
+		r1 = rf(path, node)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Connection) EnsurePath(path string) error {
+	glog.Infof("EnsurePath(%s) START", path)
+	ret := _m.Called(path)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Connection) Exists(path string) (bool, error) {
+	glog.Infof("Exists(%s) START", path)
+	ret := _m.Called(path)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Connection) Delete(path string) error {
+	glog.Infof("Delete(%s) START", path)
+	ret := _m.Called(path)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Connection) ChildrenW(path string, done <-chan struct{}) (children []string, event <-chan client.Event, err error) {
+	glog.Infof("Childrenw(%s,%v) START", path, done)
+	ret := _m.Called(path, done)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(string, <-chan struct{}) []string); ok {
+		r0  = rf(path, done)
+	} else {
+		if  ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 <-chan client.Event
+	if rf, ok := ret.Get(0).(func(string, <-chan struct{}) <-chan client.Event); ok {
+		r1  = rf(path, done)
+	} else {
+		if  ret.Get(1) != nil {
+			r1 = ret.Get(1).(<-chan client.Event)
+		}
+	}
+	var r2 error
+	if rf, ok := ret.Get(2).(func(string, <-chan struct{}) error); ok {
+		r2  = rf(path, done)
+	} else {
+		if  ret.Get(2) != nil {
+			r2 = ret.Error(1)
+		}
+	}
+
+	return r0, r1, r2
+}
+
+func (_m *Connection) Children(p string) (children []string, err error) {
+	glog.Infof("Children(%s) START", p)
+	ret := _m.Called(p)
+
+	//var r0 []string
+	if rf, ok := ret.Get(0).(func(string) []string); ok {
+		children = rf(p)
+	} else {
+		if ret.Get(0) != nil {
+			children = ret.Get(0).([]string)
+		}
+	}
+
+	//var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		err = rf(p)
+	} else {
+		err = ret.Error(1)
+	}
+
+	return children, err
+}
+func (_m *Connection) Get(path string, node client.Node) error {
+	glog.Infof("Get(%s,%v) START", path, node)
+	ret := _m.Called(path, node)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, client.Node) error); ok {
+		r0 = rf(path, node)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Connection) Set(path string, node client.Node) error {
+	glog.Infof("Set(%s,%v) START", path, node)
+	ret := _m.Called(path, node)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, client.Node) error); ok {
+		r0 = rf(path, node)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Connection) NewLock(path string) client.Lock {
+	glog.Infof("NewLock(%s) START", path)
+	ret := _m.Called(path)
+
+	var r0 client.Lock
+	if rf, ok := ret.Get(0).(func(string) client.Lock); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(client.Lock)
+	}
+
+	return r0
+}
+func (_m *Connection) NewLeader(path string, data client.Node) client.Leader {
+	glog.Infof("NewLeader(%s,%v) START", path, data)
+	ret := _m.Called(path, data)
+
+	var r0 client.Leader
+	if rf, ok := ret.Get(0).(func(string, client.Node) client.Leader); ok {
+		r0 = rf(path, data)
+	} else {
+		r0 = ret.Get(0).(client.Leader)
+	}
+
+	return r0
+}
+
+func (_m *Connection) GetW(path string, node client.Node, done <-chan struct{}) (<-chan client.Event, error) {
+	glog.Infof("GetW(%s,%v,%v) START", path, node, done)
+	ret := _m.Called(path, node, done)
+
+	var r0 <-chan client.Event
+	if rf, ok := ret.Get(0).(func(string, client.Node, <-chan struct{}) <-chan client.Event); ok {
+		r0 = rf(path, node, done)
+	} else {
+		r0 = ret.Get(0).(<-chan client.Event)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(2).(func(string, client.Node, <-chan struct{}) error); ok {
+		r1  = rf(path, node, done)
+	} else {
+		if  ret.Get(1) != nil {
+			r1 = ret.Error(1)
+		}
+	}
+
+	return r0, r1
+
+}

--- a/scheduler/localsync.go
+++ b/scheduler/localsync.go
@@ -79,8 +79,12 @@ retry:
 				glog.Errorf("Could not get services: %s", err)
 				wait = time.After(minWait)
 				continue retry
-			} else if zkservice.SyncServices(conn, svcs); err != nil {
+			} else if err = zkservice.SyncServices(conn, svcs); err != nil {
 				glog.Errorf("Could not do a local sync of services: %s", err)
+				wait = time.After(minWait)
+				continue retry
+			} else if err := zkservice.UpdateServicesVhosts(rootConn, svcs); err != nil {
+				glog.Errorf("Could not sync serviceVHosts: %s", err)
 				wait = time.After(minWait)
 				continue retry
 			}

--- a/zzk/service/service.go
+++ b/zzk/service/service.go
@@ -65,6 +65,29 @@ type ServiceNode struct {
 	version interface{}
 }
 
+// ID implements zzk.Node
+func (node *ServiceNode) GetID() string {
+	return node.ID
+}
+
+// Create implements zzk.Node
+func (node *ServiceNode) Create(conn client.Connection) error {
+	return UpdateService(conn, *node.Service, false)
+}
+
+// Update implements zzk.Node
+func (node *ServiceNode) Update(conn client.Connection) error {
+	// We have to get the node first, so the version is set properly.
+	var tempNode ServiceNode=ServiceNode{Service:&service.Service{}}
+	svcPath := servicepath(node.ID)
+	if err := conn.Get(svcPath, &tempNode); err != nil {
+		glog.V(2).Infof("Error getting ServiceNode for %s: %s", node.ID, err)
+		return err
+	}
+	tempNode.Service = node.Service
+	return conn.Set(svcPath, &tempNode)
+}
+
 // Version implements client.Node
 func (node *ServiceNode) Version() interface{} { return node.version }
 

--- a/zzk/service/service.go
+++ b/zzk/service/service.go
@@ -65,19 +65,6 @@ type ServiceNode struct {
 	version interface{}
 }
 
-// Update implements zzk.Node
-func (node *ServiceNode) Update(conn client.Connection) error {
-	// We have to get the node first, so the version is set properly.
-	var tempNode ServiceNode=ServiceNode{Service:&service.Service{}}
-	svcPath := servicepath(node.ID)
-	if err := conn.Get(svcPath, &tempNode); err != nil {
-		glog.V(2).Infof("Error getting ServiceNode for %s: %s", node.ID, err)
-		return err
-	}
-	tempNode.Service = node.Service
-	return conn.Set(svcPath, &tempNode)
-}
-
 // Version implements client.Node
 func (node *ServiceNode) Version() interface{} { return node.version }
 

--- a/zzk/service/service.go
+++ b/zzk/service/service.go
@@ -72,7 +72,7 @@ func (node *ServiceNode) GetID() string {
 
 // Create implements zzk.Node
 func (node *ServiceNode) Create(conn client.Connection) error {
-	return UpdateService(conn, *node.Service, false)
+	return UpdateService(conn, *node.Service, false, false)
 }
 
 // Update implements zzk.Node

--- a/zzk/service/service.go
+++ b/zzk/service/service.go
@@ -65,16 +65,6 @@ type ServiceNode struct {
 	version interface{}
 }
 
-// ID implements zzk.Node
-func (node *ServiceNode) GetID() string {
-	return node.ID
-}
-
-// Create implements zzk.Node
-func (node *ServiceNode) Create(conn client.Connection) error {
-	return UpdateService(conn, *node.Service, false, false)
-}
-
 // Update implements zzk.Node
 func (node *ServiceNode) Update(conn client.Connection) error {
 	// We have to get the node first, so the version is set properly.

--- a/zzk/service/service.go
+++ b/zzk/service/service.go
@@ -65,6 +65,8 @@ type ServiceNode struct {
 	version interface{}
 }
 
+// comment to make git rebase happy
+
 // Update implements zzk.Node
 func (node *ServiceNode) Update(conn client.Connection) error {
 	// We have to get the node first, so the version is set properly.

--- a/zzk/service/servicevhost.go
+++ b/zzk/service/servicevhost.go
@@ -123,7 +123,7 @@ func newVhostKey(serviceID string, vhostName string, enabled bool) VHostKey {
 func UpdateServicesVhosts(conn client.Connection, svcs []service.Service) error {
 	for _,svc := range svcs {
 		if err := UpdateServiceVhosts(conn, &svc) ; err != nil {
-			glog.Infof("Error Updating ServiceVhosts for Service %s: %s", svc.Name, err)
+			glog.Errorf("Error Updating ServiceVhosts for Service %s: %s", svc.Name, err)
 			return err
 		}
 	}

--- a/zzk/service/servicevhost.go
+++ b/zzk/service/servicevhost.go
@@ -119,6 +119,17 @@ func newVhostKey(serviceID string, vhostName string, enabled bool) VHostKey {
 	return VHostKey(fmt.Sprintf("%s_%s_%s", state, serviceID, vhostName))
 }
 
+
+func UpdateServicesVhosts(conn client.Connection, svcs []service.Service) error {
+	for _,svc := range svcs {
+		if err := UpdateServiceVhosts(conn, &svc) ; err != nil {
+			glog.Infof("Error Updating ServiceVhosts for Service %s: %s", svc.Name, err)
+			return err
+		}
+	}
+	return nil
+}
+
 // UpdateServiceVhosts updates vhosts of a service
 func UpdateServiceVhosts(conn client.Connection, svc *service.Service) error {
 	glog.V(2).Infof("UpdateServiceVhosts for ID:%s Name:%s", svc.ID, svc.Name)

--- a/zzk/service/servicevhost_test.go
+++ b/zzk/service/servicevhost_test.go
@@ -5,7 +5,9 @@ import (
 "github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/domain/servicedefinition"
 )
-// Tests:
+
+
+// Current test is very basic. For future work, I'd like to have the following tests:
 // Initial conditions:
 // - no servicevhosts node
 // - empty servicevhosts node

--- a/zzk/service/servicevhost_test.go
+++ b/zzk/service/servicevhost_test.go
@@ -1,0 +1,68 @@
+package service
+import (
+"testing"
+"github.com/control-center/serviced/coordinator/client/mocks"
+"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/domain/servicedefinition"
+)
+// Tests:
+// Initial conditions:
+// - no servicevhosts node
+// - empty servicevhosts node
+// - servicevhosts node with other data
+// - servicevhosts node already populated
+// Inputs:
+// - service with no vhost - no change to initial conditions
+// - service with vhost - end state should have servicevhosts node populated with service entry
+
+type ServiceProfile struct {
+	Name string
+	VHostNames []string
+}
+
+func makeService(sp ServiceProfile) *service.Service {
+	svc := new (service.Service)
+	svc.Name = sp.Name
+	for _, vhn := range(sp.VHostNames) {
+		svc.Endpoints = append(
+			svc.Endpoints, service.ServiceEndpoint{
+				Name:vhn,
+				VHostList: []servicedefinition.VHost {
+					{
+						Name: vhn,
+						Enabled: true,
+					},
+				},
+			})
+	}
+	svc.Endpoints = []service.ServiceEndpoint {
+		{
+			VHostList: []servicedefinition.VHost{
+				{
+					Name: "test1",
+					Enabled: true,
+				},
+			},
+		},
+	}
+	return svc
+}
+
+func TestUpdateServiceVHosts(t *testing.T) {
+	testSvcProfile := ServiceProfile{
+		Name: "Test Service",
+		VHostNames: []string {"vhost1", "vhost2"},
+	}
+
+	mockConn := new(mocks.Connection)
+	mockSvc := makeService(testSvcProfile)
+
+	mockConn.On("Children",zkServiceVhosts).Return([]string{"foo", "bar"}, nil)
+	mockConn.On("Get",zkServiceVhosts + "/:vhOn:__test1",&ServiceVhostNode{"","",false,nil}).Return(nil)
+	mockConn.On("Set",zkServiceVhosts + "/:vhOn:__test1",&ServiceVhostNode{"","test1",true,nil}).Return(nil)
+
+	UpdateServiceVhosts(mockConn, mockSvc)
+
+	mockConn.AssertNumberOfCalls(t, "Children", 1)
+	mockConn.AssertNumberOfCalls(t, "Set", 1)
+}

--- a/zzk/service/servicevhost_test.go
+++ b/zzk/service/servicevhost_test.go
@@ -1,11 +1,24 @@
-package service
-import (
-"testing"
-"github.com/control-center/serviced/coordinator/client/mocks"
-"github.com/control-center/serviced/domain/service"
-	"github.com/control-center/serviced/domain/servicedefinition"
-)
+// Copyright 2015 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+package service
+
+import (
+	"github.com/control-center/serviced/coordinator/client/mocks"
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/domain/servicedefinition"
+	"testing"
+)
 
 // Current test is very basic. For future work, I'd like to have the following tests:
 // Initial conditions:
@@ -18,30 +31,30 @@ import (
 // - service with vhost - end state should have servicevhosts node populated with service entry
 
 type ServiceProfile struct {
-	Name string
+	Name       string
 	VHostNames []string
 }
 
 func makeService(sp ServiceProfile) *service.Service {
-	svc := new (service.Service)
+	svc := new(service.Service)
 	svc.Name = sp.Name
-	for _, vhn := range(sp.VHostNames) {
+	for _, vhn := range sp.VHostNames {
 		svc.Endpoints = append(
 			svc.Endpoints, service.ServiceEndpoint{
-				Name:vhn,
-				VHostList: []servicedefinition.VHost {
+				Name: vhn,
+				VHostList: []servicedefinition.VHost{
 					{
-						Name: vhn,
+						Name:    vhn,
 						Enabled: true,
 					},
 				},
 			})
 	}
-	svc.Endpoints = []service.ServiceEndpoint {
+	svc.Endpoints = []service.ServiceEndpoint{
 		{
 			VHostList: []servicedefinition.VHost{
 				{
-					Name: "test1",
+					Name:    "test1",
 					Enabled: true,
 				},
 			},
@@ -52,16 +65,16 @@ func makeService(sp ServiceProfile) *service.Service {
 
 func TestUpdateServiceVHosts(t *testing.T) {
 	testSvcProfile := ServiceProfile{
-		Name: "Test Service",
-		VHostNames: []string {"vhost1", "vhost2"},
+		Name:       "Test Service",
+		VHostNames: []string{"vhost1", "vhost2"},
 	}
 
 	mockConn := new(mocks.Connection)
 	mockSvc := makeService(testSvcProfile)
 
-	mockConn.On("Children",zkServiceVhosts).Return([]string{"foo", "bar"}, nil)
-	mockConn.On("Get",zkServiceVhosts + "/:vhOn:__test1",&ServiceVhostNode{"","",false,nil}).Return(nil)
-	mockConn.On("Set",zkServiceVhosts + "/:vhOn:__test1",&ServiceVhostNode{"","test1",true,nil}).Return(nil)
+	mockConn.On("Children", zkServiceVhosts).Return([]string{"foo", "bar"}, nil)
+	mockConn.On("Get", zkServiceVhosts+"/:vhOn:__test1", &ServiceVhostNode{"", "", false, nil}).Return(nil)
+	mockConn.On("Set", zkServiceVhosts+"/:vhOn:__test1", &ServiceVhostNode{"", "test1", true, nil}).Return(nil)
 
 	UpdateServiceVhosts(mockConn, mockSvc)
 


### PR DESCRIPTION
Fix for CC-1633 - add routine to update servicevhosts in zookeeper on every sync. 
Fix for bug discovered while fixing CC-1633: return value from SyncServices was not being checked. When I checked it, it was returning an error. Properly initializing the ServiceNode on Update() fixed this problem.
Add unit test for servicevhost. This also entails adding a mock for the Zookeeper connection, to make it a true unit test.