### PR TITLE
Small refinement for HA scenarios

### DIFF
--- a/node/agent.go
+++ b/node/agent.go
@@ -757,7 +757,7 @@ func (a *HostAgent) setupVolume(tenantID string, service *service.Service, volum
 		return "", fmt.Errorf("could not get subvolume %s: %s", tenantID, err)
 	}
 	resourcePath := filepath.Join(vol.Path(), volume.ResourcePath)
-	if err = os.MkdirAll(resourcePath, 0770); err != nil {
+	if err = os.MkdirAll(resourcePath, 0770); err != nil && !os.IsExist(err) {
 		return "", fmt.Errorf("Could not create resource path: %s, %s", resourcePath, err)
 	}
 

--- a/volume/devicemapper/devicemapper.go
+++ b/volume/devicemapper/devicemapper.go
@@ -214,7 +214,9 @@ func (d *DeviceMapperDriver) Get(volumeName string) (volume.Volume, error) {
 		device := vol.Metadata.CurrentDevice()
 		mountpoint := vol.Path()
 		label := vol.Tenant()
+
 		if err := d.DeviceSet.MountDevice(device, mountpoint, label); err != nil {
+			glog.Errorf("Error mounting device %q on %q for volume %q: %s", device, mountpoint, volumeName, err)
 			return nil, err
 		}
 		glog.V(2).Infof("Mounted device %s to %s", device, mountpoint)
@@ -290,7 +292,7 @@ func (d *DeviceMapperDriver) Release(volumeName string) error {
 	d.DeviceSet.Lock()
 	defer d.DeviceSet.Unlock()
 	if err := d.deactivateDevice(device); err != nil {
-		glog.Errorf("Error removing device (%s)", err)
+		glog.Errorf("Error removing device %s for volume %s: %s", device, volumeName, err)
 		return err
 	}
 	glog.V(2).Infof("Deactivated device")


### PR DESCRIPTION
Ignore file-exists errors when setting up the volume directory on an agent.  

Not sure why this hasn't been a problem in other multi-host deployments, but after an HA failover I ran into cases where the agent nodes were failing to start services because the client-side mount point for the application already existed.