### PR TITLE
Diagnose unit-test failures 

### DIFF
--- a/health/cache.go
+++ b/health/cache.go
@@ -16,6 +16,8 @@ package health
 import (
 	"sync"
 	"time"
+	"fmt"
+	"os"
 )
 
 // HealthStatusKey is the key to the health status item in the cache.
@@ -68,9 +70,12 @@ func (cache *HealthStatusCache) SetPurgeFrequency(interval time.Duration) {
 }
 
 func (cache *HealthStatusCache) setPurgeFrequency(interval time.Duration) {
+	fmt.Fprintf(os.Stderr, "setPurgeFrequency for %.02f seconds STARTED\n", interval.Seconds())
 	if cache.stop != nil {
 		close(cache.stop)
+		fmt.Fprintf(os.Stderr, "setPurgeFrequency: Waiting ...\n")
 		cache.wg.Wait()
+		fmt.Fprintf(os.Stderr, "setPurgeFrequency: Wait finished\n")
 	}
 	if interval > 0 {
 		cache.stop = make(chan struct{})
@@ -92,6 +97,7 @@ func (cache *HealthStatusCache) setPurgeFrequency(interval time.Duration) {
 	} else {
 		cache.stop = nil
 	}
+	fmt.Fprintf(os.Stderr, "setPurgeFrequency for %.02f seconds FINISHED\n", interval.Seconds())
 }
 
 // Size returns the size of the cache.

--- a/health/cache.go
+++ b/health/cache.go
@@ -70,9 +70,10 @@ func (cache *HealthStatusCache) SetPurgeFrequency(interval time.Duration) {
 }
 
 func (cache *HealthStatusCache) setPurgeFrequency(interval time.Duration) {
-	fmt.Fprintf(os.Stderr, "setPurgeFrequency for %.02f seconds STARTED\n", interval.Seconds())
+	//fmt.Fprintf(os.Stderr, "setPurgeFrequency for %.02f seconds STARTED\n", interval.Seconds())
 	if cache.stop != nil {
 		close(cache.stop)
+		//cache.stop = nil
 		fmt.Fprintf(os.Stderr, "setPurgeFrequency: Waiting ...\n")
 		cache.wg.Wait()
 		fmt.Fprintf(os.Stderr, "setPurgeFrequency: Wait finished\n")
@@ -97,7 +98,7 @@ func (cache *HealthStatusCache) setPurgeFrequency(interval time.Duration) {
 	} else {
 		cache.stop = nil
 	}
-	fmt.Fprintf(os.Stderr, "setPurgeFrequency for %.02f seconds FINISHED\n", interval.Seconds())
+	//fmt.Fprintf(os.Stderr, "setPurgeFrequency for %.02f seconds FINISHED\n", interval.Seconds())
 }
 
 // Size returns the size of the cache.

--- a/health/cache.go
+++ b/health/cache.go
@@ -74,7 +74,7 @@ func (cache *HealthStatusCache) setPurgeFrequency(interval time.Duration) {
 	if cache.stop != nil {
 		close(cache.stop)
 		//cache.stop = nil
-		fmt.Fprintf(os.Stderr, "setPurgeFrequency: Waiting ...\n")
+		//fmt.Fprintf(os.Stderr, "setPurgeFrequency: Waiting ...\n")
 		cache.wg.Wait()
 		fmt.Fprintf(os.Stderr, "setPurgeFrequency: Wait finished\n")
 	}

--- a/health/cache_test.go
+++ b/health/cache_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package health_test
 
 import (

--- a/health/cache_test.go
+++ b/health/cache_test.go
@@ -16,6 +16,8 @@
 package health_test
 
 import (
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -28,6 +30,25 @@ func Test(t *testing.T) { TestingT(t) }
 var _ = Suite(&HealthStatusCacheTestSuite{})
 
 type HealthStatusCacheTestSuite struct{}
+
+// FIXME: This is temporary code to diagnose occassional build failures where some test in this package is getting
+//        wedged such that the GO test runner cancels the test after 10 minutes.  Once the problem has been isolated
+//        and fixed, these setup and teardown methods will be removed.
+func (s *HealthStatusCacheTestSuite) SetUpSuite(c *C) {
+	fmt.Fprintf(os.Stderr, " STARTED HealthStatusCacheTestSuite\n")
+}
+
+func (s *HealthStatusCacheTestSuite) SetUpTest(c *C) {
+	fmt.Fprintf(os.Stderr, " STARTED %s\n", c.TestName())
+}
+
+func (s *HealthStatusCacheTestSuite) TearDownTest(c *C) {
+	fmt.Fprintf(os.Stderr, "FINISHED %s\n", c.TestName())
+}
+
+func (s *HealthStatusCacheTestSuite) TearDownSuite(c *C) {
+	fmt.Fprintf(os.Stderr, "FINISHED HealthStatusCacheTestSuite\n")
+}
 
 func (s *HealthStatusCacheTestSuite) TestCRUD_NotExists(c *C) {
 	// Get an item from the cache that does not exist

--- a/health/check_test.go
+++ b/health/check_test.go
@@ -17,6 +17,8 @@ package health_test
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
 	"time"
 
 	. "github.com/control-center/serviced/health"
@@ -33,6 +35,25 @@ type jsonhealthcheck struct {
 var _ = Suite(&HealthCheckTestSuite{})
 
 type HealthCheckTestSuite struct{}
+
+// FIXME: This is temporary code to diagnose occassional build failures where some test in this package is getting
+//        wedged such that the GO test runner cancels the test after 10 minutes.  Once the problem has been isolated
+//        and fixed, these setup and teardown methods will be removed.
+func (s *HealthCheckTestSuite) SetUpSuite(c *C) {
+	fmt.Fprintf(os.Stderr, " STARTED HealthCheckTestSuite\n")
+}
+
+func (s *HealthCheckTestSuite) SetUpTest(c *C) {
+	fmt.Fprintf(os.Stderr, " STARTED %s\n", c.TestName())
+}
+
+func (s *HealthCheckTestSuite) TearDownTest(c *C) {
+	fmt.Fprintf(os.Stderr, "FINISHED %s\n", c.TestName())
+}
+
+func (s *HealthCheckTestSuite) TearDownSuite(c *C) {
+	fmt.Fprintf(os.Stderr, "FINISHED HealthCheckTestSuite\n")
+}
 
 func (s *HealthCheckTestSuite) TestMarshalJSON(c *C) {
 	// Verify the marshaller

--- a/health/check_test.go
+++ b/health/check_test.go
@@ -77,201 +77,201 @@ func (s *HealthCheckTestSuite) TestMarshalJSON(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(actual, DeepEquals, expected)
 }
-
-func (s *HealthCheckTestSuite) TestMarshalJSON_Map(c *C) {
-	// Verify the marshaller works given a map of HealthCheck data
-	checkMap := map[string]HealthCheck{
-		"testscript": {
-			Script:    "echo testscript",
-			Timeout:   time.Minute,
-			Interval:  2 * time.Second,
-			Tolerance: 5,
-		},
-	}
-	data, err := json.Marshal(&checkMap)
-	c.Assert(err, IsNil)
-	expected := map[string]jsonhealthcheck{
-		"testscript": {
-			Script:    "echo testscript",
-			Timeout:   60,
-			Interval:  2,
-			Tolerance: 5,
-		},
-	}
-	actual := make(map[string]jsonhealthcheck)
-	err = json.Unmarshal(data, &actual)
-	c.Assert(err, IsNil)
-	c.Check(actual, DeepEquals, expected)
-}
-
-func (s *HealthCheckTestSuite) TestUnmarshalJSON(c *C) {
-	// Verify the unmarshaller
-	jhc := jsonhealthcheck{
-		Script:    "echo testscript",
-		Timeout:   60,
-		Interval:  2,
-		Tolerance: 5,
-	}
-	bytes, err := json.Marshal(jhc)
-	c.Assert(err, IsNil)
-
-	expected := HealthCheck{
-		Script:    "echo testscript",
-		Timeout:   time.Minute,
-		Interval:  2 * time.Second,
-		Tolerance: 5,
-	}
-	var actual HealthCheck
-	err = json.Unmarshal(bytes, &actual)
-	c.Assert(err, IsNil)
-	c.Assert(actual, DeepEquals, expected)
-}
-
-func (s *HealthCheckTestSuite) TestUnmarshalJSON_Map(c *C) {
-	// Verify the unmarshaller works given a map of HealthCheck data
-	jhcMap := map[string]jsonhealthcheck{
-		"testscript": {
-			Script:    "echo testscript",
-			Timeout:   60,
-			Interval:  2,
-			Tolerance: 5,
-		},
-	}
-	bytes, err := json.Marshal(jhcMap)
-	c.Assert(err, IsNil)
-
-	expected := map[string]HealthCheck{
-		"testscript": {
-			Script:    "echo testscript",
-			Timeout:   time.Minute,
-			Interval:  2 * time.Second,
-			Tolerance: 5,
-		},
-	}
-	actual := make(map[string]HealthCheck)
-	err = json.Unmarshal(bytes, &actual)
-	c.Assert(err, IsNil)
-	c.Assert(actual, DeepEquals, expected)
-}
-
-func (s *HealthCheckTestSuite) TestGetTimeout(c *C) {
-	// Verify the healthcheck timeout
-	check := HealthCheck{
-		Script:    "echo testscript",
-		Timeout:   0,
-		Interval:  2 * time.Second,
-		Tolerance: 0,
-	}
-	c.Check(check.GetTimeout(), Equals, DefaultTimeout)
-	check.Timeout = 15 * time.Second
-	c.Check(check.GetTimeout(), Equals, check.Timeout)
-}
-
-func (s *HealthCheckTestSuite) TestExpires(c *C) {
-	// Verify the expiration duration
-	check := HealthCheck{
-		Script:    "echo testscript",
-		Timeout:   time.Second,
-		Interval:  2 * time.Second,
-		Tolerance: 0,
-	}
-	expected := time.Duration(DefaultTolerance) * (check.Timeout + check.Interval)
-	c.Assert(check.Expires(), Equals, expected)
-	check.Tolerance = 100
-	expected = time.Duration(check.Tolerance) * (check.Timeout + check.Interval)
-	c.Assert(check.Expires(), Equals, expected)
-}
-
-func (s *HealthCheckTestSuite) TestNotRunning(c *C) {
-	// Verify the health status is not running
-	check := HealthCheck{
-		Script:    "echo testscript",
-		Timeout:   time.Second,
-		Interval:  2 * time.Second,
-		Tolerance: 0,
-	}
-	stat := check.NotRunning()
-	c.Check(stat.Status, Equals, NotRunning)
-	c.Check(stat.StartedAt.IsZero(), Equals, false)
-	c.Check(stat.Duration, Equals, time.Duration(0))
-}
-
-func (s *HealthCheckTestSuite) TestUnknown(c *C) {
-	// Verify the health status is unknown
-	check := HealthCheck{
-		Script:    "echo testscript",
-		Timeout:   time.Second,
-		Interval:  2 * time.Second,
-		Tolerance: 0,
-	}
-	stat := check.Unknown()
-	c.Check(stat.Status, Equals, Unknown)
-	c.Check(stat.StartedAt.IsZero(), Equals, false)
-	c.Check(stat.Duration, Equals, time.Duration(0))
-}
-
-func (s *HealthCheckTestSuite) TestRun_Passed(c *C) {
-	// Verify a passing health check
-	check := HealthCheck{
-		Script:    "echo -n testscript",
-		Timeout:   time.Second,
-		Interval:  time.Second,
-		Tolerance: 0,
-	}
-	stat := check.Run()
-	c.Check(stat.Status, Equals, OK)
-	c.Check(stat.Duration > 0, Equals, true)
-}
-
-func (s *HealthCheckTestSuite) TestRun_Timeout(c *C) {
-	// Verify a timed out health check
-	check := HealthCheck{
-		Script:    "sleep 5",
-		Timeout:   250 * time.Millisecond,
-		Interval:  time.Second,
-		Tolerance: 0,
-	}
-	stat := check.Run()
-	c.Check(stat.Status, Equals, Timeout)
-	c.Check(stat.Duration >= check.Timeout, Equals, true)
-	c.Check(stat.Duration < 5*time.Second, Equals, true)
-}
-
-func (s *HealthCheckTestSuite) TestRun_Failed(c *C) {
-	// Verify a failing health check
-	check := HealthCheck{
-		Script:    "echo -n failure >&2; return 1",
-		Timeout:   time.Second,
-		Interval:  time.Second,
-		Tolerance: 0,
-	}
-	stat := check.Run()
-	c.Check(stat.Status, Equals, Failed)
-	c.Check(stat.Duration > 0, Equals, true)
-}
-
-func (s *HealthCheckTestSuite) TestPing(c *C) {
-	// Verify ping
-	check := HealthCheck{
-		Script:    "echo -n testscript",
-		Timeout:   time.Second,
-		Interval:  500 * time.Millisecond,
-		Tolerance: 0,
-	}
-	cancel := make(chan struct{})
-	startTime := time.Now()
-	interval := 0
-	check.Ping(cancel, func(stat HealthStatus) {
-		switch interval {
-		case 0:
-			c.Check(time.Since(startTime) < check.Interval, Equals, true)
-			startTime = time.Now()
-		case 1:
-			close(cancel)
-			c.Check(time.Since(startTime) >= check.Interval, Equals, true)
-		default:
-			c.Errorf("Ping ran %d times longer than expected", interval-1)
-		}
-		interval++
-	})
-}
+//
+//func (s *HealthCheckTestSuite) TestMarshalJSON_Map(c *C) {
+//	// Verify the marshaller works given a map of HealthCheck data
+//	checkMap := map[string]HealthCheck{
+//		"testscript": {
+//			Script:    "echo testscript",
+//			Timeout:   time.Minute,
+//			Interval:  2 * time.Second,
+//			Tolerance: 5,
+//		},
+//	}
+//	data, err := json.Marshal(&checkMap)
+//	c.Assert(err, IsNil)
+//	expected := map[string]jsonhealthcheck{
+//		"testscript": {
+//			Script:    "echo testscript",
+//			Timeout:   60,
+//			Interval:  2,
+//			Tolerance: 5,
+//		},
+//	}
+//	actual := make(map[string]jsonhealthcheck)
+//	err = json.Unmarshal(data, &actual)
+//	c.Assert(err, IsNil)
+//	c.Check(actual, DeepEquals, expected)
+//}
+//
+//func (s *HealthCheckTestSuite) TestUnmarshalJSON(c *C) {
+//	// Verify the unmarshaller
+//	jhc := jsonhealthcheck{
+//		Script:    "echo testscript",
+//		Timeout:   60,
+//		Interval:  2,
+//		Tolerance: 5,
+//	}
+//	bytes, err := json.Marshal(jhc)
+//	c.Assert(err, IsNil)
+//
+//	expected := HealthCheck{
+//		Script:    "echo testscript",
+//		Timeout:   time.Minute,
+//		Interval:  2 * time.Second,
+//		Tolerance: 5,
+//	}
+//	var actual HealthCheck
+//	err = json.Unmarshal(bytes, &actual)
+//	c.Assert(err, IsNil)
+//	c.Assert(actual, DeepEquals, expected)
+//}
+//
+//func (s *HealthCheckTestSuite) TestUnmarshalJSON_Map(c *C) {
+//	// Verify the unmarshaller works given a map of HealthCheck data
+//	jhcMap := map[string]jsonhealthcheck{
+//		"testscript": {
+//			Script:    "echo testscript",
+//			Timeout:   60,
+//			Interval:  2,
+//			Tolerance: 5,
+//		},
+//	}
+//	bytes, err := json.Marshal(jhcMap)
+//	c.Assert(err, IsNil)
+//
+//	expected := map[string]HealthCheck{
+//		"testscript": {
+//			Script:    "echo testscript",
+//			Timeout:   time.Minute,
+//			Interval:  2 * time.Second,
+//			Tolerance: 5,
+//		},
+//	}
+//	actual := make(map[string]HealthCheck)
+//	err = json.Unmarshal(bytes, &actual)
+//	c.Assert(err, IsNil)
+//	c.Assert(actual, DeepEquals, expected)
+//}
+//
+//func (s *HealthCheckTestSuite) TestGetTimeout(c *C) {
+//	// Verify the healthcheck timeout
+//	check := HealthCheck{
+//		Script:    "echo testscript",
+//		Timeout:   0,
+//		Interval:  2 * time.Second,
+//		Tolerance: 0,
+//	}
+//	c.Check(check.GetTimeout(), Equals, DefaultTimeout)
+//	check.Timeout = 15 * time.Second
+//	c.Check(check.GetTimeout(), Equals, check.Timeout)
+//}
+//
+//func (s *HealthCheckTestSuite) TestExpires(c *C) {
+//	// Verify the expiration duration
+//	check := HealthCheck{
+//		Script:    "echo testscript",
+//		Timeout:   time.Second,
+//		Interval:  2 * time.Second,
+//		Tolerance: 0,
+//	}
+//	expected := time.Duration(DefaultTolerance) * (check.Timeout + check.Interval)
+//	c.Assert(check.Expires(), Equals, expected)
+//	check.Tolerance = 100
+//	expected = time.Duration(check.Tolerance) * (check.Timeout + check.Interval)
+//	c.Assert(check.Expires(), Equals, expected)
+//}
+//
+//func (s *HealthCheckTestSuite) TestNotRunning(c *C) {
+//	// Verify the health status is not running
+//	check := HealthCheck{
+//		Script:    "echo testscript",
+//		Timeout:   time.Second,
+//		Interval:  2 * time.Second,
+//		Tolerance: 0,
+//	}
+//	stat := check.NotRunning()
+//	c.Check(stat.Status, Equals, NotRunning)
+//	c.Check(stat.StartedAt.IsZero(), Equals, false)
+//	c.Check(stat.Duration, Equals, time.Duration(0))
+//}
+//
+//func (s *HealthCheckTestSuite) TestUnknown(c *C) {
+//	// Verify the health status is unknown
+//	check := HealthCheck{
+//		Script:    "echo testscript",
+//		Timeout:   time.Second,
+//		Interval:  2 * time.Second,
+//		Tolerance: 0,
+//	}
+//	stat := check.Unknown()
+//	c.Check(stat.Status, Equals, Unknown)
+//	c.Check(stat.StartedAt.IsZero(), Equals, false)
+//	c.Check(stat.Duration, Equals, time.Duration(0))
+//}
+//
+//func (s *HealthCheckTestSuite) TestRun_Passed(c *C) {
+//	// Verify a passing health check
+//	check := HealthCheck{
+//		Script:    "echo -n testscript",
+//		Timeout:   time.Second,
+//		Interval:  time.Second,
+//		Tolerance: 0,
+//	}
+//	stat := check.Run()
+//	c.Check(stat.Status, Equals, OK)
+//	c.Check(stat.Duration > 0, Equals, true)
+//}
+//
+//func (s *HealthCheckTestSuite) TestRun_Timeout(c *C) {
+//	// Verify a timed out health check
+//	check := HealthCheck{
+//		Script:    "sleep 5",
+//		Timeout:   250 * time.Millisecond,
+//		Interval:  time.Second,
+//		Tolerance: 0,
+//	}
+//	stat := check.Run()
+//	c.Check(stat.Status, Equals, Timeout)
+//	c.Check(stat.Duration >= check.Timeout, Equals, true)
+//	c.Check(stat.Duration < 5*time.Second, Equals, true)
+//}
+//
+//func (s *HealthCheckTestSuite) TestRun_Failed(c *C) {
+//	// Verify a failing health check
+//	check := HealthCheck{
+//		Script:    "echo -n failure >&2; return 1",
+//		Timeout:   time.Second,
+//		Interval:  time.Second,
+//		Tolerance: 0,
+//	}
+//	stat := check.Run()
+//	c.Check(stat.Status, Equals, Failed)
+//	c.Check(stat.Duration > 0, Equals, true)
+//}
+//
+//func (s *HealthCheckTestSuite) TestPing(c *C) {
+//	// Verify ping
+//	check := HealthCheck{
+//		Script:    "echo -n testscript",
+//		Timeout:   time.Second,
+//		Interval:  500 * time.Millisecond,
+//		Tolerance: 0,
+//	}
+//	cancel := make(chan struct{})
+//	startTime := time.Now()
+//	interval := 0
+//	check.Ping(cancel, func(stat HealthStatus) {
+//		switch interval {
+//		case 0:
+//			c.Check(time.Since(startTime) < check.Interval, Equals, true)
+//			startTime = time.Now()
+//		case 1:
+//			close(cancel)
+//			c.Check(time.Since(startTime) >= check.Interval, Equals, true)
+//		default:
+//			c.Errorf("Ping ran %d times longer than expected", interval-1)
+//		}
+//		interval++
+//	})
+//}

--- a/health/check_test.go
+++ b/health/check_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package health_test
 
 import (


### PR DESCRIPTION
DO NOT MERGE

In the past week or so, we have repeated build failures where the tests in the `health` package appear to be stuck, such that the GO test runner cancels tests for that package after 10 minutes - see below for several examples. The errors in the Jenkins log look like:
```
*** Test killed: ran too long (10m0s).
FAIL	github.com/control-center/serviced/health	605.045s
```

This change is an attempt to isolate the offending test case so we can fix the underlying problem.  To be effective, this change needs to be combined with adding `-- -v` to the end of the Jenkins command line for the PR unit-test job.  Hopefully, a few executions of the Jenkins PR job will reveal the problem, and this PR will not need to be merged.

Here are some of the jobs that have failed in the last week because of this problem:
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-unit/1071
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-unit/1063
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-unit/1062
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1079
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1068
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1066
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1065
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1064
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1061
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1059