### PR TITLE
Fixes CC-1853 "Serviced dies after trying to remove a deploy."

### DIFF
--- a/volume/devicemapper/devicemapper.go
+++ b/volume/devicemapper/devicemapper.go
@@ -333,7 +333,10 @@ func (d *DeviceMapperDriver) Release(volumeName string) error {
 		}
 
 		glog.V(1).Infof("Deactivating device (%s)", device)
-		if err := d.deactivateDevice(device); err != nil {
+		d.DeviceSet.Lock()
+		err := d.deactivateDevice(device)
+		d.DeviceSet.Unlock()
+		if err != nil {
 			glog.Errorf("Error removing device %q for volume %s: %s", device, volumeName, err)
 			return err
 		}


### PR DESCRIPTION
Internal method "deactivateDevice" assumes a lock has been acquired prior to calling it.  There was a place in the public Release method that called it without acquiring a lock first.  In certain cases, this would result in a panic.