### PR TITLE
CC-1707 (Shutdown takes too long) - port CC-1698 changes to support branch

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -361,7 +361,6 @@ func (d *daemon) run() (err error) {
 	}
 
 	zzk.ShutdownConnections()
-	volume.ShutdownAll()
 	switch sig {
 	case syscall.SIGHUP:
 		glog.Infof("Not shutting down isvcs")

--- a/web/cpserver.go
+++ b/web/cpserver.go
@@ -399,18 +399,18 @@ func (sc *ServiceConfig) syncAllVhosts(shutdown <-chan interface{}) error {
 
 	for {
 		zkServiceVhost := service.ZKServicePublicEndpoints
+		select {
+		case <-shutdown:
+			close(cancelChan)
+			return nil
+		default:
+		}
 		glog.V(1).Infof("Running registry.WatchChildren for zookeeper path: %s", zkServiceVhost)
 		err := registry.WatchChildren(rootConn, zkServiceVhost, cancelChan, syncVhosts, pepWatchError)
 		if err != nil {
 			glog.V(1).Infof("Will retry in 10 seconds to WatchChildren(%s) due to error: %v", zkServiceVhost, err)
 			<-time.After(time.Second * 10)
 			continue
-		}
-		select {
-		case <-shutdown:
-			close(cancelChan)
-			return nil
-		default:
 		}
 	}
 }


### PR DESCRIPTION
The primary fix is non-code: make sure you're using lvm thin pool storage (not loopback).
This PR includes a couple of changes JP suggested to help with shutdown issues.