### PR TITLE
Provide some initial unit-tests for Facade

### DIFF
--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -92,12 +92,12 @@ func Test(t *testing.T) {
 	TestingT(t)
 }
 
-//Instantiate the gocheck suite. Initialize the DaoTest and the embedded FacadeTest
+//Instantiate the gocheck suite. Initialize the DaoTest and the embedded FacadeIntegrationTset
 var _ = Suite(&DaoTest{})
 
 //DaoTest gocheck test type for setting up isvcs and other resources needed by tests
 type DaoTest struct {
-	facade.FacadeTest
+	facade.FacadeIntegrationTest
 	Dao    *ControlPlaneDao
 	zkConn coordclient.Connection
 }
@@ -120,7 +120,7 @@ func (dt *DaoTest) SetUpSuite(c *C) {
 		c.Fatalf("Could not start es container: %s", err)
 	}
 	dt.MappingsFile = "controlplane.json"
-	dt.FacadeTest.SetUpSuite(c)
+	dt.FacadeIntegrationTest.SetUpSuite(c)
 
 	dsn := coordzk.NewDSN([]string{"127.0.0.1:2181"}, time.Second*15).String()
 	glog.Infof("zookeeper dsn: %s", dsn)
@@ -158,7 +158,7 @@ func (dt *DaoTest) SetUpSuite(c *C) {
 //SetUpTest run before each test.
 func (dt *DaoTest) SetUpTest(c *C) {
 	//Facade tests delete the contents of the database for every test
-	dt.FacadeTest.SetUpTest(c)
+	dt.FacadeIntegrationTest.SetUpTest(c)
 	//DAO tests expect default pool and system user
 
 	if err := dt.Facade.CreateDefaultPool(dt.CTX, "default"); err != nil {
@@ -174,7 +174,7 @@ func (dt *DaoTest) SetUpTest(c *C) {
 //TearDownSuite stops all isvcs
 func (dt *DaoTest) TearDownSuite(c *C) {
 	isvcs.Mgr.Stop()
-	dt.FacadeTest.TearDownSuite(c)
+	dt.FacadeIntegrationTest.TearDownSuite(c)
 }
 
 func (dt *DaoTest) TestDao_ValidateEndpoints(t *C) {

--- a/datastore/mocks/Connection.go
+++ b/datastore/mocks/Connection.go
@@ -1,0 +1,86 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocks
+
+import "github.com/control-center/serviced/datastore"
+import "github.com/stretchr/testify/mock"
+
+type Connection struct {
+	mock.Mock
+}
+
+func (_m *Connection) Put(key datastore.Key, data datastore.JSONMessage) error {
+	ret := _m.Called(key, data)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Key, datastore.JSONMessage) error); ok {
+		r0 = rf(key, data)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Connection) Get(key datastore.Key) (datastore.JSONMessage, error) {
+	ret := _m.Called(key)
+
+	var r0 datastore.JSONMessage
+	if rf, ok := ret.Get(0).(func(datastore.Key) datastore.JSONMessage); ok {
+		r0 = rf(key)
+	} else {
+		r0 = ret.Get(0).(datastore.JSONMessage)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Key) error); ok {
+		r1 = rf(key)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Connection) Delete(key datastore.Key) error {
+	ret := _m.Called(key)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Key) error); ok {
+		r0 = rf(key)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Connection) Query(query interface{}) ([]datastore.JSONMessage, error) {
+	ret := _m.Called(query)
+
+	var r0 []datastore.JSONMessage
+	if rf, ok := ret.Get(0).(func(interface{}) []datastore.JSONMessage); ok {
+		r0 = rf(query)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]datastore.JSONMessage)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(interface{}) error); ok {
+		r1 = rf(query)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/datastore/mocks/Context.go
+++ b/datastore/mocks/Context.go
@@ -1,0 +1,41 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocks
+
+import "github.com/control-center/serviced/datastore"
+import "github.com/stretchr/testify/mock"
+
+type Context struct {
+	mock.Mock
+}
+
+func (_m *Context) Connection() (datastore.Connection, error) {
+	ret := _m.Called()
+
+	var r0 datastore.Connection
+	if rf, ok := ret.Get(0).(func() datastore.Connection); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(datastore.Connection)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/datastore/mocks/EntityStore.go
+++ b/datastore/mocks/EntityStore.go
@@ -1,0 +1,58 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocks
+
+import "github.com/control-center/serviced/datastore"
+import "github.com/stretchr/testify/mock"
+
+type EntityStore struct {
+	mock.Mock
+}
+
+func (_m *EntityStore) Put(ctx datastore.Context, key datastore.Key, entity datastore.ValidEntity) error {
+	ret := _m.Called(ctx, key, entity)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, datastore.Key, datastore.ValidEntity) error); ok {
+		r0 = rf(ctx, key, entity)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *EntityStore) Get(ctx datastore.Context, key datastore.Key, entity datastore.ValidEntity) error {
+	ret := _m.Called(ctx, key, entity)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, datastore.Key, datastore.ValidEntity) error); ok {
+		r0 = rf(ctx, key, entity)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *EntityStore) Delete(ctx datastore.Context, key datastore.Key) error {
+	ret := _m.Called(ctx, key)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, datastore.Key) error); ok {
+		r0 = rf(ctx, key)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/domain/host/hoststore.go
+++ b/domain/host/hoststore.go
@@ -28,6 +28,7 @@ func NewStore() Store {
 	return &storeImpl{}
 }
 
+// Store type for interacting with Host persistent storage
 type Store interface {
 	datastore.EntityStore
 
@@ -41,7 +42,6 @@ type Store interface {
 	GetN(ctx datastore.Context, limit uint64) ([]Host, error)
 }
 
-//HostStore type for interacting with Host persistent storage
 type storeImpl struct {
 	datastore.DataStore
 }

--- a/domain/host/hoststore.go
+++ b/domain/host/hoststore.go
@@ -24,17 +24,30 @@ import (
 )
 
 //NewStore creates a HostStore
-func NewStore() *HostStore {
-	return &HostStore{}
+func NewStore() Store {
+	return &storeImpl{}
+}
+
+type Store interface {
+	datastore.EntityStore
+
+	// FindHostsWithPoolID returns all hosts with the given poolid.
+	FindHostsWithPoolID(ctx datastore.Context, poolID string) ([]Host, error)
+
+	// GetHostByIP looks up a host by the given ip address
+	GetHostByIP(ctx datastore.Context, hostIP string) (*Host, error)
+
+	// GetN returns all hosts up to limit.
+	GetN(ctx datastore.Context, limit uint64) ([]Host, error)
 }
 
 //HostStore type for interacting with Host persistent storage
-type HostStore struct {
+type storeImpl struct {
 	datastore.DataStore
 }
 
 // FindHostsWithPoolID returns all hosts with the given poolid.
-func (hs *HostStore) FindHostsWithPoolID(ctx datastore.Context, poolID string) ([]Host, error) {
+func (hs *storeImpl) FindHostsWithPoolID(ctx datastore.Context, poolID string) ([]Host, error) {
 	id := strings.TrimSpace(poolID)
 	if id == "" {
 		return nil, errors.New("empty poolId not allowed")
@@ -50,7 +63,7 @@ func (hs *HostStore) FindHostsWithPoolID(ctx datastore.Context, poolID string) (
 }
 
 // GetHostByIP looks up a host by the given ip address
-func (hs *HostStore) GetHostByIP(ctx datastore.Context, hostIP string) (*Host, error) {
+func (hs *storeImpl) GetHostByIP(ctx datastore.Context, hostIP string) (*Host, error) {
 	if hostIP = strings.TrimSpace(hostIP); hostIP == "" {
 		return nil, errors.New("empty hostIP not allowed")
 	}
@@ -72,7 +85,7 @@ func (hs *HostStore) GetHostByIP(ctx datastore.Context, hostIP string) (*Host, e
 }
 
 // GetN returns all hosts up to limit.
-func (hs *HostStore) GetN(ctx datastore.Context, limit uint64) ([]Host, error) {
+func (hs *storeImpl) GetN(ctx datastore.Context, limit uint64) ([]Host, error) {
 	q := datastore.NewQuery(ctx)
 	query := search.Query().Search("_exists_:ID")
 	search := search.Search("controlplane").Type(kind).Size(strconv.FormatUint(limit, 10)).Query(query)

--- a/domain/host/hoststore_test.go
+++ b/domain/host/hoststore_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&S{
 type S struct {
 	elastic.ElasticTest
 	ctx datastore.Context
-	hs  *HostStore
+	hs  Store
 }
 
 func (s *S) SetUpTest(c *C) {

--- a/domain/host/mocks/Store.go
+++ b/domain/host/mocks/Store.go
@@ -1,0 +1,126 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocks
+
+import "github.com/control-center/serviced/domain/host"
+import "github.com/stretchr/testify/mock"
+
+import "github.com/control-center/serviced/datastore"
+
+type Store struct {
+	mock.Mock
+}
+
+func (_m *Store) Put(ctx datastore.Context, key datastore.Key, entity datastore.ValidEntity) error {
+	ret := _m.Called(ctx, key, entity)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, datastore.Key, datastore.ValidEntity) error); ok {
+		r0 = rf(ctx, key, entity)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+func (_m *Store) Get(ctx datastore.Context, key datastore.Key, entity datastore.ValidEntity) error {
+	ret := _m.Called(ctx, key, entity)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, datastore.Key, datastore.ValidEntity) error); ok {
+		r0 = rf(ctx, key, entity)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+func (_m *Store) Delete(ctx datastore.Context, key datastore.Key) error {
+	ret := _m.Called(ctx, key)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, datastore.Key) error); ok {
+		r0 = rf(ctx, key)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+func (_m *Store) FindHostsWithPoolID(ctx datastore.Context, poolID string) ([]host.Host, error) {
+	ret := _m.Called(ctx, poolID)
+
+	var r0 []host.Host
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) []host.Host); ok {
+		r0 = rf(ctx, poolID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]host.Host)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, poolID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) GetHostByIP(ctx datastore.Context, hostIP string) (*host.Host, error) {
+	ret := _m.Called(ctx, hostIP)
+
+	var r0 *host.Host
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) *host.Host); ok {
+		r0 = rf(ctx, hostIP)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*host.Host)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, hostIP)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) GetN(ctx datastore.Context, limit uint64) ([]host.Host, error) {
+	ret := _m.Called(ctx, limit)
+
+	var r0 []host.Host
+	if rf, ok := ret.Get(0).(func(datastore.Context, uint64) []host.Host); ok {
+		r0 = rf(ctx, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]host.Host)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, uint64) error); ok {
+		r1 = rf(ctx, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/domain/pool/mocks/Store.go
+++ b/domain/pool/mocks/Store.go
@@ -1,0 +1,124 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocks
+
+import "github.com/control-center/serviced/domain/pool"
+import "github.com/stretchr/testify/mock"
+
+import "github.com/control-center/serviced/datastore"
+
+type Store struct {
+	mock.Mock
+}
+
+func (_m *Store) Put(ctx datastore.Context, key datastore.Key, entity datastore.ValidEntity) error {
+	ret := _m.Called(ctx, key, entity)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, datastore.Key, datastore.ValidEntity) error); ok {
+		r0 = rf(ctx, key, entity)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+func (_m *Store) Get(ctx datastore.Context, key datastore.Key, entity datastore.ValidEntity) error {
+	ret := _m.Called(ctx, key, entity)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, datastore.Key, datastore.ValidEntity) error); ok {
+		r0 = rf(ctx, key, entity)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+func (_m *Store) Delete(ctx datastore.Context, key datastore.Key) error {
+	ret := _m.Called(ctx, key)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, datastore.Key) error); ok {
+		r0 = rf(ctx, key)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+func (_m *Store) GetResourcePools(ctx datastore.Context) ([]pool.ResourcePool, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []pool.ResourcePool
+	if rf, ok := ret.Get(0).(func(datastore.Context) []pool.ResourcePool); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]pool.ResourcePool)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) GetResourcePoolsByRealm(ctx datastore.Context, realm string) ([]pool.ResourcePool, error) {
+	ret := _m.Called(ctx, realm)
+
+	var r0 []pool.ResourcePool
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) []pool.ResourcePool); ok {
+		r0 = rf(ctx, realm)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]pool.ResourcePool)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, realm)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) HasVirtualIP(ctx datastore.Context, poolID string, virtualIP string) (bool, error) {
+	ret := _m.Called(ctx, poolID, virtualIP)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string) bool); ok {
+		r0 = rf(ctx, poolID, virtualIP)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string, string) error); ok {
+		r1 = rf(ctx, poolID, virtualIP)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/domain/pool/poolstore.go
+++ b/domain/pool/poolstore.go
@@ -23,23 +23,36 @@ import (
 )
 
 //NewStore creates a ResourcePool store
-func NewStore() *Store {
-	return &Store{}
+func NewStore() Store {
+	return &storeImpl{}
+}
+
+type Store interface {
+	datastore.EntityStore
+
+	// GetResourcePools Get a list of all the resource pools
+	GetResourcePools(ctx datastore.Context) ([]ResourcePool, error)
+
+	// GetResourcePoolsByRealm gets a list of resource pools for a given realm
+	GetResourcePoolsByRealm(ctx datastore.Context, realm string) ([]ResourcePool, error)
+
+	// HasVirtualIP returns true if there is a virtual ip found for the given pool
+	HasVirtualIP(ctx datastore.Context, poolID, virtualIP string) (bool, error)
 }
 
 //Store type for interacting with ResourcePool persistent storage
-type Store struct {
+type storeImpl struct {
 	datastore.DataStore
 }
 
 //GetResourcePools Get a list of all the resource pools
-func (ps *Store) GetResourcePools(ctx datastore.Context) ([]ResourcePool, error) {
+func (ps *storeImpl) GetResourcePools(ctx datastore.Context) ([]ResourcePool, error) {
 	glog.V(3).Infof("Pool Store.GetResourcePools")
 	return query(ctx, "_exists_:ID")
 }
 
 // GetResourcePoolsByRealm gets a list of resource pools for a given realm
-func (s *Store) GetResourcePoolsByRealm(ctx datastore.Context, realm string) ([]ResourcePool, error) {
+func (s *storeImpl) GetResourcePoolsByRealm(ctx datastore.Context, realm string) ([]ResourcePool, error) {
 	glog.V(3).Infof("Pool Store.GetResourcePoolsByRealm")
 	id := strings.TrimSpace(realm)
 	if id == "" {
@@ -56,7 +69,7 @@ func (s *Store) GetResourcePoolsByRealm(ctx datastore.Context, realm string) ([]
 }
 
 // HasVirtualIP returns true if there is a virtual ip found for the given pool
-func (s *Store) HasVirtualIP(ctx datastore.Context, poolID, virtualIP string) (bool, error) {
+func (s *storeImpl) HasVirtualIP(ctx datastore.Context, poolID, virtualIP string) (bool, error) {
 	if poolID = strings.TrimSpace(poolID); poolID == "" {
 		return false, errors.New("empty pool id not allowed")
 	} else if virtualIP = strings.TrimSpace(virtualIP); virtualIP == "" {

--- a/domain/pool/poolstore.go
+++ b/domain/pool/poolstore.go
@@ -27,6 +27,7 @@ func NewStore() Store {
 	return &storeImpl{}
 }
 
+// Store type for interacting with ResourcePool persistent storage
 type Store interface {
 	datastore.EntityStore
 
@@ -40,7 +41,6 @@ type Store interface {
 	HasVirtualIP(ctx datastore.Context, poolID, virtualIP string) (bool, error)
 }
 
-//Store type for interacting with ResourcePool persistent storage
 type storeImpl struct {
 	datastore.DataStore
 }

--- a/domain/pool/poolstore_test.go
+++ b/domain/pool/poolstore_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&S{
 type S struct {
 	elastic.ElasticTest
 	ctx datastore.Context
-	ps  *Store
+	ps  Store
 }
 
 func (s *S) SetUpTest(c *C) {

--- a/domain/registry/mocks/ImageRegistryStore.go
+++ b/domain/registry/mocks/ImageRegistryStore.go
@@ -1,0 +1,111 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocks
+
+import "github.com/control-center/serviced/domain/registry"
+import "github.com/stretchr/testify/mock"
+
+import "github.com/control-center/serviced/datastore"
+
+type ImageRegistryStore struct {
+	mock.Mock
+}
+
+func (_m *ImageRegistryStore) Get(ctx datastore.Context, id string) (*registry.Image, error) {
+	ret := _m.Called(ctx, id)
+
+	var r0 *registry.Image
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) *registry.Image); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*registry.Image)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *ImageRegistryStore) Put(ctx datastore.Context, image *registry.Image) error {
+	ret := _m.Called(ctx, image)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, *registry.Image) error); ok {
+		r0 = rf(ctx, image)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *ImageRegistryStore) Delete(ctx datastore.Context, id string) error {
+	ret := _m.Called(ctx, id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *ImageRegistryStore) GetImages(ctx datastore.Context) ([]registry.Image, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []registry.Image
+	if rf, ok := ret.Get(0).(func(datastore.Context) []registry.Image); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]registry.Image)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *ImageRegistryStore) SearchLibraryByTag(ctx datastore.Context, library string, tag string) ([]registry.Image, error) {
+	ret := _m.Called(ctx, library, tag)
+
+	var r0 []registry.Image
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string) []registry.Image); ok {
+		r0 = rf(ctx, library, tag)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]registry.Image)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string, string) error); ok {
+		r1 = rf(ctx, library, tag)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/domain/registry/store.go
+++ b/domain/registry/store.go
@@ -22,17 +22,34 @@ import (
 )
 
 // NewStore creates a new image registry store
-func NewStore() *ImageRegistryStore {
-	return &ImageRegistryStore{}
+func NewStore() ImageRegistryStore {
+	return &storeImpl{}
 }
 
 // RegistryImageStore is the database for the docker image registry
-type ImageRegistryStore struct {
+type ImageRegistryStore interface {
+	// Get an image by id.  Return ErrNoSuchEntity if not found
+	Get(ctx datastore.Context, id string) (*Image, error)
+
+	// Put adds/updates an image to the registry
+	Put(ctx datastore.Context, image *Image) error
+
+	// Delete removes an image from the registry
+	Delete(ctx datastore.Context, id string) error
+
+	// GetImages returns all the images that are in the registry
+	GetImages(ctx datastore.Context) ([]Image, error)
+
+	// SearchLibraryByTag looks for repos that are registered under a library and tag
+	SearchLibraryByTag(ctx datastore.Context, library, tag string) ([]Image, error)
+}
+
+type storeImpl struct {
 	ds datastore.DataStore
 }
 
 // Get an image by id.  Return ErrNoSuchEntity if not found
-func (s *ImageRegistryStore) Get(ctx datastore.Context, id string) (*Image, error) {
+func (s *storeImpl) Get(ctx datastore.Context, id string) (*Image, error) {
 	image := &Image{}
 	if err := s.ds.Get(ctx, Key(id), image); err != nil {
 		return nil, err
@@ -41,17 +58,17 @@ func (s *ImageRegistryStore) Get(ctx datastore.Context, id string) (*Image, erro
 }
 
 // Put adds/updates an image to the registry
-func (s *ImageRegistryStore) Put(ctx datastore.Context, image *Image) error {
+func (s *storeImpl) Put(ctx datastore.Context, image *Image) error {
 	return s.ds.Put(ctx, image.key(), image)
 }
 
 // Delete removes an image from the registry
-func (s *ImageRegistryStore) Delete(ctx datastore.Context, id string) error {
+func (s *storeImpl) Delete(ctx datastore.Context, id string) error {
 	return s.ds.Delete(ctx, Key(id))
 }
 
 // GetImages returns all the images that are in the registry
-func (s *ImageRegistryStore) GetImages(ctx datastore.Context) ([]Image, error) {
+func (s *storeImpl) GetImages(ctx datastore.Context) ([]Image, error) {
 	query := search.Query().Search("_exists_:Library")
 	search := search.Search("controlplane").Type(kind).Size("50000").Query(query)
 	q := datastore.NewQuery(ctx)
@@ -63,7 +80,7 @@ func (s *ImageRegistryStore) GetImages(ctx datastore.Context) ([]Image, error) {
 }
 
 // SearchLibraryByTag looks for repos that are registered under a library and tag
-func (s *ImageRegistryStore) SearchLibraryByTag(ctx datastore.Context, library, tag string) ([]Image, error) {
+func (s *storeImpl) SearchLibraryByTag(ctx datastore.Context, library, tag string) ([]Image, error) {
 	if library = strings.TrimSpace(library); library == "" {
 		return nil, errors.New("empty library not allowed")
 	} else if tag = strings.TrimSpace(tag); tag == "" {

--- a/domain/registry/store_test.go
+++ b/domain/registry/store_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&S{
 type S struct {
 	elastic.ElasticTest
 	ctx   datastore.Context
-	store *ImageRegistryStore
+	store ImageRegistryStore
 }
 
 func (s *S) SetUpTest(c *C) {

--- a/domain/service/mocks/Store.go
+++ b/domain/service/mocks/Store.go
@@ -1,0 +1,239 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocks
+
+import "github.com/control-center/serviced/domain/service"
+import "github.com/stretchr/testify/mock"
+
+import "github.com/control-center/serviced/datastore"
+
+import "time"
+
+type Store struct {
+	mock.Mock
+}
+
+func (_m *Store) Put(ctx datastore.Context, svc *service.Service) error {
+	ret := _m.Called(ctx, svc)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, *service.Service) error); ok {
+		r0 = rf(ctx, svc)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Store) Get(ctx datastore.Context, id string) (*service.Service, error) {
+	ret := _m.Called(ctx, id)
+
+	var r0 *service.Service
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) *service.Service); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*service.Service)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) Delete(ctx datastore.Context, id string) error {
+	ret := _m.Called(ctx, id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Store) GetServices(ctx datastore.Context) ([]service.Service, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []service.Service
+	if rf, ok := ret.Get(0).(func(datastore.Context) []service.Service); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]service.Service)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) GetUpdatedServices(ctx datastore.Context, since time.Duration) ([]service.Service, error) {
+	ret := _m.Called(ctx, since)
+
+	var r0 []service.Service
+	if rf, ok := ret.Get(0).(func(datastore.Context, time.Duration) []service.Service); ok {
+		r0 = rf(ctx, since)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]service.Service)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, time.Duration) error); ok {
+		r1 = rf(ctx, since)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) GetTaggedServices(ctx datastore.Context, tags ...string) ([]service.Service, error) {
+	ret := _m.Called(ctx, tags)
+
+	var r0 []service.Service
+	if rf, ok := ret.Get(0).(func(datastore.Context, ...string) []service.Service); ok {
+		r0 = rf(ctx, tags...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]service.Service)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, ...string) error); ok {
+		r1 = rf(ctx, tags...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) GetServicesByPool(ctx datastore.Context, poolID string) ([]service.Service, error) {
+	ret := _m.Called(ctx, poolID)
+
+	var r0 []service.Service
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) []service.Service); ok {
+		r0 = rf(ctx, poolID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]service.Service)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, poolID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) GetServicesByDeployment(ctx datastore.Context, deploymentID string) ([]service.Service, error) {
+	ret := _m.Called(ctx, deploymentID)
+
+	var r0 []service.Service
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) []service.Service); ok {
+		r0 = rf(ctx, deploymentID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]service.Service)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, deploymentID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) GetChildServices(ctx datastore.Context, parentID string) ([]service.Service, error) {
+	ret := _m.Called(ctx, parentID)
+
+	var r0 []service.Service
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) []service.Service); ok {
+		r0 = rf(ctx, parentID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]service.Service)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, parentID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) FindChildService(ctx datastore.Context, deploymentID string, parentID string, serviceName string) (*service.Service, error) {
+	ret := _m.Called(ctx, deploymentID, parentID, serviceName)
+
+	var r0 *service.Service
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string, string) *service.Service); ok {
+		r0 = rf(ctx, deploymentID, parentID, serviceName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*service.Service)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string, string, string) error); ok {
+		r1 = rf(ctx, deploymentID, parentID, serviceName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) FindTenantByDeploymentID(ctx datastore.Context, deploymentID string, name string) (*service.Service, error) {
+	ret := _m.Called(ctx, deploymentID, name)
+
+	var r0 *service.Service
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string) *service.Service); ok {
+		r0 = rf(ctx, deploymentID, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*service.Service)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string, string) error); ok {
+		r1 = rf(ctx, deploymentID, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/domain/service/serviceeval_test.go
+++ b/domain/service/serviceeval_test.go
@@ -262,7 +262,7 @@ var context_testcases = []Service{
 
 var addresses []string
 
-func createSvcs(store *Store, ctx datastore.Context) error {
+func createSvcs(store Store, ctx datastore.Context) error {
 	for _, testcase := range startup_testcases {
 		if err := store.Put(ctx, &testcase.service); err != nil {
 			return err
@@ -276,7 +276,7 @@ func createSvcs(store *Store, ctx datastore.Context) error {
 	return nil
 }
 
-func createContextSvcs(store *Store, ctx datastore.Context) error {
+func createContextSvcs(store Store, ctx datastore.Context) error {
 	for _, testcase := range context_testcases {
 		if err := store.Put(ctx, &testcase); err != nil {
 			return err

--- a/domain/service/servicestore_test.go
+++ b/domain/service/servicestore_test.go
@@ -40,7 +40,7 @@ var _ = Suite(&S{
 type S struct {
 	elastic.ElasticTest
 	ctx   datastore.Context
-	store *Store
+	store Store
 }
 
 func (s *S) SetUpTest(c *C) {

--- a/domain/servicetemplate/mocks/Store.go
+++ b/domain/servicetemplate/mocks/Store.go
@@ -1,0 +1,77 @@
+package mocks
+
+import "github.com/control-center/serviced/domain/servicetemplate"
+import "github.com/stretchr/testify/mock"
+
+import "github.com/control-center/serviced/datastore"
+
+type Store struct {
+	mock.Mock
+}
+
+func (_m *Store) Get(ctx datastore.Context, id string) (*servicetemplate.ServiceTemplate, error) {
+	ret := _m.Called(ctx, id)
+
+	var r0 *servicetemplate.ServiceTemplate
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) *servicetemplate.ServiceTemplate); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*servicetemplate.ServiceTemplate)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) Put(ctx datastore.Context, st servicetemplate.ServiceTemplate) error {
+	ret := _m.Called(ctx, st)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, servicetemplate.ServiceTemplate) error); ok {
+		r0 = rf(ctx, st)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Store) Delete(ctx datastore.Context, id string) error {
+	ret := _m.Called(ctx, id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Store) GetServiceTemplates(ctx datastore.Context) ([]*servicetemplate.ServiceTemplate, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []*servicetemplate.ServiceTemplate
+	if rf, ok := ret.Get(0).(func(datastore.Context) []*servicetemplate.ServiceTemplate); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*servicetemplate.ServiceTemplate)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/domain/servicetemplate/templatestore_test.go
+++ b/domain/servicetemplate/templatestore_test.go
@@ -39,7 +39,7 @@ var _ = Suite(&S{
 type S struct {
 	elastic.ElasticTest
 	ctx   datastore.Context
-	store *Store
+	store Store
 }
 
 func (s *S) SetUpTest(c *C) {

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -43,7 +43,7 @@ type Facade struct {
 	hostStore     host.Store
 	registryStore *registry.ImageRegistryStore
 	poolStore     pool.Store
-	templateStore *servicetemplate.Store
+	templateStore servicetemplate.Store
 	serviceStore  service.Store
 
 	zzk           ZZK
@@ -63,6 +63,8 @@ func (f *Facade) SetHostStore(store host.Store) { f.hostStore = store }
 func (f *Facade) SetPoolStore(store pool.Store) { f.poolStore = store }
 
 func (f *Facade) SetServiceStore(store service.Store) { f.serviceStore = store }
+
+func (f *Facade) SetTemplateStore(store servicetemplate.Store) { f.templateStore = store }
 
 func (f *Facade) SetHealthCache(hcache *health.HealthStatusCache) { f.hcache = hcache }
 

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -40,9 +40,9 @@ func New() *Facade {
 
 // Facade is an entrypoint to available controlplane methods
 type Facade struct {
-	hostStore     *host.HostStore
+	hostStore     host.Store
 	registryStore *registry.ImageRegistryStore
-	poolStore     *pool.Store
+	poolStore     pool.Store
 	templateStore *servicetemplate.Store
 	serviceStore  *service.Store
 
@@ -57,6 +57,10 @@ type Facade struct {
 func (f *Facade) SetZZK(zzk ZZK) { f.zzk = zzk }
 
 func (f *Facade) SetDFS(dfs dfs.DFS) { f.dfs = dfs }
+
+func (f *Facade) SetHostStore(store host.Store) { f.hostStore = store }
+
+func (f *Facade) SetPoolStore(store pool.Store) { f.poolStore = store }
 
 func (f *Facade) SetHealthCache(hcache *health.HealthStatusCache) { f.hcache = hcache }
 

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -44,7 +44,7 @@ type Facade struct {
 	registryStore *registry.ImageRegistryStore
 	poolStore     pool.Store
 	templateStore *servicetemplate.Store
-	serviceStore  *service.Store
+	serviceStore  service.Store
 
 	zzk           ZZK
 	dfs           dfs.DFS
@@ -61,6 +61,8 @@ func (f *Facade) SetDFS(dfs dfs.DFS) { f.dfs = dfs }
 func (f *Facade) SetHostStore(store host.Store) { f.hostStore = store }
 
 func (f *Facade) SetPoolStore(store pool.Store) { f.poolStore = store }
+
+func (f *Facade) SetServiceStore(store service.Store) { f.serviceStore = store }
 
 func (f *Facade) SetHealthCache(hcache *health.HealthStatusCache) { f.hcache = hcache }
 

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -41,7 +41,7 @@ func New() *Facade {
 // Facade is an entrypoint to available controlplane methods
 type Facade struct {
 	hostStore     host.Store
-	registryStore *registry.ImageRegistryStore
+	registryStore registry.ImageRegistryStore
 	poolStore     pool.Store
 	templateStore servicetemplate.Store
 	serviceStore  service.Store
@@ -59,6 +59,8 @@ func (f *Facade) SetZZK(zzk ZZK) { f.zzk = zzk }
 func (f *Facade) SetDFS(dfs dfs.DFS) { f.dfs = dfs }
 
 func (f *Facade) SetHostStore(store host.Store) { f.hostStore = store }
+
+func (f *Facade) SetRegistryStore(store registry.ImageRegistryStore) { f.registryStore = store }
 
 func (f *Facade) SetPoolStore(store pool.Store) { f.poolStore = store }
 

--- a/facade/facade_test.go
+++ b/facade/facade_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build integration
+// +build unit integration
 
 package facade
 
@@ -24,5 +24,3 @@ import (
 func Test(t *testing.T) {
 	TestingT(t)
 }
-
-var _ = Suite(&FacadeTest{})

--- a/facade/facade_unit_test.go
+++ b/facade/facade_unit_test.go
@@ -1,0 +1,64 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package facade
+
+import (
+	datastoremocks "github.com/control-center/serviced/datastore/mocks"
+	dfsmocks "github.com/control-center/serviced/dfs/mocks"
+	hostmocks "github.com/control-center/serviced/domain/host/mocks"
+	poolmocks "github.com/control-center/serviced/domain/pool/mocks"
+	zzkmocks "github.com/control-center/serviced/facade/mocks"
+	"github.com/stretchr/testify/mock"
+	. "gopkg.in/check.v1"
+)
+
+var _ = Suite(&FacadeUnitTest{})
+
+type FacadeUnitTest struct {
+	Facade    *Facade
+	ctx       *datastoremocks.Context
+	zzk       *zzkmocks.ZZK
+	dfs       *dfsmocks.DFS
+	hostStore *hostmocks.Store
+	poolStore *poolmocks.Store
+}
+
+func (ft *FacadeUnitTest) SetUpSuite(c *C) {
+	ft.Facade = New()
+}
+
+func (ft *FacadeUnitTest) SetUpTest(c *C) {
+	ft.ctx = &datastoremocks.Context{}
+
+	ft.dfs = &dfsmocks.DFS{}
+	ft.Facade.SetDFS(ft.dfs)
+
+	ft.hostStore = &hostmocks.Store{}
+	ft.Facade.SetHostStore(ft.hostStore)
+
+	ft.poolStore = &poolmocks.Store{}
+	ft.Facade.SetPoolStore(ft.poolStore)
+
+	ft.zzk = &zzkmocks.ZZK{}
+	ft.Facade.SetZZK(ft.zzk)
+}
+
+// Mock all DFS locking operations into no-ops
+func (ft *FacadeUnitTest) setupMockDFSLocking() {
+	ft.dfs.On("Lock", mock.AnythingOfType("string")).Return()
+	ft.dfs.On("LockWithTimeout", mock.AnythingOfType("string"), mock.AnythingOfType("time.Duration")).Return(nil)
+	ft.dfs.On("Unlock").Return()
+}

--- a/facade/facade_unit_test.go
+++ b/facade/facade_unit_test.go
@@ -13,7 +13,7 @@
 
 // +build unit
 
-package facade
+package facade_test
 
 import (
 	datastoremocks "github.com/control-center/serviced/datastore/mocks"
@@ -21,6 +21,7 @@ import (
 	hostmocks "github.com/control-center/serviced/domain/host/mocks"
 	poolmocks "github.com/control-center/serviced/domain/pool/mocks"
 	zzkmocks "github.com/control-center/serviced/facade/mocks"
+	"github.com/control-center/serviced/facade"
 	"github.com/stretchr/testify/mock"
 	. "gopkg.in/check.v1"
 )
@@ -28,7 +29,7 @@ import (
 var _ = Suite(&FacadeUnitTest{})
 
 type FacadeUnitTest struct {
-	Facade    *Facade
+	Facade    *facade.Facade
 	ctx       *datastoremocks.Context
 	zzk       *zzkmocks.ZZK
 	dfs       *dfsmocks.DFS
@@ -37,7 +38,7 @@ type FacadeUnitTest struct {
 }
 
 func (ft *FacadeUnitTest) SetUpSuite(c *C) {
-	ft.Facade = New()
+	ft.Facade = facade.New()
 }
 
 func (ft *FacadeUnitTest) SetUpTest(c *C) {

--- a/facade/facade_unit_test.go
+++ b/facade/facade_unit_test.go
@@ -20,6 +20,9 @@ import (
 	dfsmocks "github.com/control-center/serviced/dfs/mocks"
 	hostmocks "github.com/control-center/serviced/domain/host/mocks"
 	poolmocks "github.com/control-center/serviced/domain/pool/mocks"
+	registrymocks "github.com/control-center/serviced/domain/registry/mocks"
+	servicemocks "github.com/control-center/serviced/domain/service/mocks"
+	templatemocks "github.com/control-center/serviced/domain/servicetemplate/mocks"
 	zzkmocks "github.com/control-center/serviced/facade/mocks"
 	"github.com/control-center/serviced/facade"
 	"github.com/stretchr/testify/mock"
@@ -29,12 +32,15 @@ import (
 var _ = Suite(&FacadeUnitTest{})
 
 type FacadeUnitTest struct {
-	Facade    *facade.Facade
-	ctx       *datastoremocks.Context
-	zzk       *zzkmocks.ZZK
-	dfs       *dfsmocks.DFS
-	hostStore *hostmocks.Store
-	poolStore *poolmocks.Store
+	Facade        *facade.Facade
+	ctx           *datastoremocks.Context
+	zzk           *zzkmocks.ZZK
+	dfs           *dfsmocks.DFS
+	hostStore     *hostmocks.Store
+	poolStore     *poolmocks.Store
+	registryStore *registrymocks.ImageRegistryStore
+	serviceStore  *servicemocks.Store
+	templateStore *templatemocks.Store
 }
 
 func (ft *FacadeUnitTest) SetUpSuite(c *C) {
@@ -52,6 +58,15 @@ func (ft *FacadeUnitTest) SetUpTest(c *C) {
 
 	ft.poolStore = &poolmocks.Store{}
 	ft.Facade.SetPoolStore(ft.poolStore)
+
+	ft.registryStore = &registrymocks.ImageRegistryStore{}
+	ft.Facade.SetRegistryStore(ft.registryStore)
+
+	ft.serviceStore = &servicemocks.Store{}
+	ft.Facade.SetServiceStore(ft.serviceStore)
+
+	ft.templateStore = &templatemocks.Store{}
+	ft.Facade.SetTemplateStore(ft.templateStore)
 
 	ft.zzk = &zzkmocks.ZZK{}
 	ft.Facade.SetZZK(ft.zzk)

--- a/facade/host_test.go
+++ b/facade/host_test.go
@@ -29,7 +29,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *FacadeTest) Test_HostCRUD(t *C) {
+func (s *FacadeIntegrationTest) Test_HostCRUD(t *C) {
 	testid := "deadb10f"
 	poolid := "pool-id"
 	defer s.Facade.RemoveHost(s.CTX, testid)
@@ -95,7 +95,7 @@ func (s *FacadeTest) Test_HostCRUD(t *C) {
 	}
 }
 
-func (s *FacadeTest) TestRestoreHosts(c *C) {
+func (s *FacadeIntegrationTest) TestRestoreHosts(c *C) {
 	// create pool for testing
 	resourcePool := pool.New("poolid")
 	s.Facade.AddResourcePool(s.CTX, resourcePool)
@@ -197,7 +197,7 @@ func (s *FacadeTest) TestRestoreHosts(c *C) {
 	c.Assert(actual, DeepEquals, hosts1)
 }
 
-func (s *FacadeTest) Test_HostRemove(t *C) {
+func (s *FacadeIntegrationTest) Test_HostRemove(t *C) {
 	//create pool for testing
 	resoucePool := pool.New("poolid")
 	s.Facade.AddResourcePool(s.CTX, resoucePool)

--- a/facade/host_unit_test.go
+++ b/facade/host_unit_test.go
@@ -1,0 +1,63 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package facade_test
+
+import (
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain/host"
+	"github.com/stretchr/testify/mock"
+	. "gopkg.in/check.v1"
+)
+
+func (ft *FacadeUnitTest) Test_GetHost(c *C) {
+	hostID := "someHostID"
+	expectedHost := host.Host{ID: hostID}
+	key := host.HostKey(hostID)
+	ft.hostStore.On("Get", ft.ctx, key, mock.AnythingOfType("*host.Host")).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			host := args.Get(2).(*host.Host)
+			*host = expectedHost
+		})
+
+	result, err := ft.Facade.GetHost(ft.ctx, hostID)
+
+	c.Assert(err, IsNil)
+	c.Assert(result.ID, Equals, hostID)
+}
+
+func (ft *FacadeUnitTest) Test_GetHostFailsForNoSuchEntity(c *C) {
+	hostID := "someHostID"
+	key := host.HostKey(hostID)
+	ft.hostStore.On("Get", ft.ctx, key, mock.AnythingOfType("*host.Host")).Return(datastore.ErrNoSuchEntity{})
+
+	result, err := ft.Facade.GetHost(ft.ctx, hostID)
+
+	c.Assert(result, IsNil)
+	c.Assert(err, IsNil)
+}
+
+func (ft *FacadeUnitTest) Test_GetHostFailsForOtherDBError(c *C) {
+	hostID := "someHostID"
+	key := host.HostKey(hostID)
+	expectedError := datastore.ErrEmptyKind
+	ft.hostStore.On("Get", ft.ctx, key, mock.AnythingOfType("*host.Host")).Return(expectedError)
+
+	result, err := ft.Facade.GetHost(ft.ctx, hostID)
+
+	c.Assert(result, IsNil)
+	c.Assert(err, Equals, expectedError)
+}

--- a/facade/pool.go
+++ b/facade/pool.go
@@ -417,8 +417,8 @@ func (f *Facade) CreateDefaultPool(ctx datastore.Context, id string) error {
 
 func (f *Facade) calcPoolCapacity(ctx datastore.Context, pool *pool.ResourcePool) error {
 	hosts, err := f.hostStore.FindHostsWithPoolID(ctx, pool.ID)
-
 	if err != nil {
+		// FIXME: this error shouldn't be ignored. Either log it and/or have the caller fail and return the error
 		return err
 	}
 
@@ -432,13 +432,13 @@ func (f *Facade) calcPoolCapacity(ctx datastore.Context, pool *pool.ResourcePool
 	pool.CoreCapacity = coreCapacity
 	pool.MemoryCapacity = memCapacity
 
-	return err
+	return nil
 }
 
 func (f *Facade) calcPoolCommitment(ctx datastore.Context, pool *pool.ResourcePool) error {
 	services, err := f.serviceStore.GetServicesByPool(ctx, pool.ID)
-
 	if err != nil {
+		// FIXME: this error shouldn't be ignored. Either log it and/or have the caller fail and return the error
 		return err
 	}
 
@@ -449,7 +449,7 @@ func (f *Facade) calcPoolCommitment(ctx datastore.Context, pool *pool.ResourcePo
 
 	pool.MemoryCommitment = memCommitment
 
-	return err
+	return nil
 }
 
 // GetPoolIPs gets all IPs available to a resource pool

--- a/facade/pool_test.go
+++ b/facade/pool_test.go
@@ -24,7 +24,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (ft *FacadeTest) Test_NewResourcePool(t *C) {
+func (ft *FacadeIntegrationTest) Test_NewResourcePool(t *C) {
 	fmt.Println(" ##### Test_NewResourcePool: starting")
 	poolID := "Test_NewResourcePool"
 	result, err := ft.Facade.GetResourcePool(ft.CTX, poolID)
@@ -53,7 +53,7 @@ func (ft *FacadeTest) Test_NewResourcePool(t *C) {
 	fmt.Println(" ##### Test_NewResourcePool: PASSED")
 }
 
-func (ft *FacadeTest) Test_UpdateResourcePool(t *C) {
+func (ft *FacadeIntegrationTest) Test_UpdateResourcePool(t *C) {
 	fmt.Println(" ##### Test_UpdateResourcePool: starting")
 	poolID := "Test_UpdateResourcePool"
 	result, err := ft.Facade.GetResourcePool(ft.CTX, poolID)
@@ -83,7 +83,7 @@ func (ft *FacadeTest) Test_UpdateResourcePool(t *C) {
 	fmt.Println(" ##### Test_UpdateResourcePool: PASSED")
 }
 
-func (ft *FacadeTest) Test_GetResourcePool(t *C) {
+func (ft *FacadeIntegrationTest) Test_GetResourcePool(t *C) {
 	fmt.Println(" ##### Test_GetResourcePool: starting")
 	poolID := "Test_GetResourcePool"
 	result, err := ft.Facade.GetResourcePool(ft.CTX, poolID)
@@ -112,7 +112,7 @@ func (ft *FacadeTest) Test_GetResourcePool(t *C) {
 	fmt.Println(" ##### Test_GetResourcePool: PASSED")
 }
 
-func (ft *FacadeTest) Test_RemoveResourcePool(t *C) {
+func (ft *FacadeIntegrationTest) Test_RemoveResourcePool(t *C) {
 	fmt.Println(" ##### Test_RemoveResourcePool: starting")
 	poolID := "Test_RemoveResourcePool"
 
@@ -140,7 +140,7 @@ func (ft *FacadeTest) Test_RemoveResourcePool(t *C) {
 	fmt.Println(" ##### Test_RemoveResourcePool: PASSED")
 }
 
-func (ft *FacadeTest) TestRestoreResourcePools(c *C) {
+func (ft *FacadeIntegrationTest) TestRestoreResourcePools(c *C) {
 	pools1 := []pool.ResourcePool{
 		{
 			ID:    "testpool-1",
@@ -213,7 +213,7 @@ func (ft *FacadeTest) TestRestoreResourcePools(c *C) {
 	c.Assert(actual, DeepEquals, pools2)
 }
 
-func (ft *FacadeTest) Test_GetResourcePools(t *C) {
+func (ft *FacadeIntegrationTest) Test_GetResourcePools(t *C) {
 	result, err := ft.Facade.GetResourcePools(ft.CTX)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -246,7 +246,7 @@ func (ft *FacadeTest) Test_GetResourcePools(t *C) {
 	}
 }
 
-func (ft *FacadeTest) Test_GetPoolsIPs(t *C) {
+func (ft *FacadeIntegrationTest) Test_GetPoolsIPs(t *C) {
 	assignIPsPool := pool.New("Test_GetPoolsIPs")
 	err := ft.Facade.AddResourcePool(ft.CTX, assignIPsPool)
 	defer func() {
@@ -305,7 +305,7 @@ func (ft *FacadeTest) Test_GetPoolsIPs(t *C) {
 
 }
 
-func (ft *FacadeTest) Test_VirtualIPs(t *C) {
+func (ft *FacadeIntegrationTest) Test_VirtualIPs(t *C) {
 	fmt.Println(" ##### Test_VirtualIPs")
 	myPoolID := "Test_VirtualIPs"
 	assignIPsPool := pool.New(myPoolID)
@@ -407,7 +407,7 @@ func (ft *FacadeTest) Test_VirtualIPs(t *C) {
 	}
 }
 
-func (ft *FacadeTest) Test_InvalidVirtualIPs(t *C) {
+func (ft *FacadeIntegrationTest) Test_InvalidVirtualIPs(t *C) {
 	fmt.Println(" ##### Test_InvalidVirtualIPs")
 	myPoolID := "Test_InvalidVirtualIPs"
 	assignIPsPool := pool.New(myPoolID)
@@ -502,7 +502,7 @@ func (ft *FacadeTest) Test_InvalidVirtualIPs(t *C) {
 	}
 }
 
-func (ft *FacadeTest) Test_PoolCapacity(t *C) {
+func (ft *FacadeIntegrationTest) Test_PoolCapacity(t *C) {
 	hostid := "deadb23f"
 	poolid := "pool-id"
 
@@ -536,7 +536,7 @@ func (ft *FacadeTest) Test_PoolCapacity(t *C) {
 	}
 }
 
-func (ft *FacadeTest) Test_PoolCommitment(t *C) {
+func (ft *FacadeIntegrationTest) Test_PoolCommitment(t *C) {
 	poolid := "pool-id"
 
 	//create pool for test

--- a/facade/pool_unit_test.go
+++ b/facade/pool_unit_test.go
@@ -1,0 +1,99 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package facade
+
+import (
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain/host"
+	"github.com/control-center/serviced/domain/pool"
+	"github.com/stretchr/testify/mock"
+	. "gopkg.in/check.v1"
+)
+
+func (ft *FacadeUnitTest) Test_GetResourcePool(c *C) {
+	ft.setupMockDFSLocking()
+	poolID := "somePoolID"
+	expectedPool := pool.ResourcePool{ID: poolID}
+	key := pool.Key(poolID)
+	ft.hostStore.On("FindHostsWithPoolID", ft.ctx, mock.AnythingOfType("string")).
+		Return([]host.Host{
+			{ID: "host1", Cores: 2, Memory: 3},
+			{ID: "host2", Cores: 3, Memory: 4},
+		}, nil)
+	ft.poolStore.On("Get", ft.ctx, key, mock.AnythingOfType("*pool.ResourcePool")).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			pool := args.Get(2).(*pool.ResourcePool)
+			*pool = expectedPool
+		})
+
+	result, err := ft.Facade.GetResourcePool(ft.ctx, poolID)
+
+	c.Assert(err, IsNil)
+	c.Assert(result.ID, Equals, poolID)
+	c.Assert(result.CoreCapacity, Equals, 5)
+	c.Assert(result.MemoryCapacity, Equals, uint64(7))
+}
+
+func (ft *FacadeUnitTest) Test_GetResourcePoolWithNoHosts(c *C) {
+	ft.setupMockDFSLocking()
+	poolID := "somePoolID"
+	expectedPool := pool.ResourcePool{ID: poolID}
+	key := pool.Key(poolID)
+	ft.hostStore.On("FindHostsWithPoolID", ft.ctx, mock.AnythingOfType("string")).
+		Return([]host.Host{}, nil)
+	ft.poolStore.On("Get", ft.ctx, key, mock.AnythingOfType("*pool.ResourcePool")).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			pool := args.Get(2).(*pool.ResourcePool)
+			*pool = expectedPool
+		})
+
+	result, err := ft.Facade.GetResourcePool(ft.ctx, poolID)
+
+	c.Assert(err, IsNil)
+	c.Assert(result, Not(IsNil))
+	c.Assert(result.ID, Equals, poolID)
+	c.Assert(result.CoreCapacity, Equals, 0)
+	c.Assert(result.MemoryCapacity, Equals, uint64(0))
+}
+
+func (ft *FacadeUnitTest) Test_GetResourcePoolFailsForNoSuchEntity(c *C) {
+	ft.setupMockDFSLocking()
+	poolID := "somePoolID"
+	key := pool.Key(poolID)
+
+	ft.poolStore.On("Get", ft.ctx, key, mock.AnythingOfType("*pool.ResourcePool")).Return(datastore.ErrNoSuchEntity{})
+
+	result, err := ft.Facade.GetResourcePool(ft.ctx, poolID)
+
+	c.Assert(result, IsNil)
+	c.Assert(err, IsNil)
+}
+
+func (ft *FacadeUnitTest) Test_GetResourcePoolFailsForOtherDBError(c *C) {
+	ft.setupMockDFSLocking()
+	poolID := "somePoolID"
+	key := pool.Key(poolID)
+	expectedError := datastore.ErrEmptyKind
+
+	ft.poolStore.On("Get", ft.ctx, key, mock.AnythingOfType("*pool.ResourcePool")).Return(expectedError)
+
+	result, err := ft.Facade.GetResourcePool(ft.ctx, poolID)
+
+	c.Assert(result, IsNil)
+	c.Assert(err, Equals, expectedError)
+}

--- a/facade/pool_unit_test.go
+++ b/facade/pool_unit_test.go
@@ -13,7 +13,7 @@
 
 // +build unit
 
-package facade
+package facade_test
 
 import (
 	"github.com/control-center/serviced/datastore"

--- a/facade/registry_test.go
+++ b/facade/registry_test.go
@@ -21,7 +21,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (ft *FacadeTest) TestGetRegistryImage(c *C) {
+func (ft *FacadeIntegrationTest) TestGetRegistryImage(c *C) {
 	expected := &registry.Image{
 		Library: "library",
 		Repo:    "reponame",
@@ -36,14 +36,14 @@ func (ft *FacadeTest) TestGetRegistryImage(c *C) {
 	c.Assert(actual, DeepEquals, expected)
 }
 
-func (ft *FacadeTest) TestGetRegistryImage_NotFound(c *C) {
+func (ft *FacadeIntegrationTest) TestGetRegistryImage_NotFound(c *C) {
 	result, err := ft.Facade.GetRegistryImage(ft.CTX, "someImageID")
 	c.Assert(err, NotNil)
 	c.Assert(datastore.IsErrNoSuchEntity(err), Equals, true)
 	c.Assert(result, IsNil)
 }
 
-func (ft *FacadeTest) TestSetRegistryImage(c *C) {
+func (ft *FacadeIntegrationTest) TestSetRegistryImage(c *C) {
 	expected := &registry.Image{
 		Library: "library",
 		Repo:    "reponame",
@@ -95,7 +95,7 @@ func (ft *FacadeTest) TestSetRegistryImage(c *C) {
 	c.Assert(actual, DeepEquals, expected2)
 }
 
-func (ft *FacadeTest) TestDeleteRegistryImage(c *C) {
+func (ft *FacadeIntegrationTest) TestDeleteRegistryImage(c *C) {
 	expected := &registry.Image{
 		Library: "library",
 		Repo:    "reponame",
@@ -115,7 +115,7 @@ func (ft *FacadeTest) TestDeleteRegistryImage(c *C) {
 	c.Assert(datastore.IsErrNoSuchEntity(err), Equals, true)
 }
 
-func (ft *FacadeTest) TestGetRegistryImages(c *C) {
+func (ft *FacadeIntegrationTest) TestGetRegistryImages(c *C) {
 	expected := []registry.Image{
 		{
 			Library: "library",
@@ -151,7 +151,7 @@ func (ft *FacadeTest) TestGetRegistryImages(c *C) {
 	c.Assert(actual, DeepEquals, expected)
 }
 
-func (ft *FacadeTest) TestSearchRegistryLibraryByTag(c *C) {
+func (ft *FacadeIntegrationTest) TestSearchRegistryLibraryByTag(c *C) {
 	expected1 := []registry.Image{
 		{
 			Library: "library",

--- a/facade/registry_unit_test.go
+++ b/facade/registry_unit_test.go
@@ -1,0 +1,57 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package facade_test
+
+import (
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain/registry"
+	. "gopkg.in/check.v1"
+)
+
+func (ft *FacadeUnitTest) Test_GetRegistryImage(c *C) {
+	imageID := "someImageID"
+	expectedImage := registry.Image{UUID: imageID}
+	ft.registryStore.On("Get", ft.ctx, imageID).
+		Return(&expectedImage, nil)
+
+	result, err := ft.Facade.GetRegistryImage(ft.ctx, imageID)
+
+	c.Assert(err, IsNil)
+	c.Assert(result.UUID, Equals, imageID)
+}
+
+func (ft *FacadeUnitTest) Test_GetRegistryImageFailsForNoSuchEntity(c *C) {
+	imageID := "someImageID"
+	ft.registryStore.On("Get", ft.ctx, imageID).
+		Return(nil, datastore.ErrNoSuchEntity{})
+
+	result, err := ft.Facade.GetRegistryImage(ft.ctx, imageID)
+
+	c.Assert(result, IsNil)
+	c.Assert(err, Equals, datastore.ErrNoSuchEntity{})
+}
+
+func (ft *FacadeUnitTest) Test_GetRegistryImageFailsForOtherDBError(c *C) {
+	imageID := "someImageID"
+	expectedError := datastore.ErrEmptyKind
+	ft.registryStore.On("Get", ft.ctx, imageID).
+		Return(nil, expectedError)
+
+	result, err := ft.Facade.GetRegistryImage(ft.ctx, imageID)
+
+	c.Assert(result, IsNil)
+	c.Assert(err, Equals, expectedError)
+}

--- a/facade/service.go
+++ b/facade/service.go
@@ -1586,7 +1586,7 @@ func filterByNameRegex(nmregex string, services []service.Service) ([]service.Se
 func (f *Facade) getService(ctx datastore.Context, id string) (service.Service, error) {
 	glog.V(3).Infof("Facade.getService: id=%s", id)
 	store := f.serviceStore
-	svc, err := store.Get(datastore.Get(), id)
+	svc, err := store.Get(ctx, id)
 	if err != nil || svc == nil {
 		return service.Service{}, err
 	}

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -40,7 +40,7 @@ var (
 )
 
 
-func (ft *FacadeTest) TestFacade_validateServiceName(c *C) {
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceName(c *C) {
 	svcA := service.Service{
 		ID:           "validate-service-name-A",
 		Name:         "TestFacade_validateServiceNameA",
@@ -95,7 +95,7 @@ func (ft *FacadeTest) TestFacade_validateServiceName(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (ft *FacadeTest) TestFacade_validateServiceTenant(c *C) {
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceTenant(c *C) {
 	svcA := service.Service{
 		ID:           "validate-service-tenant-A",
 		Name:         "TestFacade_validateServiceTenantA",
@@ -143,7 +143,7 @@ func (ft *FacadeTest) TestFacade_validateServiceTenant(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (ft *FacadeTest) setup_validateServiceStart(c *C, endpoints ...service.ServiceEndpoint) *service.Service {
+func (ft *FacadeIntegrationTest) setup_validateServiceStart(c *C, endpoints ...service.ServiceEndpoint) *service.Service {
 	err := ft.Facade.AddResourcePool(ft.CTX, &pool.ResourcePool{ID: "test-pool"})
 	c.Assert(err, IsNil)
 	svc := service.Service{
@@ -159,7 +159,7 @@ func (ft *FacadeTest) setup_validateServiceStart(c *C, endpoints ...service.Serv
 	return &svc
 }
 
-func (ft *FacadeTest) TestFacade_validateServiceStart_missingAddressAssignment(c *C) {
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceStart_missingAddressAssignment(c *C) {
 	// set up the endpoint with a missing address assignment
 	endpoint := service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{
 		Name:        "ep1",
@@ -176,7 +176,7 @@ func (ft *FacadeTest) TestFacade_validateServiceStart_missingAddressAssignment(c
 
 }
 
-func (ft *FacadeTest) TestFacade_validateServiceStart_checkVHostFail(c *C) {
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceStart_checkVHostFail(c *C) {
 	// set up the endpoint with an invalid vhost
 	endpoint := service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{
 		Name:        "ep2",
@@ -195,7 +195,7 @@ func (ft *FacadeTest) TestFacade_validateServiceStart_checkVHostFail(c *C) {
 	c.Assert(err, Equals, ErrTestEPValidationFail)
 }
 
-func (ft *FacadeTest) TestFacade_validateServiceStart_checkPortFail(c *C) {
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceStart_checkPortFail(c *C) {
 	// set up the endpoint with in invalid public port
 	endpoint := service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{
 		Name:        "ep3",
@@ -214,7 +214,7 @@ func (ft *FacadeTest) TestFacade_validateServiceStart_checkPortFail(c *C) {
 	c.Assert(err, Equals, ErrTestEPValidationFail)
 }
 
-func (ft *FacadeTest) TestFacade_validateServiceStart(c *C) {
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceStart(c *C) {
 	// successfully add address assignment, vhost, and port
 	ep1 := service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{
 		Name:        "ep1",
@@ -268,12 +268,12 @@ func (ft *FacadeTest) TestFacade_validateServiceStart(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (ft *FacadeTest) TestFacade_validateService_badServiceID(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_validateService_badServiceID(t *C) {
 	_, err := ft.Facade.validateServiceUpdate(ft.CTX, &service.Service{ID: "badID"})
 	t.Assert(err, ErrorMatches, "No such entity {kind:service, id:badID}")
 }
 
-func (ft *FacadeTest) TestFacade_validateServiceEndpoints_noDupsInOneService(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceEndpoints_noDupsInOneService(t *C) {
 	svc := service.Service{
 		ID:           "svc1",
 		Name:         "TestFacade_validateServiceEndpoints",
@@ -291,7 +291,7 @@ func (ft *FacadeTest) TestFacade_validateServiceEndpoints_noDupsInOneService(t *
 	t.Assert(err, IsNil)
 }
 
-func (ft *FacadeTest) TestFacade_validateServiceEndpoints_noDupsInAllServices(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceEndpoints_noDupsInAllServices(t *C) {
 	svc := service.Service{
 		ID:           "svc1",
 		Name:         "TestFacade_validateServiceEndpoints",
@@ -332,7 +332,7 @@ func (ft *FacadeTest) TestFacade_validateServiceEndpoints_noDupsInAllServices(t 
 	t.Assert(err, IsNil)
 }
 
-func (ft *FacadeTest) TestFacade_validateServiceEndpoints_dupsInOneService(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceEndpoints_dupsInOneService(t *C) {
 	svc := service.Service{
 		ID:           "svc1",
 		Name:         "TestFacade_validateServiceEndpoints",
@@ -351,7 +351,7 @@ func (ft *FacadeTest) TestFacade_validateServiceEndpoints_dupsInOneService(t *C)
 	t.Check(strings.Contains(err.Error(), "found duplicate endpoint name"), Equals, true)
 }
 
-func (ft *FacadeTest) TestFacade_validateServiceEndpoints_dupsBtwnServices(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceEndpoints_dupsBtwnServices(t *C) {
 	svc := service.Service{
 		ID:           "svc1",
 		Name:         "TestFacade_validateServiceEndpoints",
@@ -393,7 +393,7 @@ func (ft *FacadeTest) TestFacade_validateServiceEndpoints_dupsBtwnServices(t *C)
 	t.Check(strings.Contains(err.Error(), "found duplicate endpoint name"), Equals, true)
 }
 
-func (ft *FacadeTest) TestFacade_migrateServiceConfigs_noConfigs(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_migrateServiceConfigs_noConfigs(t *C) {
 	_, newSvc, err := ft.setupMigrationServices(t, nil)
 	t.Assert(err, IsNil)
 
@@ -401,7 +401,7 @@ func (ft *FacadeTest) TestFacade_migrateServiceConfigs_noConfigs(t *C) {
 	t.Assert(err, IsNil)
 }
 
-func (ft *FacadeTest) TestFacade_migrateServiceConfigs_noChanges(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_migrateServiceConfigs_noChanges(t *C) {
 	_, newSvc, err := ft.setupMigrationServices(t, getOriginalConfigs())
 	t.Assert(err, IsNil)
 
@@ -410,7 +410,7 @@ func (ft *FacadeTest) TestFacade_migrateServiceConfigs_noChanges(t *C) {
 }
 
 // Verify migration of configuration data when the user has not changed any config files
-func (ft *FacadeTest) TestFacade_migrateService_withoutUserConfigChanges(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_migrateService_withoutUserConfigChanges(t *C) {
 	_, newSvc, err := ft.setupMigrationServices(t, getOriginalConfigs())
 	t.Assert(err, IsNil)
 	newSvc.ConfigFiles = nil
@@ -430,7 +430,7 @@ func (ft *FacadeTest) TestFacade_migrateService_withoutUserConfigChanges(t *C) {
 	t.Assert(len(confs), Equals, 0)
 }
 
-func (ft *FacadeTest) TestFacade_GetServiceEndpoints_UndefinedService(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_GetServiceEndpoints_UndefinedService(t *C) {
 	endpointMap, err := ft.Facade.GetServiceEndpoints(ft.CTX, "undefined", true, true, true)
 
 	t.Assert(err, NotNil)
@@ -438,7 +438,7 @@ func (ft *FacadeTest) TestFacade_GetServiceEndpoints_UndefinedService(t *C) {
 	t.Assert(endpointMap, IsNil)
 }
 
-func (ft *FacadeTest) TestFacade_GetServiceEndpoints_ZKUnavailable(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_GetServiceEndpoints_ZKUnavailable(t *C) {
 	svc, err := ft.setupServiceWithEndpoints(t)
 	t.Assert(err, IsNil)
 	serviceIDs := []string{svc.ID}
@@ -452,7 +452,7 @@ func (ft *FacadeTest) TestFacade_GetServiceEndpoints_ZKUnavailable(t *C) {
 	t.Assert(endpointMap, IsNil)
 }
 
-func (ft *FacadeTest) TestFacade_GetServiceEndpoints_ServiceNotRunning(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_GetServiceEndpoints_ServiceNotRunning(t *C) {
 	svc, err := ft.setupServiceWithEndpoints(t)
 	t.Assert(err, IsNil)
 	serviceIDs := []string{svc.ID}
@@ -471,7 +471,7 @@ func (ft *FacadeTest) TestFacade_GetServiceEndpoints_ServiceNotRunning(t *C) {
 	t.Assert(endpoints[1].Endpoint.Application, Equals, "test_ep_2")
 }
 
-func (ft *FacadeTest) TestFacade_GetServiceEndpoints_ServiceRunning(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_GetServiceEndpoints_ServiceRunning(t *C) {
 	svc, err := ft.setupServiceWithEndpoints(t)
 	t.Assert(err, IsNil)
 	serviceIDs := []string{svc.ID}
@@ -507,7 +507,7 @@ func (ft *FacadeTest) TestFacade_GetServiceEndpoints_ServiceRunning(t *C) {
 	t.Assert(endpoints[3].Endpoint.Application, Equals, "test_ep_2")
 }
 
-func (ft *FacadeTest) setupServiceWithEndpoints(t *C) (*service.Service, error) {
+func (ft *FacadeIntegrationTest) setupServiceWithEndpoints(t *C) (*service.Service, error) {
 	svc := service.Service{
 		ID:           "svc1",
 		Name:         "TestFacade_GetServiceEndpoints",
@@ -535,7 +535,7 @@ func (ft *FacadeTest) setupServiceWithEndpoints(t *C) (*service.Service, error) 
 }
 
 // Test a trivial migration of a single property
-func (ft *FacadeTest) TestFacade_MigrateServices_Modify_Success(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_Modify_Success(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -559,7 +559,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_Modify_Success(t *C) {
 	t.Assert(out.Description, Equals, "migrated_service")
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_Modify_Fail(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_Modify_Fail(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -613,7 +613,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_Modify_Fail(t *C) {
 	t.Assert(actual, Equals, expected)
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_Modify_FailDupNew(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_Modify_FailDupNew(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -642,7 +642,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_Modify_FailDupNew(t *C) {
 	t.Assert(err, Equals, ErrServiceCollision)
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_Added_Success(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_Added_Success(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -658,7 +658,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_Added_Success(t *C) {
 	ft.assertServiceAdded(t, newSvc)
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_Added_FailDup(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_Added_FailDup(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -675,7 +675,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_Added_FailDup(t *C) {
 	t.Assert(err, Equals, ErrServiceCollision)
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_Added_FailDupNew(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_Added_FailDupNew(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -691,7 +691,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_Added_FailDupNew(t *C) {
 	t.Assert(err, Equals, ErrServiceCollision)
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_AddedAndModified(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_AddedAndModified(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -719,7 +719,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_AddedAndModified(t *C) {
 	t.Assert(out.Description, Equals, "migrated_service")
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_AddedAndModified_FailDup(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_AddedAndModified_FailDup(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -743,7 +743,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_AddedAndModified_FailDup(t *C) 
 	t.Assert(err, Equals, ErrServiceCollision)
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_AddedAndDeployed_FailDup(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_AddedAndDeployed_FailDup(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -771,7 +771,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_AddedAndDeployed_FailDup(t *C) 
 	t.Assert(err, ErrorMatches, "service exists")
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_Deploy_Success(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_Deploy_Success(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -803,7 +803,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_Deploy_Success(t *C) {
 	t.Assert(foundAddedService, Equals, true)
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_Deploy_FailDup(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_Deploy_FailDup(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -828,7 +828,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_Deploy_FailDup(t *C) {
 	t.Assert(err, ErrorMatches, "service exists")
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_Deploy_FailDupNew(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_Deploy_FailDupNew(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -856,7 +856,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_Deploy_FailDupNew(t *C) {
 	t.Assert(err, ErrorMatches, "service exists")
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_Deploy_FailInvalidParentID(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_Deploy_FailInvalidParentID(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -871,7 +871,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_Deploy_FailInvalidParentID(t *C
 	t.Assert(err, ErrorMatches, "No such entity.*")
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_Deploy_FailInvalidServiceDefinition(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_Deploy_FailInvalidServiceDefinition(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -893,7 +893,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_Deploy_FailInvalidServiceDefini
 	t.Check(strings.Contains(err.Error(), "string bogus-launch not in [auto manual]"), Equals, true)
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_FailDupeEndpointsWithinANewService(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_FailDupeEndpointsWithinANewService(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -932,7 +932,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_FailDupeEndpointsWithinANewServ
 	t.Assert(err, Equals, ErrServiceDuplicateEndpoint)
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_FailDupeEndpointsAcrossNewServices(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_FailDupeEndpointsAcrossNewServices(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -969,7 +969,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_FailDupeEndpointsAcrossNewServi
 	t.Assert(err, Equals, ErrServiceDuplicateEndpoint)
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_FailDupeEndpointsAcrossNewAndModifiedServices(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_FailDupeEndpointsAcrossNewAndModifiedServices(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -1004,7 +1004,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_FailDupeEndpointsAcrossNewAndMo
 	t.Assert(err, Equals, ErrServiceDuplicateEndpoint)
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_FailDupeEndpointsAcrossNewAndDeployedServices(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_FailDupeEndpointsAcrossNewAndDeployedServices(t *C) {
 	err := ft.setupMigrationTestWithoutEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -1051,7 +1051,7 @@ func (ft *FacadeTest) TestFacade_MigrateServices_FailDupeEndpointsAcrossNewAndDe
 	t.Assert(err, Equals, ErrServiceDuplicateEndpoint)
 }
 
-func (ft *FacadeTest) TestFacade_MigrateServices_FailDupeExistingEndpoint(t *C) {
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_FailDupeExistingEndpoint(t *C) {
 	err := ft.setupMigrationTestWithEndpoints(t)
 	t.Assert(err, IsNil)
 
@@ -1074,15 +1074,15 @@ func (ft *FacadeTest) TestFacade_MigrateServices_FailDupeExistingEndpoint(t *C) 
 	t.Assert(err, Equals, ErrServiceDuplicateEndpoint)
 }
 
-func (ft *FacadeTest) setupMigrationTestWithoutEndpoints(t *C) error {
+func (ft *FacadeIntegrationTest) setupMigrationTestWithoutEndpoints(t *C) error {
 	return ft.setupMigrationTest(t, false)
 }
 
-func (ft *FacadeTest) setupMigrationTestWithEndpoints(t *C) error{
+func (ft *FacadeIntegrationTest) setupMigrationTestWithEndpoints(t *C) error{
 	return ft.setupMigrationTest(t, true)
 }
 
-func (ft *FacadeTest) setupMigrationTest(t *C, addEndpoint bool) error {
+func (ft *FacadeIntegrationTest) setupMigrationTest(t *C, addEndpoint bool) error {
 	tenant := service.Service{
 		ID:           "original_service_id_tenant",
 		Name:         "original_service_name_tenant",
@@ -1138,7 +1138,7 @@ func (ft *FacadeTest) setupMigrationTest(t *C, addEndpoint bool) error {
 	return nil
 }
 
-func (ft *FacadeTest) setupMigrationServices(t *C, originalConfigs map[string]servicedefinition.ConfigFile) (*service.Service, *service.Service, error) {
+func (ft *FacadeIntegrationTest) setupMigrationServices(t *C, originalConfigs map[string]servicedefinition.ConfigFile) (*service.Service, *service.Service, error) {
 	svc := service.Service{
 		ID:              "svc1",
 		Name:            "TestFacade_migrateServiceConfigs_oldSvc",
@@ -1178,7 +1178,7 @@ func (ft *FacadeTest) setupMigrationServices(t *C, originalConfigs map[string]se
 	return oldSvc, &newSvc, nil
 }
 
-func (ft *FacadeTest) getConfigFiles(svc *service.Service) ([]*serviceconfigfile.SvcConfigFile, error) {
+func (ft *FacadeIntegrationTest) getConfigFiles(svc *service.Service) ([]*serviceconfigfile.SvcConfigFile, error) {
 	tenantID, servicePath, err := ft.Facade.getServicePath(ft.CTX, svc.ID)
 	if err != nil {
 		return nil, err
@@ -1194,7 +1194,7 @@ func getOriginalConfigs() map[string]servicedefinition.ConfigFile {
 	return originalConfigs
 }
 
-func (ft *FacadeTest) createNewChildService(t *C) *service.Service {
+func (ft *FacadeIntegrationTest) createNewChildService(t *C) *service.Service {
 	originalID := "original_service_id_child_0"
 	oldSvc, err := ft.Facade.GetService(ft.CTX, originalID)
 	t.Assert(err, IsNil)
@@ -1206,7 +1206,7 @@ func (ft *FacadeTest) createNewChildService(t *C) *service.Service {
 	return &newSvc
 }
 
-func (ft *FacadeTest) assertServiceAdded(t *C, newSvc *service.Service) {
+func (ft *FacadeIntegrationTest) assertServiceAdded(t *C, newSvc *service.Service) {
 	svcs, err := ft.Facade.GetServices(ft.CTX, dao.ServiceRequest{TenantID: newSvc.ParentServiceID})
 	t.Assert(err, IsNil)
 	t.Assert(len(svcs), Equals, 4)				// there should be 1 additional service
@@ -1221,7 +1221,7 @@ func (ft *FacadeTest) assertServiceAdded(t *C, newSvc *service.Service) {
 	t.Assert(foundAddedService, Equals, true)
 }
 
-func (ft *FacadeTest) createServiceDeploymentRequest(t *C) *dao.ServiceDeploymentRequest {
+func (ft *FacadeIntegrationTest) createServiceDeploymentRequest(t *C) *dao.ServiceDeploymentRequest {
 	deployRequest := dao.ServiceDeploymentRequest{
 		ParentID: "original_service_id_child_0",
 

--- a/facade/service_unit_test.go
+++ b/facade/service_unit_test.go
@@ -1,0 +1,180 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package facade_test
+
+import (
+	"fmt"
+
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/utils"
+	. "gopkg.in/check.v1"
+)
+
+func (ft *FacadeUnitTest) Test_GetTenantIDForRootApp(c *C) {
+	serviceID := getRandomServiceID(c)
+	expectedService := service.Service{ID: serviceID}
+	ft.serviceStore.On("Get", ft.ctx, serviceID).Return(&expectedService, nil)
+
+	result, err := ft.Facade.GetTenantID(ft.ctx, serviceID)
+
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, serviceID)
+}
+
+func (ft *FacadeUnitTest) Test_GetTenantIDForRootAppFailsForNoSuchEntity(c *C) {
+	serviceID := getRandomServiceID(c)
+	ft.serviceStore.On("Get", ft.ctx, serviceID).Return(nil, datastore.ErrNoSuchEntity{})
+
+	result, err := ft.Facade.GetTenantID(ft.ctx, serviceID)
+
+	c.Assert(len(result), Equals, 0)
+	c.Assert(err, Not(IsNil))
+	c.Assert(err, Equals, datastore.ErrNoSuchEntity{})
+}
+
+func (ft *FacadeUnitTest) Test_GetTenantIDForRootAppFailsForOtherDBError(c *C) {
+	serviceID := getRandomServiceID(c)
+	expectedError := fmt.Errorf("expected error: oops")
+	ft.serviceStore.On("Get", ft.ctx, serviceID).Return(nil, expectedError)
+
+	result, err := ft.Facade.GetTenantID(ft.ctx, serviceID)
+
+	c.Assert(len(result), Equals, 0)
+	c.Assert(err, Equals, expectedError)
+}
+
+func (ft *FacadeUnitTest) Test_GetTenantIDForRootAppUsesCache(c *C) {
+	serviceID := getRandomServiceID(c)
+	expectedService := service.Service{ID: serviceID}
+	ft.serviceStore.On("Get", ft.ctx, serviceID).Return(&expectedService, nil)
+
+	// Do the first lookup to seed the internal cache
+	result, err := ft.Facade.GetTenantID(ft.ctx, serviceID)
+
+	// verify the first lookup worked
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, serviceID)
+
+	// Change the mock to force an error if the DB is called.
+	// If the cache is working, then this mock should never be invoked
+	ft.serviceStore.On("Get", ft.ctx, serviceID).Return(nil, datastore.ErrEmptyKind)
+
+	// Do the second lookup to hit the internal cache, but not call the mock
+	result, err = ft.Facade.GetTenantID(ft.ctx, serviceID)
+
+	// verify the second lookup worked just like the first
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, serviceID)
+}
+
+func (ft *FacadeUnitTest) Test_GetTenantIDForChildApp(c *C) {
+	parentID := getRandomServiceID(c)
+	childID := getRandomServiceID(c)
+	parent := service.Service{ID: parentID}
+	child := service.Service{ID: childID, ParentServiceID: parentID}
+	ft.serviceStore.On("Get", ft.ctx, parentID).Return(&parent, nil)
+	ft.serviceStore.On("Get", ft.ctx, childID).Return(&child, nil)
+
+	result, err := ft.Facade.GetTenantID(ft.ctx, childID)
+
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, parentID)
+}
+
+func (ft *FacadeUnitTest) Test_GetTenantIDForGrandchildApp(c *C) {
+	parentID := getRandomServiceID(c)
+	childID := getRandomServiceID(c)
+	grandchildID := getRandomServiceID(c)
+	parent := service.Service{ID: parentID}
+	child := service.Service{ID: childID, ParentServiceID: parentID}
+	grandchild := service.Service{ID: grandchildID, ParentServiceID: childID}
+	ft.serviceStore.On("Get", ft.ctx, parentID).Return(&parent, nil)
+	ft.serviceStore.On("Get", ft.ctx, childID).Return(&child, nil)
+	ft.serviceStore.On("Get", ft.ctx, grandchildID).Return(&grandchild, nil)
+
+	// Do the first lookup to seed the internal cache
+	result, err := ft.Facade.GetTenantID(ft.ctx, grandchildID)
+
+	// verify the first lookup worked
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, parentID)
+
+	// Change the mock to force an error if the DB is called.
+	// If the cache is working, then this mock should never be invoked
+	ft.serviceStore.On("Get", ft.ctx, parentID).Return(nil, datastore.ErrEmptyKind)
+	ft.serviceStore.On("Get", ft.ctx, childID).Return(nil, datastore.ErrEmptyKind)
+	ft.serviceStore.On("Get", ft.ctx, grandchildID).Return(nil, datastore.ErrEmptyKind)
+
+	// Add a new grandchild that's not in the cache, but shares a parent that should be in the cache.
+	grandchildID2 := getRandomServiceID(c)
+	grandchild2 := service.Service{ID: grandchildID2, ParentServiceID: childID}
+	ft.serviceStore.On("Get", ft.ctx, grandchildID2).Return(&grandchild2, nil)
+
+	// Do the second lookup to hit the internal cache, but not call the mock
+	result, err = ft.Facade.GetTenantID(ft.ctx, grandchildID2)
+
+	// verify the second lookup worked just like the first
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, parentID)
+}
+
+func (ft *FacadeUnitTest) Test_GetTenantIDForGrandchildAppUsesCache(c *C) {
+	parentID := getRandomServiceID(c)
+	childID := getRandomServiceID(c)
+	grandchildID := getRandomServiceID(c)
+	parent := service.Service{ID: parentID}
+	child := service.Service{ID: childID, ParentServiceID: parentID}
+	grandchild := service.Service{ID: grandchildID, ParentServiceID: childID}
+	ft.serviceStore.On("Get", ft.ctx, parentID).Return(&parent, nil)
+	ft.serviceStore.On("Get", ft.ctx, childID).Return(&child, nil)
+	ft.serviceStore.On("Get", ft.ctx, grandchildID).Return(&grandchild, nil)
+
+	result, err := ft.Facade.GetTenantID(ft.ctx, grandchildID)
+
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, parentID)
+}
+
+func (ft *FacadeUnitTest) Test_GetTenantIDForIntermediateParentFails(c *C) {
+	parentID := getRandomServiceID(c)
+	childID := getRandomServiceID(c)
+	grandchildID := getRandomServiceID(c)
+	parent := service.Service{ID: parentID}
+	grandchild := service.Service{ID: grandchildID, ParentServiceID: childID}
+	expectedError := fmt.Errorf("expected error: oops")
+	ft.serviceStore.On("Get", ft.ctx, parentID).Return(&parent, nil)
+	ft.serviceStore.On("Get", ft.ctx, childID).Return(nil, expectedError)
+	ft.serviceStore.On("Get", ft.ctx, grandchildID).Return(&grandchild, nil)
+
+	result, err := ft.Facade.GetTenantID(ft.ctx, grandchildID)
+
+	c.Assert(len(result), Equals, 0)
+	c.Assert(err, Not(IsNil))
+	c.Assert(err, Equals, expectedError)
+}
+
+// Since the facade is optimized to cache serviceIDs, we need to generate a unique serviceID for each test
+func getRandomServiceID(c *C) string {
+	serviceID, err := utils.NewUUID()
+	if err != nil {
+		c.Fatalf("Failed to generate random service ID: %s", err)
+	}
+	return serviceID
+}
+//service store returned not-found
+//service store returned other error
+//service store return err=nil and svc=nil

--- a/facade/servicetemplate_test.go
+++ b/facade/servicetemplate_test.go
@@ -27,7 +27,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (ft *FacadeTest) TestFacadeServiceTemplate(t *C) {
+func (ft *FacadeIntegrationTest) TestFacadeServiceTemplate(t *C) {
 	glog.V(0).Infof("TestFacadeServiceTemplate started")
 	defer glog.V(0).Infof("TestFacadeServiceTemplate finished")
 
@@ -123,7 +123,7 @@ func (ft *FacadeTest) TestFacadeServiceTemplate(t *C) {
 	}
 }
 
-func (ft *FacadeTest) TestFacadeValidServiceForStart(t *C) {
+func (ft *FacadeIntegrationTest) TestFacadeValidServiceForStart(t *C) {
 	testService := service.Service{
 		ID: "TestFacadeValidServiceForStart_ServiceID",
 		Endpoints: []service.ServiceEndpoint{
@@ -143,7 +143,7 @@ func (ft *FacadeTest) TestFacadeValidServiceForStart(t *C) {
 	}
 }
 
-func (ft *FacadeTest) TestFacadeInvalidServiceForStart(t *C) {
+func (ft *FacadeIntegrationTest) TestFacadeInvalidServiceForStart(t *C) {
 	testService := service.Service{
 		ID: "TestFacadeInvalidServiceForStart_ServiceID",
 		Endpoints: []service.ServiceEndpoint{

--- a/facade/servicetemplate_unit_test.go
+++ b/facade/servicetemplate_unit_test.go
@@ -1,0 +1,65 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package facade_test
+
+import (
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain/servicetemplate"
+	. "gopkg.in/check.v1"
+)
+
+func (ft *FacadeUnitTest) Test_GetServiceTemplates(c *C) {
+	var templateList []*servicetemplate.ServiceTemplate
+	templateList = append(templateList, &servicetemplate.ServiceTemplate{ID: "template1"})
+	templateList = append(templateList, &servicetemplate.ServiceTemplate{ID: "template2"})
+	ft.templateStore.On("GetServiceTemplates", ft.ctx).Return(templateList, nil)
+
+	result, err := ft.Facade.GetServiceTemplates(ft.ctx)
+
+	c.Assert(err, IsNil)
+	c.Assert(result, Not(IsNil))
+	c.Assert(len(result), Equals, len(templateList))
+
+	for _, expectedTemplate := range templateList {
+		actualTemplate, ok := result[expectedTemplate.ID]
+		c.Assert(ok, Equals, true)
+		c.Assert(actualTemplate, Not(IsNil))
+		c.Assert(actualTemplate, DeepEquals, *expectedTemplate)
+	}
+}
+
+func (ft *FacadeUnitTest) Test_GetServiceTemplatesEmpty(c *C) {
+	var emptyList []*servicetemplate.ServiceTemplate
+	ft.templateStore.On("GetServiceTemplates", ft.ctx).Return(emptyList, nil)
+
+	result, err := ft.Facade.GetServiceTemplates(ft.ctx)
+
+	c.Assert(err, IsNil)
+	c.Assert(result, Not(IsNil))
+	c.Assert(len(result), Equals, 0)
+}
+
+func (ft *FacadeUnitTest) Test_GetServiceTemplatesFails(c *C) {
+	expectedError := datastore.ErrEmptyKind
+	ft.templateStore.On("GetServiceTemplates", ft.ctx).Return(nil, expectedError)
+
+	result, err := ft.Facade.GetServiceTemplates(ft.ctx)
+
+	c.Assert(err, Not(IsNil))
+	c.Assert(err, Equals, expectedError)
+	c.Assert(result, Not(IsNil))
+	c.Assert(len(result), Equals, 0)
+}

--- a/facade/testutils.go
+++ b/facade/testutils.go
@@ -32,8 +32,8 @@ import (
 	gocheck "gopkg.in/check.v1"
 )
 
-//FacadeTest used for running tests where a facade type is needed.
-type FacadeTest struct {
+// FacadeIntegrationTest used for running integration tests where a facade type is needed.
+type FacadeIntegrationTest struct {
 	elastic.ElasticTest
 	CTX    datastore.Context
 	Facade *Facade
@@ -41,8 +41,10 @@ type FacadeTest struct {
 	dfs    *dfsmocks.DFS
 }
 
+var _ = gocheck.Suite(&FacadeIntegrationTest{})
+
 //SetUpSuite sets up test suite
-func (ft *FacadeTest) SetUpSuite(c *gocheck.C) {
+func (ft *FacadeIntegrationTest) SetUpSuite(c *gocheck.C) {
 	//set up index and mappings before setting up elastic
 	ft.Index = "controlplane"
 	if ft.Mappings == nil {
@@ -67,7 +69,7 @@ func (ft *FacadeTest) SetUpSuite(c *gocheck.C) {
 	ft.setupMockDFS()
 }
 
-func (ft *FacadeTest) SetUpTest(c *gocheck.C) {
+func (ft *FacadeIntegrationTest) SetUpTest(c *gocheck.C) {
 	ft.ElasticTest.SetUpTest(c)
 	ft.zzk = &zzkmocks.ZZK{}
 	ft.Facade.SetZZK(ft.zzk)
@@ -78,7 +80,7 @@ func (ft *FacadeTest) SetUpTest(c *gocheck.C) {
 	LogstashContainerReloader = reloadLogstashContainerStub
 }
 
-func (ft *FacadeTest) setupMockZZK() {
+func (ft *FacadeIntegrationTest) setupMockZZK() {
 	ft.zzk.On("AddResourcePool", mock.AnythingOfType("*pool.ResourcePool")).Return(nil)
 	ft.zzk.On("UpdateResourcePool", mock.AnythingOfType("*pool.ResourcePool")).Return(nil)
 	ft.zzk.On("RemoveResourcePool", mock.AnythingOfType("string")).Return(nil)
@@ -97,11 +99,11 @@ func (ft *FacadeTest) setupMockZZK() {
 
 }
 
-func (ft *FacadeTest) setupMockDFS() {
+func (ft *FacadeIntegrationTest) setupMockDFS() {
 	ft.dfs.On("Destroy", mock.AnythingOfType("string")).Return(nil)
 }
 
-func (ft *FacadeTest) TearDownTest(c *gocheck.C) {
+func (ft *FacadeIntegrationTest) TearDownTest(c *gocheck.C) {
 }
 
 func reloadLogstashContainerStub(_ datastore.Context, _ FacadeInterface) error {


### PR DESCRIPTION
Make facade more unit-testable and provide some initial unit-tests for most of the primary domain services. The goal with this PR is just to establish a pattern for integration and unit-tests in the same package, and provide some examples for unit-testing some of the primary services in facade.