### PR TITLE
Add CLI command to print default configuration values

### DIFF
--- a/cli/api/utils.go
+++ b/cli/api/utils.go
@@ -15,8 +15,6 @@ package api
 
 import (
 	"fmt"
-	"os"
-	"strconv"
 	"strings"
 
 	"github.com/control-center/serviced/utils"
@@ -43,37 +41,6 @@ func GetAgentIP(defaultRPCPort int) string {
 		glog.Fatalf("Failed to get IP address: %s", err)
 	}
 	return agentIP + fmt.Sprintf(":%d", defaultRPCPort)
-}
-
-// GetDockerDNS returns the docker dns address
-func GetDockerDNS() []string {
-	if len(options.DockerDNS) > 0 {
-		return options.DockerDNS
-	}
-
-	dockerdns := os.Getenv("SERVICED_DOCKER_DNS")
-	return strings.Split(dockerdns, ",")
-}
-
-// GetESStartupTimeout returns the Elastic Search Startup Timeout
-func GetESStartupTimeout() int {
-	var timeout int
-
-	if t := options.ESStartupTimeout; t > 0 {
-		timeout = options.ESStartupTimeout
-	} else if t := os.Getenv("ES_STARTUP_TIMEOUT"); t != "" {
-		if res, err := strconv.Atoi(t); err != nil {
-			timeout = res
-		}
-	}
-
-	if timeout == 0 {
-		timeout = defaultTimeout
-	} else if timeout < minTimeout {
-		timeout = minTimeout
-	}
-
-	return timeout
 }
 
 type version []int

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -121,6 +121,7 @@ func New(driver api.API, config utils.ConfigReader) *ServicedCli {
 
 	c.initVersion()
 	c.initPool()
+	c.initConfig()
 	c.initHealthCheck()
 	c.initHost()
 	c.initTemplate()

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -46,7 +46,6 @@ func New(driver api.API, config utils.ConfigReader) *ServicedCli {
 		glog.Fatal("Missing configuration data!")
 	}
 	defaultOps := getDefaultOptions(config)
-	masterIP := config.StringVal("MASTER_IP", "127.0.0.1")
 
 	c := &ServicedCli{
 		driver: driver,
@@ -109,7 +108,7 @@ func New(driver api.API, config utils.ConfigReader) *ServicedCli {
 		// Reimplementing GLOG flags :(
 		cli.BoolTFlag{"logtostderr", "log to standard error instead of files"},
 		cli.BoolFlag{"alsologtostderr", "log to standard error as well as files"},
-		cli.StringFlag{"logstashurl", config.StringVal("LOG_ADDRESS", fmt.Sprintf("%s:5042", masterIP)), "logstash url and port"},
+		cli.StringFlag{"logstashurl", defaultOps.LogstashURL, "logstash url and port"},
 		cli.StringFlag{"logstash-es", defaultOps.LogstashES, "host and port for logstash elastic search"},
 		cli.IntFlag{"logstash-max-days", defaultOps.LogstashMaxDays, "days to keep Logstash data"},
 		cli.IntFlag{"logstash-max-size", defaultOps.LogstashMaxSize, "max size of Logstash data to keep in gigabytes"},
@@ -297,7 +296,6 @@ func setLogging(ctx *cli.Context) error {
 			return err
 		}
 	}
-
 	if ctx.IsSet("vmodule") {
 		if err := glog.SetVModule(ctx.GlobalString("vmodule")); err != nil {
 			return err

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -208,10 +208,6 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 		options.FSType = volume.DriverTypeNFS
 	}
 
-	if len(options.StorageArgs) == 0 {
-		options.StorageArgs = getDefaultStorageOptions(options.FSType)
-	}
-
 	if err := validation.IsSubnet16(options.VirtualAddressSubnet); err != nil {
 		fmt.Fprintf(os.Stderr, "error validating virtual-address-subnet: %s\n", err)
 		return fmt.Errorf("error validating virtual-address-subnet: %s", err)

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -198,12 +198,6 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 		DockerLogDriver:      ctx.GlobalString("log-driver"),
 		DockerLogConfigList:  ctx.GlobalStringSlice("log-config"),
 	}
-	if os.Getenv("SERVICED_MASTER") == "1" {
-		options.Master = true
-	}
-	if os.Getenv("SERVICED_AGENT") == "1" {
-		options.Agent = true
-	}
 
 	options.Endpoint = validateEndpoint(options)
 

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -1,0 +1,48 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/codegangsta/cli"
+	"sort"
+)
+
+// Initializer for serviced config subcommands
+func (c *ServicedCli) initConfig() {
+	c.app.Commands = append(c.app.Commands, cli.Command{
+		Name:        "config",
+		Usage:       "Reports on serviced configuration",
+		Description: "serviced config",
+		Action:      c.cmdConfig,
+	})
+}
+
+// serviced config
+func (c *ServicedCli) cmdConfig(ctx *cli.Context) {
+	configValues := c.config.GetConfigValues()
+
+	// build a sorted list of keys
+	keys := []string{}
+	for key, _ := range(configValues) {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range(keys) {
+		entry, _ := configValues[key]
+		fmt.Printf("%s=%s\n", entry.Name, entry.Value)
+	}
+}

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -29,6 +29,7 @@ import (
 	"github.com/zenoss/glog"
 )
 
+
 func getDefaultOptions(config utils.ConfigReader) api.Options {
 	masterIP := config.StringVal("MASTER_IP", "127.0.0.1")
 
@@ -59,6 +60,7 @@ func getDefaultOptions(config utils.ConfigReader) api.Options {
 		VirtualAddressSubnet: config.StringVal("VIRTUAL_ADDRESS_SUBNET", "10.3"),
 		MasterPoolID:         config.StringVal("MASTER_POOLID", "default"),
 		LogstashES:           config.StringVal("LOGSTASH_ES", fmt.Sprintf("%s:9100", masterIP)),
+		LogstashURL:          config.StringVal("LOG_ADDRESS", fmt.Sprintf("%s:5042", masterIP)),
 		LogstashMaxDays:      config.IntVal("LOGSTASH_MAX_DAYS", 14),
 		LogstashMaxSize:      config.IntVal("LOGSTASH_MAX_SIZE", 10),
 		DebugPort:            config.IntVal("DEBUG_PORT", 6006),

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -100,6 +100,8 @@ func getDefaultOptions(config utils.ConfigReader) api.Options {
 		options.BackupsPath = filepath.Join(varpath, "backups")
 	}
 
+	options.StorageArgs = getDefaultStorageOptions(options.FSType, config)
+
 	return options
 }
 

--- a/cli/cmd/storageoptions.go
+++ b/cli/cmd/storageoptions.go
@@ -15,40 +15,39 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
+	"github.com/control-center/serviced/utils"
 	"github.com/control-center/serviced/volume"
 )
 
-func getDefaultStorageOptions(driverType volume.DriverType) []string {
+func getDefaultStorageOptions(driverType volume.DriverType, config utils.ConfigReader) []string {
 	var options []string
 	switch driverType {
 	case volume.DriverTypeRsync:
 	case volume.DriverTypeBtrFS:
 	case volume.DriverTypeDeviceMapper:
-		addStorageOption("SERVICED_DM_THINPOOLDEV", "", func(v string) {
+		addStorageOption(config, "DM_THINPOOLDEV", "", func(v string) {
 			options = append(options, fmt.Sprintf("dm.thinpooldev=%s", v))
 		})
-		addStorageOption("SERVICED_DM_BASESIZE", "100G", func(v string) {
+		addStorageOption(config, "DM_BASESIZE", "100G", func(v string) {
 			options = append(options, fmt.Sprintf("dm.basesize=%s", v))
 		})
-		addStorageOption("SERVICED_DM_LOOPDATASIZE", "", func(v string) {
+		addStorageOption(config, "DM_LOOPDATASIZE", "", func(v string) {
 			options = append(options, fmt.Sprintf("dm.loopdatasize=%s", v))
 		})
-		addStorageOption("SERVICED_DM_LOOPMETADATASIZE", "", func(v string) {
+		addStorageOption(config, "DM_LOOPMETADATASIZE", "", func(v string) {
 			options = append(options, fmt.Sprintf("dm.loopmetadatasize=%s", v))
 		})
-		addStorageOption("SERVICED_DM_ARGS", "", func(v string) {
+		addStorageOption(config, "DM_ARGS", "", func(v string) {
 			options = append(options, strings.Split(v, " ")...)
 		})
 	}
 	return options
 }
 
-func addStorageOption(k, dflt string, parse func(v string)) {
-	v := dflt
-	if v = strings.TrimSpace(os.Getenv(k)); v != "" {
+func addStorageOption(config utils.ConfigReader, key, dflt string, parse func(v string)) {
+	if v := strings.TrimSpace(config.StringVal(key, dflt)); v != "" {
 		parse(v)
 	}
 }

--- a/cli/cmd/storageoptions_test.go
+++ b/cli/cmd/storageoptions_test.go
@@ -1,0 +1,137 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+// Package agent implements a service that runs on a serviced node. It is
+// responsible for ensuring that a particular node is running the correct services
+// and reporting the state and health of those services back to the master
+// serviced.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/control-center/serviced/utils"
+	"reflect"
+	"github.com/control-center/serviced/volume"
+)
+
+func TestAddStorageOptionWithEmptyDefault(t *testing.T) {
+	configReader := utils.TestConfigReader(map[string]string{})
+	var options []string
+
+	addStorageOption(configReader, "EMPTY_DEFAULT", "", func(value string) {
+		options = append(options, value)
+	})
+
+	verifyOptions(t, options, []string{})
+}
+
+func TestAddStorageOptionWithNonEmptyDefault(t *testing.T) {
+	configReader := utils.TestConfigReader(map[string]string{})
+	var options []string
+
+	addStorageOption(configReader, "USE_DEFAULT", "default", func(value string) {
+		options = append(options, value)
+	})
+
+	verifyOptions(t, options, []string{"default"})
+}
+
+func TestAddStorageOptionWithEnvValue(t *testing.T) {
+	configReader := utils.TestConfigReader(map[string]string{"IGNORE_DEFAULT": "ignore"})
+	var options []string
+
+	addStorageOption(configReader, "IGNORE_DEFAULT", "default", func(value string) {
+		options = append(options, value)
+	})
+
+	verifyOptions(t, options, []string{"ignore"})
+}
+
+func TestGetDefaultNFSOptions(t *testing.T) {
+	configReader := utils.TestConfigReader(map[string]string{})
+	options := getDefaultStorageOptions(volume.DriverTypeNFS, configReader)
+	verifyOptions(t, options, []string{})
+}
+
+func TestGetDefaultRSyncOptions(t *testing.T) {
+	configReader := utils.TestConfigReader(map[string]string{})
+	options := getDefaultStorageOptions(volume.DriverTypeRsync, configReader)
+	verifyOptions(t, options, []string{})
+}
+
+func TestGetDefaultBtrfsOptions(t *testing.T) {
+	configReader := utils.TestConfigReader(map[string]string{})
+	options := getDefaultStorageOptions(volume.DriverTypeBtrFS, configReader)
+	verifyOptions(t, options, []string{})
+}
+
+func TestGetDefaultDevicemapperOptions(t *testing.T) {
+	configReader := utils.TestConfigReader(map[string]string{})
+	options := getDefaultStorageOptions(volume.DriverTypeDeviceMapper, configReader)
+	verifyOptions(t, options, []string{"dm.basesize=100G"})
+}
+
+func TestGetDefaultNFSOptionsWithDMOptionsSet(t *testing.T) {
+	configReader := utils.TestConfigReader(map[string]string{"DM_THINPOOLDEV": "foo"})
+	options := getDefaultStorageOptions(volume.DriverTypeNFS, configReader)
+	verifyOptions(t, options, []string{})
+}
+
+func TestGetDefaultRSyncOptionsWithDMOptionsSet(t *testing.T) {
+	configReader := utils.TestConfigReader(map[string]string{"DM_THINPOOLDEV": "foo"})
+	options := getDefaultStorageOptions(volume.DriverTypeRsync, configReader)
+	verifyOptions(t, options, []string{})
+}
+
+func TestGetDefaultBrtrfsOptionsWithDMOptionsSet(t *testing.T) {
+	configReader := utils.TestConfigReader(map[string]string{"DM_THINPOOLDEV": "foo"})
+	options := getDefaultStorageOptions(volume.DriverTypeBtrFS, configReader)
+	verifyOptions(t, options, []string{})
+}
+
+func TestGetDefaultDevicemapperOptionsForThinpoolDevice(t *testing.T) {
+	configReader := utils.TestConfigReader(map[string]string{"DM_THINPOOLDEV": "foo"})
+	options := getDefaultStorageOptions(volume.DriverTypeDeviceMapper, configReader)
+	verifyOptions(t, options, []string{"dm.thinpooldev=foo", "dm.basesize=100G"})
+}
+
+func TestGetDefaultDevicemapperOptionsForAll(t *testing.T) {
+	configReader := utils.TestConfigReader(map[string]string{
+		"DM_THINPOOLDEV": "foo",
+		"DM_BASESIZE": "200G",
+		"DM_LOOPDATASIZE": "10G",
+		"DM_LOOPMETADATASIZE": "1G",
+		"DM_ARGS": "arg1=a,arg2=b,arg3=c",
+	})
+	options := getDefaultStorageOptions(volume.DriverTypeDeviceMapper, configReader)
+	verifyOptions(t, options, []string{
+		"dm.thinpooldev=foo",
+		"dm.basesize=200G",
+		"dm.loopdatasize=10G",
+		"dm.loopmetadatasize=1G",
+		"arg1=a,arg2=b,arg3=c",
+	})
+}
+
+func verifyOptions(t *testing.T, actual []string, expected []string) {
+	if len(actual) !=len(expected) {
+		t.Errorf("length of options incorrect: expected %d got %d; options=%v", len(expected), len(actual), actual)
+	} else if len(expected) > 0 && !reflect.DeepEqual(expected, actual) {
+		t.Errorf("options incorrect: expected %v got %v", expected, actual)
+	}
+
+}

--- a/utils/parser.go
+++ b/utils/parser.go
@@ -33,19 +33,26 @@ func (err ParseError) Error() string {
 	return fmt.Sprintf("could not parse line: %s", err.String)
 }
 
+type ConfigValue struct {
+	Name  string
+	Value string
+}
+
 type ConfigReader interface {
 	StringVal(key, dflt string) string
 	StringSlice(key string, dflt []string) []string
 	IntVal(key string, dflt int) int
 	BoolVal(key string, dflt bool) bool
+	GetConfigValues() map[string]ConfigValue
 }
 
 type EnvironConfigReader struct {
 	prefix string
+	configValues map[string]ConfigValue
 }
 
 func NewEnvironConfigReader(filename, prefix string) (*EnvironConfigReader, error) {
-	r := &EnvironConfigReader{prefix}
+	r := &EnvironConfigReader{prefix, map[string]ConfigValue{}}
 
 	file, err := os.Open(filename)
 	if err != nil {
@@ -61,7 +68,7 @@ func NewEnvironConfigReader(filename, prefix string) (*EnvironConfigReader, erro
 // NewEnvironOnlyConfigReader creates an EnvironConfigReader without parsing
 // a file first.
 func NewEnvironOnlyConfigReader(prefix string) *EnvironConfigReader {
-	return &EnvironConfigReader{prefix}
+	return &EnvironConfigReader{prefix, map[string]ConfigValue{}}
 }
 
 // parse is a really dumb reader parser.  It maps only key values in the form
@@ -89,11 +96,16 @@ func (p *EnvironConfigReader) parse(reader io.Reader) error {
 }
 
 func (p *EnvironConfigReader) StringVal(name string, defaultval string) string {
-	if val := os.Getenv(p.prefix + name); val != "" {
-		return val
-	} else {
-		return defaultval
+	configValue := ConfigValue{
+		Name:  p.getFullValueName(name),
+		Value: defaultval,
 	}
+
+	if val := os.Getenv(configValue.Name); val != "" {
+		configValue.Value = val
+	}
+	p.configValues[name] = configValue
+	return configValue.Value
 }
 
 func (p *EnvironConfigReader) StringSlice(name string, defaultval []string) []string {
@@ -101,6 +113,9 @@ func (p *EnvironConfigReader) StringSlice(name string, defaultval []string) []st
 	if strval != "" {
 		return strings.Split(strval, ",")
 	}
+	entry, _ := p.configValues[name]
+	entry.Value = strings.Join(defaultval,",")
+	p.configValues[name] = entry
 	return defaultval
 }
 
@@ -111,6 +126,9 @@ func (p *EnvironConfigReader) IntVal(name string, defaultval int) int {
 			return val
 		}
 	}
+	entry, _ := p.configValues[name]
+	entry.Value = fmt.Sprintf("%d", defaultval)
+	p.configValues[name] = entry
 	return defaultval
 }
 
@@ -133,7 +151,14 @@ func (p *EnvironConfigReader) BoolVal(name string, defaultval bool) bool {
 			}
 		}
 	}
+	entry, _ := p.configValues[name]
+	entry.Value = fmt.Sprintf("%v", defaultval)
+	p.configValues[name] = entry
 	return defaultval
+}
+
+func (p *EnvironConfigReader) GetConfigValues() map[string]ConfigValue {
+	return p.configValues
 }
 
 func keyvalue(line []byte) error {
@@ -155,4 +180,8 @@ func translate(value string) string {
 		return ""
 	}
 	return string(result)
+}
+
+func (p *EnvironConfigReader) getFullValueName(name string) string {
+	return p.prefix + name
 }

--- a/utils/testutils.go
+++ b/utils/testutils.go
@@ -66,3 +66,7 @@ func (r TestConfigReader) BoolVal(name string, dflt bool) bool {
 	}
 	return dflt
 }
+
+func (p TestConfigReader) GetConfigValues() map[string]ConfigValue {
+	return map[string]ConfigValue{}
+}


### PR DESCRIPTION
Fixes CC-1799.

Here is sample output from running the command in my local zendev environment 
```
# serviced config
SERVICED_ADMIN_GROUP=sudo
SERVICED_AGENT=false
SERVICED_CERT_FILE=
SERVICED_CONTROLLER_BINARY=/home/gjones/src/europa/src/golang/src/github.com/control-center/serviced/serviced-controller
SERVICED_DEBUG_PORT=6006
SERVICED_DM_ARGS=
SERVICED_DM_BASESIZE=100G
SERVICED_DM_LOOPDATASIZE=
SERVICED_DM_LOOPMETADATASIZE=
SERVICED_DM_THINPOOLDEV=
SERVICED_DOCKER_DNS=
SERVICED_DOCKER_LOG_CONFIG=max-file=5,max-size=10m
SERVICED_DOCKER_LOG_DRIVER=json-file
SERVICED_DOCKER_REGISTRY=gjones-dev:5000
SERVICED_ENDPOINT=
SERVICED_ES_STARTUP_TIMEOUT=240
SERVICED_FS_TYPE=devicemapper
SERVICED_HOME=
SERVICED_ISVCS_ENV=
SERVICED_ISVCS_START=
SERVICED_ISVCS_ZOOKEEPER_ID=0
SERVICED_ISVCS_ZOOKEEPER_QUORUM=
SERVICED_KEY_FILE=
SERVICED_LOGSTASH_ES=127.0.0.1:9100
SERVICED_LOGSTASH_MAX_DAYS=14
SERVICED_LOGSTASH_MAX_SIZE=10
SERVICED_LOG_ADDRESS=127.0.0.1:5042
SERVICED_LOG_LEVEL=0
SERVICED_MASTER=false
SERVICED_MASTER_IP=127.0.0.1
SERVICED_MASTER_POOLID=default
SERVICED_MAX_CONTAINER_AGE=86400
SERVICED_MAX_DFS_TIMEOUT=300
SERVICED_MAX_RPC_CLIENTS=3
SERVICED_MUX_PORT=22250
SERVICED_NFS_CLIENT=1
SERVICED_OUTBOUND_IP=
SERVICED_RPC_DIAL_TIMEOUT=30
SERVICED_RPC_PORT=4979
SERVICED_SNAPSHOT_TTL=12
SERVICED_STATIC_IPS=
SERVICED_STATS_PERIOD=10
SERVICED_STATS_PORT=127.0.0.1:8443
SERVICED_UI_PORT=:443
SERVICED_VARPATH=/tmp/serviced-gjones/var
SERVICED_VHOST_ALIASES=
SERVICED_VIRTUAL_ADDRESS_SUBNET=10.3
SERVICED_ZK=
```