### PR TITLE
Workaround for govet incompatiblity with GO 1.4.2

### DIFF
--- a/get_govet.sh
+++ b/get_govet.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# On Jan 7 2015, a change was made to govet which made it incompatible with GO 1.4.2
+# The way 'go get' works, it always checks out the tip of the GO tools repo, which means
+# all of our Jenkins builds were failing.
+#
+# The workaround is to checkout a specific older version of GO tools which is compatible
+# with GO 1.4.2.
+#
+echo "Checking for correct govet version"
+
+#
+# if we don't ahve govet already, or we have the wrong version, then
+# we need to get the right version.
+#
+go_getit=false
+if [ ! -d ${GOSRC}/${GOTOOLS_SRC} ];then
+	echo "GO tools not installed"
+	go_getit=true
+else
+	cd ${GOSRC}/${GOTOOLS_SRC}
+	GOVET_VERSION=`git rev-parse --verify HEAD`
+	if [ "$GOVET_VERSION" != "c262de870b618eed648983aa994b03bc04641c72" ]; then
+		echo "govet version $GOVET_VERSION is incorrect"
+		go_getit=true
+	fi
+fi
+
+if [ "$go_getit" = "true" ]; then
+	echo "Retrieving govet ..."
+	GOVET_SRC=${GOTOOLS_SRC}/cmd/vet
+	go get ${GOVET_SRC}
+	if [ $? -ne 0 ]; then
+		cd ${GOSRC}/${GOTOOLS_SRC}
+		git checkout c262de870b618eed648983aa994b03bc04641c72 >/dev/null 2>&1
+		go get ${GOVET_SRC}
+	fi
+fi

--- a/makefile
+++ b/makefile
@@ -134,17 +134,14 @@ $(GOSRC)/$(godep_SRC):
 	go get $(godep_SRC)
 
 GOVET     = $(GOBIN)/govet
-govet_SRC = golang.org/x/tools/cmd/vet
-
-# Download govet source to $GOPATH/src/.
-$(GOSRC)/$(govet_SRC):
-	go get $(govet_SRC)
+GOTOOLS_SRC = golang.org/x/tools
 
 #
 # FIXME: drop -composites=false to get full coverage
 GOVET_EXCLUDE_DIRS = Godeps/ build/ chef/ vagrant/
 GOVET_TARGET_DIRS =  $(filter-out $(GOVET_EXCLUDE_DIRS), $(sort $(dir $(wildcard */*))))
-govet: $(GOSRC)/$(govet_SRC)
+govet:
+	GOSRC=$(GOSRC) GOTOOLS_SRC=$(GOTOOLS_SRC) ./get_govet.sh
 	@echo "GOVET_TARGET_DIRS='${GOVET_TARGET_DIRS}'"
 	go tool vet -composites=false $(GOVET_FLAGS) $(GOVET_TARGET_DIRS)
 


### PR DESCRIPTION
Fixes Jenkins build problems that look like:
```
go get golang.org/x/tools/cmd/vet
package golang.org/x/tools/cmd/vet
    imports go/constant: unrecognized import path "go/constant"
package golang.org/x/tools/cmd/vet
    imports go/importer: unrecognized import path "go/importer"
package golang.org/x/tools/cmd/vet
    imports go/types: unrecognized import path "go/types"
```
These problems were caused by a new version of govet which is not compatible with GO 1.4.2