### PR TITLE
CC-2270: Add more information to log output

### DIFF
--- a/container/controller.go
+++ b/container/controller.go
@@ -742,10 +742,9 @@ func (c *Controller) checkPrereqs(prereqsPassed chan bool, rpcDead chan struct{}
 			failedAny := false
 			for _, script := range c.prereqs {
 				glog.Infof("Running prereq command: %s", script.Script)
-				cmd := exec.Command("sh", "-c", script.Script)
-				err := cmd.Run()
+				out, err := exec.Command("sh", "-c", script.Script).CombinedOutput()
 				if err != nil {
-					msg := fmt.Sprintf("Not starting service yet, waiting on prereq: %s", script.Name)
+					msg := fmt.Sprintf("Service %s not starting. Output: %s; error: %s", script.Name, out, err)
 					glog.Warning(msg)
 					fmt.Fprintln(os.Stderr, msg)
 					failedAny = true


### PR DESCRIPTION
Function checkPrereqs() provides no information about the original error
in logs. This looks like a bad idea, so this commit adds error
status and output to logs to make debug easier.

For example it converts message [0] to [1]

[0] - `Not starting service yet, waiting on prereq: MariaDB connectivity`
[1] - `Service MariaDB connectivity not starting. Output: ERROR 2003
(HY000): Can't connect to MySQL server on '127.0.0.1' (111)
ERROR:zen.zendb:Error executing command: ['mysql', '--batch',
'--skip-column-names', '--user=zenoss', '--host=127.0.0.1',
'--port=3306', '--database=zodb']
; error: exit status 1
`