### PR TITLE
CC-2071: PAM failure for system_user spams the control center logs

### DIFF
--- a/web/auth_linux_test.go
+++ b/web/auth_linux_test.go
@@ -188,15 +188,15 @@ func TestAuthentication(t *testing.T) {
 		user := tc.user
 		creds := login{Username: user.username, Password: tc.testPassword}
 		pamResult := pamValidateLoginOnly(&creds, adminGroup)
-		if (pamResult == nil) != tc.expectedPamResult {
+		if pamResult != tc.expectedPamResult {
 			t.Errorf("pam validation for user %s failed: %s", user.username, tc.description)
 		}
 		groupResult := isGroupMember(user.username, adminGroup)
-		if (groupResult == nil) != tc.expectedGroupResult {
+		if groupResult != tc.expectedGroupResult {
 			t.Errorf("group membership for user %s failed: %s", user.username, tc.description)
 		}
 		result := pamValidateLogin(&creds, adminGroup)
-		if (result == nil) != tc.expectedResult {
+		if result != tc.expectedResult {
 			t.Errorf("User Authentication for user %s failed: %s", user.username, tc.description)
 		}
 	}

--- a/web/auth_unsupported.go
+++ b/web/auth_unsupported.go
@@ -17,11 +17,9 @@ package web
 
 import (
 	"github.com/zenoss/glog"
-
-	"errors"
 )
 
 func pamValidateLogin(_ *login, _ string) bool {
 	glog.Errorf("pamValidateLogin is not supported on this platform")
-	return errors.New("pamValidateLogin is not supported on this platform")
+	return false
 }

--- a/web/session.go
+++ b/web/session.go
@@ -167,7 +167,7 @@ func restLogin(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClie
 		return
 	}
 
-	if err := pamValidateLogin(&creds, adminGroup); (err == nil) || cpValidateLogin(&creds, client) {
+	if pamValidateLogin(&creds, adminGroup) || cpValidateLogin(&creds, client) {
 		sessionsLock.Lock()
 		defer sessionsLock.Unlock()
 
@@ -198,7 +198,6 @@ func restLogin(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClie
 
 		w.WriteJson(&simpleResponse{"Accepted", homeLink()})
 	} else {
-		glog.Errorf("Unable to validate credentials for user %s: PAM error: %s", creds.Username, err)
 		writeJSON(w, &simpleResponse{"Login failed", loginLink()}, http.StatusUnauthorized)
 	}
 }

--- a/web/session.go
+++ b/web/session.go
@@ -167,7 +167,7 @@ func restLogin(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClie
 		return
 	}
 
-	if pamValidateLogin(&creds, adminGroup) || cpValidateLogin(&creds, client) {
+	if validateLogin(&creds, client) {
 		sessionsLock.Lock()
 		defer sessionsLock.Unlock()
 
@@ -200,6 +200,21 @@ func restLogin(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClie
 	} else {
 		writeJSON(w, &simpleResponse{"Login failed", loginLink()}, http.StatusUnauthorized)
 	}
+}
+
+func validateLogin(creds *login, client *node.ControlClient) bool {
+	var systemUser userdomain.User
+
+	err := client.GetSystemUser(0, &systemUser)
+	if err == nil && creds.Username == systemUser.Name {
+		validated := cpValidateLogin(creds, client)
+
+		if validated {
+			return validated
+		}
+	}
+
+	return pamValidateLogin(creds, adminGroup)
 }
 
 func cpValidateLogin(creds *login, client *node.ControlClient) bool {


### PR DESCRIPTION
New solution for https://jira.zenoss.com/browse/CC-2071 proposed by Ian.

First commit reverts previous solution (https://github.com/control-center/serviced/pull/2663), so it might be easier use the second commit for review.