### PR TITLE
Fixes CC-1826 "Public Endpoint: Starting a public endpoint with a previously used and deleted port fails to start"

### DIFF
--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -363,6 +363,7 @@ func (s *Service) AddVirtualHost(application, vhostName string) error {
 
 // AddPort Add a port for given service, this method avoids duplicate ports
 func (s *Service) AddPort(application string, portAddr string) error {
+	portAddr = ScrubPortString(portAddr)
 	if s.Endpoints != nil {
 		//find the matching endpoint
 		for i := range s.Endpoints {

--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -17,9 +17,9 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
-	"regexp"
 
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain"
@@ -352,7 +352,7 @@ func (s *Service) AddVirtualHost(application, vhostName string) error {
 						vhosts = append(vhosts, vhost)
 					}
 				}
-				ep.VHostList = append(vhosts, servicedefinition.VHost{Name: _vhostName})
+				ep.VHostList = append(vhosts, servicedefinition.VHost{Name: _vhostName, Enabled: true})
 				return nil
 			}
 		}
@@ -375,7 +375,7 @@ func (s *Service) AddPort(application string, portAddr string) error {
 						ports = append(ports, port)
 					}
 				}
-				ep.PortList = append(ports, servicedefinition.Port{PortAddr: portAddr})
+				ep.PortList = append(ports, servicedefinition.Port{PortAddr: portAddr, Enabled: true})
 				return nil
 			}
 		}
@@ -449,12 +449,12 @@ func (s *Service) EnablePort(application string, portAddr string, enable bool) e
 }
 
 // Make best effort to make a port address valid
-func ScrubPortString(port string) string{
+func ScrubPortString(port string) string {
 	// remove possible protocol at string beginning
 	scrubbed := protocolPrefixRegex.ReplaceAllString(port, "")
 
 	matched, _ := regexp.MatchString("^[0-9]+$", scrubbed)
-	if  matched {
+	if matched {
 		scrubbed = fmt.Sprintf(":%s", scrubbed)
 	}
 

--- a/web/publicendpointresource.go
+++ b/web/publicendpointresource.go
@@ -106,6 +106,9 @@ func restAddVirtualHost(w *rest.ResponseWriter, r *rest.Request, client *node.Co
 		return
 	}
 
+	// Restart the service
+	client.RestartService(dao.ScheduleServiceRequest{ServiceID: service.ID}, &unused)
+
 	restSuccess(w)
 }
 
@@ -132,6 +135,9 @@ func restRemoveVirtualHost(w *rest.ResponseWriter, r *rest.Request, client *node
 		restServerError(w, err)
 		return
 	}
+
+	// Restart the service
+	client.RestartService(dao.ScheduleServiceRequest{ServiceID: service.ID}, &unused)
 
 	restSuccess(w)
 }
@@ -358,6 +364,10 @@ func restAddPort(w *rest.ResponseWriter, r *rest.Request, client *node.ControlCl
 	}
 
 	glog.V(2).Infof("Service (%s) updated", service.Name)
+
+	// Restart the service
+	client.RestartService(dao.ScheduleServiceRequest{ServiceID: service.ID}, &unused)
+
 	restSuccess(w)
 }
 
@@ -391,7 +401,10 @@ func restRemovePort(w *rest.ResponseWriter, r *rest.Request, client *node.Contro
 		return
 	}
 
-	glog.V(2).Info("Successfully added port %s to service (%s)", port, service.Name)
+	glog.V(2).Info("Successfully removed port %s from service (%s)", port, service.Name)
+
+	// Restart the service
+	client.RestartService(dao.ScheduleServiceRequest{ServiceID: service.ID}, &unused)
 
 	restSuccess(w)
 }

