### PR TITLE
Fixes CC-1700 "Error executing step 3: SNAPSHOT - During RM upgrade"

### DIFF
--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -83,6 +83,8 @@ type API interface {
 	GetSnapshots() ([]dao.SnapshotInfo, error)
 	GetSnapshotsByServiceID(string) ([]dao.SnapshotInfo, error)
 	GetSnapshotByServiceIDAndTag(string, string) (string, error)
+	GetInvalidSnapshots() ([]string, error)
+	GetInvalidSnapshotsByServiceID(string) ([]string, error)
 	AddSnapshot(SnapshotConfig) (string, error)
 	RemoveSnapshot(string) error
 	Rollback(string, bool) error

--- a/cli/api/snapshot_test.go
+++ b/cli/api/snapshot_test.go
@@ -25,6 +25,18 @@ func TestListSnapshots(t *testing.T) {
 func BenchmarkListSnapshots(b *testing.B) {
 }
 
+func TestListInvalidSnapshots(t *testing.T) {
+}
+
+func BenchmarkListInvalidSnapshots(b *testing.B) {
+}
+
+func TestListInvalidSnapshotsByServiceID(t *testing.T) {
+}
+
+func BenchmarkListInvalidSnapshotsByServiceID(b *testing.B) {
+}
+
 func TestListSnapshotsByServiceID(t *testing.T) {
 }
 

--- a/dao/elasticsearch/filesystem.go
+++ b/dao/elasticsearch/filesystem.go
@@ -329,6 +329,27 @@ func (dao *ControlPlaneDao) ListSnapshots(serviceID string, snapshots *[]model.S
 	return
 }
 
+// ListInvalidSnapshots returns a list of all invalid snapshots for a service.  Invalid snapshots are leftover from a previous
+//  serviced version and can be deleted
+func (dao *ControlPlaneDao) ListInvalidSnapshots(serviceID string, snapshotIDs *[]string) (err error) {
+	ctx := datastore.Get()
+
+	// synchronize the dfs
+	dfslocker := dao.facade.DFSLock(ctx)
+	dfslocker.Lock()
+	defer dfslocker.Unlock()
+
+	snapshots, err := dao.facade.ListInvalidSnapshots(ctx, serviceID)
+	if err != nil {
+		return err
+	}
+	*snapshotIDs = make([]string, 0)
+	for _, snapshotID := range snapshots {
+		*snapshotIDs = append(*snapshotIDs, snapshotID)
+	}
+	return
+}
+
 // ResetRegistry prompts all images to be pushed back into the docker registry
 func (dao *ControlPlaneDao) ResetRegistry(_ model.EntityRequest, _ *int) (err error) {
 	err = dao.facade.SyncRegistryImages(datastore.Get(), true)

--- a/dao/interface.go
+++ b/dao/interface.go
@@ -313,6 +313,9 @@ type ControlPlane interface {
 	// ListSnapshots returns a list of all snapshots for a service
 	ListSnapshots(serviceID string, snapshots *[]SnapshotInfo) (err error)
 
+	// ListInvalidSnapshots returns a list of all invalid snapshots for a service
+	ListInvalidSnapshots(serviceID string, snapshotIDs *[]string) (err error)
+
 	// ResetRegistry prompts all images to be re-pushed into the docker
 	// registry.
 	ResetRegistry(_ EntityRequest, _ *int) (err error)

--- a/dao/mocks/ControlPlane.go
+++ b/dao/mocks/ControlPlane.go
@@ -639,6 +639,18 @@ func (_m *ControlPlane) ListSnapshots(serviceID string, snapshots *[]dao.Snapsho
 
 	return r0
 }
+func (_m *ControlPlane) ListInvalidSnapshots(serviceID string, snapshots *[]string) error {
+	ret := _m.Called(serviceID, snapshots)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *[]string) error); ok {
+		r0 = rf(serviceID, snapshots)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
 func (_m *ControlPlane) ResetRegistry(req dao.EntityRequest, unused *int) error {
 	ret := _m.Called(req, unused)
 

--- a/dfs/delete.go
+++ b/dfs/delete.go
@@ -13,22 +13,33 @@
 
 package dfs
 
+import "github.com/control-center/serviced/volume"
 import "github.com/zenoss/glog"
 
 // Delete removes application data of a particular snapshot from the dfs and
 // registry.
 func (dfs *DistributedFilesystem) Delete(snapshotID string) error {
+	validSnapshot := true
 	vol, info, err := dfs.getSnapshotVolumeAndInfo(snapshotID)
-	if err != nil {
+
+	if err == volume.ErrInvalidSnapshot {
+		validSnapshot = false
+	} else if err != nil {
 		return err
 	}
-	if err := dfs.deleteImages(info.TenantID, info.Label); err != nil {
-		return err
+
+	if validSnapshot {
+		if err := dfs.deleteImages(info.TenantID, info.Label); err != nil {
+			return err
+		}
 	}
+
+	// even if it is an invalid snapshot, attempt to remove it
 	if err := vol.RemoveSnapshot(snapshotID); err != nil {
 		glog.Errorf("Could not delete snapshot %s: %s", snapshotID, err)
 		return err
 	}
+
 	return nil
 }
 

--- a/dfs/delete_test.go
+++ b/dfs/delete_test.go
@@ -103,3 +103,11 @@ func (s *DFSTestSuite) TestDelete_Success(c *C) {
 	err := s.dfs.Delete("Base_Snapshot")
 	c.Assert(err, IsNil)
 }
+
+func (s *DFSTestSuite) TestDelete_NoInfo_Success(c *C) {
+	vol := s.getVolumeFromSnapshot("Base_Snapshot", "Base")
+	vol.On("SnapshotInfo", "Base_Snapshot").Return(nil, volume.ErrInvalidSnapshot)
+	vol.On("RemoveSnapshot", "Base_Snapshot").Return(nil)
+	err := s.dfs.Delete("Base_Snapshot")
+	c.Assert(err, IsNil)
+}

--- a/dfs/dfs.go
+++ b/dfs/dfs.go
@@ -49,6 +49,8 @@ type DFS interface {
 	Delete(snapshotID string) error
 	// List lists snapshots for a particular application
 	List(tenantID string) (snapshots []string, err error)
+	// ListInvalid lists any invalid snapshots for a particular application
+	ListInvalid(tenantID string) (snapshots []string, err error)
 	// Info provides detailed info for a particular snapshot
 	Info(snapshotID string) (*SnapshotInfo, error)
 	// Backup saves and exports the current state of the system

--- a/dfs/info.go
+++ b/dfs/info.go
@@ -37,7 +37,7 @@ func (dfs *DistributedFilesystem) getSnapshotVolumeAndInfo(snapshotID string) (v
 	info, err := vol.SnapshotInfo(snapshotID)
 	if err != nil {
 		glog.Errorf("Could not get info for snapshot %s: %s", snapshotID, err)
-		return nil, nil, err
+		return vol, nil, err
 	}
 	return vol, info, nil
 }

--- a/dfs/listinvalid.go
+++ b/dfs/listinvalid.go
@@ -1,0 +1,31 @@
+// Copyright 2015 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dfs
+
+import "github.com/zenoss/glog"
+
+// List returns the list of invalid snapshots for a given tenant.
+func (dfs *DistributedFilesystem) ListInvalid(tenantID string) ([]string, error) {
+	vol, err := dfs.disk.Get(tenantID)
+	if err != nil {
+		glog.Errorf("Could not get volume for tenant %s: %s", tenantID, err)
+		return nil, err
+	}
+	snapshots, err := vol.InvalidSnapshots()
+	if err != nil {
+		glog.Errorf("Could not get invalid snapshots for tenant %s: %s", tenantID, err)
+		return nil, err
+	}
+	return snapshots, nil
+}

--- a/dfs/listinvalid_test.go
+++ b/dfs/listinvalid_test.go
@@ -1,0 +1,47 @@
+// Copyright 2015 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package dfs_test
+
+import (
+	volumemocks "github.com/control-center/serviced/volume/mocks"
+	. "gopkg.in/check.v1"
+)
+
+func (s *DFSTestSuite) TestListInvalid_NoVolume(c *C) {
+	s.disk.On("Get", "tenant").Return(&volumemocks.Volume{}, ErrTestVolumeNotFound)
+	snapshots, err := s.dfs.ListInvalid("tenant")
+	c.Assert(snapshots, IsNil)
+	c.Assert(err, Equals, ErrTestVolumeNotFound)
+}
+
+func (s *DFSTestSuite) TestListInvalid_NoSnapshots(c *C) {
+	vol := &volumemocks.Volume{}
+	s.disk.On("Get", "tenant").Return(vol, nil)
+	vol.On("InvalidSnapshots").Return(nil, ErrTestNoSnapshots)
+	snapshots, err := s.dfs.ListInvalid("tenant")
+	c.Assert(snapshots, IsNil)
+	c.Assert(err, Equals, ErrTestNoSnapshots)
+}
+
+func (s *DFSTestSuite) TestListInvalid_Success(c *C) {
+	vol := &volumemocks.Volume{}
+	s.disk.On("Get", "tenant").Return(vol, nil)
+	snaps := []string{"tenant_label1", "tenant_label2"}
+	vol.On("InvalidSnapshots").Return(snaps, nil)
+	snapshots, err := s.dfs.ListInvalid("tenant")
+	c.Assert(snapshots, DeepEquals, snaps)
+	c.Assert(err, IsNil)
+}

--- a/dfs/mocks/DFS.go
+++ b/dfs/mocks/DFS.go
@@ -159,6 +159,27 @@ func (_m *DFS) List(tenantID string) ([]string, error) {
 
 	return r0, r1
 }
+func (_m *DFS) ListInvalid(tenantID string) ([]string, error) {
+	ret := _m.Called(tenantID)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(string) []string); ok {
+		r0 = rf(tenantID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(tenantID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
 func (_m *DFS) Info(snapshotID string) (*dfs.SnapshotInfo, error) {
 	ret := _m.Called(snapshotID)
 

--- a/facade/dfs.go
+++ b/facade/dfs.go
@@ -197,6 +197,22 @@ func (f *Facade) ListSnapshots(ctx datastore.Context, serviceID string) ([]strin
 	return snapshots, nil
 }
 
+// ListInvalidSnapshots returns a list of strings that describes  any invalid snapshots for the
+// given application.  Invalid snapshots are leftovers from an older version.  They can be deleted.
+func (f *Facade) ListInvalidSnapshots(ctx datastore.Context, serviceID string) ([]string, error) {
+	tenantID, err := f.GetTenantID(ctx, serviceID)
+	if err != nil {
+		glog.Errorf("Could not find tenant for service %s: %s", serviceID, err)
+		return nil, err
+	}
+	snapshots, err := f.dfs.ListInvalid(tenantID)
+	if err != nil {
+		glog.Errorf("Could not list invalid snapshots for tenant %s: %s", tenantID, err)
+		return nil, err
+	}
+	return snapshots, nil
+}
+
 // TagSnapshot adds tags to an existing snapshot
 func (f *Facade) TagSnapshot(snapshotID string, tagName string) error {
 	if err := f.dfs.Tag(snapshotID, tagName); err != nil {

--- a/node/cp_client.go
+++ b/node/cp_client.go
@@ -302,6 +302,10 @@ func (s *ControlClient) ListSnapshots(serviceID string, snapshots *[]dao.Snapsho
 	return s.rpcClient.Call("ControlPlane.ListSnapshots", serviceID, snapshots, 0)
 }
 
+func (s *ControlClient) ListInvalidSnapshots(serviceID string, snapshotIDs *[]string) (err error) {
+	return s.rpcClient.Call("ControlPlane.ListInvalidSnapshots", serviceID, snapshotIDs, 0)
+}
+
 func (s *ControlClient) ResetRegistry(req dao.EntityRequest, unused *int) (err error) {
 	return s.rpcClient.Call("ControlPlane.ResetRegistry", req, unused, 0)
 }

--- a/volume/btrfs/btrfs.go
+++ b/volume/btrfs/btrfs.go
@@ -331,9 +331,18 @@ func (v *BtrfsVolume) snapshotPath(label string) string {
 }
 
 // isSnapshot checks to see if <rawLabel> describes a snapshot (i.e., begins
-// with the tenant prefix)
+// with the tenant prefix and has a valid metadata file
 func (v *BtrfsVolume) isSnapshot(rawLabel string) bool {
-	return strings.HasPrefix(rawLabel, v.getSnapshotPrefix())
+	if strings.HasPrefix(rawLabel, v.getSnapshotPrefix()) {
+		reader, err := v.ReadMetadata(rawLabel, ".SNAPSHOTINFO")
+		if err != nil {
+			glog.Errorf("Could not read metadata for snapshot %s: %s", rawLabel, err)
+			return false
+		}
+		reader.Close()
+		return true
+	}
+	return false
 }
 
 // writeSnapshotInfo writes metadata about a snapshot

--- a/volume/btrfs/btrfs.go
+++ b/volume/btrfs/btrfs.go
@@ -376,6 +376,10 @@ func (v *BtrfsVolume) writeSnapshotInfo(label string, info *volume.SnapshotInfo)
 
 // SnapshotInfo returns the meta info for a snapshot
 func (v *BtrfsVolume) SnapshotInfo(label string) (*volume.SnapshotInfo, error) {
+	if v.isInvalidSnapshot(label) {
+		return nil, volume.ErrInvalidSnapshot
+	}
+
 	reader, err := v.ReadMetadata(label, ".SNAPSHOTINFO")
 	if err != nil {
 		glog.Errorf("Could not get info for snapshot %s: %s", label, err)
@@ -579,6 +583,10 @@ func getEnvMinDuration(envvar string, def, min int32) time.Duration {
 
 // Rollback implements volume.Volume.Rollback
 func (v *BtrfsVolume) Rollback(label string) error {
+	if v.isInvalidSnapshot(label) {
+		return volume.ErrInvalidSnapshot
+	}
+
 	if exists, err := v.snapshotExists(label); err != nil || !exists {
 		if err != nil {
 			return err

--- a/volume/btrfs/btrfs.go
+++ b/volume/btrfs/btrfs.go
@@ -345,6 +345,19 @@ func (v *BtrfsVolume) isSnapshot(rawLabel string) bool {
 	return false
 }
 
+// isInvalidSnapshot checks to see if <rawLabel> describes a snapshot (i.e., begins
+// with the tenant prefix but does NOT have a valid metadata file
+func (v *BtrfsVolume) isInvalidSnapshot(rawLabel string) bool {
+	if strings.HasPrefix(rawLabel, v.getSnapshotPrefix()) {
+		reader, err := v.ReadMetadata(rawLabel, ".SNAPSHOTINFO")
+		if err != nil {
+			return true
+		}
+		reader.Close()
+	}
+	return false
+}
+
 // writeSnapshotInfo writes metadata about a snapshot
 func (v *BtrfsVolume) writeSnapshotInfo(label string, info *volume.SnapshotInfo) error {
 	writer, err := v.WriteMetadata(label, ".SNAPSHOTINFO")
@@ -486,13 +499,53 @@ func (v *BtrfsVolume) Snapshots() ([]string, error) {
 	return labels, nil
 }
 
+// InvalidSnapshots implements volume.Volume.InvalidSnapshots
+func (v *BtrfsVolume) InvalidSnapshots() ([]string, error) {
+	v.Lock()
+	defer v.Unlock()
+
+	glog.V(2).Infof("listing snapshots of volume:%v and v.name:%s ", v.path, v.name)
+	output, err := volume.RunBtrFSCmd(v.sudoer, "subvolume", "list", "-s", v.path)
+	if err != nil {
+		glog.Errorf("Could not list subvolumes of %s: %s", v.path, err)
+		return nil, err
+	}
+
+	var files []os.FileInfo
+	for _, line := range strings.Split(string(output), "\n") {
+		glog.V(0).Infof("line: %s", line)
+		if parts := strings.Split(line, "path"); len(parts) == 2 {
+			rawLabel := strings.TrimSpace(parts[1])
+			rawLabel = strings.TrimPrefix(rawLabel, "volumes/")
+			if v.isInvalidSnapshot(rawLabel) {
+				label := v.prettySnapshotLabel(rawLabel)
+				file, err := os.Stat(filepath.Join(v.Driver().Root(), rawLabel))
+				if err != nil {
+					glog.Errorf("Could not stat snapshot %s: %s", label, err)
+					return nil, err
+				}
+				files = append(files, file)
+				glog.V(2).Infof("found snapshot:%s", label)
+			}
+		}
+	}
+	labels := volume.FileInfoSlice(files).Labels()
+	return labels, nil
+}
+
 // RemoveSnapshot implements volume.Volume.RemoveSnapshot
 func (v *BtrfsVolume) RemoveSnapshot(label string) error {
 	if exists, err := v.snapshotExists(label); err != nil || !exists {
 		if err != nil {
 			return err
-		} else {
-			return volume.ErrSnapshotDoesNotExist
+		} else { //check the invalid snapshot list, we can remove those as well
+			if exists, err = v.invalidSnapshotExists(label); err != nil || !exists {
+				if err != nil {
+					return err
+				} else {
+					return volume.ErrSnapshotDoesNotExist
+				}
+			}
 		}
 	}
 
@@ -629,6 +682,23 @@ func (v *BtrfsVolume) snapshotExists(label string) (exists bool, err error) {
 	plabel := v.prettySnapshotLabel(label)
 	if snapshots, err := v.Snapshots(); err != nil {
 		glog.Errorf("Could not get current snapshot list: %v", err)
+		return false, ErrBtrfsListingSnapshots
+	} else {
+		for _, snapLabel := range snapshots {
+			if rlabel == snapLabel || plabel == snapLabel {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// invalidSnapshotExists queries the list of invalid snapshots for the given label
+func (v *BtrfsVolume) invalidSnapshotExists(label string) (exists bool, err error) {
+	rlabel := v.rawSnapshotLabel(label)
+	plabel := v.prettySnapshotLabel(label)
+	if snapshots, err := v.InvalidSnapshots(); err != nil {
+		glog.Errorf("Could not get current invalid snapshot list: %v", err)
 		return false, ErrBtrfsListingSnapshots
 	} else {
 		for _, snapLabel := range snapshots {

--- a/volume/btrfs/btrfs_test.go
+++ b/volume/btrfs/btrfs_test.go
@@ -16,6 +16,7 @@
 package btrfs_test
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -32,15 +33,6 @@ var (
 	_                  = Suite(&BtrfsSuite{})
 	btrfsArgs []string = []string{}
 )
-
-func arrayContains(array []string, element string) bool {
-	for _, x := range array {
-		if x == element {
-			return true
-		}
-	}
-	return false
-}
 
 // Wire in gocheck
 func Test(t *testing.T) { TestingT(t) }
@@ -71,65 +63,14 @@ func (s *BtrfsSuite) TestBtrfsSnapshots(c *C) {
 }
 
 func (s *BtrfsSuite) TestBtrfsBadSnapshots(c *C) {
-	err := volume.InitDriver("btrfs", s.root, btrfsArgs)
-	c.Assert(err, IsNil)
-	d, err := volume.GetDriver(s.root)
-	c.Assert(err, IsNil)
-	c.Assert(d, NotNil)
+	badsnapshot := func(label string, vol volume.Volume) error {
+		//create an invalid snapshot by snapshotting and then writing garbage to .SnapshotInfo
+		badSnapshotPath := filepath.Join(s.root, fmt.Sprintf("%s_%s", vol.Name(), label))
+		_, err := volume.RunBtrFSCmd(true, "subvolume", "snapshot", "-r", vol.Path(), badSnapshotPath)
+		return err
+	}
 
-	vol, err := d.Create("Base")
-	c.Assert(err, IsNil)
-	c.Assert(vol, NotNil)
-
-	//create a subvolume that looks like a snapshot but is missing .SnapshotInfo
-	badSnapshotPath := filepath.Join(s.root, "Base_badsnapshot")
-	_, err = volume.RunBtrFSCmd(true, "subvolume", "snapshot", "-r", vol.Path(), badSnapshotPath)
-	c.Assert(err, IsNil)
-
-	// Make sure it shows up as an invalid snapshot
-	snaps, err := vol.InvalidSnapshots()
-	c.Assert(err, IsNil)
-	c.Assert(len(snaps), Equals, 1)
-	c.Assert(arrayContains(snaps, "Base_badsnapshot"), Equals, true)
-
-	// Make sure we can still list snapshots, and the bad one isn't included
-	snaps, err = vol.Snapshots()
-	c.Assert(err, IsNil)
-	c.Assert(len(snaps), Equals, 0)
-
-	// Make sure we can still add another snapshot
-	err = vol.Snapshot("Snap", "snapshot-message-0", []string{"SnapTag", "tagA"})
-	c.Assert(err, IsNil)
-
-	// And it shows up in the list
-	snaps, err = vol.Snapshots()
-	c.Assert(err, IsNil)
-	c.Assert(len(snaps), Equals, 1)
-	c.Assert(arrayContains(snaps, "Base_Snap"), Equals, true)
-
-	// Trying to get info on the first snapshot fails
-	snapInfo, err := vol.SnapshotInfo("Base_badsnapshot")
-	c.Assert(err, NotNil)
-	c.Assert(snapInfo, IsNil)
-
-	// Trying to get info on the second snapshot works
-	snapInfo, err = vol.SnapshotInfo("Base_Snap")
-	c.Assert(err, IsNil)
-	c.Assert(snapInfo, NotNil)
-
-	// Trying to roll back to the bad snapshot fails
-	err = vol.Rollback("Base_badsnapshot")
-	c.Assert(err, NotNil)
-
-	// We can delete the bad snapshot
-	err = vol.RemoveSnapshot("Base_badsnapshot")
-	c.Assert(err, IsNil)
-
-	// And it is actually removed
-	snaps, err = vol.InvalidSnapshots()
-	c.Assert(err, IsNil)
-	c.Assert(len(snaps), Equals, 0)
-
+	drivertest.DriverTestBadSnapshot(c, "btrfs", s.root, badsnapshot, btrfsArgs)
 }
 
 func (s *BtrfsSuite) TestBtrfsSnapshotTags(c *C) {

--- a/volume/devicemapper/devicemapper.go
+++ b/volume/devicemapper/devicemapper.go
@@ -291,7 +291,7 @@ func (d *DeviceMapperDriver) Release(volumeName string) error {
 	for _, device := range devices {
 		if device == "" {
 			// this can happen when all previously active devices have been deactivated
-			continue;
+			continue
 		}
 
 		// Perversely, deactivateDevice() will not actually work unless the device is activated.
@@ -691,6 +691,12 @@ func (v *DeviceMapperVolume) GetSnapshotWithTag(tagName string) (*volume.Snapsho
 // Snapshots implements volume.Volume.Snapshots
 func (v *DeviceMapperVolume) Snapshots() ([]string, error) {
 	return v.Metadata.ListSnapshots(), nil
+}
+
+// InvalidSnapshots implements volume.Volume.InvalidSnapshots
+func (v *DeviceMapperVolume) InvalidSnapshots() ([]string, error) {
+	//TODO:  Can we have invalid snapshots in devicemapper?
+	return []string{}, nil
 }
 
 // RemoveSnapshot implements volume.Volume.RemoveSnapshot

--- a/volume/devicemapper/devicemapper.go
+++ b/volume/devicemapper/devicemapper.go
@@ -541,6 +541,9 @@ func (v *DeviceMapperVolume) writeSnapshotInfo(label string, info *volume.Snapsh
 
 // SnapshotInfo returns the meta info for a snapshot
 func (v *DeviceMapperVolume) SnapshotInfo(label string) (*volume.SnapshotInfo, error) {
+	if v.isInvalidSnapshot(label) {
+		return nil, volume.ErrInvalidSnapshot
+	}
 	reader, err := v.ReadMetadata(label, ".SNAPSHOTINFO")
 	if err != nil {
 		glog.Errorf("Could not get info for snapshot %s: %s", label, err)
@@ -690,13 +693,36 @@ func (v *DeviceMapperVolume) GetSnapshotWithTag(tagName string) (*volume.Snapsho
 
 // Snapshots implements volume.Volume.Snapshots
 func (v *DeviceMapperVolume) Snapshots() ([]string, error) {
-	return v.Metadata.ListSnapshots(), nil
+	var result []string
+	for _, s := range v.Metadata.ListSnapshots() {
+		if !v.isInvalidSnapshot(s) {
+			result = append(result, s)
+		}
+	}
+
+	return result, nil
 }
 
 // InvalidSnapshots implements volume.Volume.InvalidSnapshots
 func (v *DeviceMapperVolume) InvalidSnapshots() ([]string, error) {
-	//TODO:  Can we have invalid snapshots in devicemapper?
-	return []string{}, nil
+	var result []string
+	for _, s := range v.Metadata.ListSnapshots() {
+		if v.isInvalidSnapshot(s) {
+			result = append(result, s)
+		}
+	}
+
+	return result, nil
+}
+
+// isInvalidSnapshot checks to see if the snapshot is missing a .SNAPSHOTINFO file
+func (v *DeviceMapperVolume) isInvalidSnapshot(rawLabel string) bool {
+	reader, err := v.ReadMetadata(rawLabel, ".SNAPSHOTINFO")
+	if err != nil {
+		return true
+	}
+	reader.Close()
+	return false
 }
 
 // RemoveSnapshot implements volume.Volume.RemoveSnapshot
@@ -735,6 +761,10 @@ func (v *DeviceMapperVolume) RemoveSnapshot(label string) error {
 
 // Rollback implements volume.Volume.Rollback
 func (v *DeviceMapperVolume) Rollback(label string) error {
+	if v.isInvalidSnapshot(label) {
+		return volume.ErrInvalidSnapshot
+	}
+
 	glog.V(2).Infof("Rollback() (%s) START", v.name)
 	defer glog.V(2).Infof("Rollback() (%s) END", v.name)
 	if !v.snapshotExists(label) {

--- a/volume/drivertest/drivertest.go
+++ b/volume/drivertest/drivertest.go
@@ -421,6 +421,68 @@ func DriverTestSnapshotContainerMounts(c *C, drivername volume.DriverType, root 
 	c.Assert(status, Equals, 1)
 }
 
+func DriverTestBadSnapshot(c *C, drivername volume.DriverType, root string, badsnapshot func(string, volume.Volume) error, args []string) {
+	driver := newDriver(c, drivername, root, args)
+	defer cleanup(c, driver)
+
+	vol := createBase(c, driver, "Base")
+	verifyBase(c, driver, vol)
+
+	//create the bad snapshot
+	err := badsnapshot("badsnapshot", vol)
+	c.Assert(err, IsNil)
+
+	// Make sure we can still list snapshots, and the bad one isn't included
+	snaps, err := vol.Snapshots()
+	c.Assert(err, IsNil)
+	c.Assert(len(snaps), Equals, 0)
+
+	// Make sure it shows up as an invalid snapshot
+	snaps, err = vol.InvalidSnapshots()
+	c.Assert(err, IsNil)
+	c.Assert(len(snaps), Equals, 1)
+	c.Assert(arrayContains(snaps, "Base_badsnapshot"), Equals, true)
+
+	// Make sure we can still add another snapshot
+	err = vol.Snapshot("Snap", "snapshot-message-0", []string{"SnapTag", "tagA"})
+	c.Assert(err, IsNil)
+
+	// And it shows up in the list
+	snaps, err = vol.Snapshots()
+	c.Assert(err, IsNil)
+	c.Assert(len(snaps), Equals, 1)
+	c.Assert(arrayContains(snaps, "Base_Snap"), Equals, true)
+
+	// Trying to get info on the first snapshot fails
+	snapInfo, err := vol.SnapshotInfo("Base_badsnapshot")
+	c.Assert(err, ErrorMatches, volume.ErrInvalidSnapshot.Error())
+	c.Assert(snapInfo, IsNil)
+
+	// Trying to get info on the second snapshot works
+	snapInfo, err = vol.SnapshotInfo("Base_Snap")
+	c.Assert(err, IsNil)
+	c.Assert(snapInfo, NotNil)
+
+	// Trying to roll back to the bad snapshot fails
+	err = vol.Rollback("Base_badsnapshot")
+	c.Assert(err, ErrorMatches, volume.ErrInvalidSnapshot.Error())
+
+	// We can delete the bad snapshot
+	err = vol.RemoveSnapshot("Base_badsnapshot")
+	c.Assert(err, IsNil)
+
+	// And it is actually removed
+	snaps, err = vol.InvalidSnapshots()
+	c.Assert(err, IsNil)
+	c.Assert(len(snaps), Equals, 0)
+
+	// Add the bad snapshot back and make sure we can remove the volume
+	err = badsnapshot("badsnapshot", vol)
+	c.Assert(err, IsNil)
+	c.Assert(driver.Remove("Base"), IsNil)
+	c.Assert(driver.Exists("Base"), Equals, false)
+}
+
 func DriverTestResize(c *C, drivername volume.DriverType, root string, args []string) {
 	switch drivername {
 	case volume.DriverTypeDeviceMapper:

--- a/volume/mocks/Volume.go
+++ b/volume/mocks/Volume.go
@@ -137,6 +137,27 @@ func (_m *Volume) Snapshots() ([]string, error) {
 
 	return r0, r1
 }
+func (_m *Volume) InvalidSnapshots() ([]string, error) {
+	ret := _m.Called()
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
 func (_m *Volume) RemoveSnapshot(label string) error {
 	ret := _m.Called(label)
 

--- a/volume/nfs/nfs.go
+++ b/volume/nfs/nfs.go
@@ -222,6 +222,12 @@ func (v *NFSVolume) Snapshots() ([]string, error) {
 	return nil, ErrNotSupported
 }
 
+// InvalidSnapshots implements volume.Volume.InvalidSnapshots
+func (v *NFSVolume) InvalidSnapshots() ([]string, error) {
+	//TODO:  Can we have invalid snapshots in devicemapper?
+	return nil, ErrNotSupported
+}
+
 // RemoveSnapshot implements volume.Volume.RemoveSnapshot
 func (v *NFSVolume) RemoveSnapshot(label string) error {
 	return ErrNotSupported

--- a/volume/rsync/rsync.go
+++ b/volume/rsync/rsync.go
@@ -536,6 +536,12 @@ func (v *RsyncVolume) Snapshots() ([]string, error) {
 	return v.getSnapshotList()
 }
 
+// InvalidSnapshots implements volume.Volume.InvalidSnapshots
+func (v *RsyncVolume) InvalidSnapshots() ([]string, error) {
+	//TODO:  Can we have invalid snapshots in rsync?
+	return []string{}, nil
+}
+
 // getSnapshotWithTag internal impl without locking calls
 func (v *RsyncVolume) getSnapshotWithTag(tagName string, lock bool) (*volume.SnapshotInfo, error) {
 	// Get all snapshots on the volume

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -148,6 +148,8 @@ type Volume interface {
 	ReadMetadata(label, name string) (io.ReadCloser, error)
 	// Snapshots lists all snapshots of this volume
 	Snapshots() ([]string, error)
+	// InvalidSnapshots lists all snapshots of this volume that are no longer valid (e.g. created with an incompatible version of serviced)
+	InvalidSnapshots() ([]string, error)
 	// RemoveSnapshot removes the snapshot with name <label>
 	RemoveSnapshot(label string) error
 	// Rollback replaces the current state of the volume with that snapshotted

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -85,6 +85,7 @@ var (
 	ErrBadMount                = errors.New("bad mount path")
 	ErrInsufficientPermissions = errors.New("insufficient permissions to run command")
 	ErrTagAlreadyExists        = errors.New("a snapshot with the given tag already exists")
+	ErrInvalidSnapshot         = errors.New("invalid snapshot")
 )
 
 func init() {


### PR DESCRIPTION
This problem is caused when an old snapshot from CC 1.0.x exists on the system after an upgrade to CC 1.1.x or higher.  This PR ignores those snapshots for normal operations, and also adds an ability to query for and delete invalid snapshots through the API.  "serviced snapshot list" will now include (and mark) invalid snapshots so that the user may delete them.