### PR TITLE
Fixes ZEN-21972 - Connection refused flare msg in Advanced->Control Center tab

### DIFF
--- a/node/agent.go
+++ b/node/agent.go
@@ -702,6 +702,7 @@ func configureContainer(a *HostAgent, client dao.ControlPlane,
 		fmt.Sprintf("SERVICED_RPC_PORT=%s", a.rpcport),
 		fmt.Sprintf("SERVICED_LOG_ADDRESS=%s", a.logstashURL),
 		fmt.Sprintf("SERVICED_UI_PORT=%s", strings.Split(a.uiport, ":")[1]),
+		fmt.Sprintf("SERVICED_MASTER_IP=%s", strings.Split(a.master, ":")[0]),
 		fmt.Sprintf("TZ=%s", os.Getenv("TZ")),
 		// XXX: Hopefully temp fix for CC-1384 & CC-1631 (docker/docker issue 14203).
 		fmt.Sprintf("DOCKER_14203_FIX='%s'", fix),


### PR DESCRIPTION
Added environment variable for SERVICED_MASTER_IP to containers.  This is currently only used here:

https://github.com/zenoss/zenoss-prodbin/pull/1496