### PR TITLE
Fixes CC-2186 "zk: api error, Could not update service state, services are not starting"

### DIFF
--- a/dfs/docker/docker.go
+++ b/dfs/docker/docker.go
@@ -44,6 +44,7 @@ func IsImageNotFound(err error) bool {
 		var checks = []*regexp.Regexp{
 			regexp.MustCompile("Tag .* not found in repository .*"),
 			regexp.MustCompile("Error: image .* not found"),
+			regexp.MustCompile("could not find image"),
 		}
 		for _, check := range checks {
 			if ok := check.MatchString(err.Error()); ok {

--- a/dfs/docker/docker_test.go
+++ b/dfs/docker/docker_test.go
@@ -282,3 +282,19 @@ func (s *DockerSuite) TestFindImageByHash(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(actualhash, Equals, lowerLayerHash)
 }
+
+// Make sure that IsImageNotFound returns true for the errors produced by
+//  calling certain methods with a non-existant image
+func (s *DockerSuite) TestIsImageNotFound(c *C) {
+	// test on FindImage
+	_, err := s.docker.FindImage("fakebox")
+	c.Assert(IsImageNotFound(err), Equals, true)
+
+	// test on TagImage
+	err = s.docker.TagImage("fakebox", "localhost:5000/busybox:tag")
+	c.Assert(IsImageNotFound(err), Equals, true)
+
+	// test on PullImage
+	err = s.docker.PullImage("localhost:5000/fakebox:fake")
+	c.Assert(IsImageNotFound(err), Equals, true)
+}


### PR DESCRIPTION
CC-2186
This fixes a problem that was introduced when we updated go-dockerclient, which returns different error messages for "image not found" errors.