### PR TITLE
Support xhosting from capybara container to host OS

### DIFF
--- a/acceptance/runUIAcceptance.sh
+++ b/acceptance/runUIAcceptance.sh
@@ -103,7 +103,11 @@ CALLER_UID=`id -u`
 CALLER_GID=`id -g`
 
 if [ "$debug" == true ]; then
-    DEBUG_OPTION="-e DISPLAY=unix$DISPLAY"
+    if [[ "$DISPLAY" =~ "\:[0-9]" ]]; then
+        DEBUG_OPTION="-e DISPLAY=unix$DISPLAY"
+    else
+        DEBUG_OPTION="-e DISPLAY=$DISPLAY"
+    fi
 fi
 
 if [ -n "${TAGS}" ]; then

--- a/acceptance/ui/features/support/env.rb
+++ b/acceptance/ui/features/support/env.rb
@@ -133,7 +133,6 @@ printf "Using HOST_IP=%s\n", HOST_IP
 printf "Using TARGET_HOST=%s\n", TARGET_HOST
 printf "Using DISPLAY=%s\n", ENV["DISPLAY"]
 
-
 #
 # Register Chrome (Firefox is the selenium default)
 Capybara.register_driver :selenium_chrome do |app|
@@ -177,7 +176,12 @@ Capybara::Webkit.configure do |config|
 end
 
 Before do
-  if Capybara.current_driver == :selenium || Capybara.current_driver == :selenium_chrome
+  debug = false
+  if ENV["DISPLAY"].include? "unix:"
+        debug = true
+  end
+
+  if !debug && (Capybara.current_driver == :selenium || Capybara.current_driver == :selenium_chrome)
     require 'headless'
 
     headless = Headless.new

--- a/acceptance/ui/features/support/env.rb
+++ b/acceptance/ui/features/support/env.rb
@@ -176,8 +176,9 @@ Capybara::Webkit.configure do |config|
 end
 
 Before do
+  # Any DISPLAY value other than ":99" implies we're xhosting the browser outside of the docker container
   debug = false
-  if ENV["DISPLAY"].include? "unix:"
+  if ENV["DISPLAY"] != ":99"
         debug = true
   end
 


### PR DESCRIPTION
In the first generation of the docker container for capybara, you could use the `--debug` command line option on `runCucumber.sh` to set things up such that the browser would display on your local X server.  

Apparently something changed in the selenium drivers and/or `headless` gem which broke that feature when I upgraded the test stack to all of the latest versions in the `zenoss/capybara:1.1.0`. After some trial/error testing, I found that not instantiating the `headless` gem allowed the browsers to display on the host OS.

