### PR TITLE
Feature/cc 1679

### DIFF
--- a/web/routes.go
+++ b/web/routes.go
@@ -83,7 +83,7 @@ func (sc *ServiceConfig) getRoutes() []rest.Route {
 		rest.Route{"GET", "/services/vhosts", gz(sc.authorizedClient(restGetVirtualHosts))},
 		rest.Route{"PUT", "/services/:serviceId/endpoint/:application/vhosts/*name", gz(sc.authorizedClient(restAddVirtualHost))},
 		rest.Route{"DELETE", "/services/:serviceId/endpoint/:application/vhosts/*name", gz(sc.authorizedClient(restRemoveVirtualHost))},
-		rest.Route{"POST", "/services/:serviceId/endpoint/:application/vhosts/:name/enable", gz(sc.authorizedClient(restVirtualHostEnable))},
+		rest.Route{"POST", "/services/:serviceId/endpoint/:application/vhosts/*name", gz(sc.authorizedClient(restVirtualHostEnable))},
 
 		// Services (Endpoint Ports)
 		rest.Route{"PUT", "/services/:serviceId/endpoint/:application/ports/*portname", gz(sc.authorizedClient(restAddPort))},

--- a/web/ui/src/common/resourcesFactory.js
+++ b/web/ui/src/common/resourcesFactory.js
@@ -65,14 +65,14 @@
             enableVHost: {
                 method: "POST",
                 url: (serviceID, endpointName, vhostName) => {
-                    return `/services/${serviceID}/endpoint/${endpointName}/vhosts/${vhostName}/enable`;
+                    return `/services/${serviceID}/endpoint/${endpointName}/vhosts/${vhostName}`;
                 },
                 payload: () => {return JSON.stringify({Enable:true});}
             },
             disableVHost: {
                 method: "POST",
                 url: (serviceID, endpointName, vhostName) => {
-                    return `/services/${serviceID}/endpoint/${endpointName}/vhosts/${vhostName}/enable`;
+                    return `/services/${serviceID}/endpoint/${endpointName}/vhosts/${vhostName}`;
                 },
                 payload: () => {return JSON.stringify({Enable:false});}
             },


### PR DESCRIPTION
The problem is in the routes.  When passing "abc.xyz.com" into ":name", it gets interpreted as the value "abc" with a format parameter.  The /enable wasn't necessary because it's already part of the payload, so changing ":name" to "*name" and dropping "/enable" from the url argument results in the route getting the complete vhost name.  There was nothing wrong in cpserver.go