### PR TITLE
fix for go1.6: Need to reverse sort the ciphers

### DIFF
--- a/utils/tls.go
+++ b/utils/tls.go
@@ -16,8 +16,15 @@ package utils
 import (
 	"crypto/tls"
 	"fmt"
+	"sort"
 	"strings"
 )
+
+type ciphers []uint16
+
+func (c ciphers) Len() int           { return len(c) }
+func (c ciphers) Less(i, j int) bool { return c[i] < c[j] }
+func (c ciphers) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 
 // DefaultTLSMinVersion minimum TLS version supported
 const DefaultTLSMinVersion = "VersionTLS10"
@@ -57,9 +64,9 @@ func GetDefaultCiphers() []string {
 }
 
 // SetCiphers that can be used
-func SetCiphers(ciphers []string) error {
-	newCiphers := make([]uint16, 0, len(ciphers))
-	for _, cipherName := range ciphers {
+func SetCiphers(cipherNames []string) error {
+	newCiphers := make([]uint16, 0, len(cipherNames))
+	for _, cipherName := range cipherNames {
 		upperCipher := strings.ToUpper(strings.TrimSpace(cipherName))
 		var cipher uint16
 		var ok bool
@@ -70,6 +77,8 @@ func SetCiphers(ciphers []string) error {
 
 	}
 	tlsCiphers = newCiphers
+	// reverse sort the ciphers, since the uint value determines the order
+	sort.Sort(sort.Reverse(ciphers(tlsCiphers)))
 	return nil
 }
 


### PR DESCRIPTION
Lesser cipher values must go after ciphers of greater value, otherwise you get something like:
TLSConfig.CipherSuites index 3 contains an HTTP/2-approved cipher suite (0xc02b)