### PR TITLE
Adds more verbose help function to service run

### DIFF
--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -396,6 +396,44 @@ func (c *ServicedCli) printServicesAll(ctx *cli.Context) {
 	}
 }
 
+func (c *ServicedCli) printHelpForRun(svc *service.Service, command string) (returncode int) {
+	var (
+		found             bool
+		availablecommands []string
+	)
+	for commandname := range svc.Commands {
+		availablecommands = append(availablecommands, commandname)
+		if commandname == command {
+			found = true
+		}
+	}
+
+	sort.Strings(availablecommands)
+	if command == "help" {
+		fmt.Printf("Available commands for %v:\n", svc.Name)
+		for _, commandname := range availablecommands {
+			fmt.Printf("    %-20v  %v\n", commandname, svc.Commands[commandname].Description)
+		}
+		if len(availablecommands) == 0 {
+			fmt.Println("    No commands available.")
+		}
+		return 0
+
+	} else if !found {
+		fmt.Printf("Command %#v not available.\n", command)
+		fmt.Printf("Available commands for %v:\n", svc.Name)
+		for _, commandname := range availablecommands {
+			fmt.Printf("    %-20v  %v\n", commandname, svc.Commands[commandname].Description)
+		}
+		if len(availablecommands) == 0 {
+			fmt.Println("    No commands available.")
+		}
+		return 1
+
+	}
+	return -1
+}
+
 // Bash-completion command that completes the service ID as the first argument
 // and runnable commands as the second argument
 func (c *ServicedCli) printServiceRun(ctx *cli.Context) {
@@ -1045,6 +1083,10 @@ func (c *ServicedCli) cmdServiceRun(ctx *cli.Context) error {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return c.exit(1)
+	}
+
+	if returncode := c.printHelpForRun(svc, args[1]); returncode >= 0 {
+		return c.exit(returncode)
 	}
 
 	command = args[1]

--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -64,6 +64,18 @@ var DefaultTestServices = []service.Service{
 			"hello":   "echo hello world",
 			"goodbye": "echo goodbye world",
 		},
+		Commands: map[string]domain.Command{
+			"hello": domain.Command{
+				Command:         "echo hello world",
+				Description:     "Just says 'hello world'.",
+				CommitOnSuccess: false,
+			},
+			"goodbye": domain.Command{
+				Command:         "echo goodbye world",
+				Description:     "Just says 'goodbye world'.",
+				CommitOnSuccess: false,
+			},
+		},
 	}, {
 		ID:             "test-service-2",
 		Name:           "Zope",
@@ -892,11 +904,30 @@ func ExampleServicedCLI_CmdServiceShell_err() {
 	// hello
 }
 */
-func ExampleServicedCLI_CmdServiceRun_exec() {
-	InitServiceAPITest("serviced", "service", "run", "-i", "test-service-1", "hello", "-i")
+func ExampleServicedCLI_CmdServiceRun_exec_aloha() {
+	InitServiceAPITest("serviced", "service", "run", "-i", "test-service-1", "aloha")
 
 	// Output:
-	// echo hello world -i
+	// Command "aloha" not available.
+	// Available commands for Zenoss:
+	//     goodbye               Just says 'goodbye world'.
+	//     hello                 Just says 'hello world'.
+}
+
+func ExampleServicedCLI_CmdServiceRun_exec_hello() {
+	InitServiceAPITest("serviced", "service", "run", "-i", "test-service-1", "hello")
+
+	// Output:
+	// echo hello world
+}
+
+func ExampleServicedCLI_CmdServiceRun_help() {
+	InitServiceAPITest("serviced", "service", "run", "-i", "test-service-1", "help")
+
+	// Output:
+	// Available commands for Zenoss:
+	//     goodbye               Just says 'goodbye world'.
+	//     hello                 Just says 'hello world'.
 }
 
 /*

--- a/domain/common.go
+++ b/domain/common.go
@@ -25,6 +25,7 @@ type MinMax struct {
 
 type Command struct {
 	Command         string
+	Description     string
 	CommitOnSuccess bool
 }
 


### PR DESCRIPTION
"serviced service run <svc> help" displays commands available to that service.

Additionally, if a Command has a Description defined, the help message will
display that in the "Available commands" listing.

Closes CC-1102