### PR TITLE
briefly delay initial isvc healthchecks

### DIFF
--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -73,6 +73,7 @@ const DEFAULT_HEALTHCHECK_NAME = "running"
 const DEFAULT_HEALTHCHECK_INTERVAL = time.Duration(30) * time.Second
 const DEFAULT_HEALTHCHECK_TIMEOUT = time.Duration(10) * time.Second
 
+const STARTUP_HEALTHCHECK_DELAY = time.Duration(5) * time.Second
 const WAIT_FOR_INITIAL_HEALTHCHECK = time.Duration(2) * time.Minute
 
 type actionrequest struct {
@@ -676,6 +677,9 @@ func (svc *IService) startupHealthcheck() <-chan error {
 				err <- nil
 				return
 			}
+
+			// Wait just a brief moment to give processes time to really start (particularly zookeeper)
+			time.Sleep(STARTUP_HEALTHCHECK_DELAY)
 
 			startCheck := time.Now()
 			for {


### PR DESCRIPTION
Give the ZK process in the container a couple of seconds to start so that the underlying ZK client lib in serviced doesn't spam the CC log

Fixes [CC-1701](https://jira.zenoss.com/browse/CC-1701)
