### PR TITLE
Bump iscvs versions for openSSH vuln

### DIFF
--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -24,9 +24,9 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO    = "zenoss/serviced-isvcs"
-	IMAGE_TAG     = "v38"
+	IMAGE_TAG     = "v39"
 	ZK_IMAGE_REPO = "zenoss/isvcs-zookeeper"
-	ZK_IMAGE_TAG  = "v2"
+	ZK_IMAGE_TAG  = "v3"
 )
 
 func Init(esStartupTimeoutInSeconds int, dockerLogDriver string, dockerLogConfig map[string]string) {


### PR DESCRIPTION
(cherry picked from commit caa60c9e19cca9e74899a0c31550f37d85af4899)

https://jira.zenoss.com/browse/CC-1772