### PR TITLE
Fix `serviced volume status`

### DIFF
--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -109,6 +109,7 @@ func New(driver api.API, config utils.ConfigReader) *ServicedCli {
 		cli.StringSliceFlag{"log-config", convertToStringSlice(defaultOps.DockerLogConfigList), "comma-separated list of key=value settings for docker log driver"},
 
 		cli.IntFlag{"ui-poll-frequency", defaultOps.UIPollFrequency, "frequency in seconds that the UI polls serviced for changes"},
+		cli.IntFlag{"storage-stats-update-interval", defaultOps.StorageStatsUpdateInterval, "frequency in seconds that the thin pool usage will be analyzed"},
 
 		// Reimplementing GLOG flags :(
 		cli.BoolTFlag{"logtostderr", "log to standard error instead of files"},

--- a/cli/cmd/volume.go
+++ b/cli/cmd/volume.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/control-center/serviced/volume"
+	"github.com/zenoss/glog"
 )
 
 // Initializer for serviced pool subcommands
@@ -47,22 +48,17 @@ func (c *ServicedCli) initVolume() {
 
 // serviced volume status
 func (c *ServicedCli) cmdVolumeStatus(ctx *cli.Context) {
-	// CC-2253: pulling this command until we can fix this
-	/*
-		response, err := c.driver.GetVolumeStatus()
-		if err != nil {
-			glog.Errorf("error getting volume status: %v", err)
-			return
-		}
-		if ctx.Bool("verbose") {
-			printStatusesJson(response)
-		} else {
-			printStatuses(response)
-		}
+	response, err := c.driver.GetVolumeStatus()
+	if err != nil {
+		glog.Errorf("error getting volume status: %v", err)
 		return
-	*/
-
-	fmt.Println("Operation not available")
+	}
+	if ctx.Bool("verbose") {
+		printStatusesJson(response)
+	} else {
+		printStatuses(response)
+	}
+	return
 }
 
 func printStatuses(statuses *volume.Statuses) {

--- a/dfs/snapshot.go
+++ b/dfs/snapshot.go
@@ -16,10 +16,9 @@ package dfs
 import (
 	"time"
 
-	"errors"
-
-	"github.com/control-center/serviced/volume"
 	"github.com/zenoss/glog"
+	"github.com/control-center/serviced/volume"
+	"errors"
 )
 
 const (
@@ -112,7 +111,6 @@ func generateSnapshotLabel() string {
 
 // checks to see if there is enough free space on volume to perform a snapshot
 func ensureFreeSpace(vol volume.Volume, dfs *DistributedFilesystem, snapshotSpacePercent int) (bool, error) {
-	glog.Warningf("Calling volume.GetStatus()")
 	status := volume.GetStatus()
 	statusMap := status.DeviceMapperStatusMap[dfs.disk.Root()]
 	var amountNeeded float64
@@ -120,7 +118,7 @@ func ensureFreeSpace(vol volume.Volume, dfs *DistributedFilesystem, snapshotSpac
 	for i := 0; i < len(statusMap.Tenants); i++ {
 		currentTenant := statusMap.Tenants[i]
 		if currentTenant.TenantID == vol.Tenant() {
-			amountNeeded = float64(currentTenant.FilesystemUsed) * float64(snapshotSpacePercent/100)
+			amountNeeded = float64(currentTenant.FilesystemUsed) * float64(snapshotSpacePercent / 100)
 			foundTenant = true
 		}
 	}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -274,15 +274,9 @@ func (sr *StatsReporter) updateStorageStats() {
 func (sr *StatsReporter) updateStats() {
 	// Stats for host.
 	sr.updateHostStats()
-
-	// CC-2253: Pulling this code to get a release out, will restore as soon as
-	// the problems are worked out.
-	/*
-		if sr.isMasterHost {
-			sr.updateStorageStats()
-		}
-	*/
-
+	if sr.isMasterHost {
+		sr.updateStorageStats()
+	}
 	// Stats for the containers.
 	var running []dao.RunningService
 	running, err := zkservice.LoadRunningServicesByHost(sr.conn, sr.hostID)

--- a/volume/devicemapper/devicemapper.go
+++ b/volume/devicemapper/devicemapper.go
@@ -1194,7 +1194,7 @@ func (d *DeviceMapperDriver) GetTenantStorageStats() ([]volume.TenantStorageStat
 		// It's direct-lvm, so build the metadata device from the pool name
 		mdDevice = fmt.Sprintf("/dev/mapper/%s_tmeta", status.PoolName)
 	}
-	blockstats, err := getDeviceBlockStats(status.PoolName, mdDevice)
+	blockstats, err := d.getDeviceBlockStats(status.PoolName, mdDevice)
 	if err != nil {
 		return nil, err
 	}
@@ -1251,8 +1251,8 @@ func (d *DeviceMapperDriver) GetTenantStorageStats() ([]volume.TenantStorageStat
 			result = append(result, tss)
 
 		} else {
-			// Something is horribly wrong; there is no device matching your tenant
-			return nil, fmt.Errorf("Tenant %s doesn't have an associated device", tenant)
+			// There is no device matching the tenant
+			return nil, fmt.Errorf("Tenant %s DFS has not yet been initialized", tenant)
 		}
 	}
 	return result, nil

--- a/volume/devicemapper/stats.go
+++ b/volume/devicemapper/stats.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/control-center/serviced/commons/diet"
 	"github.com/control-center/serviced/utils"
+	"github.com/zenoss/glog"
 )
 
 var storageStatsUpdateInterval time.Duration = 300
@@ -71,22 +72,6 @@ func hasMetadataSnap(pool string) (bool, error) {
 	return block != "-", nil
 }
 
-func reserveMetadataSnap(pool string) error {
-	cmd := exec.Command("dmsetup", "message", pool, "0", "reserve_metadata_snap")
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-	return nil
-}
-
-func releaseMetadataSnap(pool string) error {
-	cmd := exec.Command("dmsetup", "message", pool, "0", "release_metadata_snap")
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-	return nil
-}
-
 func getMetadataBlock(pool string) (string, error) {
 	cmd := exec.Command("dmsetup", "status", pool)
 	out, err := cmd.Output()
@@ -97,6 +82,36 @@ func getMetadataBlock(pool string) (string, error) {
 	return strings.TrimSpace(parts[6]), nil
 }
 
+// reserveMetadataSnap reserves a userspace snapshot of a thin pool's metadata.
+// We shell out to send the message to the device-mapper subsystem, but we lock
+// our internal DeviceSet to avoid any complications with creating or removing
+// devices simultaneously.
+func (d *DeviceMapperDriver) reserveMetadataSnap(pool string) error {
+	d.DeviceSet.Lock()
+	defer d.DeviceSet.Unlock()
+	cmd := exec.Command("dmsetup", "message", pool, "0", "reserve_metadata_snap")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// releaseMetadataSnap releases an existing userspace snapshot of a thin pool's
+// metadata.  We shell out to send the message to the device-mapper subsystem,
+// but we lock our internal DeviceSet to avoid any complications with creating
+// or removing devices simultaneously.
+func (d *DeviceMapperDriver) releaseMetadataSnap(pool string) error {
+	d.DeviceSet.Lock()
+	defer d.DeviceSet.Unlock()
+	cmd := exec.Command("dmsetup", "message", pool, "0", "release_metadata_snap")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// getDevices acts on an existing userspace metadata snapshot, and has no
+// potential devicemapper conflicts. It simply dumps the XML and parses it.
 func getDevices(pool, block, metadatadev string) (map[int]*DeviceBlockStats, error) {
 	cmd := exec.Command("thin_dump", "-f", "xml", metadatadev, "-m", block)
 	stdout, err := cmd.StdoutPipe()
@@ -176,6 +191,8 @@ func parseMetadata(r io.Reader) (map[int]*DeviceBlockStats, error) {
 	return devices, nil
 }
 
+// getDeviceSize calls lsblk in a subprocess to retrieve the size in bytes of
+// a given device.
 func getDeviceSize(dev string) (uint64, error) {
 	cmd := exec.Command("lsblk", "-dbno", "SIZE", dev)
 	out, err := cmd.Output()
@@ -189,6 +206,10 @@ func getDeviceSize(dev string) (uint64, error) {
 	return size, nil
 }
 
+// getFilesystemStats calls dumpe2fs in a subprocess to retrieve filesystem
+// statistics. Currently, only ext2/3/4 filesystems are supported by this call;
+// XFS filesystems appear to require mounting in order to retrieve the same
+// information.
 func getFilesystemStats(dev string) (uint64, uint64, error) {
 	cmd := exec.Command("dumpe2fs", dev)
 	out, err := cmd.StdoutPipe()
@@ -238,13 +259,14 @@ type cachedStat struct {
 	value  map[int]*DeviceBlockStats
 }
 
-func getDeviceBlockStats(pool, metadatadev string) (map[int]*DeviceBlockStats, error) {
+func (d *DeviceMapperDriver) getDeviceBlockStats(pool, metadatadev string) (map[int]*DeviceBlockStats, error) {
 	var value map[int]*DeviceBlockStats
 	pool = fmt.Sprintf("/dev/mapper/%s", strings.TrimPrefix(pool, "/dev/mapper/"))
 	statscache.locks.LockKey(pool)
 	defer statscache.locks.UnlockKey(pool)
 	val, ok := statscache.cache[pool]
 	if !ok || time.Now().After(val.expiry) {
+		glog.Infof("Refreshing storage stats cache from thin pool metadata")
 		// Check for an existing snapshot of the metadata device.
 		hasSnap, err := hasMetadataSnap(pool)
 		if err != nil {
@@ -254,15 +276,15 @@ func getDeviceBlockStats(pool, metadatadev string) (map[int]*DeviceBlockStats, e
 		// of band processes
 		if hasSnap {
 			// Release the existing snapshot.
-			if err := releaseMetadataSnap(pool); err != nil {
+			if err := d.releaseMetadataSnap(pool); err != nil {
 				return nil, err
 			}
 		}
 		// Take a userspace-accessible snapshot of the metadata device.
-		if err := reserveMetadataSnap(pool); err != nil {
+		if err := d.reserveMetadataSnap(pool); err != nil {
 			return nil, err
 		}
-		defer releaseMetadataSnap(pool)
+		defer d.releaseMetadataSnap(pool)
 		// Ask for the block at which the metadata snap is accessible
 		block, err := getMetadataBlock(pool)
 		if err != nil {
@@ -274,10 +296,14 @@ func getDeviceBlockStats(pool, metadatadev string) (map[int]*DeviceBlockStats, e
 		if err != nil {
 			return nil, err
 		}
-		statscache.cache[pool] = &cachedStat{
-			expiry: time.Now().Add(storageStatsUpdateInterval * time.Second),
-			pool:   pool,
-			value:  value,
+		// Don't cache if there aren't any devices besides the base device yet
+		// (e.g., initial deployment)
+		if len(value) > 1 {
+			statscache.cache[pool] = &cachedStat{
+				expiry: time.Now().Add(storageStatsUpdateInterval * time.Second),
+				pool:   pool,
+				value:  value,
+			}
 		}
 	} else {
 		value = val.value

--- a/web/resources.go
+++ b/web/resources.go
@@ -776,42 +776,39 @@ func restGetServicedVersion(w *rest.ResponseWriter, r *rest.Request, client *nod
 }
 
 func restGetStorage(w *rest.ResponseWriter, r *rest.Request, client *node.ControlClient) {
-	// CC-2253: disabling this until we fix this
-	/*
-		volumeStatuses := volume.GetStatus()
-		if volumeStatuses == nil || len(volumeStatuses.GetAllStatuses()) == 0 {
-			err := fmt.Errorf("Unexpected error getting volume status")
-			glog.Errorf("%s", err)
-			restServerError(w, err)
-			return
-		}
+	volumeStatuses := volume.GetStatus()
+	if volumeStatuses == nil || len(volumeStatuses.GetAllStatuses()) == 0 {
+		err := fmt.Errorf("Unexpected error getting volume status")
+		glog.Errorf("%s", err)
+		restServerError(w, err)
+		return
+	}
 
-
-		// REST collections should return arrays, not maps
-		statuses := volumeStatuses.GetAllStatuses()
-		storageInfo := make([]VolumeInfo, 0, len(statuses))
-		for volumeName, volumeStatus := range statuses {
-			volumeInfo := VolumeInfo{Name: volumeName, Status: volumeStatus}
-			tags := map[string][]string{}
-			profile, err := volumeProfile.ReBuild("1h-ago", tags)
-			if err != nil {
-				glog.Errorf("Unexpected error getting volume statuses: %v", err)
-				restServerError(w, err)
-				return
-			}
-			//add graphs to profile
-			profile.GraphConfigs = make([]domain.GraphConfig, 1)
-			profile.GraphConfigs[0] = newVolumeUsageGraph(tags)
-			volumeInfo.MonitoringProfile = *profile
-			storageInfo = append(storageInfo, volumeInfo)
-		}
-	*/
 	type VolumeInfo struct {
 		Name              string
 		Status            volume.Status
 		MonitoringProfile domain.MonitorProfile
 	}
-	storageInfo := []VolumeInfo{}
+
+	// REST collections should return arrays, not maps
+	statuses := volumeStatuses.GetAllStatuses()
+	storageInfo := make([]VolumeInfo, 0, len(statuses))
+	for volumeName, volumeStatus := range statuses {
+		volumeInfo := VolumeInfo{Name: volumeName, Status: volumeStatus}
+		tags := map[string][]string{}
+		profile, err := volumeProfile.ReBuild("1h-ago", tags)
+		if err != nil {
+			glog.Errorf("Unexpected error getting volume statuses: %v", err)
+			restServerError(w, err)
+			return
+		}
+		//add graphs to profile
+		profile.GraphConfigs = make([]domain.GraphConfig, 1)
+		profile.GraphConfigs[0] = newVolumeUsageGraph(tags)
+		volumeInfo.MonitoringProfile = *profile
+		storageInfo = append(storageInfo, volumeInfo)
+	}
+
 	w.WriteJson(storageInfo)
 }
 
@@ -823,8 +820,8 @@ func RestBackupCreate(w *rest.ResponseWriter, r *rest.Request, client *node.Cont
 	dir := ""
 	filePath := ""
 	req := dao.BackupRequest{
-		Dirpath:              dir,
-		SnapshotSpacePercent: snapshotSpacePercent,
+		Dirpath: 		dir,
+		SnapshotSpacePercent: 	snapshotSpacePercent,
 	}
 	err := client.AsyncBackup(req, &filePath)
 	if err != nil {


### PR DESCRIPTION
This PR makes volume status friendlier to the device-mapper kernel driver by:
* Actually using the storage stats update threshold (an oversight in the original commit), so stats are collected only once every 5 minutes by default
* Locking the internal devicemapper driver while creating/removing metadata snapshots, so device creation/deletion can't muck it up underneath

This is primarily a reversal of the changeset in #2753, and then the application of locking and the missing daemon flag for the stats interval.