### PR TITLE
Fixes occasional failures in Cucumber tests

### DIFF
--- a/acceptance/ui/features/pools.feature
+++ b/acceptance/ui/features/pools.feature
@@ -37,7 +37,6 @@ Feature: Resource Pool Management
   Scenario: Add a resource pool without specifying a name
     When I am on the resource pool page
       And I click the add Resource Pool button
-      And I fill in the Resource Pool name field with ""
       And I fill in the Description field with "none"
       And I click "Add Resource Pool"
     Then I should see "Adding pool failed"


### PR DESCRIPTION
cherry-pick pull-request #2196
(committed by "zendev port cherry-pick")

Fixes the occasional failure of the cucumber test case "Add a resource pool without specifying a name".
This [build](http://jenkins.zendev.org/job/serviced-1.1.x-merge-acceptance/149/) contains an example of such an error.  

The error is a case where, for some unknown reason, the test manages to create a new pool with the name "none" when in fact the test case should fail because the pool name is not specified, but the description is specified as just "none".  I don't think we ever isolated the root cause the but the changes in #2196 seem to have resolved the issue on develop
