### PR TITLE
bump isvcs version

### DIFF
--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -24,7 +24,7 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO    = "zenoss/serviced-isvcs"
-	IMAGE_TAG     = "v39"
+	IMAGE_TAG     = "v40"
 	ZK_IMAGE_REPO = "zenoss/isvcs-zookeeper"
 	ZK_IMAGE_TAG  = "v3"
 )


### PR DESCRIPTION
Bump isvcs to use new query service, fixing https://jira.zenoss.com/browse/CC-CC-1905