### PR TITLE
Inject Facade into web tier

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -836,8 +836,18 @@ func (d *daemon) initDAO() (dao.ControlPlane, error) {
 func (d *daemon) initWeb() {
 	// TODO: Make bind port for web server optional?
 	glog.V(4).Infof("Starting web server: uiport: %v; port: %v; zookeepers: %v", options.UIPort, options.Endpoint, options.Zookeepers)
-	cpserver := web.NewServiceConfig(options.UIPort, options.Endpoint, options.ReportStats, options.HostAliases,
-		options.TLS, options.MuxPort, options.AdminGroup, options.CertPEMFile, options.KeyPEMFile, options.UIPollFrequency)
+	cpserver := web.NewServiceConfig(
+		options.UIPort,
+		options.Endpoint,
+		options.ReportStats,
+		options.HostAliases,
+		options.TLS,
+		options.MuxPort,
+		options.AdminGroup,
+		options.CertPEMFile,
+		options.KeyPEMFile,
+		options.UIPollFrequency,
+		d.facade)
 	go cpserver.Serve(d.shutdown)
 	go cpserver.ServePublicPorts(d.shutdown, d.cpDao)
 }

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -23,7 +23,6 @@ import (
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/domain/servicestate"
 	template "github.com/control-center/serviced/domain/servicetemplate"
-	"github.com/control-center/serviced/facade"
 	"github.com/control-center/serviced/metrics"
 	"github.com/control-center/serviced/script"
 	"github.com/control-center/serviced/volume"
@@ -50,7 +49,7 @@ type API interface {
 	GetResourcePool(string) (*pool.ResourcePool, error)
 	AddResourcePool(PoolConfig) (*pool.ResourcePool, error)
 	RemoveResourcePool(string) error
-	GetPoolIPs(string) (*facade.PoolIPs, error)
+	GetPoolIPs(string) (*pool.PoolIPs, error)
 	AddVirtualIP(pool.VirtualIP) error
 	RemoveVirtualIP(pool.VirtualIP) error
 

--- a/cli/api/pool.go
+++ b/cli/api/pool.go
@@ -15,7 +15,6 @@ package api
 
 import (
 	"github.com/control-center/serviced/domain/pool"
-	"github.com/control-center/serviced/facade"
 )
 
 const ()
@@ -82,7 +81,7 @@ func (a *api) RemoveResourcePool(id string) error {
 }
 
 // Returns a list of Host IPs for a given pool
-func (a *api) GetPoolIPs(id string) (*facade.PoolIPs, error) {
+func (a *api) GetPoolIPs(id string) (*pool.PoolIPs, error) {
 	client, err := a.connectMaster()
 	if err != nil {
 		return nil, err

--- a/cli/cmd/pool_test.go
+++ b/cli/cmd/pool_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/control-center/serviced/cli/api"
 	"github.com/control-center/serviced/domain/host"
 	"github.com/control-center/serviced/domain/pool"
-	"github.com/control-center/serviced/facade"
 	"github.com/control-center/serviced/utils"
 )
 
@@ -131,7 +130,7 @@ func (t PoolAPITest) RemoveResourcePool(id string) error {
 	return nil
 }
 
-func (t PoolAPITest) GetPoolIPs(id string) (*facade.PoolIPs, error) {
+func (t PoolAPITest) GetPoolIPs(id string) (*pool.PoolIPs, error) {
 	p, err := t.GetResourcePool(id)
 	if err != nil {
 		return nil, err
@@ -139,7 +138,7 @@ func (t PoolAPITest) GetPoolIPs(id string) (*facade.PoolIPs, error) {
 		return nil, ErrNoPoolFound
 	}
 
-	return &facade.PoolIPs{PoolID: p.ID, HostIPs: t.hostIPs}, nil
+	return &pool.PoolIPs{PoolID: p.ID, HostIPs: t.hostIPs}, nil
 }
 
 func TestServicedCLI_CmdPoolList_one(t *testing.T) {

--- a/datastore/mocks/Driver.go
+++ b/datastore/mocks/Driver.go
@@ -1,0 +1,44 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package mocks
+
+package mocks
+
+import (
+	"github.com/control-center/serviced/datastore"
+	"github.com/stretchr/testify/mock"
+)
+
+type Driver struct {
+	mock.Mock
+}
+
+// GetConnection provides a mock function with given fields:
+func (_m *Driver) GetConnection() (datastore.Connection, error) {
+	ret := _m.Called()
+
+	var r0 datastore.Connection
+	if rf, ok := ret.Get(0).(func() datastore.Connection); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(datastore.Connection)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/domain/pool/pool.go
+++ b/domain/pool/pool.go
@@ -16,6 +16,7 @@ package pool
 import (
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain"
+	"github.com/control-center/serviced/domain/host"
 
 	"reflect"
 	"sort"
@@ -44,6 +45,14 @@ type ResourcePool struct {
 	UpdatedAt         time.Time
 	MonitoringProfile domain.MonitorProfile
 	datastore.VersionedEntity
+}
+
+
+// PoolIPs type for IP resources available in a ResourcePool
+type PoolIPs struct {
+	PoolID     string
+	HostIPs    []host.HostIPResource
+	VirtualIPs []VirtualIP
 }
 
 type ByIP []VirtualIP

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -69,7 +69,7 @@ type FacadeInterface interface {
 
 	GetResourcePools(ctx datastore.Context) ([]pool.ResourcePool, error)
 
-	GetPoolIPs(ctx datastore.Context, poolID string) (*PoolIPs, error)
+	GetPoolIPs(ctx datastore.Context, poolID string) (*pool.PoolIPs, error)
 
 	HasIP(ctx datastore.Context, poolID string, ipAddr string) (bool, error)
 

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -57,13 +57,23 @@ type FacadeInterface interface {
 
 	AddHost(ctx datastore.Context, entity *host.Host) error
 
+	GetHost(ctx datastore.Context, hostID string) (*host.Host, error)
+
 	GetHosts(ctx datastore.Context) ([]host.Host, error)
+
+	FindHostsInPool(ctx datastore.Context, poolID string) ([]host.Host, error)
 
 	AddResourcePool(ctx datastore.Context, entity *pool.ResourcePool) error
 
+	GetResourcePool(ctx datastore.Context, poolID string) (*pool.ResourcePool, error)
+
 	GetResourcePools(ctx datastore.Context) ([]pool.ResourcePool, error)
 
+	GetPoolIPs(ctx datastore.Context, poolID string) (*PoolIPs, error)
+
 	HasIP(ctx datastore.Context, poolID string, ipAddr string) (bool, error)
+
+	RemoveResourcePool(ctx datastore.Context, id string) error
 
 	UpdateResourcePool(ctx datastore.Context, entity *pool.ResourcePool) error
 

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -13,17 +13,20 @@
 
 package mocks
 
-import "github.com/stretchr/testify/mock"
+import (
+	"time"
 
-import "time"
-import "github.com/control-center/serviced/dao"
-import "github.com/control-center/serviced/datastore"
-import "github.com/control-center/serviced/domain"
-import "github.com/control-center/serviced/domain/host"
-import "github.com/control-center/serviced/domain/pool"
-import "github.com/control-center/serviced/domain/service"
-import "github.com/control-center/serviced/domain/servicestate"
-import "github.com/control-center/serviced/domain/servicetemplate"
+	"github.com/control-center/serviced/dao"
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain"
+	"github.com/control-center/serviced/domain/host"
+	"github.com/control-center/serviced/domain/pool"
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/domain/servicestate"
+	"github.com/control-center/serviced/domain/servicetemplate"
+	"github.com/control-center/serviced/facade"
+	"github.com/stretchr/testify/mock"
+)
 
 type FacadeInterface struct {
 	mock.Mock
@@ -149,8 +152,30 @@ func (m *FacadeInterface) AddHost(ctx datastore.Context, entity *host.Host) erro
 
 	return r0
 }
+func (m *FacadeInterface) GetHost(ctx datastore.Context, hostID string) (*host.Host, error) {
+	ret := m.Called(ctx, hostID)
+
+	var r0 *host.Host
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*host.Host)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
 func (m *FacadeInterface) GetHosts(ctx datastore.Context) ([]host.Host, error) {
 	ret := m.Called(ctx)
+
+	var r0 []host.Host
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]host.Host)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *FacadeInterface) FindHostsInPool(ctx datastore.Context, poolID string) ([]host.Host, error) {
+	ret := m.Called(ctx, poolID)
 
 	var r0 []host.Host
 	if ret.Get(0) != nil {
@@ -167,12 +192,34 @@ func (m *FacadeInterface) AddResourcePool(ctx datastore.Context, entity *pool.Re
 
 	return r0
 }
+func (m *FacadeInterface) GetResourcePool(ctx datastore.Context, poolID string) (*pool.ResourcePool, error) {
+	ret := m.Called(ctx, poolID)
+
+	var r0 *pool.ResourcePool
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*pool.ResourcePool)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
 func (m *FacadeInterface) GetResourcePools(ctx datastore.Context) ([]pool.ResourcePool, error) {
 	ret := m.Called(ctx)
 
 	var r0 []pool.ResourcePool
 	if ret.Get(0) != nil {
 		r0 = ret.Get(0).([]pool.ResourcePool)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *FacadeInterface) GetPoolIPs(ctx datastore.Context, poolID string) (*facade.PoolIPs, error) {
+	ret := m.Called(ctx, poolID)
+
+	var r0 *facade.PoolIPs
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*facade.PoolIPs)
 	}
 	r1 := ret.Error(1)
 
@@ -185,6 +232,13 @@ func (m *FacadeInterface) HasIP(ctx datastore.Context, poolID string, ipAddr str
 	r1 := ret.Error(1)
 
 	return r0, r1
+}
+func (m *FacadeInterface) RemoveResourcePool(ctx datastore.Context, id string) error {
+	ret := m.Called(ctx, id)
+
+	r0 := ret.Error(0)
+
+	return r0
 }
 func (m *FacadeInterface) UpdateResourcePool(ctx datastore.Context, entity *pool.ResourcePool) error {
 	ret := m.Called(ctx, entity)

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -24,7 +24,6 @@ import (
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/domain/servicestate"
 	"github.com/control-center/serviced/domain/servicetemplate"
-	"github.com/control-center/serviced/facade"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -214,12 +213,12 @@ func (m *FacadeInterface) GetResourcePools(ctx datastore.Context) ([]pool.Resour
 
 	return r0, r1
 }
-func (m *FacadeInterface) GetPoolIPs(ctx datastore.Context, poolID string) (*facade.PoolIPs, error) {
+func (m *FacadeInterface) GetPoolIPs(ctx datastore.Context, poolID string) (*pool.PoolIPs, error) {
 	ret := m.Called(ctx, poolID)
 
-	var r0 *facade.PoolIPs
+	var r0 *pool.PoolIPs
 	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(*facade.PoolIPs)
+		r0 = ret.Get(0).(*pool.PoolIPs)
 	}
 	r1 := ret.Error(1)
 

--- a/facade/pool.go
+++ b/facade/pool.go
@@ -44,13 +44,6 @@ var (
 	ErrDefaultPool   = errors.New("facade: cannot delete default resource pool")
 )
 
-// PoolIPs type for IP resources available in a ResourcePool
-type PoolIPs struct {
-	PoolID     string
-	HostIPs    []host.HostIPResource
-	VirtualIPs []pool.VirtualIP
-}
-
 // AddResourcePool adds a new resource pool
 func (f *Facade) AddResourcePool(ctx datastore.Context, entity *pool.ResourcePool) error {
 	if err := f.DFSLock(ctx).LockWithTimeout("add resource pool", userLockTimeout); err != nil {
@@ -457,7 +450,7 @@ func (f *Facade) calcPoolCommitment(ctx datastore.Context, pool *pool.ResourcePo
 }
 
 // GetPoolIPs gets all IPs available to a resource pool
-func (f *Facade) GetPoolIPs(ctx datastore.Context, poolID string) (*PoolIPs, error) {
+func (f *Facade) GetPoolIPs(ctx datastore.Context, poolID string) (*pool.PoolIPs, error) {
 	glog.V(0).Infof("Facade.GetPoolIPs: %+v", poolID)
 	hosts, err := f.FindHostsInPool(ctx, poolID)
 	if err != nil {
@@ -483,7 +476,7 @@ func (f *Facade) GetPoolIPs(ctx datastore.Context, poolID string) (*PoolIPs, err
 	virtualIPs := make([]pool.VirtualIP, 0)
 	virtualIPs = append(virtualIPs, myPool.VirtualIPs...)
 
-	return &PoolIPs{PoolID: poolID, HostIPs: hostIPs, VirtualIPs: virtualIPs}, nil
+	return &pool.PoolIPs{PoolID: poolID, HostIPs: hostIPs, VirtualIPs: virtualIPs}, nil
 }
 
 var defaultRealm = "default"

--- a/rpc/master/interface.go
+++ b/rpc/master/interface.go
@@ -18,7 +18,6 @@ import (
 	"github.com/control-center/serviced/domain/host"
 	"github.com/control-center/serviced/domain/pool"
 	"github.com/control-center/serviced/domain/service"
-	"github.com/control-center/serviced/facade"
 	"github.com/control-center/serviced/volume"
 	"time"
 )
@@ -73,7 +72,7 @@ type ClientInterface interface {
 	RemoveResourcePool(poolID string) error
 
 	// GetPoolIPs returns a all IPs in a ResourcePool.
-	GetPoolIPs(poolID string) (*facade.PoolIPs, error)
+	GetPoolIPs(poolID string) (*pool.PoolIPs, error)
 
 	// AddVirtualIP adds a VirtualIP to a specific pool
 	AddVirtualIP(requestVirtualIP pool.VirtualIP) error

--- a/rpc/master/mocks/ClientInterface.go
+++ b/rpc/master/mocks/ClientInterface.go
@@ -6,7 +6,6 @@ import "github.com/control-center/serviced/domain/applicationendpoint"
 import "github.com/control-center/serviced/domain/host"
 import "github.com/control-center/serviced/domain/pool"
 import "github.com/control-center/serviced/domain/service"
-import "github.com/control-center/serviced/facade"
 import "github.com/control-center/serviced/volume"
 import "time"
 
@@ -224,15 +223,15 @@ func (_m *ClientInterface) RemoveResourcePool(poolID string) error {
 
 	return r0
 }
-func (_m *ClientInterface) GetPoolIPs(poolID string) (*facade.PoolIPs, error) {
+func (_m *ClientInterface) GetPoolIPs(poolID string) (*pool.PoolIPs, error) {
 	ret := _m.Called(poolID)
 
-	var r0 *facade.PoolIPs
-	if rf, ok := ret.Get(0).(func(string) *facade.PoolIPs); ok {
+	var r0 *pool.PoolIPs
+	if rf, ok := ret.Get(0).(func(string) *pool.PoolIPs); ok {
 		r0 = rf(poolID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*facade.PoolIPs)
+			r0 = ret.Get(0).(*pool.PoolIPs)
 		}
 	}
 

--- a/rpc/master/pool_client.go
+++ b/rpc/master/pool_client.go
@@ -15,7 +15,6 @@ package master
 
 import (
 	"github.com/control-center/serviced/domain/pool"
-	"github.com/control-center/serviced/facade"
 )
 
 //GetResourcePool gets the pool for the given poolID or nil
@@ -52,8 +51,8 @@ func (c *Client) RemoveResourcePool(poolID string) error {
 }
 
 //GetPoolIPs returns a all IPs in a ResourcePool.
-func (c *Client) GetPoolIPs(poolID string) (*facade.PoolIPs, error) {
-	var poolIPs facade.PoolIPs
+func (c *Client) GetPoolIPs(poolID string) (*pool.PoolIPs, error) {
+	var poolIPs pool.PoolIPs
 	if err := c.call("GetPoolIPs", poolID, &poolIPs); err != nil {
 		return nil, err
 	}

--- a/rpc/master/pool_server.go
+++ b/rpc/master/pool_server.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 
 	"github.com/control-center/serviced/domain/pool"
-	"github.com/control-center/serviced/facade"
 )
 
 // GetResourcePools returns all ResourcePools
@@ -60,7 +59,7 @@ func (s *Server) RemoveResourcePool(poolID string, _ *struct{}) error {
 }
 
 // GetPoolIPs gets all ips available to a pool
-func (s *Server) GetPoolIPs(poolID string, reply *facade.PoolIPs) error {
+func (s *Server) GetPoolIPs(poolID string, reply *pool.PoolIPs) error {
 	response, err := s.f.GetPoolIPs(s.context(), poolID)
 	if err != nil {
 		return err

--- a/web/poolresource.go
+++ b/web/poolresource.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/facade"
+	"fmt"
 )
 
 //restGetPools retrieves all Resource Pools. Response is map[pool-id]ResourcePool
@@ -105,7 +106,11 @@ func restUpdatePool(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext
 	if err != nil {
 		restBadRequest(w, err)
 		return
+	} else if len(poolID) == 0 {
+		restBadRequest(w, fmt.Errorf("poolID must be specified for PUT"))
+		return
 	}
+
 	var payload pool.ResourcePool
 	err = r.DecodeJsonPayload(&payload)
 	if err != nil {

--- a/web/poolresource.go
+++ b/web/poolresource.go
@@ -4,40 +4,38 @@
 package web
 
 import (
+	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain"
 	"github.com/control-center/serviced/domain/pool"
-	"github.com/control-center/serviced/rpc/master"
 	"github.com/zenoss/glog"
 	"github.com/zenoss/go-json-rest"
 
 	"net/url"
 
 	"github.com/control-center/serviced/dao"
+	"github.com/control-center/serviced/facade"
 )
 
 //restGetPools retrieves all Resource Pools. Response is map[pool-id]ResourcePool
 func restGetPools(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
-	client, err := ctx.getMasterClient()
-	if err != nil {
-		restServerError(w, err)
-		return
-	}
-
-	pools, err := client.GetResourcePools()
+	facade := ctx.getFacade()
+	dataCtx := ctx.getDatastoreContext()
+	pools, err := facade.GetResourcePools(dataCtx)
 	if err != nil {
 		glog.Error("Could not get resource pools: ", err)
 		restServerError(w, err)
 		return
 	}
+
 	poolsMap := make(map[string]*pool.ResourcePool)
 	for i, pool := range pools {
-		hostIDs, err := getPoolHostIds(pool.ID, client)
+		hostIDs, err := getPoolHostIds(pool.ID, facade, dataCtx)
 		if err != nil {
 			restServerError(w, err)
 			return
 		}
 
-		if err := buildPoolMonitoringProfile(&pools[i], hostIDs, client); err != nil {
+		if err := buildPoolMonitoringProfile(&pools[i], hostIDs, facade, dataCtx); err != nil {
 			restServerError(w, err)
 			return
 		}
@@ -56,26 +54,22 @@ func restGetPool(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
 		return
 	}
 
-	client, err := ctx.getMasterClient()
-	if err != nil {
-		restServerError(w, err)
-		return
-	}
-
-	pool, err := client.GetResourcePool(poolID)
+	facade := ctx.getFacade()
+	dataCtx := ctx.getDatastoreContext()
+	pool, err := facade.GetResourcePool(dataCtx, poolID)
 	if err != nil {
 		glog.Error("Could not get resource pool: ", err)
 		restServerError(w, err)
 		return
 	}
 
-	hostIDs, err := getPoolHostIds(pool.ID, client)
+	hostIDs, err := getPoolHostIds(pool.ID, facade, dataCtx)
 	if err != nil {
 		restServerError(w, err)
 		return
 	}
 
-	if err := buildPoolMonitoringProfile(pool, hostIDs, client); err != nil {
+	if err := buildPoolMonitoringProfile(pool, hostIDs, facade, dataCtx); err != nil {
 		restServerError(w, err)
 		return
 	}
@@ -93,13 +87,9 @@ func restAddPool(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
 		restBadRequest(w, err)
 		return
 	}
-	client, err := ctx.getMasterClient()
-	if err != nil {
-		restServerError(w, err)
-		return
-	}
 
-	err = client.AddResourcePool(payload)
+	facade := ctx.getFacade()
+	err = facade.AddResourcePool(ctx.getDatastoreContext(), &payload)
 	if err != nil {
 		glog.Error("Unable to add pool: ", err)
 		restServerError(w, err)
@@ -123,12 +113,9 @@ func restUpdatePool(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext
 		restBadRequest(w, err)
 		return
 	}
-	client, err := ctx.getMasterClient()
-	if err != nil {
-		restServerError(w, err)
-		return
-	}
-	err = client.UpdateResourcePool(payload)
+
+	facade := ctx.getFacade()
+	err = facade.UpdateResourcePool(ctx.getDatastoreContext(), &payload)
 	if err != nil {
 		glog.Error("Unable to update pool: ", err)
 		restServerError(w, err)
@@ -145,12 +132,9 @@ func restRemovePool(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext
 		restBadRequest(w, err)
 		return
 	}
-	client, err := ctx.getMasterClient()
-	if err != nil {
-		restServerError(w, err)
-		return
-	}
-	err = client.RemoveResourcePool(poolID)
+
+	facade := ctx.getFacade()
+	err = facade.RemoveResourcePool(ctx.getDatastoreContext(), poolID)
 	if err != nil {
 		glog.Error("Could not remove resource pool: ", err)
 		restServerError(w, err)
@@ -169,12 +153,9 @@ func restGetHostsForResourcePool(w *rest.ResponseWriter, r *rest.Request, ctx *r
 		restBadRequest(w, err)
 		return
 	}
-	client, err := ctx.getMasterClient()
-	if err != nil {
-		restServerError(w, err)
-		return
-	}
-	hosts, err := client.FindHostsInPool(poolID)
+
+	facade := ctx.getFacade()
+	hosts, err := facade.FindHostsInPool(ctx.getDatastoreContext(), poolID)
 	if err != nil {
 		glog.Errorf("Could not get hosts: %v", err)
 		restServerError(w, err)
@@ -200,13 +181,8 @@ func restGetPoolIps(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext
 		return
 	}
 
-	client, err := ctx.getMasterClient()
-	if err != nil {
-		restServerError(w, err)
-		return
-	}
-
-	ips, err := client.GetPoolIPs(poolID)
+	facade := ctx.getFacade()
+	ips, err := facade.GetPoolIPs(ctx.getDatastoreContext(), poolID)
 	if err != nil {
 		glog.Error("Could not get resource pool: ", err)
 		restServerError(w, err)
@@ -217,8 +193,8 @@ func restGetPoolIps(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext
 	w.WriteJson(&ips)
 }
 
-func getPoolHostIds(poolID string, client master.ClientInterface) ([]string, error) {
-	hosts, err := client.FindHostsInPool(poolID)
+func getPoolHostIds(poolID string, facade facade.FacadeInterface, dataCtx datastore.Context) ([]string, error) {
+	hosts, err := facade.FindHostsInPool(dataCtx, poolID)
 	if err != nil {
 		glog.Errorf("Could not get hosts: %v", err)
 		return nil, err
@@ -231,13 +207,13 @@ func getPoolHostIds(poolID string, client master.ClientInterface) ([]string, err
 	return hostIDs, nil
 }
 
-func buildPoolMonitoringProfile(pool *pool.ResourcePool, hostIDs []string, client master.ClientInterface) error {
+func buildPoolMonitoringProfile(pool *pool.ResourcePool, hostIDs []string, facade facade.FacadeInterface, dataCtx datastore.Context) error {
 	var totalMemory uint64 = 0
 	var totalCores int = 0
 
 	//calculate total memory and total cores
 	for i := range hostIDs {
-		host, err := client.GetHost(hostIDs[i])
+		host, err := facade.GetHost(dataCtx, hostIDs[i])
 		if err != nil {
 			glog.Errorf("Failed to get host for id=%s -> %s", hostIDs[i], err)
 			return err

--- a/web/poolresource_test.go
+++ b/web/poolresource_test.go
@@ -74,7 +74,10 @@ func (s *TestWebSuite) TestRestUpdatePool(c *C) {
 }
 
 func (s *TestWebSuite) TestRestUpdatePoolFails(c *C) {
-	request := s.buildRequest("PUT", "/pools", `{"ID": "somePool"}`)
+	poolID := "testPool"
+	poolJson := `{"ID": "` + poolID + `", "Description": "test pool"}`
+	request := s.buildRequest("PUT", "/pools", poolJson)
+	request.PathParams["poolId"] = poolID
 	expectedError := fmt.Errorf("mock update failed")
 	s.mockFacade.
 		On("UpdateResourcePool", s.ctx.getDatastoreContext(), mock.AnythingOfType("*pool.ResourcePool")).
@@ -96,6 +99,15 @@ func (s *TestWebSuite) TestRestUpdatePoolFailsForInvalidURL(c *C) {
 
 func (s *TestWebSuite) TestRestUpdatePoolFailsForBadJSON(c *C) {
 	request := s.buildRequest("PUT", "/pools", "{this is not valid json}")
+	request.PathParams["poolId"] = "someID"
+
+	restUpdatePool(&(s.writer), &request, s.ctx)
+
+	s.assertBadRequest(c)
+}
+
+func (s *TestWebSuite) TestResUpdatePoolFailsForMissingPoolID(c *C) {
+	request := s.buildRequest("PUT","/pools", `{"ID": "somePool"}`)
 
 	restUpdatePool(&(s.writer), &request, s.ctx)
 

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -1,0 +1,103 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/control-center/serviced/datastore"
+	datastoreMocks "github.com/control-center/serviced/datastore/mocks"
+	facadeMocks "github.com/control-center/serviced/facade/mocks"
+	"github.com/zenoss/go-json-rest"
+	. "gopkg.in/check.v1"
+)
+
+// Wire gocheck into the go test runner
+func TestWeb(t *testing.T) { TestingT(t) }
+
+type TestWebSuite struct{
+	ctx        *requestContext
+	recorder   *httptest.ResponseRecorder
+	writer     rest.ResponseWriter
+	mockDriver *datastoreMocks.Driver
+	mockFacade *facadeMocks.FacadeInterface
+}
+
+// verify TestWebSuite implements the Suite interface
+var _ = Suite(&TestWebSuite{})
+
+func (s *TestWebSuite) SetUpTest(c *C) {
+	s.mockDriver = &datastoreMocks.Driver{}
+	datastore.Register(s.mockDriver)
+
+	s.mockFacade = &facadeMocks.FacadeInterface{}
+	config := ServiceConfig{facade: s.mockFacade}
+	s.ctx = newRequestContext(&config)
+
+	s.recorder = httptest.NewRecorder()
+	s.writer = rest.NewResponseWriter(s.recorder, false)
+}
+
+func (s *TestWebSuite) TearDownTest(c *C) {
+	s.ctx = nil
+	s.recorder = nil
+	s.writer = rest.ResponseWriter{}
+	s.mockDriver = nil
+	s.mockFacade = nil
+}
+
+// Build a REST request suitable for testing.
+func (s *TestWebSuite) buildRequest(action, url, payload string) rest.Request {
+	reader := strings.NewReader(payload)
+	httpRequest, _ := http.NewRequest(action, url, reader)
+	return rest.Request{
+		httpRequest,
+		nil,
+	}
+}
+
+// Verify that the Body string from the recorder is a valid 'simpleResponse' containing
+func (s *TestWebSuite) assertSimpleResponse(c *C, expectedDetails string, expectedLinks []link) {
+	body := s.recorder.Body.String()
+	c.Assert(len(body), Not(Equals), 0)
+
+	response := simpleResponse{}
+	err := json.Unmarshal([]byte(body), &response)
+	c.Assert(err, IsNil)
+
+	c.Assert(response.Detail, Matches, expectedDetails)
+	s.assertLinks(c, response.Links, expectedLinks)
+}
+
+func (s *TestWebSuite) assertLinks(c *C, actual, expected []link) {
+	c.Assert(len(actual), Equals, len(expected))
+	c.Assert(len(actual), DeepEquals, len(expected))
+}
+
+func (s *TestWebSuite) assertBadRequest(c *C) {
+	c.Assert(s.recorder.Code, Equals, http.StatusInternalServerError)
+	s.assertSimpleResponse(c, "Bad Request: .*",  homeLink())
+}
+
+func (s *TestWebSuite) assertServerError(c *C, expectedError error) {
+	c.Assert(s.recorder.Code, Equals, http.StatusInternalServerError)
+	s.assertSimpleResponse(c, fmt.Sprintf("Internal Server Error: %s", expectedError),  homeLink())
+}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -70,7 +70,7 @@ func (s *TestWebSuite) buildRequest(action, url, payload string) rest.Request {
 	httpRequest, _ := http.NewRequest(action, url, reader)
 	return rest.Request{
 		httpRequest,
-		nil,
+		map[string]string{},
 	}
 }
 


### PR DESCRIPTION
This PR injects an instance of Facade into the web tier as a first step in decoupling the REST layer from the RPC layer.

The bulk of the changes are in the first commit; the rest are adding mostly related to unit-tests. More unit-tests are required to validate all of the REST endpoints for resource pools, but I wanted to get a preliminary review first.  

Follow-up refactors can address replacing RPC calls for hosts, and eventually the other domain endpoints as well