### PR TITLE
Cleanup loopback devices created for smoke and acceptance tests

### DIFF
--- a/acceptance.sh
+++ b/acceptance.sh
@@ -13,7 +13,10 @@
 #######################################################
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
-SERVICED=${DIR}/serviced
+SERVICED=$(which serviced)
+SERVICED_STORAGE=$(which serviced-storage)
+# Use a directory unique to this test to avoid collisions with other kinds of tests
+SERVICED_VARPATH=/tmp/serviced-acceptance/var
 IP=$(ip addr show docker0 | grep -w inet | awk {'print $2'} | cut -d/ -f1)
 HOSTNAME=$(hostname)
 
@@ -60,8 +63,11 @@ add_to_etc_hosts() {
 }
 
 start_serviced() {
+    # Note that we have to set SERVICED_MASTER instead of using the -master command line arg
+    #   all of to force the proper subdirectories to be created under SERVICED_VARPATH
     echo "Starting serviced..."
-    sudo GOPATH=${GOPATH} PATH=${PATH} SERVICED_NOREGISTRY="true" ${SERVICED} -master -agent server &
+    mkdir -p ${SERVICED_VARPATH}
+    sudo GOPATH=${GOPATH} PATH=${PATH} SERVICED_VARPATH=${SERVICED_VARPATH} SERVICED_MASTER=1 ${SERVICED} -agent server &
 
     echo "Waiting 180 seconds for serviced to become the leader..."
     retry 180 wget --no-check-certificate http://${HOSTNAME}:443 -O- &>/dev/null
@@ -96,9 +102,17 @@ cleanup() {
     docker ps -a -q | xargs --no-run-if-empty docker rm -fv
 
     # Unmount all of the devicemapper volumes so that the mount points can be deleted
-    echo "Cleaning up /tmp/serviced-root/var ..."
-    sudo umount -f /tmp/serviced-root/var/volumes/* 2>/dev/null
-    sudo rm -rf /tmp/serviced-root/var
+    echo "Unmounting ${SERVICED_VARPATH}/volumes/* ..."
+    sudo umount -f ${SERVICED_VARPATH}/volumes/* 2>/dev/null
+
+    # Disable the DM device so that the space for the loopback device is really freed
+    # when we remove SERVICED_VARPATH/volumes
+    echo "Cleaning up serviced storage ..."
+    sudo ${SERVICED_STORAGE} -v disable ${SERVICED_VARPATH}/volumes
+
+    echo "Removing up ${SERVICED_VARPATH} ..."
+    sudo rm -rf ${SERVICED_VARPATH}
+
 }
 trap cleanup EXIT
 

--- a/acceptance/ui/features/hosts.feature
+++ b/acceptance/ui/features/hosts.feature
@@ -43,6 +43,7 @@ Feature: Host Management
       And the Host and port field should be flagged as invalid
       And I should see an empty Hosts page
 
+  @tgj
   Scenario: Add an invalid host with an invalid port
     Given there are no hosts added
     When I am on the hosts page
@@ -52,7 +53,7 @@ Feature: Host Management
       And I fill in the RAM Commitment field with "table://hosts/defaultHost/commitment"
       And I click "Add Host"
     Then I should see "Error"
-      And I should see "Bad Request: dial tcp 172.17.42.1:9999"
+      And I should see "Bad Request: dial tcp4 172.17.42.1:9999"
       And I should see an empty Hosts page
 
   Scenario: Add an invalid host with an invalid Resource Pool field

--- a/acceptance/ui/features/hosts.feature
+++ b/acceptance/ui/features/hosts.feature
@@ -43,7 +43,6 @@ Feature: Host Management
       And the Host and port field should be flagged as invalid
       And I should see an empty Hosts page
 
-  @tgj
   Scenario: Add an invalid host with an invalid port
     Given there are no hosts added
     When I am on the hosts page

--- a/acceptance/ui/features/support/env.rb
+++ b/acceptance/ui/features/support/env.rb
@@ -59,6 +59,7 @@ if Capybara.app_host.empty?
     Capybara.app_host = "http://localhost"
 end
 printf "Using app_host=%s\n", Capybara.app_host
+printf "Using userid=%s\n", ENV["APPLICATION_USERID"]
 
 #
 # NOTE: Cucumber does not provide an API to override the output directory


### PR DESCRIPTION
The smoke test and acceptance tests were removing $SERVICED_VARPATH/volumes, which deleted the loop back files, but because the actual devicemapper devices were not disabled, the space for those loop back files was not released. This would periodically cause some of the Jenkins build slaves to run out of disk.  Rebooting the boxes was a brute force workaround.

These changes use the `serviced-storage` tool to disable the devicemapper device so that space is really freed when the test is complete.