### PR TITLE
allow ':' char when validating image ids

### DIFF
--- a/domain/registry/validation.go
+++ b/domain/registry/validation.go
@@ -15,7 +15,7 @@ package registry
 
 import "github.com/control-center/serviced/validation"
 
-const excludeChars = " \t\r\n\v\f/:?"
+const excludeChars = " \t\r\n\v\f/?"
 
 func (image *Image) ValidEntity() error {
 	violations := validation.NewValidationError()


### PR DESCRIPTION
docker 1.10 now prepends "sha256:" to all of the image ids.  Before we were testing against ":" chars.  This should be allowed.

docker.FindImage can still search for image ids with or without sha256: and will return the same image

we don't ever search directly by image ID, we only search by the full image tag. TENANT/IMAGENAME:TAG