--- a/web/ui/src/Services/ServiceDetailsController.js
+++ b/web/ui/src/Services/ServiceDetailsController.js
@@ -118,7 +118,7 @@
                         }
                     },{
                         role: "ok",
-                        label: "add_public_endpoint",
+                        label: "add_public_endpoint_confirm",
                         action: function(){
                             var newPublicEndpoint = $scope.publicEndpoints.add;
 
@@ -129,7 +129,7 @@
                                 $scope.addPublicEndpoint(newPublicEndpoint)
                                     .success(function(data, status){
                                         $notification.create("Added public endpoint", "The " + newPublicEndpoint.app_ep.Application +
-                                           " service must be restarted before the new endpoint will be available").success();
+                                           " service is being restarted.").success();
                                         this.close();
                                     }.bind(this))
                                     .error(function(data, status){
@@ -499,7 +499,8 @@
 
             $modalService.create({
                 template: $translate.instant("remove_public_endpoint") + ": <strong>"+
-                          (publicEndpoint.Name ? publicEndpoint.Name : "port " + publicEndpoint.PortAddr) + "</strong>",
+                          (publicEndpoint.Name ? publicEndpoint.Name : "port " + publicEndpoint.PortAddr) + "</strong><br><br>"+
+                          "The <strong>" + publicEndpoint.Application + "</strong> service will be restarted.",
                 model: $scope,
                 title: "remove_public_endpoint",
                 actions: [
@@ -507,7 +508,7 @@
                         role: "cancel"
                     },{
                         role: "ok",
-                        label: "remove_public_endpoint",
+                        label: "remove_public_endpoint_confirm",
                         classes: "btn-danger",
                         action: function(){
                             if(publicEndpoint.type === "vhost"){

--- a/web/ui/src/Services/ServiceDetailsController.js
+++ b/web/ui/src/Services/ServiceDetailsController.js
@@ -500,7 +500,8 @@
             $modalService.create({
                 template: $translate.instant("remove_public_endpoint") + ": <strong>"+
                           (publicEndpoint.Name ? publicEndpoint.Name : "port " + publicEndpoint.PortAddr) + "</strong><br><br>"+
-                          "The <strong>" + publicEndpoint.Application + "</strong> service will be restarted.",
+                          "After the public endpoint is removed, the <strong>" + publicEndpoint.Application +
+                          "</strong> service will automatically be restarted.",
                 model: $scope,
                 title: "remove_public_endpoint",
                 actions: [

--- a/web/ui/src/Services/add-public-endpoint.html
+++ b/web/ui/src/Services/add-public-endpoint.html
@@ -29,6 +29,6 @@
 <div ng-show="publicEndpoints.add.type === 'port'">
     <div class="form-group">
         <label for="add_public_endpoint_port" translate>public_endpoint_portnumber</label>
-        <input type="text" id="add_public_endpoint_confirm" ng-model="publicEndpoints.add.port" class="form-control" placeholder="ip:port"></input>
+        <input type="text" id="add_public_endpoint_port" ng-model="publicEndpoints.add.port" class="form-control" placeholder="ip:port"></input>
     </div>
 </div>

--- a/web/ui/src/Services/add-public-endpoint.html
+++ b/web/ui/src/Services/add-public-endpoint.html
@@ -32,3 +32,7 @@
         <input type="text" id="add_public_endpoint_port" ng-model="publicEndpoints.add.port" class="form-control" placeholder="ip:port"></input>
     </div>
 </div>
+
+<div class="warningMessage">
+    After the public endpoint is added, the selected service will automatically be restarted.
+</div>

--- a/web/ui/src/Services/add-public-endpoint.html
+++ b/web/ui/src/Services/add-public-endpoint.html
@@ -29,6 +29,6 @@
 <div ng-show="publicEndpoints.add.type === 'port'">
     <div class="form-group">
         <label for="add_public_endpoint_port" translate>public_endpoint_portnumber</label>
-        <input type="text" id="add_public_endpoint_port" ng-model="publicEndpoints.add.port" class="form-control" placeholder="ip:port"></input>
+        <input type="text" id="add_public_endpoint_confirm" ng-model="publicEndpoints.add.port" class="form-control" placeholder="ip:port"></input>
     </div>
 </div>

--- a/web/ui/static/i18n/en_US.json
+++ b/web/ui/static/i18n/en_US.json
@@ -370,11 +370,13 @@
     "endpoint": "Endpoint",
     "public_endpoint_type": "Type",
     "add_public_endpoint": "Add Public Endpoint",
+    "add_public_endpoint_confirm": "Add and Restart Service",
     "public_endpoint_portnumber": "Port Address",
     "public_endpoint_hostname": "VHost Hostname",
     "public_endpoint_vhost": "VHost",
     "public_endpoint_port": "Port",
     "remove_public_endpoint": "Remove Public Endpoint",
+    "remove_public_endpoint_confirm": "Remove and Restart Service",
     "public_endpoint_url": "URL",
     "port_number_invalid": "Invalid port number",
 


### PR DESCRIPTION
Users are now forced to restart the affected service when adding or deleting a public endpoint.  New language in the dialog and on the button makes it clear that the action will restart the service.

Additionally, new public endpoints are enabled by default when they are created.