### PR TITLE
Fixed snapshot CLI unit tests

### DIFF
--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 
 	"github.com/control-center/serviced/cli/api"
 	"github.com/control-center/serviced/utils"
@@ -60,6 +61,13 @@ func pipeStderr(f func(...string), args ...string) {
 	w.Close()
 	os.Stderr = stderr
 	fmt.Printf("%s", <-output)
+}
+
+// Trims leading and trailing whitespace from each line of a multi-line string
+func TrimLines(valueToTrim string) string {
+	re := regexp.MustCompile(valueToTrim)
+	trimmedOutput := re.ReplaceAllString("\\s*\\n\\s*", "\n")
+	return trimmedOutput
 }
 
 var DefaultAPITest = APITest{}

--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -960,49 +960,33 @@ func ExampleServicedCLI_CmdServiceListSnapshots() {
 
 }
 
-func ExampleServicedCLI_CmdServiceListSnapshots_ShowTagsShort(t *testing.T) {
-	expected, err := DefaultServiceAPITest.GetSnapshotsByServiceID("test-service-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var actual []dao.SnapshotInfo
+func TestServicedCLI_CmdServiceListSnapshots_ShowTagsShort(t *testing.T) {
 	output := pipe(InitServiceAPITest, "serviced", "service", "list-snapshots", "test-service-1", "-t")
-	if err := json.Unmarshal(output, &actual); err != nil {
-		t.Fatalf("error unmarshaling resource: %s", err)
-	}
+	expected :=
+		"Snapshot                                 Description        Tags" +
+			"\ntest-service-1-snapshot-1                description 1      tag-1" +
+			"\ntest-service-1-snapshot-2                description 2      tag-2,tag-3" +
+			"\ntest-service-1-invalid [DEPRECATED]"
 
-	// Did you remember to update SnapshotInfo.Equals?
-	if len(actual) != len(expected) {
-		t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
-	}
-	for i, _ := range actual {
-		if !actual[i].Equals(&expected[i]) {
-			t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
-		}
+	outStr := fmt.Sprintf("%s", output)
+
+	if TrimLines(expected) != TrimLines(outStr) {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s", outStr, expected)
 	}
 }
 
-func ExampleServicedCLI_CmdServiceListSnapshots_ShowTagsLong(t *testing.T) {
-	expected, err := DefaultServiceAPITest.GetSnapshotsByServiceID("test-service-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var actual []dao.SnapshotInfo
+func TestServicedCLI_CmdServiceListSnapshots_ShowTagsLong(t *testing.T) {
 	output := pipe(InitServiceAPITest, "serviced", "service", "list-snapshots", "test-service-1", "--show-tags")
-	if err := json.Unmarshal(output, &actual); err != nil {
-		t.Fatalf("error unmarshaling resource: %s", err)
-	}
+	expected :=
+		"Snapshot                                 Description        Tags" +
+			"\ntest-service-1-snapshot-1                description 1      tag-1" +
+			"\ntest-service-1-snapshot-2                description 2      tag-2,tag-3" +
+			"\ntest-service-1-invalid [DEPRECATED]"
 
-	// Did you remember to update SnapshotInfo.Equals?
-	if len(actual) != len(expected) {
-		t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
-	}
-	for i, _ := range actual {
-		if !actual[i].Equals(&expected[i]) {
-			t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
-		}
+	outStr := fmt.Sprintf("%s", output)
+
+	if TrimLines(expected) != TrimLines(outStr) {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s", outStr, expected)
 	}
 }
 

--- a/cli/cmd/snapshot_test.go
+++ b/cli/cmd/snapshot_test.go
@@ -16,7 +16,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -193,49 +192,37 @@ func ExampleServicedCLI_CmdSnapshotList() {
 
 }
 
-func ExampleServicedCLI_CmdSnapshotList_ShowTagsShort(t *testing.T) {
-	expected, err := DefaultSnapshotAPITest.GetSnapshots()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var actual []dao.SnapshotInfo
+func TestServicedCLI_CmdSnapshotList_ShowTagsShort(t *testing.T) {
 	output := pipe(InitSnapshotAPITest, "serviced", "snapshot", "list", "-t")
-	if err := json.Unmarshal(output, &actual); err != nil {
-		t.Fatalf("error unmarshaling resource: %s", err)
-	}
+	expected :=
+		"Snapshot                                 Description        Tags" +
+			"\ntest-service-1-snapshot-1                description 1      tag-1" +
+			"\ntest-service-1-snapshot-2                description 2      tag-2,tag-3" +
+			"\ntest-service-1-invalid [DEPRECATED]" +
+			"\ntest-service-2-snapshot-1" +
+			"\ntest-service-2-invalid [DEPRECATED]"
 
-	// Did you remember to update SnapshotInfo.Equals?
-	if len(actual) != len(expected) {
-		t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
-	}
-	for i, _ := range actual {
-		if !actual[i].Equals(&expected[i]) {
-			t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
-		}
+	outStr := fmt.Sprintf("%s", output)
+
+	if TrimLines(expected) != TrimLines(outStr) {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s", outStr, expected)
 	}
 }
 
-func ExampleServicedCLI_CmdSnapshotList_ShowTagsLong(t *testing.T) {
-	expected, err := DefaultSnapshotAPITest.GetSnapshots()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var actual []dao.SnapshotInfo
+func TestServicedCLI_CmdSnapshotList_ShowTagsLong(t *testing.T) {
 	output := pipe(InitSnapshotAPITest, "serviced", "snapshot", "list", "--show-tags")
-	if err := json.Unmarshal(output, &actual); err != nil {
-		t.Fatalf("error unmarshaling resource: %s", err)
-	}
+	expected :=
+		"Snapshot                                 Description        Tags" +
+			"\ntest-service-1-snapshot-1                description 1      tag-1" +
+			"\ntest-service-1-snapshot-2                description 2      tag-2,tag-3" +
+			"\ntest-service-1-invalid [DEPRECATED]" +
+			"\ntest-service-2-snapshot-1" +
+			"\ntest-service-2-invalid [DEPRECATED]"
 
-	// Did you remember to update SnapshotInfo.Equals?
-	if len(actual) != len(expected) {
-		t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
-	}
-	for i, _ := range actual {
-		if !actual[i].Equals(&expected[i]) {
-			t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
-		}
+	outStr := fmt.Sprintf("%s", output)
+
+	if TrimLines(expected) != TrimLines(outStr) {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s", outStr, expected)
 	}
 }
 
@@ -248,49 +235,34 @@ func ExampleServicedCLI_CmdSnapshotList_byServiceID() {
 	// test-service-1-invalid [DEPRECATED]
 }
 
-func ExampleServicedCLI_CmdSnapshotList_byServiceID_ShowTagsShort(t *testing.T) {
-	expected, err := DefaultSnapshotAPITest.GetSnapshotsByServiceID("test-service-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var actual []dao.SnapshotInfo
+func TestServicedCLI_CmdSnapshotList_byServiceID_ShowTagsShort(t *testing.T) {
 	output := pipe(InitSnapshotAPITest, "serviced", "snapshot", "list", "test-service-1", "-t")
-	if err := json.Unmarshal(output, &actual); err != nil {
-		t.Fatalf("error unmarshaling resource: %s", err)
+	expected :=
+		"Snapshot                                 Description        Tags" +
+			"\ntest-service-1-snapshot-1                description 1      tag-1" +
+			"\ntest-service-1-snapshot-2                description 2      tag-2,tag-3" +
+			"\ntest-service-1-invalid [DEPRECATED]"
+
+	outStr := fmt.Sprintf("%s", output)
+
+	if TrimLines(expected) != TrimLines(outStr) {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s", outStr, expected)
 	}
 
-	// Did you remember to update SnapshotInfo.Equals?
-	if len(actual) != len(expected) {
-		t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
-	}
-	for i, _ := range actual {
-		if !actual[i].Equals(&expected[i]) {
-			t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
-		}
-	}
 }
 
-func ExampleServicedCLI_CmdSnapshotList_byServiceID_ShowTagsLong(t *testing.T) {
-	expected, err := DefaultSnapshotAPITest.GetSnapshotsByServiceID("test-service-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var actual []dao.SnapshotInfo
+func TestervicedCLI_CmdSnapshotList_byServiceID_ShowTagsLong(t *testing.T) {
 	output := pipe(InitSnapshotAPITest, "serviced", "snapshot", "list", "test-service-1", "--show-tags")
-	if err := json.Unmarshal(output, &actual); err != nil {
-		t.Fatalf("error unmarshaling resource: %s", err)
-	}
+	expected :=
+		"Snapshot                                 Description        Tags" +
+			"\ntest-service-1-snapshot-1                description 1      tag-1" +
+			"\ntest-service-1-snapshot-2                description 2      tag-2,tag-3" +
+			"\ntest-service-1-invalid [DEPRECATED]"
 
-	// Did you remember to update SnapshotInfo.Equals?
-	if len(actual) != len(expected) {
-		t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
-	}
-	for i, _ := range actual {
-		if !actual[i].Equals(&expected[i]) {
-			t.Fatalf("\ngot:\n%+v\nwant:\n%+v", actual, expected)
-		}
+	outStr := fmt.Sprintf("%s", output)
+
+	if TrimLines(expected) != TrimLines(outStr) {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s", outStr, expected)
 	}
 }
 


### PR DESCRIPTION
Trim whitespace from each line of the expected and actual outputs before comparing.