### PR TITLE
fixes CC-2186 for docker 1.10

### DIFF
--- a/dfs/docker/docker.go
+++ b/dfs/docker/docker.go
@@ -45,6 +45,7 @@ func IsImageNotFound(err error) bool {
 			regexp.MustCompile("Tag .* not found in repository .*"),
 			regexp.MustCompile("Error: image .* not found"),
 			regexp.MustCompile("could not find image"),
+			regexp.MustCompile("no such id"),
 		}
 		for _, check := range checks {
 			if ok := check.MatchString(err.Error()); ok {


### PR DESCRIPTION
Added another string to check for in 'IsImageNotFound'. This different error message was introduced after the move to docker 1.10.  There is a unit test that would catch this, but only if the tests were run on docker 1.10.