### PR TITLE
Don't allow vhost names that contain a period ('.')

### DIFF
--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -342,6 +342,11 @@ func (s *Service) GetServicePorts() []ServiceEndpoint {
 
 // AddVirtualHost Add a virtual host for given service, this method avoids duplicates vhosts
 func (s *Service) AddVirtualHost(application, vhostName string) error {
+	// We currently don't allow vhosts that contain a '.'
+	if strings.Contains(vhostName, ".") {
+		return fmt.Errorf("Virtual host name must not contain a '.'")
+	}
+
 	if s.Endpoints != nil {
 
 		//find the matching endpoint

--- a/domain/service/service_test.go
+++ b/domain/service/service_test.go
@@ -46,6 +46,10 @@ func (s *S) TestAddVirtualHost(t *C) {
 		t.Errorf("Expected error adding vhost")
 	}
 
+	if err = svc.AddVirtualHost("server", "name.something"); err == nil {
+		t.Errorf("Expected error adding vhost with '.'")
+	}
+
 	if err = svc.AddVirtualHost("server", "name"); err != nil {
 		t.Errorf("Unexpected error adding vhost: %v", err)
 	}
@@ -115,7 +119,7 @@ func (s *S) TestAddPort(t *C) {
 	if err = svc.AddPort("server", "1234", false, "http"); err != nil {
 		t.Errorf("Unexpected error adding port: %v", err)
 	}
-	
+
 	// TODO: More tests for proper port range, etc, need to be added
 	// once the code is added to the facade/cli.
 


### PR DESCRIPTION
Adding a vhost that contains a "." results in unexpected behavior.  For now, we will not allow vhosts that contain periods.

Fixes CC-866