### PR TITLE
Route messages from the ZK lib to our application log

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -393,6 +393,7 @@ func (d *daemon) initContext() (datastore.Context, error) {
 }
 
 func (d *daemon) initZK(zks []string) (*coordclient.Client, error) {
+	coordzk.RegisterZKLogger()
 	dsn := coordzk.NewDSN(zks, time.Second*15).String()
 	glog.Infof("zookeeper dsn: %s", dsn)
 	return coordclient.New("zookeeper", dsn, "/", nil)

--- a/coordinator/client/zookeeper/logger.go
+++ b/coordinator/client/zookeeper/logger.go
@@ -1,0 +1,34 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package zookeeper
+
+import (
+	"fmt"
+
+	zklib "github.com/control-center/go-zookeeper/zk"
+	"github.com/zenoss/glog"
+)
+
+type zkLogger struct {}
+
+// Assert that our logging shim implements the Logger interface
+var _ zklib.Logger =  zkLogger{}
+
+// Register a logger for the Zookeeper library which will messages from their library to our application log
+func RegisterZKLogger() {
+	zklib.DefaultLogger = zkLogger{}
+}
+
+func (logger zkLogger) Printf(format string, args ...interface{}) {
+	glog.V(1).Infof("zklib: %s", fmt.Sprintf(format, args))
+}


### PR DESCRIPTION
The new ZK library we added for 1.2, includes a bunch of Printfs which flood stdout with a steady stream of messages like:
```
Authentication failed: [read tcp 127.0.0.1:38108->127.0.0.1:2181: read: connection reset by peer]
Connected to [127.0.0.1:2181]
Connected to [127.0.0.1:2181]
Authenticated: id=[95600377665880064 10000], timeout=%!d(MISSING)
Authenticated: id=[95600377665880065 10000], timeout=%!d(MISSING)
Recv loop terminated: err=[EOF]
Send loop terminated: err=[<nil>]
Recv loop terminated: err=[EOF]
Send loop terminated: err=[<nil>]
```