### PR TITLE
New TestableMutex class

### DIFF
--- a/commons/sync/testablemutex.go
+++ b/commons/sync/testablemutex.go
@@ -1,0 +1,75 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package rpcutils
+
+package sync
+
+// A TestableLocker represents an object that can be locked and unlocked.
+type TestableLocker interface {
+	Lock(string)
+	TestAndLock(name string) (bool, string)
+	Unlock()
+}
+
+// A TestableMutex is a mutual exclusion lock that provides an additional method for
+// requesting a lock without blocking.
+type TestableMutex struct {
+	ch     chan struct{}
+	holder string
+}
+
+// NewTestableMutex initializes a new TestableMutex. Its initial state is unlocked.
+func NewTestableMutex() *TestableMutex {
+	m := &TestableMutex{
+		ch: make(chan struct{}, 1),
+	}
+	m.ch <- struct{}{} // Unlocked
+	return m
+}
+
+// Lock locks the TestableMutex.
+// If the mutex is already in use, the calling goroutine
+// blocks until the mutex is available.
+func (m *TestableMutex) Lock(name string) {
+	select {
+	case <-m.ch:
+		m.holder = name
+	}
+}
+
+// TestAndLock attempts to lock the TestableMutex but returns immediately.
+// The bool returned indicates whether the lock was obtained.
+// The string is the name of the current holder of the lock.
+func (m *TestableMutex) TestAndLock(name string) (gotLock bool, holder string) {
+	select {
+	case <-m.ch:
+		m.holder = name
+		return true, m.holder
+	default:
+		return false, m.holder
+	}
+}
+
+// Unlock unlocks the TestableMutex.
+// It is a run-time error if the mutex is not locked on entry to Unlock.
+//
+// A locked TestableMutex is not associated with a particular goroutine.
+// It is allowed for one goroutine to lock a TestableMutex and then
+// arrange for another goroutine to unlock it.
+func (m *TestableMutex) Unlock() {
+	m.holder = ""
+	select {
+	case m.ch <- struct{}{}:
+	default:
+		panic("unlock of unlocked testable mutex")
+	}
+}

