### PR TITLE
Feature/cc 2366

### DIFF
--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -341,7 +341,7 @@ func (s *Service) GetServicePorts() []ServiceEndpoint {
 }
 
 // AddVirtualHost Add a virtual host for given service, this method avoids duplicates vhosts
-func (s *Service) AddVirtualHost(application, vhostName string) (*servicedefinition.VHost, error) {
+func (s *Service) AddVirtualHost(application, vhostName string, isEnabled bool) (*servicedefinition.VHost, error) {
 	// We currently don't allow vhosts that contain a '.'
 	if strings.Contains(vhostName, ".") {
 		return nil, fmt.Errorf("Virtual host name must not contain a '.'")
@@ -361,7 +361,7 @@ func (s *Service) AddVirtualHost(application, vhostName string) (*servicedefinit
 						vhosts = append(vhosts, vhost)
 					}
 				}
-				vhost := &servicedefinition.VHost{Name: _vhostName, Enabled: true}
+				vhost := &servicedefinition.VHost{Name: _vhostName, Enabled: isEnabled}
 				ep.VHostList = append(vhosts, *vhost)
 				return vhost, nil
 			}

--- a/domain/service/service_test.go
+++ b/domain/service/service_test.go
@@ -42,20 +42,20 @@ func (s *S) TestAddVirtualHost(t *C) {
 	}
 
 	var err error
-	if _, err = svc.AddVirtualHost("empty_server", "name"); err == nil {
+	if _, err = svc.AddVirtualHost("empty_server", "name", true); err == nil {
 		t.Errorf("Expected error adding vhost")
 	}
 
-	if _, err = svc.AddVirtualHost("server", "name.something"); err == nil {
+	if _, err = svc.AddVirtualHost("server", "name.something", true); err == nil {
 		t.Errorf("Expected error adding vhost with '.'")
 	}
 
-	if _, err = svc.AddVirtualHost("server", "name"); err != nil {
+	if _, err = svc.AddVirtualHost("server", "name", true); err != nil {
 		t.Errorf("Unexpected error adding vhost: %v", err)
 	}
 
 	//no duplicate hosts can be added... hostnames are case-insensitive
-	if _, err = svc.AddVirtualHost("server", "NAME"); err != nil {
+	if _, err = svc.AddVirtualHost("server", "NAME", true); err != nil {
 		t.Errorf("Unexpected error adding vhost: %v", err)
 	}
 
@@ -65,6 +65,14 @@ func (s *S) TestAddVirtualHost(t *C) {
 
 	if svc.Endpoints[0].VHostList[0].Enabled != true {
 		t.Errorf("Virtualhost %s should be enabled", svc.Endpoints[0].VHostList[0].Name)
+	}
+
+	if _, err = svc.AddVirtualHost("server", "name2", false); err != nil {
+		t.Errorf("Unexpected error adding vhost: %v", err)
+	}
+	
+	if svc.Endpoints[0].VHostList[1].Enabled != false {
+		t.Errorf("Virtualhost %s should be disabled", svc.Endpoints[0].VHostList[1].Name)
 	}
 }
 
@@ -129,6 +137,14 @@ func (s *S) TestAddPort(t *C) {
 
 	if svc.Endpoints[0].PortList[0].Enabled != true {
 		t.Errorf("Port %s should be enabled", svc.Endpoints[0].PortList[0].PortAddr)
+	}
+
+	if _, err = svc.AddPort("server", ":12345", false, "http", false); err != nil {
+		t.Errorf("Unexpected error adding port: %v", err)
+	}
+
+	if svc.Endpoints[0].PortList[1].Enabled != false {
+		t.Errorf("Port %s should be disabled", svc.Endpoints[0].PortList[0].PortAddr)
 	}
 }
 

--- a/facade/publicendpoint.go
+++ b/facade/publicendpoint.go
@@ -297,7 +297,7 @@ func (f *Facade) AddPublicEndpointVHost(ctx datastore.Context, serviceid, endpoi
 		}
 	}
 
-	vhost, err := svc.AddVirtualHost(endpointName, vhostName)
+	vhost, err := svc.AddVirtualHost(endpointName, vhostName, isEnabled)
 	if err != nil {
 		err := fmt.Errorf("Error adding vhost (%s) to service (%s): %v", vhostName, svc.Name, err)
 		glog.Error(err)

--- a/facade/publicendpoint_test.go
+++ b/facade/publicendpoint_test.go
@@ -104,6 +104,29 @@ func (ft *FacadeIntegrationTest) Test_PublicEndpoint_PortAdd(c *C) {
 	fmt.Println(" ##### Test_PublicEndpoint_PortAdd: PASSED")
 }
 
+func (ft *FacadeIntegrationTest) Test_PublicEndpoint_PortAdd_VerifyEnabledFlag(c *C) {
+	fmt.Println(" ##### Test_PublicEndpoint_PortAdd_VerifyEnabledFlag: STARTED")
+
+	// Add a service so we can test our public endpoint.
+	_, svcB := ft.setupServiceWithPublicEndpoints(c)
+
+	// Add mock calls.
+	ft.zzk.On("CheckRunningPublicEndpoint", registry.PublicEndpointKey(":12345-1"), svcB.ID).Return(nil)
+
+	// Add a new vhost with enabled=false.
+	_, err := ft.Facade.AddPublicEndpointPort(ft.CTX, svcB.ID, "service2", ":12345", true, "http", false, false)
+	c.Assert(err, IsNil)
+
+	// Check to make sure the new vhost is *not* enabled.
+	svc, err := ft.Facade.GetService(ft.CTX, svcB.ID)
+	c.Assert(err, IsNil)
+	if svc.Endpoints[0].PortList[0].Enabled == true {
+		c.Errorf("Expected port public endpoint to be disabled")
+	}
+
+	fmt.Println(" ##### Test_PublicEndpoint_PortAdd_VerifyEnabledFlag: PASSED")
+}
+
 func (ft *FacadeIntegrationTest) Test_PublicEndpoint_PortAdd_DuplicatePort(c *C) {
 	fmt.Println(" ##### Test_PublicEndpoint_PortAdd_DuplicatePort: starting")
 
@@ -399,6 +422,29 @@ func (ft *FacadeIntegrationTest) Test_PublicEndpoint_PortEnable_InvalidPortInUse
 	}()
 
 	fmt.Println(" ##### Test_PublicEndpoint_PortEnable_InvalidPortInUse: PASSED")
+}
+
+func (ft *FacadeIntegrationTest) Test_PublicEndpoint_VHostAdd_VerifyEnabledFlag(c *C) {
+	fmt.Println(" ##### Test_PublicEndpoint_VHostAdd_VerifyEnabledFlag: STARTED")
+
+	// Add a service so we can test our public endpoint.
+	_, svcB := ft.setupServiceWithPublicEndpoints(c)
+
+	// Mock call expectations:
+	ft.zzk.On("CheckRunningPublicEndpoint", registry.PublicEndpointKey("service2-0"), svcB.ID).Return(nil)
+
+	// Add a new vhost with enabled=false.
+	_, err := ft.Facade.AddPublicEndpointVHost(ft.CTX, svcB.ID, "service2", "service2", false, false)
+	c.Assert(err, IsNil)
+
+	// Check to make sure the new vhost is *not* enabled.
+	svc, err := ft.Facade.GetService(ft.CTX, svcB.ID)
+	c.Assert(err, IsNil)
+	if svc.Endpoints[0].VHostList[0].Enabled == true {
+		c.Errorf("Expected service vhost public endpoint to be disabled")
+	}
+
+	fmt.Println(" ##### Test_PublicEndpoint_VHostAdd_VerifyEnabledFlag: PASSED")
 }
 
 func (ft *FacadeIntegrationTest) Test_PublicEndpoint_VHostAdd_InvalidService(c *C) {


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-2366
Adds the enable flag to the Service object and passes the flag when a vhost is added.