### PR TITLE
CC-1919: disabled core limit on containers

### DIFF
--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -269,6 +269,14 @@ func (svc *IService) create() (*docker.Container, error) {
 	hostConfig := dockerclient.HostConfig{}
 	hostConfig.LogConfig.Type = svc.dockerLogDriver
 	hostConfig.LogConfig.Config = svc.dockerLogConfig
+	// CC-1848: set core limit to 0
+	hostConfig.Ulimits = []dockerclient.ULimit{
+		{
+			Name: "core",
+			Soft: 0,
+			Hard: 0,
+		},
+	}
 
 	glog.Infof("hostConfig.LogConfig.Type=%s", hostConfig.LogConfig.Type)
 	glog.Infof("hostConfig.LogConfig.Config=%v", hostConfig.LogConfig.Config)

--- a/node/agent.go
+++ b/node/agent.go
@@ -747,6 +747,15 @@ func configureContainer(a *HostAgent, client dao.ControlPlane,
 	hcfg.LogConfig.Type = a.dockerLogDriver
 	hcfg.LogConfig.Config = a.dockerLogConfig
 
+	// CC-1848: set core ulimit to 0
+	hcfg.Ulimits = []dockerclient.ULimit{
+		{
+			Name: "core",
+			Soft: 0,
+			Hard: 0,
+		},
+	}
+
 	return cfg, hcfg, nil
 }
 


### PR DESCRIPTION
Before:
```bash
$ docker exec serviced-isvcs_zookeeper bash -c "ulimit -c"
unlimited
```

After
```bash
$ docker exec serviced-isvcs_zookeeper bash -c "ulimit -c"
0
```
