### PR TITLE
CC-2125: Better pipe handling in the case where a snapshot volume being restored already exists

### DIFF
--- a/dfs/restore.go
+++ b/dfs/restore.go
@@ -128,6 +128,13 @@ func (dfs *DistributedFilesystem) restoreVersion1(r io.Reader, data *BackupInfo)
 	pipeStreams := make(map[string]*io.PipeWriter)
 	getSnapshotStream := func(tenant, label string) *tar.Writer {
 		if _, ok := snapshotStreams[tenant]; !ok {
+			// First check to see if the snapshot already exists, and if so,
+			// return a nil writer
+			fullLabel := volume.DefaultSnapshotLabel(tenant, label)
+			if dfs.disk.Exists(fullLabel) {
+				snapshotStreams[tenant] = nil
+				return nil
+			}
 			glog.Infof("Loading snapshot data for %s", tenant)
 			r, w := io.Pipe()
 			// Store this writer for later retrieval. This is all single-threaded
@@ -169,8 +176,12 @@ func (dfs *DistributedFilesystem) restoreVersion1(r io.Reader, data *BackupInfo)
 			imageTar.Close()
 			imagesw.Close()
 			for k, w := range snapshotStreams {
-				w.Close()
-				pipeStreams[k].Close()
+				if w != nil {
+					w.Close()
+				}
+				if pw, ok := pipeStreams[k]; ok {
+					pw.Close()
+				}
 			}
 			break
 		} else if err != nil {
@@ -194,6 +205,10 @@ func (dfs *DistributedFilesystem) restoreVersion1(r io.Reader, data *BackupInfo)
 			// Find or create the pipe that's got a restoreVolume for this
 			// volume reading from the other end
 			w := getSnapshotStream(tenant, label)
+			if w == nil {
+				// Snapshot already exists, so don't bother
+				continue
+			}
 			// Strip off the parent path, so the subtar is a tar with the
 			// volume data at the root (resembling a version 0 backup)
 			hdr.Name = strings.TrimPrefix(hdr.Name, strings.Join(parts[:3], "/")+"/")

--- a/volume/devicemapper/devicemapper.go
+++ b/volume/devicemapper/devicemapper.go
@@ -1022,17 +1022,9 @@ func (v *DeviceMapperVolume) volumeDevice() string {
 	return v.Metadata.CurrentDevice()
 }
 
-func (v *DeviceMapperVolume) getSnapshotPrefix() string {
-	return v.Tenant() + "_"
-}
-
 // rawSnapshotLabel ensures that <label> has the tenant prefix for this volume
 func (v *DeviceMapperVolume) rawSnapshotLabel(label string) string {
-	prefix := v.getSnapshotPrefix()
-	if !strings.HasPrefix(label, prefix) {
-		return prefix + label
-	}
-	return label
+	return volume.DefaultSnapshotLabel(v.Tenant(), label)
 }
 
 func (v *DeviceMapperVolume) snapshotExists(label string) bool {

--- a/volume/utils.go
+++ b/volume/utils.go
@@ -21,6 +21,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"sort"
+	"strings"
 	"syscall"
 
 	"github.com/zenoss/glog"
@@ -131,4 +132,12 @@ func FilesystemBytesSize(path string) int64 {
 	s := syscall.Statfs_t{}
 	syscall.Statfs(path, &s)
 	return int64(s.Bsize) * int64(s.Blocks)
+}
+
+func DefaultSnapshotLabel(tenant, label string) string {
+	prefix := tenant + "_"
+	if !strings.HasPrefix(label, prefix) {
+		label = prefix + label
+	}
+	return label
 }


### PR DESCRIPTION
When we encountered a snapshot to be restored, we would create a tar substream and start restoring from it. If that restore process detected that the snapshot already existed, it would return, saying it was complete, but the incoming files would still be written to the tar, which would block forever because nothing was reading from it anymore. 

This checks first to avoid restoring snapshots that already exist at a higher level.