--- a/commons/sync/testablemutex_test.go
+++ b/commons/sync/testablemutex_test.go
@@ -1,0 +1,336 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package rpcutils
+
+// +build unit
+
+package sync
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+type TestAndLockResponse struct {
+	result bool
+	owner  string
+}
+
+func TestTestableMutex_Lock(t *testing.T) {
+	name1 := "lock 1"
+	name2 := "lock 2"
+
+	locker := NewTestableMutex()
+
+	// lock the mutex
+	lock1Response := make(chan struct{})
+	go func() {
+		locker.Lock(name1)
+		lock1Response <- struct{}{}
+	}()
+	select {
+	case <-lock1Response:
+		t.Logf("(ok) lock 1 acquired")
+	case <-time.After(250 * time.Millisecond):
+		t.Fatalf("timeout while acquiring lock 1")
+	}
+
+	// test that a second lock blocks
+	lock2Response := make(chan struct{})
+	go func() {
+		locker.Lock(name2)
+		t.Logf("--- got lock 2, sending event")
+		lock2Response <- struct{}{}
+	}()
+	select {
+	case <-lock2Response:
+		t.Fatalf("lock 2 did not block as expected")
+	case <-time.After(time.Second):
+		t.Logf("(ok) lock 2 is blocking")
+	}
+
+	// unlock
+	unlock1Response := make(chan struct{})
+	go func() {
+		t.Logf("--- unlocking 1")
+		locker.Unlock()
+		unlock1Response <- struct{}{}
+	}()
+	select {
+	case <-unlock1Response:
+		t.Logf("(ok) unlocked 1")
+	case <-time.After(time.Second):
+		t.Fatalf("timeout while unlocking 1")
+	}
+
+	// test that the second lock unblocked
+	select {
+	case <-lock2Response:
+		t.Logf("(ok) lock 2 unblocked")
+	case <-time.After(time.Second * 3):
+		t.Errorf("timeout waiting for lock 2 to unblock")
+	}
+
+	// check if the second lock can unlock
+	unlock2Response := make(chan struct{})
+	go func() {
+		locker.Unlock()
+		unlock2Response <- struct{}{}
+	}()
+	select {
+	case <-unlock2Response:
+		t.Logf("(ok) unlocked 2")
+	case <-time.After(time.Second):
+		t.Fatalf("timeout while unlocking 2")
+	}
+}
+
+func TestTestableMutex_TestAndLock(t *testing.T) {
+	name1 := "lock 1"
+	name2 := "lock 2"
+	name3 := "lock 3"
+
+	locker := NewTestableMutex()
+
+	// lock the mutex
+	lock1Response := make(chan struct{})
+	go func() {
+		locker.Lock(name1)
+		lock1Response <- struct{}{}
+	}()
+	select {
+	case <-lock1Response:
+		t.Logf("(ok) lock 1 acquired")
+	case <-time.After(time.Second):
+		t.Fatalf("timeout while acquiring lock 1")
+	}
+
+	// test that a try-lock fails and does not block
+	lock2Response := make(chan TestAndLockResponse)
+	go func() {
+		ok, owner := locker.TestAndLock(name2)
+		lock2Response <- TestAndLockResponse{
+			result: ok,
+			owner:  owner,
+		}
+	}()
+	select {
+	case response2 := <-lock2Response:
+		if response2.result {
+			t.Errorf("lock 2 succeeded")
+		}
+		if response2.owner != name1 {
+			t.Errorf("wrong owner returned: expected '%s', got '%s'", name1, response2.owner)
+		}
+	case <-time.After(time.Second):
+		t.Errorf("lock 2 is blocking")
+	}
+
+	// unlock
+	unlock1Response := make(chan struct{})
+	go func() {
+		locker.Unlock()
+		unlock1Response <- struct{}{}
+	}()
+	select {
+	case <-unlock1Response:
+		t.Logf("(ok) unlocked 1")
+	case <-time.After(time.Second):
+		t.Fatalf("timeout while unlocking 1")
+	}
+
+	// test that a try-lock now succeeds
+	lock3Response := make(chan TestAndLockResponse)
+	go func() {
+		ok, owner := locker.TestAndLock(name3)
+		lock3Response <- TestAndLockResponse{
+			result: ok,
+			owner:  owner,
+		}
+	}()
+	select {
+	case response3 := <-lock3Response:
+		if !response3.result {
+			t.Errorf("lock 2 failed")
+		}
+		if response3.owner != name3 {
+			t.Errorf("wrong owner returned: expected '%s', got '%s'", name3, response3.owner)
+		}
+	case <-time.After(time.Second):
+		t.Errorf("lock 3 is blocking")
+	}
+
+	// check if the second lock can unlock
+	unlock2Response := make(chan struct{})
+	go func() {
+		locker.Unlock()
+		unlock2Response <- struct{}{}
+	}()
+	select {
+	case <-unlock2Response:
+		t.Logf("(ok) unlocked 2")
+	case <-time.After(time.Second):
+		t.Errorf("timeout while unlocking 2")
+	}
+}
+
+func TestTestableMutex_DoubleUnlock(t *testing.T) {
+	name1 := "lock 1"
+
+	locker := NewTestableMutex()
+
+	// lock the mutex
+	lock1Response := make(chan struct{})
+	go func() {
+		locker.Lock(name1)
+		lock1Response <- struct{}{}
+	}()
+	select {
+	case <-lock1Response:
+		t.Logf("(ok) lock 1 acquired")
+	case <-time.After(time.Second):
+		t.Fatalf("timeout while acquiring lock 1")
+	}
+
+	// unlock
+	unlock1Response := make(chan struct{})
+	go func() {
+		locker.Unlock()
+		unlock1Response <- struct{}{}
+	}()
+	select {
+	case <-unlock1Response:
+		t.Logf("(ok) unlocked 1")
+	case <-time.After(time.Second):
+		t.Errorf("timeout while unlocking 1")
+	}
+
+	// second unlock, should panic
+	unlock2Response := make(chan bool)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Logf("(ok) caught panic")
+				unlock2Response <- true
+			} else {
+				unlock2Response <- false
+			}
+		}()
+		locker.Unlock()
+	}()
+	select {
+	case response2 := <-unlock2Response:
+		if !response2 {
+			t.Errorf("no panic from unlock 2")
+		} else {
+			// Panicked, as expected (logged by goroutine)
+		}
+	case <-time.After(time.Second):
+		t.Errorf("timeout while unlocking 2")
+	}
+}
+
+// Make sure multiple write locks are released one at a time
+func TestTestableMutex_MultipleLockers(t *testing.T) {
+	numGoroutines := 4
+
+	// setup
+	locker := NewTestableMutex()
+
+	// data to be managed by the lock
+	var listA []int
+	var listB []int
+	var listC []int
+
+	// get a lock so goroutines block
+	lockmainResponse := make(chan struct{})
+	go func() {
+		locker.Lock("lock main")
+		lockmainResponse <- struct{}{}
+	}()
+	select {
+	case <-lockmainResponse:
+		// Acquired, as expected
+	case <-time.After(time.Second):
+		t.Fatalf("timeout while acquiring lock main")
+	}
+
+	// spin off several goroutines
+	ready := make(chan int)
+	done := make(chan int)
+	for i := 1; i <= numGoroutines; i++ {
+		go func(myId int) {
+			defer func() { done <- myId }() // Signal that I am done
+			// Signal that I am ready
+			ready <- myId
+			// Lock/block
+			locker.Lock(fmt.Sprintf("goroutine %d", myId))
+			// Update the data
+			time.Sleep(250 * time.Millisecond)
+			listA = append(listA, myId)
+			time.Sleep(250 * time.Millisecond)
+			listB = append(listB, myId)
+			time.Sleep(250 * time.Millisecond)
+			listC = append(listC, myId)
+			// Unlock
+			locker.Unlock()
+		}(i)
+	}
+
+	// wait until all goroutines are ready
+	numEvents := 0
+	timeout := time.NewTimer(2 * time.Second)
+	for numEvents < numGoroutines {
+		select {
+		case <-ready:
+			numEvents++
+		case <-timeout.C:
+			t.Fatalf("goroutines never got ready")
+		}
+	}
+	time.Sleep(250 * time.Microsecond) // event is sent before Lock() is called
+
+	// unlock
+	unlockmainResponse := make(chan struct{})
+	go func() {
+		locker.Unlock()
+		unlockmainResponse <- struct{}{}
+	}()
+	select {
+	case <-unlockmainResponse:
+		t.Logf("main unlocked")
+	case <-time.After(time.Second):
+		t.Fatalf("timeout while unlocking main")
+	}
+
+	// wait for the goroutines to finish (they should proceed one at a time as another unlocks)
+	numEvents = 0
+	timeout = time.NewTimer((time.Duration(numGoroutines) * time.Second) + (2 * time.Second))
+	for numEvents < numGoroutines {
+		select {
+		case ev := <-done:
+			t.Logf("goroutine %d is done", ev)
+			numEvents++
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for goroutines to update the data")
+		}
+	}
+
+	// verify all the data lists are the same
+	t.Logf("data lists: A=%v, B=%v, C=%v", listA, listB, listC)
+	for i := 0; i < len(listA); i++ {
+		if listA[i] != listB[i] || listB[i] != listC[i] {
+			t.Fatalf("lists do not match at element %d", i)
+		}
+	}
+}


### PR DESCRIPTION
Similar to Go's sync.Mutex, but provides:
- A method for trying to acquire the lock without blocking.
- A field to indicate the current holder of the lock.

Rationale: During tasks like backing up the system, we don't want data in ES or ZK to be changed. But tasks started by the user (like deleting a pool) should not just block--would prefer to report "busy performing backup now, try again later."

This implementation does not rely on any specific technologies, so putting it in the commons folder for potential use by others.