### PR TITLE
Changes to serviced-storage to deactivate devices

### DIFF
--- a/tools/serviced-storage/main.go
+++ b/tools/serviced-storage/main.go
@@ -36,6 +36,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/control-center/serviced/servicedversion"
 	"github.com/jessevdk/go-flags"
+	"github.com/zenoss/glog"
 )
 
 var Version string
@@ -116,6 +117,12 @@ func (s *ServicedStorage) initializeLogging() {
 	log.SetOutput(os.Stderr)
 	level := log.WarnLevel + log.Level(len(App.Options.Verbose))
 	log.SetLevel(level)
+
+	// Include glog output if verbosity is enabled
+	if len(App.Options.Verbose) > 0 {
+		glog.SetToStderr(true)
+		glog.SetVerbosity(len(App.Options.Verbose))
+	}
 }
 
 // Execute prints the application version to stdout and exits

--- a/volume/devicemapper/metadata.go
+++ b/volume/devicemapper/metadata.go
@@ -115,6 +115,15 @@ func (m *SnapshotMetadata) ListSnapshots() (snaps []string) {
 	return snaps
 }
 
+func (m *SnapshotMetadata) ListDevices() (devices []string) {
+	// Add the current device first so any device-based operations can act on it before any snapshots
+	devices = append(devices, m.CurrentDevice())
+	for _, device := range m.snapshotMetadata.Snapshots {
+		devices = append(devices, device)
+	}
+	return devices
+}
+
 func (m *SnapshotMetadata) LookupSnapshotDevice(snapshot string) (string, error) {
 	m.Lock()
 	defer m.Unlock()

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -135,6 +135,8 @@ type Volume interface {
 	Name() string
 	// Path returns the filesystem path to this volume
 	Path() string
+	// ExportPath returns the filesystem path to any NFS exports for this volume
+	ExportPath() string
 	// Driver returns the driver managing this volume
 	Driver() Driver
 	// Snapshot snapshots the current state of this volume and stores it

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -135,8 +135,6 @@ type Volume interface {
 	Name() string
 	// Path returns the filesystem path to this volume
 	Path() string
-	// ExportPath returns the filesystem path to any NFS exports for this volume
-	ExportPath() string
 	// Driver returns the driver managing this volume
 	Driver() Driver
 	// Snapshot snapshots the current state of this volume and stores it


### PR DESCRIPTION
Fixes CC-1795.

Three key parts of this PR:
 * deactivate devices even if they have no active mounts.
 * deactivate the current device and devices for any snapshots associated with the volume.
 * call GetDeviceStatus to make sure that the device can be deactivated.

**NOTE**: The user is responsible for unmounting any NFS-related mounts before calling `serviced-storage disable` because managing NFS state is outside the scope of serviced-storage.