### PR TITLE
Feature/fix health check tests

### DIFF
--- a/health/cache.go
+++ b/health/cache.go
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build unit
-
 package health
 
 import (

--- a/health/cache.go
+++ b/health/cache.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package health
 
 import (

--- a/health/cache_test.go
+++ b/health/cache_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit 
+
 package health_test
 
 import (

--- a/health/check.go
+++ b/health/check.go
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build unit
-
 package health
 
 import (

--- a/health/check.go
+++ b/health/check.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package health
 
 import (

--- a/health/check_test.go
+++ b/health/check_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build test
+
 package health_test
 
 import (


### PR DESCRIPTION
In the past week or so, we have repeated build failures where the tests in the `health` package appear to be stuck, such that the GO test runner cancels tests for that package after 10 minutes - see below for several examples. The errors in the Jenkins log look like:
```
*** Test killed: ran too long (10m0s).
FAIL	github.com/control-center/serviced/health	605.045s
```

The problem turned out to be a deadlock between the methods SetPurgeFrequency and DeleteExpired.

Here are some of the jobs that have failed in the last week because of this problem:
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-unit/1071
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-unit/1063
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-unit/1062
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1079
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1068
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1066
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1065
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1064
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1061
http://jenkins.zendev.org/view/Control%20Center/job/serviced-develop-pullrequests-integration/1059