### PR TITLE
CC-1974: NFSClient disabled does not break serviced on a remote agent

### DIFF
--- a/cli/api/options.go
+++ b/cli/api/options.go
@@ -257,20 +257,11 @@ func GetDefaultOptions(config utils.ConfigReader) Options {
 	defaultControllerBinary := filepath.Join(dir, "serviced-controller")
 	options.ControllerBinary = config.StringVal("CONTROLLER_BINARY", defaultControllerBinary)
 
-	// Set the volumePath to /tmp if running serviced as just an agent
 	homepath := config.StringVal("HOME", "")
 	varpath := config.StringVal("VARPATH", getDefaultVarPath(homepath))
-	if options.Master {
-		options.IsvcsPath = config.StringVal("ISVCS_PATH", filepath.Join(varpath, "isvcs"))
-		options.VolumesPath = config.StringVal("VOLUMES_PATH", filepath.Join(varpath, "volumes"))
-		options.BackupsPath = config.StringVal("BACKUPS_PATH", filepath.Join(varpath, "backups"))
-	} else {
-		tmpvarpath := getDefaultVarPath("")
-		options.IsvcsPath = filepath.Join(varpath, "isvcs")
-		options.VolumesPath = filepath.Join(tmpvarpath, "volumes")
-		options.BackupsPath = filepath.Join(varpath, "backups")
-	}
-
+	options.IsvcsPath = config.StringVal("ISVCS_PATH", filepath.Join(varpath, "isvcs"))
+	options.VolumesPath = config.StringVal("VOLUMES_PATH", filepath.Join(varpath, "volumes"))
+	options.BackupsPath = config.StringVal("BACKUPS_PATH", filepath.Join(varpath, "backups"))
 	options.StorageArgs = getDefaultStorageOptions(options.FSType, config)
 
 	return options

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/control-center/serviced/servicedversion"
 	"github.com/control-center/serviced/utils"
 	"github.com/control-center/serviced/volume"
+	"github.com/control-center/serviced/volume/nfs"
 	"github.com/zenoss/glog"
 )
 
@@ -258,6 +259,9 @@ func getRuntimeOptions(ctx *cli.Context) api.Options {
 		options.FSType = volume.DriverType(fstype)
 	} else {
 		options.FSType = volume.DriverTypeNFS
+		if options.NFSClient == "0" {
+			options.StorageArgs = append(options.StorageArgs, nfs.NetworkDisabled)
+		}
 	}
 
 	options.Endpoint = getEndpoint(options)

--- a/volume/nfs/nfs_test.go
+++ b/volume/nfs/nfs_test.go
@@ -42,7 +42,7 @@ func (s *NFSSuite) TestNFSDriver(c *C) {
 	)
 
 	root = c.MkDir()
-	d, err := Init(root, []string{"nfs_test"})
+	d, err := Init(root, []string{NetworkDisabled})
 	c.Assert(err, IsNil)
 	driver = d.(*NFSDriver)
 


### PR DESCRIPTION
TODO: rename NFSDriver to something that doesn't say nfs
* Added an option on the storage driver to disable networking
* Use the option for when the nfs client is disabled
* Make the varpath configurable for isvcs and volumes on the agent