### PR TITLE
Feature/cc 2364

### DIFF
--- a/facade/publicendpoint.go
+++ b/facade/publicendpoint.go
@@ -16,6 +16,7 @@ package facade
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
 
 	"github.com/control-center/serviced/dao"
@@ -24,6 +25,8 @@ import (
 	"github.com/control-center/serviced/domain/servicedefinition"
 	"github.com/zenoss/glog"
 )
+
+var vhostNameRegex = regexp.MustCompile("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]).)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$")
 
 // Adds a port public endpoint to a service
 func (f *Facade) AddPublicEndpointPort(ctx datastore.Context, serviceID, endpointName, portAddr string,
@@ -259,6 +262,13 @@ func (f *Facade) AddPublicEndpointVHost(ctx datastore.Context, serviceid, endpoi
 	svc, err := f.GetService(ctx, serviceid)
 	if err != nil {
 		err = fmt.Errorf("Could not find service %s: %s", serviceid, err)
+		glog.Error(err)
+		return nil, err
+	}
+
+	// Make sure the name doesn't contain invalid characters.
+	if !vhostNameRegex.MatchString(vhostName) {
+		err = fmt.Errorf("Invalid virtual host name: %s", vhostName)
 		glog.Error(err)
 		return nil, err
 	}

--- a/facade/publicendpoint_test.go
+++ b/facade/publicendpoint_test.go
@@ -432,12 +432,29 @@ func (ft *FacadeIntegrationTest) Test_PublicEndpoint_VHostAdd_DuplicateVHost(c *
 	_, svcB := ft.setupServiceWithPublicEndpoints(c)
 
 	// Add a vhost to a service, but another service already has this vhost.
-	_, err := ft.Facade.AddPublicEndpointVHost(ft.CTX, svcB.ID, "zproxy", "zproxy", true, true)
+	_, err := ft.Facade.AddPublicEndpointVHost(ft.CTX, svcB.ID, "service2", "zproxy", true, true)
 	if err == nil {
 		c.Errorf("Expected failure adding a duplicate vhost name")
 	}
 
 	fmt.Println(" ##### Test_PublicEndpoint_VHostAdd_DuplicateVHost: PASSED")
+}
+
+func (ft *FacadeIntegrationTest) Test_PublicEndpoint_VHostAdd_InvalidVHostName(c *C) {
+	fmt.Println(" ##### Test_PublicEndpoint_VHostAdd_InvalidVHostName: STARTED")
+
+	_, svcB := ft.setupServiceWithPublicEndpoints(c)
+
+	// Mock call expectations:
+	ft.zzk.On("CheckRunningPublicEndpoint", registry.PublicEndpointKey("test#$%-0"), svcB.ID).Return(nil)
+
+	// Add a vhost to a service with a vhost name that contains invalid characters.
+	_, err := ft.Facade.AddPublicEndpointVHost(ft.CTX, svcB.ID, "service2", "test#$%", true, true)
+	if err == nil {
+		c.Errorf("Expected failure adding a vhost with invalid characters")
+	}
+
+	fmt.Println(" ##### Test_PublicEndpoint_VHostAdd_InvalidVHostName: PASSED")
 }
 
 func (ft *FacadeIntegrationTest) Test_PublicEndpoint_VHostAdd(c *C) {


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-2364

A CC UI check that was only in javascript to check for valid characters in vhost name was missed when writing the facade checks.  This adds a test case for the bug, then fixes it.