### PR TITLE
fix for go1.6: metrics caching to use pointers to locks

### DIFF
--- a/metrics/cache.go
+++ b/metrics/cache.go
@@ -34,6 +34,8 @@ type MemoryUsageCache struct {
 
 // getkeylock returns a lock specifically for this key
 func (c *MemoryUsageCache) getkeylock(key string) *sync.Mutex {
+	c.Lock()
+	defer c.Unlock()
 	if _, ok := c.Locks[key]; !ok {
 		c.Locks[key] = &sync.Mutex{}
 	}

--- a/metrics/cache.go
+++ b/metrics/cache.go
@@ -58,8 +58,8 @@ func (c *MemoryUsageCache) Get(key string, getter MemoryUsageQuery) (val []Memor
 		// Start the expiration
 		go func() {
 			<-c.Clock.After(c.TTL)
-			c.Lock()
-			defer c.Unlock()
+			l.Lock()
+			defer l.Unlock()
 			delete(c.Usages, key)
 		}()
 	}

--- a/metrics/cache.go
+++ b/metrics/cache.go
@@ -26,7 +26,7 @@ type MemoryUsageQuery func() ([]MemoryUsageStats, error)
 // MemoryUsageCache is a simple TTL cache for MemoryUsageStats objects
 type MemoryUsageCache struct {
 	sync.Mutex
-	Locks  map[string]sync.Mutex
+	Locks  map[string]*sync.Mutex
 	Usages map[string][]MemoryUsageStats
 	TTL    time.Duration
 	Clock  utils.Clock
@@ -34,17 +34,10 @@ type MemoryUsageCache struct {
 
 // getkeylock returns a lock specifically for this key
 func (c *MemoryUsageCache) getkeylock(key string) *sync.Mutex {
-	var (
-		lock sync.Mutex
-		ok   bool
-	)
-	c.Lock()
-	defer c.Unlock()
-	if lock, ok = c.Locks[key]; !ok {
-		lock = sync.Mutex{}
-		c.Locks[key] = lock
+	if _, ok := c.Locks[key]; !ok {
+		c.Locks[key] = &sync.Mutex{}
 	}
-	return &lock
+	return c.Locks[key]
 }
 
 // Get retrieves a cached value if one exists; otherwise it calls getter, caches the result, and returns it
@@ -73,7 +66,7 @@ func (c *MemoryUsageCache) Get(key string, getter MemoryUsageQuery) (val []Memor
 
 func NewMemoryUsageCache(ttl time.Duration) *MemoryUsageCache {
 	return &MemoryUsageCache{
-		Locks:  make(map[string]sync.Mutex),
+		Locks:  make(map[string]*sync.Mutex),
 		Usages: make(map[string][]MemoryUsageStats),
 		TTL:    ttl,
 		Clock:  utils.RealClock,

--- a/metrics/cache_test.go
+++ b/metrics/cache_test.go
@@ -30,7 +30,7 @@ func TestCache(t *testing.T) {
 	clock := utils.NewTestClock()
 
 	cache := MemoryUsageCache{
-		Locks:  make(map[string]sync.Mutex),
+		Locks:  make(map[string]*sync.Mutex),
 		Usages: make(map[string][]MemoryUsageStats),
 		TTL:    time.Minute,
 		Clock:  clock,
@@ -87,6 +87,7 @@ func TestCache(t *testing.T) {
 
 	// Force expiration
 	clock.Fire()
+	clock.Fire() // this test clock shares one channel among all of its callers
 
 	// Cache should no longer have a value for key, try with different getter
 	x, err = cache.Get("first", getter2)


### PR DESCRIPTION
minor fix to set up for go1.6 upgrade