### PR TITLE
Send verbose flag on into test cases

### DIFF
--- a/serviced-tests.py
+++ b/serviced-tests.py
@@ -218,6 +218,9 @@ def main(options):
     if usep1:
         cmd.extend(['-p', '1'])
 
+    if options.verbose:
+        cmd.append("-v")
+
     passthru = options.arguments
     if passthru and passthru[0] == "--":
         passthru = passthru[1:]


### PR DESCRIPTION
serviced-tests.py has a verbose flag, which it keeps to itself and does
not pass on to 'go test'. This PR makes it share that flag.