### PR TITLE
Refresh the application data when deploying a new template

### DIFF
--- a/acceptance/ui/features/steps/applications_steps.rb
+++ b/acceptance/ui/features/steps/applications_steps.rb
@@ -72,7 +72,7 @@ end
 
 Then (/^I should see that the application has deployed$/) do
     expect(page).to have_content("App deployed successfully", wait: 120)
-    refreshPage() # workaround until apps consistently display on page without refreshing
+    #refreshPage() # workaround until apps consistently display on page without refreshing
 end
 
 Then (/^I should see that the application has not been deployed$/) do

--- a/web/ui/src/DeployWiz/DeployWizard.js
+++ b/web/ui/src/DeployWiz/DeployWizard.js
@@ -299,6 +299,7 @@
                 .success(function() {
                     servicesFactory.update().then(function(){
                         checkStatus = false;
+                        servicesFactory.update(true, false);
                         $notification.create("App deployed successfully").success();
                         closeModal();
                     });


### PR DESCRIPTION
If you deploy a template whose image hasn't been pulled, the application list won't show the newly deployed template.