### PR TITLE
docker registry no longer uses reverse proxying

### DIFF
--- a/cli/api/shell.go
+++ b/cli/api/shell.go
@@ -113,7 +113,7 @@ func (a *api) StartShell(config ShellConfig) error {
 	}
 
 	// TODO: change me to use sockets
-	cmd, err := shell.StartDocker(&cfg, dockerRegistry, options.Endpoint, options.ControllerBinary, options.UIPort)
+	cmd, err := shell.StartDocker(&cfg, options.DockerRegistry, options.Endpoint, options.ControllerBinary, options.UIPort)
 	if err != nil {
 		return fmt.Errorf("failed to connect to service: %s", err)
 	}
@@ -189,7 +189,7 @@ func (a *api) RunShell(config ShellConfig, stopChan chan struct{}) (int, error) 
 	}
 
 	// TODO: change me to use sockets
-	cmd, err := shell.StartDocker(&cfg, dockerRegistry, options.Endpoint, options.ControllerBinary, options.UIPort)
+	cmd, err := shell.StartDocker(&cfg, options.DockerRegistry, options.Endpoint, options.ControllerBinary, options.UIPort)
 	if err != nil {
 		return 1, fmt.Errorf("failed to connect to service: %s", err)
 	}


### PR DESCRIPTION
See link below on how to configure the docker registry:

https://jira.zenoss.com/browse/CC-2143?focusedCommentId=83137&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-83137

