### PR TITLE
Fix some occasional test failures

### DIFF
--- a/acceptance/ui/features/steps/applications_steps.rb
+++ b/acceptance/ui/features/steps/applications_steps.rb
@@ -230,6 +230,8 @@ def closeDeployWizard()
     if page_found
         # wait till it is no longer visible, and error if it remains on screen
         expect(page).not_to have_selector("#addApp")
+        # must wait for the modal shadowbox to clear as well
+        expect(page).not_to have_selector(".modal-backdrop")
     end
 end
 

--- a/acceptance/ui/features/support/hooks.rb
+++ b/acceptance/ui/features/support/hooks.rb
@@ -2,6 +2,12 @@ require "capybara-screenshot"
 
 # Write a message to the JS console so that we know when a scenario starts
 Before do |scenario|
+
+  window = Capybara.page.driver.browser.manage.window
+  if window != nil
+    window.resize_to(1280, 1024)
+  end
+
   cmd = sprintf "console.log(\"%s\")", getStartScenarioAnnouncement(scenario)
   Capybara.page.driver.execute_script(cmd)
 end


### PR DESCRIPTION
Optimizations in #2647 improved test time by shortening the wait on login for the deployment wizard to close (see code in application_steps.rb for the closeDeployWizard() method).  However, that change introduced a race where sometimes a page change would occur before the shadow-box displayed for modal dialogs had cleared.    An example of such a failure can be seen the Cucumber Report for this build - http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-merge-acceptance/407/

This PR addresses the problem by also waiting for the shadow-box to be removed before finishing closeDeployWizard(). 

The other commit is kind of unrelated; it makes sure that the browser window is sized large enough so if/when an error occurs, the screenshot we capture for debugging will show the entire screen.