### PR TITLE
CC-1691: Ensure service path exists in zookeeper

### DIFF
--- a/zzk/service/service.go
+++ b/zzk/service/service.go
@@ -403,6 +403,12 @@ func StopService(conn client.Connection, serviceID string) error {
 
 // SyncServices synchronizes all services into zookeeper
 func SyncServices(conn client.Connection, svcs []service.Service) error {
+	// Make sure service path exists (during upgrades, sometimes it disappears: CC-1691)
+	if err := conn.CreateDir(servicepath()); err != nil && err != client.ErrNodeExists {
+		glog.Errorf("Cannot create service path %s: %s", servicepath(), err)
+		return err
+	}
+
 	svcNodes, err := conn.Children(servicepath())
 	if err != nil {
 		glog.Errorf("Can not look up services: %s", err)


### PR DESCRIPTION
During 5.0.x -> 5.1.1 upgrade testing, it disappeared somehow. So
make sure it's there when we need it.