### PR TITLE
Don't flood CC log with error messages checking for isvc startup

### DIFF
--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -84,7 +84,7 @@ type actionrequest struct {
 type HealthCheckFunction func(halt <-chan struct{}) error
 
 type healthCheckDefinition struct {
-	healthCheck HealthCheckFunction
+	HealthCheck HealthCheckFunction
 	Interval    time.Duration // The interval at which to execute the script.
 	Timeout     time.Duration // A timeout in which to complete the health check.
 }
@@ -709,7 +709,7 @@ func (svc *IService) runCheckOrTimeout(checkDefinition healthCheckDefinition) er
 	halt := make(chan struct{}, 1)
 
 	go func() {
-		finished <- checkDefinition.healthCheck(halt)
+		finished <- checkDefinition.HealthCheck(halt)
 	}()
 
 	var result error

--- a/isvcs/docker_registry.go
+++ b/isvcs/docker_registry.go
@@ -36,7 +36,7 @@ func initDockerRegistry() {
 	var err error
 
 	defaultHealthCheck := healthCheckDefinition{
-		healthCheck: registryHealthCheck,
+		HealthCheck: registryHealthCheck,
 		Interval:    DEFAULT_HEALTHCHECK_INTERVAL,
 		Timeout:     DEFAULT_HEALTHCHECK_TIMEOUT,
 	}

--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -36,6 +36,13 @@ const (
 	ESGreen
 )
 
+const (
+	DEFAULT_ES_STARTUP_TIMEOUT_SECONDS = 240 //default startup timeout in seconds (4 minutes)
+	MIN_ES_STARTUP_TIMEOUT_SECONDS = 30      //minimum startup timeout in seconds
+	ES_LOGSTASH_PORT = 9100
+	ES_SERVICED_PORT = 9200
+)
+
 type ESHealth int
 
 func GetHealth(health string) ESHealth {
@@ -62,9 +69,6 @@ func (health ESHealth) String() string {
 	return "unknown"
 }
 
-const DEFAULT_ES_STARTUP_TIMEOUT_SECONDS = 240 //default startup timeout in seconds (4 minutes)
-const MIN_ES_STARTUP_TIMEOUT_SECONDS = 30      //minimum startup timeout in seconds
-
 var elasticsearch_logstash *IService
 var elasticsearch_serviced *IService
 
@@ -75,7 +79,7 @@ func initElasticSearch() {
 	serviceName = "elasticsearch-serviced"
 
 	defaultHealthCheck := healthCheckDefinition{
-		healthCheck: esHealthCheck(9200, ESYellow),
+		HealthCheck: esHealthCheck(ES_SERVICED_PORT, ESYellow),
 		Interval:    DEFAULT_HEALTHCHECK_INTERVAL,
 		Timeout:     DEFAULT_HEALTHCHECK_TIMEOUT,
 	}
@@ -85,7 +89,7 @@ func initElasticSearch() {
 	elasticsearch_servicedPortBinding := portBinding{
 		HostIp:         "127.0.0.1",
 		HostIpOverride: "SERVICED_ISVC_ELASTICSEARCH_SERVICED_PORT_9200_HOSTIP",
-		HostPort:       9200,
+		HostPort:       ES_SERVICED_PORT,
 	}
 
 	elasticsearch_serviced, err = NewIService(
@@ -115,14 +119,14 @@ func initElasticSearch() {
 
 	serviceName = "elasticsearch-logstash"
 	logStashHealthCheck := defaultHealthCheck
-	logStashHealthCheck.healthCheck = esHealthCheck(9100, ESYellow)
+	logStashHealthCheck.HealthCheck = esHealthCheck(ES_LOGSTASH_PORT, ESYellow)
 	healthChecks = map[string]healthCheckDefinition{
 		DEFAULT_HEALTHCHECK_NAME: logStashHealthCheck,
 	}
 	elasticsearch_logstashPortBinding := portBinding{
 		HostIp:         "127.0.0.1",
 		HostIpOverride: "SERVICED_ISVC_ELASTICSEARCH_LOGSTASH_PORT_9100_HOSTIP",
-		HostPort:       9100,
+		HostPort:       ES_LOGSTASH_PORT,
 	}
 
 	elasticsearch_logstash, err = NewIService(

--- a/isvcs/es.go
+++ b/isvcs/es.go
@@ -231,11 +231,11 @@ func getESHealth(url string) <-chan esres {
 // before it is healthy
 func esHasStartedHealthCheck(port int) HealthCheckFunction {
 	return func(cancel <-chan struct{}) error {
-		httpClient := http.DefaultClient
-		httpClient.Timeout = time.Duration(2) * time.Second	// use a relatively short timeout
 		url := fmt.Sprintf("http://localhost:%d", port)
-		resp, err := httpClient.Get(url)
 
+		httpClient := *http.DefaultClient
+		httpClient.Timeout = time.Duration(2) * time.Second	// use a relatively short timeout
+		resp, err := httpClient.Get(url)
 		if err != nil {
 			glog.V(2).Infof("Startup healthcheck failed: %s", err)
 		} else if resp != nil {

--- a/isvcs/zk.go
+++ b/isvcs/zk.go
@@ -14,14 +14,22 @@
 package isvcs
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/control-center/go-zookeeper/zk"
 	"github.com/zenoss/glog"
-
-	"time"
 )
 
 var Zookeeper IServiceDefinition
 var zookeeper *IService
+
+const (
+	ZK_CLIENT_PORT = 2181
+	ZK_EXHIBITOR_PORT = 12181
+	ZK_PEER_PORT = 2888
+	ZK_LEADER_PORT = 3888
+)
 
 func initZK() {
 	var err error
@@ -36,32 +44,32 @@ func initZK() {
 			{
 				HostIp:         "0.0.0.0",
 				HostIpOverride: "",
-				HostPort:       2181,
+				HostPort:       ZK_CLIENT_PORT,
 			},
 			// exhibitor port
 			{
 				HostIp:         "127.0.0.1",
 				HostIpOverride: "SERVICED_ISVC_ZOOKEEPER_PORT_12181_HOSTIP",
-				HostPort:       12181,
+				HostPort:       ZK_EXHIBITOR_PORT,
 			},
 			// peer port
 			{
 				HostIp:         "0.0.0.0",
 				HostIpOverride: "",
-				HostPort:       2888,
+				HostPort:       ZK_PEER_PORT,
 			},
 			// leader port
 			{
 				HostIp:         "0.0.0.0",
 				HostIpOverride: "",
-				HostPort:       3888,
+				HostPort:       ZK_LEADER_PORT,
 			},
 		},
 		Volumes: map[string]string{"data": "/var/zookeeper"},
 	}
 
 	defaultHealthCheck := healthCheckDefinition{
-		healthCheck: zkHealthCheck,
+		HealthCheck: zkHealthCheck,
 		Interval:    DEFAULT_HEALTHCHECK_INTERVAL,
 		Timeout:     DEFAULT_HEALTHCHECK_TIMEOUT,
 	}
@@ -80,7 +88,7 @@ func initZK() {
 func zkHealthCheck(halt <-chan struct{}) error {
 	for {
 		// establish a zookeeper connection
-		conn, ec, err := zk.Connect([]string{"127.0.0.1:2181"}, time.Second*10)
+		conn, ec, err := zk.Connect([]string{fmt.Sprintf("127.0.0.1:%d", ZK_CLIENT_PORT)}, time.Second*10)
 		defer func() {
 			if conn != nil {
 				conn.Close()

--- a/isvcs/zk.go
+++ b/isvcs/zk.go
@@ -133,11 +133,11 @@ func zkHealthCheck(halt <-chan struct{}) error {
 
 // CC-1701 - Returns nil if zookeeper has started.  Note that any HTTP response implies ZK has started.
 func zkHasStartedHealthCheck(halt <-chan struct{}) error {
-	httpClient := http.DefaultClient
-	httpClient.Timeout = time.Duration(2) * time.Second	// use a relatively short timeout
 	url := fmt.Sprintf("http://localhost:%d/exhibitor/v1/ui/index.html", ZK_EXHIBITOR_PORT)
-	resp, err := httpClient.Get(url)
 
+	httpClient := *http.DefaultClient
+	httpClient.Timeout = time.Duration(2) * time.Second	// use a relatively short timeout
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		glog.V(2).Infof("Startup healthcheck failed: %s", err)
 	} else if resp != nil {


### PR DESCRIPTION
Fixes [CC-1701](https://jira.zenoss.com/browse/CC-1701)

In the case of Zookeeper, the `read tcp 127.0.0.1:2181: connection reset by peer` messages seen at startup are the result of a hard-loop in the ZK client library for GO which assumes ZK should always be available.   The workaround is to introduce a new startup healthcheck which CC invokes first just to see if the isvc process has started and is accepting connections. Those healthchecks fail silently if the server is not responding. Once the server is responding, then the regular healthchecks start running to verify that the server is in fact healthy.

Note this PR supercedes an earlier approach in #2515 