### PR TITLE
CC-1949: Add ALLOW_LOOP_BACK to config file

### DIFF
--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -77,6 +77,10 @@
 # Set the driver type on the master for the distributed file system (rsync/btrfs/devicemapper)
 # SERVICED_FS_TYPE=devicemapper
 
+# Set to true to allow use of loopback files (instead of thin pools) with devicemapper for serviced storage.
+# NOTE: This is not recommended for production use.
+# SERVICED_ALLOW_LOOP_BACK=false
+
 # Set the aliases for this host (use in vhost muxing)
 # SERVICED_VHOST_ALIASES=foobar.com,example.com
 


### PR DESCRIPTION
Every configurable option should have an entry in /etc/default/serviced
showing its usage.