### PR TITLE
Bump isvcs image to v40.1

### DIFF
--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -24,7 +24,7 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO    = "zenoss/serviced-isvcs"
-	IMAGE_TAG     = "v40"
+	IMAGE_TAG     = "v40.1"
 	ZK_IMAGE_REPO = "zenoss/isvcs-zookeeper"
 	ZK_IMAGE_TAG  = "v3"
 )


### PR DESCRIPTION
Fixes CC-2200 

More precisely, part of the fixes for CC-2200. FYI the new serviced-isvcs image v40.1 has already been posted to docker hub.