### PR TITLE
Fixes CC-1877 "Public Endpoints with ports appears to open only 1 port"

### DIFF
--- a/web/portservers.go
+++ b/web/portservers.go
@@ -72,7 +72,7 @@ func (sc *ServiceConfig) CreatePublicPortServer(publicEndpointKey service.Public
 	listener, err := net.Listen("tcp", port)
 	stopChans := []chan bool{}
 	if err != nil {
-		glog.Errorf("Could not setup TCP listener - %s", err)
+		glog.Errorf("Could not setup TCP listener for port %s for public endpoint %s - %s", port, publicEndpointKey, err)
 		disablePort(publicEndpointKey)
 		return err
 	}

--- a/web/portservers.go
+++ b/web/portservers.go
@@ -131,6 +131,9 @@ func (sc *ServiceConfig) CreatePublicPortServer(publicEndpointKey service.Public
 			c <- true
 		}
 
+		// disablePort modifies allports, so we need a lock
+		allportsLock.Lock()
+		defer allportsLock.Unlock()
 		disablePort(publicEndpointKey)
 		listener.Close()
 		glog.Infof("Closed port %s", port)
@@ -149,6 +152,9 @@ func (sc *ServiceConfig) syncAllPublicPorts(shutdown <-chan interface{}) error {
 
 	cancelChan := make(chan interface{})
 	syncPorts := func(conn client.Connection, parentPath string, childIDs ...string) {
+		allportsLock.Lock()
+		defer allportsLock.Unlock()
+
 		glog.V(1).Infof("syncPorts STARTING for parentPath:%s childIDs:%v", parentPath, childIDs)
 
 		// start all servers that have been not started and enabled
@@ -180,9 +186,6 @@ func (sc *ServiceConfig) syncAllPublicPorts(shutdown <-chan interface{}) error {
 			}
 		}
 
-		//lock for as short a time as possible
-		allportsLock.Lock()
-		defer allportsLock.Unlock()
 		allports = newPorts
 		glog.V(1).Infof("allports: %+v", allports)
 	}

--- a/web/publicendpointresource.go
+++ b/web/publicendpointresource.go
@@ -350,6 +350,14 @@ func restAddPort(w *rest.ResponseWriter, r *rest.Request, client *node.ControlCl
 		}
 	}
 
+	// Check to make sure the port is available.  Don't allow adding a port if it's already being used.
+	err = checkPort("tcp", fmt.Sprintf("%s", scrubbedPort))
+	if err != nil {
+		glog.Error(err)
+		restServerError(w, err)
+		return
+	}
+
 	err = service.AddPort(request.Application, scrubbedPort)
 	if err != nil {
 		glog.Errorf("Error adding port to service (%s): %v", service.Name, err)


### PR DESCRIPTION
We now prevent the user from creating a port if the port is already in use.  Additionally, a deadlock has been removed that occurred if a newly-created port failed to start.