### PR TITLE
Fix selector for new healthcheck style name

### DIFF
--- a/acceptance/ui/features/steps/applications_steps.rb
+++ b/acceptance/ui/features/steps/applications_steps.rb
@@ -113,7 +113,7 @@ end
 def checkActive(entry)
     within(page.find("table[data-config='servicesTable']")) do
         within(page.find("tr", :text => entry)) do
-            return page.has_css?("[class*='good']")
+            return page.has_css?("[class*='passed']")
         end
     end
 end


### PR DESCRIPTION
Fix selector for new healthcheck stylename.

Fixes tests failures like
```
When I am on the applications page
   And I view the details for "Internal Services" in the "Applications" table
   Then "Celery" should be active
     
      expected true
           got false
       (RSpec::Expectations::ExpectationNotMetError)
      ./features/steps/applications_steps.rb:109:in `/^"(.*?)" should be active$/'
      features/internalServices.feature:42:in `Then "Celery" should be active'
```