### PR TITLE
ZEN-21286: Do not fail, when stop stopped container

### DIFF
--- a/cli/api/shell.go
+++ b/cli/api/shell.go
@@ -238,7 +238,9 @@ func (a *api) RunShell(config ShellConfig) error {
 		// Delete the container
 
 		if err := dockercli.StopContainer(container.ID, 10); err != nil {
-			glog.Fatalf("failed to stop container: %s (%s)", container.ID, err)
+			if _, ok := err.(*dockerclient.ContainerNotRunning); !ok {
+			        glog.Fatalf("failed to stop container: %s (%s)", container.ID, err)
+			}
 		} else if err := dockercli.RemoveContainer(dockerclient.RemoveContainerOptions{ID: container.ID}); err != nil {
 			glog.Fatalf("failed to remove container: %s (%s)", container.ID, err)
 		}

--- a/cli/api/shell.go
+++ b/cli/api/shell.go
@@ -237,11 +237,8 @@ func (a *api) RunShell(config ShellConfig) error {
 	default:
 		// Delete the container
 
-		if err := dockercli.StopContainer(container.ID, 10); err != nil {
-			if _, ok := err.(*dockerclient.ContainerNotRunning); !ok {
-			        glog.Fatalf("failed to stop container: %s (%s)", container.ID, err)
-			}
-		} else if err := dockercli.RemoveContainer(dockerclient.RemoveContainerOptions{ID: container.ID}); err != nil {
+		dockercli.StopContainer(container.ID, 10)
+		if err := dockercli.RemoveContainer(dockerclient.RemoveContainerOptions{ID: container.ID}); err != nil {
 			glog.Fatalf("failed to remove container: %s (%s)", container.ID, err)
 		}
 		return fmt.Errorf("Command returned non-zero exit code %d.  Container not commited.", exitcode)

--- a/container/controller.go
+++ b/container/controller.go
@@ -755,10 +755,9 @@ func (c *Controller) checkPrereqs(prereqsPassed chan bool, rpcDead chan struct{}
 			failedAny := false
 			for _, script := range c.prereqs {
 				glog.Infof("Running prereq command: %s", script.Script)
-				cmd := exec.Command("sh", "-c", script.Script)
-				err := cmd.Run()
+				out, err := exec.Command("sh", "-c", script.Script).CombinedOutput()
 				if err != nil {
-					msg := fmt.Sprintf("Not starting service yet, waiting on prereq: %s", script.Name)
+					msg := fmt.Sprintf("Service %s not starting. Output: %s; error: %s", script.Name, out, err)
 					glog.Warning(msg)
 					fmt.Fprintln(os.Stderr, msg)
 					failedAny = true


### PR DESCRIPTION
It is superficial to fail, when we try to stop docker container which
was already stopped, so let's ignore this situation.

Co-Authored-By: "Summer Mousa <smousa@zenoss.com>"