### PR TITLE
refactor REST API for host to use Facade

### DIFF
--- a/facade/interface.go
+++ b/facade/interface.go
@@ -61,6 +61,12 @@ type FacadeInterface interface {
 
 	GetHosts(ctx datastore.Context) ([]host.Host, error)
 
+	GetActiveHostIDs(ctx datastore.Context) ([]string, error)
+
+	UpdateHost(ctx datastore.Context, entity *host.Host) error
+
+	RemoveHost(ctx datastore.Context, hostID string) error
+
 	FindHostsInPool(ctx datastore.Context, poolID string) ([]host.Host, error)
 
 	AddResourcePool(ctx datastore.Context, entity *pool.ResourcePool) error

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -173,6 +173,31 @@ func (m *FacadeInterface) GetHosts(ctx datastore.Context) ([]host.Host, error) {
 
 	return r0, r1
 }
+func (m* FacadeInterface) GetActiveHostIDs(ctx datastore.Context) ([]string, error) {
+	ret := m.Called(ctx)
+
+	var r0 []string
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]string)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m* FacadeInterface) UpdateHost(ctx datastore.Context, entity *host.Host) error {
+	ret := m.Called(ctx, entity)
+
+	r0 := ret.Error(0)
+
+	return r0
+}
+func (m* FacadeInterface) RemoveHost(ctx datastore.Context, hostID string) error {
+	ret := m.Called(ctx, hostID)
+
+	r0 := ret.Error(0)
+
+	return r0
+}
 func (m *FacadeInterface) FindHostsInPool(ctx datastore.Context, poolID string) ([]host.Host, error) {
 	ret := m.Called(ctx, poolID)
 

--- a/web/hostresource.go
+++ b/web/hostresource.go
@@ -28,20 +28,17 @@ import (
 
 //restGetHosts gets all hosts. Response is map[host-id]host.Host
 func restGetHosts(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
-	response := make(map[string]*host.Host)
-	client, err := ctx.getMasterClient()
-	if err != nil {
-		restServerError(w, err)
-		return
-	}
-
-	hosts, err := client.GetHosts()
+	facade := ctx.getFacade()
+	dataCtx := ctx.getDatastoreContext()
+	hosts, err := facade.GetHosts(dataCtx)
 	if err != nil {
 		glog.Errorf("Could not get hosts: %v", err)
 		restServerError(w, err)
 		return
 	}
+
 	glog.V(2).Infof("Returning %d hosts", len(hosts))
+	response := make(map[string]*host.Host)
 	for i, host := range hosts {
 		response[host.ID] = &hosts[i]
 		if err := buildHostMonitoringProfile(&hosts[i]); err != nil {
@@ -54,14 +51,9 @@ func restGetHosts(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) 
 }
 
 func restGetActiveHostIDs(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
-
-	client, err := ctx.getMasterClient()
-	if err != nil {
-		restServerError(w, err)
-		return
-	}
-
-	hostids, err := client.GetActiveHostIDs()
+	facade := ctx.getFacade()
+	dataCtx := ctx.getDatastoreContext()
+	hostids, err := facade.GetActiveHostIDs(dataCtx)
 	if err != nil {
 		restServerError(w, err)
 		return
@@ -79,13 +71,9 @@ func restGetHost(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
 		return
 	}
 
-	client, err := ctx.getMasterClient()
-	if err != nil {
-		restServerError(w, err)
-		return
-	}
-
-	host, err := client.GetHost(hostID)
+	facade := ctx.getFacade()
+	dataCtx := ctx.getDatastoreContext()
+	host, err := facade.GetHost(dataCtx, hostID)
 	if err != nil {
 		glog.Error("Could not get host: ", err)
 		restServerError(w, err)
@@ -101,7 +89,6 @@ func restGetHost(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
 	w.WriteJson(&host)
 }
 
-//restGetMaster retrieves information related to the master.
 func restGetDefaultHostAlias(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
 	w.WriteJson(&map[string]string{"hostalias": defaultHostAlias})
 }
@@ -170,13 +157,10 @@ func restAddHost(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
 		restBadRequest(w, err)
 		return
 	}
-	masterClient, err := ctx.getMasterClient()
-	if err != nil {
-		glog.Errorf("Unable to add host: %v", err)
-		restServerError(w, err)
-		return
-	}
-	err = masterClient.AddHost(*host)
+
+	facade := ctx.getFacade()
+	dataCtx := ctx.getDatastoreContext()
+	err = facade.AddHost(dataCtx, host)
 	if err != nil {
 		glog.Errorf("Unable to add host: %v", err)
 		restServerError(w, err)
@@ -202,13 +186,9 @@ func restUpdateHost(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext
 		return
 	}
 
-	masterClient, err := ctx.getMasterClient()
-	if err != nil {
-		glog.Errorf("Unable to add host: %v", err)
-		restServerError(w, err)
-		return
-	}
-	err = masterClient.UpdateHost(payload)
+	facade := ctx.getFacade()
+	dataCtx := ctx.getDatastoreContext()
+	err = facade.UpdateHost(dataCtx, &payload)
 	if err != nil {
 		glog.Errorf("Unable to update host: %v", err)
 		restServerError(w, err)
@@ -226,13 +206,9 @@ func restRemoveHost(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext
 		return
 	}
 
-	masterClient, err := ctx.getMasterClient()
-	if err != nil {
-		glog.Errorf("Unable to add host: %v", err)
-		restServerError(w, err)
-		return
-	}
-	err = masterClient.RemoveHost(hostID)
+	facade := ctx.getFacade()
+	dataCtx := ctx.getDatastoreContext()
+	err = facade.RemoveHost(dataCtx, hostID)
 	if err != nil {
 		glog.Errorf("Could not remove host: %v", err)
 		restServerError(w, err)

--- a/web/hostresource_test.go
+++ b/web/hostresource_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Serviced Authors.
+// Copyright 2016 The Serviced Authors.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,24 +16,265 @@
 package web
 
 import (
-	"github.com/control-center/serviced/domain/host"
+	"fmt"
+	"net/http"
 
-	"testing"
+	"github.com/control-center/serviced/domain/host"
+	"github.com/stretchr/testify/mock"
+	. "gopkg.in/check.v1"
 )
 
-func TestBuildHostMonitoringProfile(t *testing.T) {
+func (s *TestWebSuite) TestRestGetHosts(c *C) {
+	expectedHosts := []host.Host{
+		{ID: "host1"},
+		{ID: "host2"},
+	}
+	expectedResult := map[string]host.Host{
+		"host1": expectedHosts[0],
+		"host2": expectedHosts[1],
+	}
+	request := s.buildRequest("GET", "/hosts", "")
+	s.mockFacade.
+		On("GetHosts", s.ctx.getDatastoreContext()).
+		Return(expectedHosts, nil)
+	
+	restGetHosts(&(s.writer), &request, s.ctx)
+	
+	c.Assert(s.recorder.Code, Equals, http.StatusOK)
+	actualResult := map[string]host.Host{}
+	s.getResult(c, &actualResult)
+	s.assertMapKeys(c, actualResult, expectedResult)
+	for hostID, host := range actualResult {
+		c.Assert(host.ID, Equals, expectedResult[hostID].ID)
+	}
+}
+
+func (s *TestWebSuite) TestRestGetHostsReturnsEmptyList(c *C) {
+	emptyHosts := []host.Host{}
+	request := s.buildRequest("GET", "/hosts", "")
+	s.mockFacade.
+		On("GetHosts", s.ctx.getDatastoreContext()).
+		Return(emptyHosts, nil)
+
+	restGetHosts(&(s.writer), &request, s.ctx)
+
+	c.Assert(s.recorder.Code, Equals, http.StatusOK)
+	actualResult := map[string]host.Host{}
+	s.getResult(c, &actualResult)
+	c.Assert(len(actualResult), Equals, 0)
+}
+
+func (s *TestWebSuite) TestRestGetHostsFails(c *C) {
+	expectedError := fmt.Errorf("mock GetHosts failed")
+	request := s.buildRequest("GET", "/hosts", "")
+	s.mockFacade.
+		On("GetHosts", s.ctx.getDatastoreContext()).
+		Return(nil, expectedError)
+
+	restGetHosts(&(s.writer), &request, s.ctx)
+
+	s.assertServerError(c, expectedError)
+}
+
+func (s *TestWebSuite) TestRestGetActiveHostIDs(c *C) {
+	expectedHostIDs := []string{
+		"host1",
+		"host2",
+	}
+	request := s.buildRequest("GET", "/hosts/running", "")
+	s.mockFacade.
+		On("GetActiveHostIDs", s.ctx.getDatastoreContext()).
+		Return(expectedHostIDs, nil)
+
+	restGetActiveHostIDs(&(s.writer), &request, s.ctx)
+
+	c.Assert(s.recorder.Code, Equals, http.StatusOK)
+	actualResult := []string{}
+	s.getResult(c, &actualResult)
+	c.Assert(len(actualResult), Equals, len(expectedHostIDs))
+	c.Assert(actualResult, DeepEquals, expectedHostIDs)
+}
+
+func (s *TestWebSuite) TestRestGetActiveHostIDFails(c *C) {
+	expectedError := fmt.Errorf("mock GetActiveHostIDs failed")
+	request := s.buildRequest("GET", "/hosts/running", "")
+	s.mockFacade.
+		On("GetActiveHostIDs", s.ctx.getDatastoreContext()).
+		Return(nil, expectedError)
+
+	restGetActiveHostIDs(&(s.writer), &request, s.ctx)
+
+	s.assertServerError(c, expectedError)
+}
+
+func (s *TestWebSuite) TestRestGetHost(c *C) {
+	hostID := "someHostID"
+	expectedHost := host.Host{ID: hostID}
+	request := s.buildRequest("GET", "/hosts/someHostID", "")
+	request.PathParams["hostId"] = hostID
+	s.mockFacade.
+		On("GetHost", s.ctx.getDatastoreContext(), hostID).
+		Return(&expectedHost, nil)
+
+	restGetHost(&(s.writer), &request, s.ctx)
+
+	c.Assert(s.recorder.Code, Equals, http.StatusOK)
+	actualResult := host.Host{}
+	s.getResult(c, &actualResult)
+	c.Assert(actualResult.ID, Equals, expectedHost.ID)
+}
+
+func (s *TestWebSuite) TestRestGetHostFails(c *C) {
+	expectedError := fmt.Errorf("mock GetHost failed")
+	hostID := "someHostID"
+	request := s.buildRequest("GET", "/hosts/someHostID", "")
+	request.PathParams["hostId"] = hostID
+	s.mockFacade.
+		On("GetHost", s.ctx.getDatastoreContext(), hostID).
+		Return(nil, expectedError)
+
+	restGetHost(&(s.writer), &request, s.ctx)
+
+	s.assertServerError(c, expectedError)
+}
+
+func (s *TestWebSuite) TestRestGetHostFailsForInvalidURL(c *C) {
+	request := s.buildRequest("GET", "/hosts", "")
+	request.PathParams["hostId"] = "%zzz"
+
+	restGetHost(&(s.writer), &request, s.ctx)
+
+	s.assertBadRequest(c)
+}
+
+func (s *TestWebSuite) TestRestAddHostFailsForBadJSON(c *C) {
+	request := s.buildRequest("POST", "/hosts/add", "{this is not valid json}")
+
+	restAddHost(&(s.writer), &request, s.ctx)
+
+	s.assertBadRequest(c)
+}
+
+func (s *TestWebSuite) TestRestAddHostFailsForBadIP(c *C) {
+	hostID := "testHost"
+	hostJSON := `{"ID": "` + hostID + `", "Description": "test host", "IPAddr": "badip:4979"}`
+	request := s.buildRequest("POST", "/hosts/add", hostJSON)
+
+	restAddHost(&(s.writer), &request, s.ctx)
+
+	s.assertBadRequest(c)
+}
+
+func (s *TestWebSuite) TestRestAddHostFailsForMissingPort(c *C) {
+	hostID := "testHost"
+	hostJSON := `{"ID": "` + hostID + `", "Description": "test host", "IPAddr": "127.0.0.1"}`
+	request := s.buildRequest("POST", "/hosts/add", hostJSON)
+
+	restAddHost(&(s.writer), &request, s.ctx)
+
+	s.assertBadRequest(c)
+}
+
+func (s *TestWebSuite) TestRestAddHostFailsForInvalidPort(c *C) {
+	hostID := "testHost"
+	hostJSON := `{"ID": "` + hostID + `", "Description": "test host", "IPAddr": "127.0.0.1:badPort"}`
+	request := s.buildRequest("POST", "/hosts/add", hostJSON)
+
+	restAddHost(&(s.writer), &request, s.ctx)
+
+	s.assertBadRequest(c)
+}
+
+func (s *TestWebSuite) TestRestUpdateHost(c *C) {
+	hostID := "testHost"
+	hostJSON := `{"ID": "` + hostID + `", "Description": "test host"}`
+	request := s.buildRequest("PUT", "/hosts/testHost", hostJSON)
+	request.PathParams["hostId"] = hostID
+	s.mockFacade.
+		On("UpdateHost", s.ctx.getDatastoreContext(), mock.AnythingOfType("*host.Host")).
+		Return(nil)
+
+	restUpdateHost(&(s.writer), &request, s.ctx)
+
+	c.Assert(s.recorder.Code, Equals, http.StatusOK)
+	s.assertSimpleResponse(c, "Updated host", hostLinks(hostID))
+}
+
+func (s *TestWebSuite) TestRestUpdateHostFails(c *C) {
+	expectedError := fmt.Errorf("mock UpdateHost failed")
+	hostID := "testHost"
+	hostJSON := `{"ID": "` + hostID + `", "Description": "test host"}`
+	request := s.buildRequest("PUT", "/hosts/testHost", hostJSON)
+	request.PathParams["hostId"] = hostID
+	s.mockFacade.
+		On("UpdateHost", s.ctx.getDatastoreContext(), mock.AnythingOfType("*host.Host")).
+		Return(expectedError)
+
+	restUpdateHost(&(s.writer), &request, s.ctx)
+
+	s.assertServerError(c, expectedError)
+}
+
+func (s *TestWebSuite) TestRestUpdateHostFailsForInvalidURL(c *C) {
+	request := s.buildRequest("PUT", "/hosts/%zzz", "")
+	request.PathParams["hostId"] = "%zzz"
+
+	restUpdateHost(&(s.writer), &request, s.ctx)
+
+	s.assertBadRequest(c)
+}
+
+func (s *TestWebSuite) TestRestUpdateHostFailsForBadJSON(c *C) {
+	request := s.buildRequest("PUT", "/hosts/someHostID", "{this is not valid json}")
+
+	restUpdateHost(&(s.writer), &request, s.ctx)
+
+	s.assertBadRequest(c)
+}
+
+func (s *TestWebSuite) TestRestRemoveHost(c *C) {
+	hostID := "testHost"
+	request := s.buildRequest("DELETE", "/hosts/testHost", "")
+	request.PathParams["hostId"] = hostID
+	s.mockFacade.
+		On("RemoveHost", s.ctx.getDatastoreContext(), hostID).
+		Return(nil)
+
+	restRemoveHost(&(s.writer), &request, s.ctx)
+
+	c.Assert(s.recorder.Code, Equals, http.StatusOK)
+	s.assertSimpleResponse(c, "Removed host", hostsLinks())
+}
+
+func (s *TestWebSuite) TestRestRemoveHostFails(c *C) {
+	expectedError := fmt.Errorf("mock RemoveHost failed")
+	hostID := "testHost"
+	request := s.buildRequest("DELETE", "/hosts/testHost", "")
+	request.PathParams["hostId"] = hostID
+	s.mockFacade.
+		On("RemoveHost", s.ctx.getDatastoreContext(), hostID).
+		Return(expectedError)
+
+	restRemoveHost(&(s.writer), &request, s.ctx)
+
+	s.assertServerError(c, expectedError)
+}
+
+func (s *TestWebSuite) TestRestRemoveHostFailsForInvalidURL(c *C) {
+	request := s.buildRequest("DELETE", "/hosts/%zzz", "")
+	request.PathParams["hostId"] = "%zzz"
+
+	restRemoveHost(&(s.writer), &request, s.ctx)
+
+	s.assertBadRequest(c)
+}
+
+func (s *TestWebSuite) TestBuildHostMonitoringProfile(c *C) {
 	host := host.Host{}
 	err := buildHostMonitoringProfile(&host)
 
-	if err != nil {
-		t.Fatalf("Failed to build host monitoring profile: err=%s", err)
-	}
-
-	if len(host.MonitoringProfile.MetricConfigs) <= 0 {
-		t.Fatalf("Failed to build host monitoring profile (missing metrics): host=%+v", host)
-	}
-
-	if len(host.MonitoringProfile.GraphConfigs) <= 0 {
-		t.Fatalf("Failed to build host monitoring profile (missing graphs): host=%+v", host)
-	}
+	c.Assert(err, IsNil)
+	c.Assert(len(host.MonitoringProfile.MetricConfigs), Not(Equals), 0)
+	c.Assert(len(host.MonitoringProfile.GraphConfigs), Equals, 6)
+	// FIXME: validate the expected content of the metric and graph configs
 }

--- a/web/hostresource_test.go
+++ b/web/hostresource_test.go
@@ -147,6 +147,14 @@ func (s *TestWebSuite) TestRestGetHostFailsForInvalidURL(c *C) {
 	s.assertBadRequest(c)
 }
 
+func (s *TestWebSuite) TestRestGetHostFailsForMissingHostID(c *C) {
+	request := s.buildRequest("GET", "/hosts", "")
+
+	restGetHost(&(s.writer), &request, s.ctx)
+
+	s.assertBadRequest(c)
+}
+
 func (s *TestWebSuite) TestRestAddHostFailsForBadJSON(c *C) {
 	request := s.buildRequest("POST", "/hosts/add", "{this is not valid json}")
 
@@ -226,6 +234,15 @@ func (s *TestWebSuite) TestRestUpdateHostFailsForInvalidURL(c *C) {
 
 func (s *TestWebSuite) TestRestUpdateHostFailsForBadJSON(c *C) {
 	request := s.buildRequest("PUT", "/hosts/someHostID", "{this is not valid json}")
+	request.PathParams["hostId"] = "someHostID"
+
+	restUpdateHost(&(s.writer), &request, s.ctx)
+
+	s.assertBadRequest(c)
+}
+
+func (s *TestWebSuite) TestRestUpdateHostFailsForMissingHostID(c *C) {
+	request := s.buildRequest("PUT", "/hosts", `{"ID": "someHostID"}`)
 
 	restUpdateHost(&(s.writer), &request, s.ctx)
 
@@ -263,6 +280,14 @@ func (s *TestWebSuite) TestRestRemoveHostFails(c *C) {
 func (s *TestWebSuite) TestRestRemoveHostFailsForInvalidURL(c *C) {
 	request := s.buildRequest("DELETE", "/hosts/%zzz", "")
 	request.PathParams["hostId"] = "%zzz"
+
+	restRemoveHost(&(s.writer), &request, s.ctx)
+
+	s.assertBadRequest(c)
+}
+
+func (s *TestWebSuite) TestRestRemoveHostFailsForMissingHostID(c *C) {
+	request := s.buildRequest("DELETE", "/hosts/testHost", "")
 
 	restRemoveHost(&(s.writer), &request, s.ctx)
 


### PR DESCRIPTION
This PR builds on changes in #2611 to remove the RPC dependency from the host REST API, replacing it with direct calls to the Facade tier.

Note that the AddHost operation still requires an RPC, but that's a client RPC call to a remote agent. Ultimately, that logic probably belongs in the Facade as well (which would allow for removing a similar call from the CLI add-host operation and simplification of the [acceptance/mockAgent/](acceptance/mockAgent/)), but that's a change for another day