### PR TITLE
Make sure we have images locally before push and snapshot

### DIFF
--- a/dfs/docker/docker.go
+++ b/dfs/docker/docker.go
@@ -67,7 +67,7 @@ type Docker interface {
 	CommitContainer(ctr, image string) (*dockerclient.Image, error)
 	GetImageHash(image string) (string, error)
 	GetContainerStats(containerID string, timeout time.Duration) (*dockerclient.Stats, error)
-	FindImageByHash(imageHash string) (*dockerclient.Image, error)
+	FindImageByHash(imageHash string, checkAllLayers bool) (*dockerclient.Image, error)
 }
 
 type DockerClient struct {
@@ -235,9 +235,9 @@ func (d *DockerClient) GetContainerStats(containerID string, timeout time.Durati
 }
 
 // FindImageByHash searches all local images for an image with the given hash
-func (d *DockerClient) FindImageByHash(imageHash string) (*dockerclient.Image, error) {
+func (d *DockerClient) FindImageByHash(imageHash string, checkAllLayers bool) (*dockerclient.Image, error) {
 	opts := dockerclient.ListImagesOptions{
-		All:     false,
+		All:     checkAllLayers,
 		Digests: false,
 	}
 

--- a/dfs/docker/docker.go
+++ b/dfs/docker/docker.go
@@ -67,6 +67,7 @@ type Docker interface {
 	CommitContainer(ctr, image string) (*dockerclient.Image, error)
 	GetImageHash(image string) (string, error)
 	GetContainerStats(containerID string, timeout time.Duration) (*dockerclient.Stats, error)
+	FindImageByHash(imageHash string) (*dockerclient.Image, error)
 }
 
 type DockerClient struct {
@@ -231,4 +232,29 @@ func (d *DockerClient) GetContainerStats(containerID string, timeout time.Durati
 	}
 
 	return result, nil
+}
+
+// FindImageByHash searches all local images for an image with the given hash
+func (d *DockerClient) FindImageByHash(imageHash string) (*dockerclient.Image, error) {
+	opts := dockerclient.ListImagesOptions{
+		All:     false,
+		Digests: false,
+	}
+
+	allImages, err := d.dc.ListImages(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, apiImage := range allImages {
+		if hash, err := d.GetImageHash(apiImage.ID); err == nil {
+			if hash == imageHash {
+				return d.FindImage(apiImage.ID)
+			}
+		} else {
+			glog.Warningf("Error computing hash for %s: %s", apiImage.ID, err)
+		}
+	}
+
+	return nil, dockerclient.ErrNoSuchImage
 }

--- a/dfs/docker/docker_test.go
+++ b/dfs/docker/docker_test.go
@@ -248,3 +248,15 @@ func (s *DockerSuite) TestGetContainerStats(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(stats, NotNil)
 }
+
+func (s *DockerSuite) TestFindImageByHash(c *C) {
+	_, err := s.docker.FindImageByHash("non_existant_hash")
+	c.Assert(err, Equals, dockerclient.ErrNoSuchImage)
+	hash, err := s.docker.GetImageHash("busybox")
+	c.Assert(err, IsNil)
+	expected, err := s.docker.FindImage("busybox")
+	c.Assert(err, IsNil)
+	img, err := s.docker.FindImageByHash(hash)
+	c.Assert(err, IsNil)
+	c.Assert(img, DeepEquals, expected)
+}

--- a/dfs/docker/docker_test.go
+++ b/dfs/docker/docker_test.go
@@ -250,14 +250,35 @@ func (s *DockerSuite) TestGetContainerStats(c *C) {
 }
 
 func (s *DockerSuite) TestFindImageByHash(c *C) {
-	_, err := s.docker.FindImageByHash("non_existant_hash")
+	_, err := s.docker.FindImageByHash("non_existant_hash", false)
 	c.Assert(err, Equals, dockerclient.ErrNoSuchImage)
 	expectedhash, err := s.docker.GetImageHash("busybox")
 	c.Assert(err, IsNil)
-	actual, err := s.docker.FindImageByHash(expectedhash)
+	actual, err := s.docker.FindImageByHash(expectedhash, false)
 	c.Assert(err, IsNil)
 	// have to compare hashes, IDs may not match
 	actualhash, err := s.docker.GetImageHash(actual.ID)
 	c.Assert(err, IsNil)
 	c.Assert(actualhash, Equals, expectedhash)
+
+	// Test "allLayers"
+	// find a lower layer of busybox
+	historyList, err := s.dc.ImageHistory("busybox")
+	c.Assert(err, IsNil)
+	c.Assert(len(historyList) > 1, Equals, true)
+	lowerLayer := historyList[1]
+
+	lowerLayerHash, err := s.docker.GetImageHash(lowerLayer.ID)
+	c.Assert(err, IsNil)
+
+	// If not checking all layers, this should fail
+	actual, err = s.docker.FindImageByHash(lowerLayerHash, false)
+	c.Assert(err, Equals, dockerclient.ErrNoSuchImage)
+
+	// With all layers = true, this should succeed
+	actual, err = s.docker.FindImageByHash(lowerLayerHash, true)
+	c.Assert(err, IsNil)
+	actualhash, err = s.docker.GetImageHash(actual.ID)
+	c.Assert(err, IsNil)
+	c.Assert(actualhash, Equals, lowerLayerHash)
 }

--- a/dfs/docker/docker_test.go
+++ b/dfs/docker/docker_test.go
@@ -252,11 +252,12 @@ func (s *DockerSuite) TestGetContainerStats(c *C) {
 func (s *DockerSuite) TestFindImageByHash(c *C) {
 	_, err := s.docker.FindImageByHash("non_existant_hash")
 	c.Assert(err, Equals, dockerclient.ErrNoSuchImage)
-	hash, err := s.docker.GetImageHash("busybox")
+	expectedhash, err := s.docker.GetImageHash("busybox")
 	c.Assert(err, IsNil)
-	expected, err := s.docker.FindImage("busybox")
+	actual, err := s.docker.FindImageByHash(expectedhash)
 	c.Assert(err, IsNil)
-	img, err := s.docker.FindImageByHash(hash)
+	// have to compare hashes, IDs may not match
+	actualhash, err := s.docker.GetImageHash(actual.ID)
 	c.Assert(err, IsNil)
-	c.Assert(img, DeepEquals, expected)
+	c.Assert(actualhash, Equals, expectedhash)
 }

--- a/dfs/docker/mocks/Docker.go
+++ b/dfs/docker/mocks/Docker.go
@@ -16,6 +16,7 @@ package mocks
 import "github.com/stretchr/testify/mock"
 
 import "io"
+
 import "time"
 
 import dockerclient "github.com/fsouza/go-dockerclient"
@@ -193,6 +194,27 @@ func (_m *Docker) GetContainerStats(containerID string, timeout time.Duration) (
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string, time.Duration) error); ok {
 		r1 = rf(containerID, timeout)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Docker) FindImageByHash(imageHash string) (*dockerclient.Image, error) {
+	ret := _m.Called(imageHash)
+
+	var r0 *dockerclient.Image
+	if rf, ok := ret.Get(0).(func(string) *dockerclient.Image); ok {
+		r0 = rf(imageHash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*dockerclient.Image)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(imageHash)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/dfs/docker/mocks/Docker.go
+++ b/dfs/docker/mocks/Docker.go
@@ -200,12 +200,12 @@ func (_m *Docker) GetContainerStats(containerID string, timeout time.Duration) (
 
 	return r0, r1
 }
-func (_m *Docker) FindImageByHash(imageHash string) (*dockerclient.Image, error) {
-	ret := _m.Called(imageHash)
+func (_m *Docker) FindImageByHash(imageHash string, checkAllLayers bool) (*dockerclient.Image, error) {
+	ret := _m.Called(imageHash, checkAllLayers)
 
 	var r0 *dockerclient.Image
-	if rf, ok := ret.Get(0).(func(string) *dockerclient.Image); ok {
-		r0 = rf(imageHash)
+	if rf, ok := ret.Get(0).(func(string, bool) *dockerclient.Image); ok {
+		r0 = rf(imageHash, checkAllLayers)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*dockerclient.Image)
@@ -213,8 +213,8 @@ func (_m *Docker) FindImageByHash(imageHash string) (*dockerclient.Image, error)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(imageHash)
+	if rf, ok := ret.Get(1).(func(string, bool) error); ok {
+		r1 = rf(imageHash, checkAllLayers)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/dfs/registry/listener.go
+++ b/dfs/registry/listener.go
@@ -20,6 +20,7 @@ import (
 	"github.com/control-center/serviced/coordinator/client"
 	"github.com/control-center/serviced/dfs/docker"
 	"github.com/control-center/serviced/domain/registry"
+	dockerclient "github.com/fsouza/go-dockerclient"
 	"github.com/zenoss/glog"
 )
 
@@ -125,8 +126,8 @@ func (l *RegistryListener) Spawn(shutdown <-chan interface{}, id string) {
 		if node.PushedAt.Unix() == 0 {
 			// Do I have the image?
 			glog.Infof("Checking if push required for id=%s node: %s:%s %s (UUID=%s)", id, node.Image.Repo, node.Image.Tag, node.Image.Tag, node.Image.UUID)
-			if img, err := l.docker.FindImage(node.Image.UUID); err == nil {
-				glog.V(1).Infof("Found image %s locally, acquiring lead", node.Image)
+			if img, err := l.findImage(&node.Image); err == nil {
+				glog.V(1).Infof("Found image %v locally, acquiring lead", node.Image)
 				func() {
 					// Become the leader so I can push the image
 					leaderDone := make(chan struct{})
@@ -147,9 +148,19 @@ func (l *RegistryListener) Spawn(shutdown <-chan interface{}, id string) {
 							glog.Errorf("Could not get %s: %s", imagepath, err)
 							return
 						}
-						if img.ID != node.Image.UUID || node.PushedAt.Unix() > 0 {
-							glog.V(1).Infof("Image %s changed, cancelling push", node.Image)
+						if node.PushedAt.Unix() > 0 {
+							glog.V(1).Infof("Image %s already pushed, cancelling push", node.Image.String())
 							return
+						}
+						if img.ID != node.Image.UUID {
+							localHash, err := l.docker.GetImageHash(img.ID)
+							if err != nil {
+								glog.Warningf("Error building hash of image: %s, cancelling push: %s", img.ID, err)
+								return
+							} else if localHash != node.Image.Hash {
+								glog.V(1).Infof("Image %s changed, cancelling push", node.Image.String())
+								return
+							}
 						}
 					}
 					// Push the image and update the registry
@@ -157,9 +168,9 @@ func (l *RegistryListener) Spawn(shutdown <-chan interface{}, id string) {
 					// so that the push will get retriggered the next time it
 					// is needed.
 					registrypath := path.Join(l.address, node.Image.String())
-					glog.V(1).Infof("Updating registry image %s from path=%s", node.Image.UUID, registrypath)
-					if err := l.docker.TagImage(node.Image.UUID, registrypath); err != nil {
-						glog.Warningf("Could not tag %s as %s: %s", node.Image.UUID, registrypath, err)
+					glog.V(1).Infof("Updating registry image %s from path=%s", img.ID, registrypath)
+					if err := l.docker.TagImage(img.ID, registrypath); err != nil {
+						glog.Warningf("Could not tag %s as %s: %s", img.ID, registrypath, err)
 						node.PushedAt = time.Unix(0, 0)
 					} else if err := l.docker.PushImage(registrypath); err != nil {
 						glog.Warningf("Could not push %s: %s", registrypath, err)
@@ -185,4 +196,53 @@ func (l *RegistryListener) Spawn(shutdown <-chan interface{}, id string) {
 		close(done)
 		done = make(chan struct{})
 	}
+}
+
+// findImage looks for the registry image locally and in the local registry.  It firsts checks locally by UUID,
+//  then by repo, tag, and hash, then it checks if the image is already in the registry, and finally it searches by hash
+func (l *RegistryListener) findImage(rImg *registry.Image) (*dockerclient.Image, error) {
+	regaddr := path.Join(l.address, rImg.String())
+	glog.V(1).Infof("Searching for image %s", regaddr)
+
+	// check for UUID
+	if img, err := l.docker.FindImage(rImg.UUID); err == nil {
+		return img, nil
+	}
+
+	// check by repo and tag, and compare hashes
+	glog.V(1).Infof("UUID %s not found locally, searching by registry address for %s", rImg.UUID, regaddr)
+	if img, err := l.docker.FindImage(regaddr); err == nil {
+		if localHash, err := l.docker.GetImageHash(img.ID); err != nil {
+			glog.Warningf("Error building hash of image: %s: %s", img.ID, err)
+		} else {
+			if localHash == rImg.Hash {
+				return img, nil
+			}
+			glog.V(1).Infof("Found %s locally, but hashes do not match", regaddr)
+		}
+	}
+
+	// attempt to pull the image, then compare hashes
+	glog.V(0).Infof("Image address %s not found locally, attempting pull", regaddr)
+	if err := l.docker.PullImage(regaddr); err == nil {
+		glog.V(1).Infof("Successfully pulled image %s from registry, checking for match", regaddr)
+		if img, err := l.docker.FindImage(regaddr); err == nil {
+			if img.ID == rImg.UUID {
+				glog.V(1).Infof("Found image %s in registry with correct UUID", regaddr)
+				return img, nil
+			}
+			if localHash, err := l.docker.GetImageHash(img.ID); err != nil {
+				glog.Warningf("Error building hash of image: %s: %s", img.ID, err)
+			} else {
+				if localHash == rImg.Hash {
+					glog.V(1).Infof("Found image %s in registry with correct Hash", regaddr)
+					return img, nil
+				}
+			}
+		}
+	}
+
+	// search all images for a matching hash
+	glog.V(0).Infof("Image %s not found in registry, searching local images by hash", regaddr)
+	return l.docker.FindImageByHash(rImg.Hash)
 }

--- a/dfs/registry/listener.go
+++ b/dfs/registry/listener.go
@@ -243,6 +243,13 @@ func (l *RegistryListener) FindImage(rImg *registry.Image) (*dockerclient.Image,
 	}
 
 	// search all images for a matching hash
+	// First just check top-level layers
 	glog.V(0).Infof("Image %s not found in registry, searching local images by hash", regaddr)
-	return l.docker.FindImageByHash(rImg.Hash)
+	if img, err := l.docker.FindImageByHash(rImg.Hash, false); err == nil {
+		return img, nil
+	}
+
+	// Now check all layers
+	glog.V(0).Infof("Hash for Image %s not found in top-level layers, searching all layers", regaddr)
+	return l.docker.FindImageByHash(rImg.Hash, true)
 }

--- a/dfs/registry/listener.go
+++ b/dfs/registry/listener.go
@@ -126,7 +126,7 @@ func (l *RegistryListener) Spawn(shutdown <-chan interface{}, id string) {
 		if node.PushedAt.Unix() == 0 {
 			// Do I have the image?
 			glog.Infof("Checking if push required for id=%s node: %s:%s %s (UUID=%s)", id, node.Image.Repo, node.Image.Tag, node.Image.Tag, node.Image.UUID)
-			if img, err := l.findImage(&node.Image); err == nil {
+			if img, err := l.FindImage(&node.Image); err == nil {
 				glog.V(1).Infof("Found image %v locally, acquiring lead", node.Image)
 				func() {
 					// Become the leader so I can push the image
@@ -200,7 +200,7 @@ func (l *RegistryListener) Spawn(shutdown <-chan interface{}, id string) {
 
 // findImage looks for the registry image locally and in the local registry.  It firsts checks locally by UUID,
 //  then by repo, tag, and hash, then it checks if the image is already in the registry, and finally it searches by hash
-func (l *RegistryListener) findImage(rImg *registry.Image) (*dockerclient.Image, error) {
+func (l *RegistryListener) FindImage(rImg *registry.Image) (*dockerclient.Image, error) {
 	regaddr := path.Join(l.address, rImg.String())
 	glog.V(1).Infof("Searching for image %s", regaddr)
 

--- a/dfs/registry/listener_test.go
+++ b/dfs/registry/listener_test.go
@@ -537,7 +537,7 @@ func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_SuccessByID(c
 
 	s.docker.On("FindImage", rImage.Image.UUID).Return(&dockerclient.Image{ID: rImage.Image.UUID}, nil).Once()
 
-	img, err := s.listener.findImage(rImage.Image)
+	img, err := s.listener.FindImage(rImage.Image)
 
 	c.Assert(err, IsNil)
 	c.Assert(img.ID, Equals, rImage.Image.UUID)
@@ -560,7 +560,7 @@ func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_SuccessByRegA
 	s.docker.On("FindImage", regaddr).Return(&dockerclient.Image{ID: "differentid"}, nil).Once()
 	s.docker.On("GetImageHash", "differentid").Return(rImage.Image.Hash, nil).Once()
 
-	img, err := s.listener.findImage(rImage.Image)
+	img, err := s.listener.FindImage(rImage.Image)
 
 	c.Assert(err, IsNil)
 	c.Assert(img.ID, Equals, "differentid")
@@ -584,7 +584,7 @@ func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_SuccessByPull
 	s.docker.On("PullImage", regaddr).Return(nil).Once()
 	s.docker.On("FindImage", regaddr).Return(&dockerclient.Image{ID: rImage.Image.UUID}, nil).Once()
 
-	img, err := s.listener.findImage(rImage.Image)
+	img, err := s.listener.FindImage(rImage.Image)
 
 	c.Assert(err, IsNil)
 	c.Assert(img.ID, Equals, rImage.Image.UUID)
@@ -609,7 +609,7 @@ func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_SuccessByPull
 	s.docker.On("FindImage", regaddr).Return(&dockerclient.Image{ID: "differentid"}, nil).Once()
 	s.docker.On("GetImageHash", "differentid").Return(rImage.Image.Hash, nil).Once()
 
-	img, err := s.listener.findImage(rImage.Image)
+	img, err := s.listener.FindImage(rImage.Image)
 
 	c.Assert(err, IsNil)
 	c.Assert(img.ID, Equals, "differentid")
@@ -633,7 +633,7 @@ func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_SuccessByHash
 	s.docker.On("PullImage", regaddr).Return(ErrTestImageNotFound).Once()
 	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(&dockerclient.Image{ID: "differentid"}, nil).Once()
 
-	img, err := s.listener.findImage(rImage.Image)
+	img, err := s.listener.FindImage(rImage.Image)
 
 	c.Assert(err, IsNil)
 	c.Assert(img.ID, Equals, "differentid")
@@ -657,7 +657,7 @@ func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_Fail(c *C) {
 	s.docker.On("PullImage", regaddr).Return(ErrTestImageNotFound).Once()
 	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(nil, ErrTestImageNotFound).Once()
 
-	img, err := s.listener.findImage(rImage.Image)
+	img, err := s.listener.FindImage(rImage.Image)
 
 	c.Assert(err, Equals, ErrTestImageNotFound)
 	c.Assert(img, IsNil)
@@ -682,7 +682,7 @@ func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_FailGettingHa
 	s.docker.On("PullImage", regaddr).Return(ErrTestImageNotFound).Once()
 	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(nil, ErrTestImageNotFound).Once()
 
-	img, err := s.listener.findImage(rImage.Image)
+	img, err := s.listener.FindImage(rImage.Image)
 
 	c.Assert(err, Equals, ErrTestImageNotFound)
 	c.Assert(img, IsNil)
@@ -707,7 +707,7 @@ func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_FailHashesDon
 	s.docker.On("PullImage", regaddr).Return(ErrTestImageNotFound).Once()
 	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(nil, ErrTestImageNotFound).Once()
 
-	img, err := s.listener.findImage(rImage.Image)
+	img, err := s.listener.FindImage(rImage.Image)
 
 	c.Assert(err, Equals, ErrTestImageNotFound)
 	c.Assert(img, IsNil)
@@ -732,7 +732,7 @@ func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_FailAfterPull
 	s.docker.On("FindImage", regaddr).Return(nil, ErrTestImageNotFound).Once()
 	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(nil, ErrTestImageNotFound).Once()
 
-	img, err := s.listener.findImage(rImage.Image)
+	img, err := s.listener.FindImage(rImage.Image)
 
 	c.Assert(err, Equals, ErrTestImageNotFound)
 	c.Assert(img, IsNil)
@@ -758,7 +758,7 @@ func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_FailAfterPull
 	s.docker.On("GetImageHash", "differentid").Return("", ErrTestImageNotFound).Once()
 	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(nil, ErrTestImageNotFound).Once()
 
-	img, err := s.listener.findImage(rImage.Image)
+	img, err := s.listener.FindImage(rImage.Image)
 
 	c.Assert(err, Equals, ErrTestImageNotFound)
 	c.Assert(img, IsNil)
@@ -784,7 +784,7 @@ func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_FailAfterPull
 	s.docker.On("GetImageHash", "differentid").Return("differenthash", nil).Once()
 	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(nil, ErrTestImageNotFound).Once()
 
-	img, err := s.listener.findImage(rImage.Image)
+	img, err := s.listener.FindImage(rImage.Image)
 
 	c.Assert(err, Equals, ErrTestImageNotFound)
 	c.Assert(img, IsNil)

--- a/dfs/registry/listener_test.go
+++ b/dfs/registry/listener_test.go
@@ -32,6 +32,10 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+var (
+	ErrTestImageNotFound = errors.New("image not found")
+)
+
 type testImage struct {
 	Image *registry.Image
 }
@@ -190,20 +194,25 @@ func (s *RegistryListenerSuite) TestRegistryListener_ImagePushed(c *C) {
 	}
 }
 
-func (s *RegistryListenerSuite) TestRegistryListener_NoLocalImage(c *C) {
+func (s *RegistryListenerSuite) TestRegistryListener_ImageNotFound(c *C) {
 	rImage := &testImage{
 		Image: &registry.Image{
 			Library: "libraryname",
 			Repo:    "reponame",
 			Tag:     "tagname",
 			UUID:    "uuidvalue",
+			Hash:    "correcthash",
 		},
 	}
+	regaddr := rImage.Address(s.listener.address)
 	_ = rImage.Create(c, s.conn)
 	imageDone := make(chan struct{})
 	defer close(imageDone)
 	evt, _ := rImage.GetW(c, s.conn, imageDone)
-	s.docker.On("FindImage", rImage.Image.UUID).Return(nil, errors.New("image not found")).Once()
+	s.docker.On("FindImage", rImage.Image.UUID).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("FindImage", regaddr).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("PullImage", regaddr).Return(ErrTestImageNotFound).Once()
+	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(nil, ErrTestImageNotFound).Once()
 
 	shutdown := make(chan interface{})
 	done := make(chan struct{})
@@ -512,5 +521,272 @@ func (s *RegistryListenerSuite) TestRegistryListener_Success(c *C) {
 		c.Fatalf("listener did not shutdown within the timeout!")
 	case <-done:
 	}
+	s.docker.AssertExpectations(c)
+}
+
+func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_SuccessByID(c *C) {
+	rImage := &testImage{
+		Image: &registry.Image{
+			Library: "libraryname",
+			Repo:    "reponame",
+			Tag:     "tagname",
+			UUID:    "uuidvalue",
+			Hash:    "hashvalue",
+		},
+	}
+
+	s.docker.On("FindImage", rImage.Image.UUID).Return(&dockerclient.Image{ID: rImage.Image.UUID}, nil).Once()
+
+	img, err := s.listener.findImage(rImage.Image)
+
+	c.Assert(err, IsNil)
+	c.Assert(img.ID, Equals, rImage.Image.UUID)
+	s.docker.AssertExpectations(c)
+}
+
+func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_SuccessByRegAddr(c *C) {
+	rImage := &testImage{
+		Image: &registry.Image{
+			Library: "libraryname",
+			Repo:    "reponame",
+			Tag:     "tagname",
+			UUID:    "uuidvalue",
+			Hash:    "hashvalue",
+		},
+	}
+	regaddr := rImage.Address(s.listener.address)
+
+	s.docker.On("FindImage", rImage.Image.UUID).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("FindImage", regaddr).Return(&dockerclient.Image{ID: "differentid"}, nil).Once()
+	s.docker.On("GetImageHash", "differentid").Return(rImage.Image.Hash, nil).Once()
+
+	img, err := s.listener.findImage(rImage.Image)
+
+	c.Assert(err, IsNil)
+	c.Assert(img.ID, Equals, "differentid")
+	s.docker.AssertExpectations(c)
+}
+
+func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_SuccessByPullAndID(c *C) {
+	rImage := &testImage{
+		Image: &registry.Image{
+			Library: "libraryname",
+			Repo:    "reponame",
+			Tag:     "tagname",
+			UUID:    "uuidvalue",
+			Hash:    "hashvalue",
+		},
+	}
+	regaddr := rImage.Address(s.listener.address)
+
+	s.docker.On("FindImage", rImage.Image.UUID).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("FindImage", regaddr).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("PullImage", regaddr).Return(nil).Once()
+	s.docker.On("FindImage", regaddr).Return(&dockerclient.Image{ID: rImage.Image.UUID}, nil).Once()
+
+	img, err := s.listener.findImage(rImage.Image)
+
+	c.Assert(err, IsNil)
+	c.Assert(img.ID, Equals, rImage.Image.UUID)
+	s.docker.AssertExpectations(c)
+}
+
+func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_SuccessByPullAndHash(c *C) {
+	rImage := &testImage{
+		Image: &registry.Image{
+			Library: "libraryname",
+			Repo:    "reponame",
+			Tag:     "tagname",
+			UUID:    "uuidvalue",
+			Hash:    "hashvalue",
+		},
+	}
+	regaddr := rImage.Address(s.listener.address)
+
+	s.docker.On("FindImage", rImage.Image.UUID).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("FindImage", regaddr).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("PullImage", regaddr).Return(nil).Once()
+	s.docker.On("FindImage", regaddr).Return(&dockerclient.Image{ID: "differentid"}, nil).Once()
+	s.docker.On("GetImageHash", "differentid").Return(rImage.Image.Hash, nil).Once()
+
+	img, err := s.listener.findImage(rImage.Image)
+
+	c.Assert(err, IsNil)
+	c.Assert(img.ID, Equals, "differentid")
+	s.docker.AssertExpectations(c)
+}
+
+func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_SuccessByHash(c *C) {
+	rImage := &testImage{
+		Image: &registry.Image{
+			Library: "libraryname",
+			Repo:    "reponame",
+			Tag:     "tagname",
+			UUID:    "uuidvalue",
+			Hash:    "hashvalue",
+		},
+	}
+	regaddr := rImage.Address(s.listener.address)
+
+	s.docker.On("FindImage", rImage.Image.UUID).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("FindImage", regaddr).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("PullImage", regaddr).Return(ErrTestImageNotFound).Once()
+	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(&dockerclient.Image{ID: "differentid"}, nil).Once()
+
+	img, err := s.listener.findImage(rImage.Image)
+
+	c.Assert(err, IsNil)
+	c.Assert(img.ID, Equals, "differentid")
+	s.docker.AssertExpectations(c)
+}
+
+func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_Fail(c *C) {
+	rImage := &testImage{
+		Image: &registry.Image{
+			Library: "libraryname",
+			Repo:    "reponame",
+			Tag:     "tagname",
+			UUID:    "uuidvalue",
+			Hash:    "hashvalue",
+		},
+	}
+	regaddr := rImage.Address(s.listener.address)
+
+	s.docker.On("FindImage", rImage.Image.UUID).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("FindImage", regaddr).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("PullImage", regaddr).Return(ErrTestImageNotFound).Once()
+	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(nil, ErrTestImageNotFound).Once()
+
+	img, err := s.listener.findImage(rImage.Image)
+
+	c.Assert(err, Equals, ErrTestImageNotFound)
+	c.Assert(img, IsNil)
+	s.docker.AssertExpectations(c)
+}
+
+func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_FailGettingHash(c *C) {
+	rImage := &testImage{
+		Image: &registry.Image{
+			Library: "libraryname",
+			Repo:    "reponame",
+			Tag:     "tagname",
+			UUID:    "uuidvalue",
+			Hash:    "hashvalue",
+		},
+	}
+	regaddr := rImage.Address(s.listener.address)
+
+	s.docker.On("FindImage", rImage.Image.UUID).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("FindImage", regaddr).Return(&dockerclient.Image{ID: "differentid"}, nil).Once()
+	s.docker.On("GetImageHash", "differentid").Return("", ErrTestImageNotFound).Once()
+	s.docker.On("PullImage", regaddr).Return(ErrTestImageNotFound).Once()
+	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(nil, ErrTestImageNotFound).Once()
+
+	img, err := s.listener.findImage(rImage.Image)
+
+	c.Assert(err, Equals, ErrTestImageNotFound)
+	c.Assert(img, IsNil)
+	s.docker.AssertExpectations(c)
+}
+
+func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_FailHashesDontMatch(c *C) {
+	rImage := &testImage{
+		Image: &registry.Image{
+			Library: "libraryname",
+			Repo:    "reponame",
+			Tag:     "tagname",
+			UUID:    "uuidvalue",
+			Hash:    "hashvalue",
+		},
+	}
+	regaddr := rImage.Address(s.listener.address)
+
+	s.docker.On("FindImage", rImage.Image.UUID).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("FindImage", regaddr).Return(&dockerclient.Image{ID: "differentid"}, nil).Once()
+	s.docker.On("GetImageHash", "differentid").Return("differenthash", nil).Once()
+	s.docker.On("PullImage", regaddr).Return(ErrTestImageNotFound).Once()
+	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(nil, ErrTestImageNotFound).Once()
+
+	img, err := s.listener.findImage(rImage.Image)
+
+	c.Assert(err, Equals, ErrTestImageNotFound)
+	c.Assert(img, IsNil)
+	s.docker.AssertExpectations(c)
+}
+
+func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_FailAfterPull(c *C) {
+	rImage := &testImage{
+		Image: &registry.Image{
+			Library: "libraryname",
+			Repo:    "reponame",
+			Tag:     "tagname",
+			UUID:    "uuidvalue",
+			Hash:    "hashvalue",
+		},
+	}
+	regaddr := rImage.Address(s.listener.address)
+
+	s.docker.On("FindImage", rImage.Image.UUID).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("FindImage", regaddr).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("PullImage", regaddr).Return(nil).Once()
+	s.docker.On("FindImage", regaddr).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(nil, ErrTestImageNotFound).Once()
+
+	img, err := s.listener.findImage(rImage.Image)
+
+	c.Assert(err, Equals, ErrTestImageNotFound)
+	c.Assert(img, IsNil)
+	s.docker.AssertExpectations(c)
+}
+
+func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_FailAfterPullGettingHash(c *C) {
+	rImage := &testImage{
+		Image: &registry.Image{
+			Library: "libraryname",
+			Repo:    "reponame",
+			Tag:     "tagname",
+			UUID:    "uuidvalue",
+			Hash:    "hashvalue",
+		},
+	}
+	regaddr := rImage.Address(s.listener.address)
+
+	s.docker.On("FindImage", rImage.Image.UUID).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("FindImage", regaddr).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("PullImage", regaddr).Return(nil).Once()
+	s.docker.On("FindImage", regaddr).Return(&dockerclient.Image{ID: "differentid"}, nil).Once()
+	s.docker.On("GetImageHash", "differentid").Return("", ErrTestImageNotFound).Once()
+	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(nil, ErrTestImageNotFound).Once()
+
+	img, err := s.listener.findImage(rImage.Image)
+
+	c.Assert(err, Equals, ErrTestImageNotFound)
+	c.Assert(img, IsNil)
+	s.docker.AssertExpectations(c)
+}
+
+func (s *RegistryListenerSuite) TestRegistryListener_TestFindImage_FailAfterPullHashesDontMatch(c *C) {
+	rImage := &testImage{
+		Image: &registry.Image{
+			Library: "libraryname",
+			Repo:    "reponame",
+			Tag:     "tagname",
+			UUID:    "uuidvalue",
+			Hash:    "hashvalue",
+		},
+	}
+	regaddr := rImage.Address(s.listener.address)
+
+	s.docker.On("FindImage", rImage.Image.UUID).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("FindImage", regaddr).Return(nil, ErrTestImageNotFound).Once()
+	s.docker.On("PullImage", regaddr).Return(nil).Once()
+	s.docker.On("FindImage", regaddr).Return(&dockerclient.Image{ID: "differentid"}, nil).Once()
+	s.docker.On("GetImageHash", "differentid").Return("differenthash", nil).Once()
+	s.docker.On("FindImageByHash", rImage.Image.Hash).Return(nil, ErrTestImageNotFound).Once()
+
+	img, err := s.listener.findImage(rImage.Image)
+
+	c.Assert(err, Equals, ErrTestImageNotFound)
+	c.Assert(img, IsNil)
 	s.docker.AssertExpectations(c)
 }

--- a/dfs/registry/mocks/Registry.go
+++ b/dfs/registry/mocks/Registry.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"github.com/control-center/serviced/coordinator/client"
+	"github.com/control-center/serviced/domain/registry"
+	dockerclient "github.com/fsouza/go-dockerclient"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -57,6 +59,27 @@ func (_m *Registry) ImagePath(image string) (string, error) {
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(image)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Registry) FindImage(rImg *registry.Image) (*dockerclient.Image, error) {
+	ret := _m.Called(rImg)
+
+	var r0 *dockerclient.Image
+	if rf, ok := ret.Get(0).(func(*registry.Image) *dockerclient.Image); ok {
+		r0 = rf(rImg)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*dockerclient.Image)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*registry.Image) error); ok {
+		r1 = rf(rImg)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/dfs/registry/pull.go
+++ b/dfs/registry/pull.go
@@ -22,6 +22,7 @@ import (
 	"github.com/control-center/serviced/coordinator/client"
 	"github.com/control-center/serviced/dfs/docker"
 	"github.com/control-center/serviced/domain/registry"
+	dockerclient "github.com/fsouza/go-dockerclient"
 	"github.com/zenoss/glog"
 )
 
@@ -34,6 +35,7 @@ type Registry interface {
 	SetConnection(conn client.Connection)
 	PullImage(cancel <-chan time.Time, image string) error
 	ImagePath(image string) (string, error)
+	FindImage(rImg *registry.Image) (*dockerclient.Image, error)
 }
 
 // ImagePath returns the proper path to the registry image

--- a/dfs/snapshot.go
+++ b/dfs/snapshot.go
@@ -40,6 +40,13 @@ func (dfs *DistributedFilesystem) Snapshot(data SnapshotInfo) (string, error) {
 			glog.Errorf("Could not find image %s for snapshot: %s", image, err)
 			return "", err
 		}
+
+		// make sure we actually have the image locally before changing the tag and triggering a push
+		if _, err := dfs.reg.FindImage(rImage); err != nil {
+			glog.Errorf("Could not find image %s locally for snapshot:  %s", rImage.String(), err)
+			return "", err
+		}
+
 		rImage.Tag = label
 		if err := dfs.index.PushImage(rImage.String(), rImage.UUID, rImage.Hash); err != nil {
 			glog.Errorf("Could not retag image %s for snapshot: %s", image, err)


### PR DESCRIPTION
Fixes CC-2029
On push, if we can't find the image locally by ID, we look for it with the following methods:
1.) Look for it locally by registry address, and compare hashes
2.) Attempt to pull it from the registry, then compare IDs or hashes
3.) Search all local images for one with a matching hash

Additionally, we now search for each image using the above method before performing a snapshot, and return an error if any of them can't be found.  This prevents an error later when a snapshot that was taken with missing images is restored.

Both of these changes address issues that occur when the master does not have all of the images locally, even if they exist in the registry.  This state could occur after an HA fail-over, or if the user switched their docker storage.