### PR TITLE
Correctly check pool name in serviced-fstrim

### DIFF
--- a/pkg/serviced-fstrim
+++ b/pkg/serviced-fstrim
@@ -47,8 +47,8 @@ done
 # locate the thinpool
 svc_vol_status=$("$SERVICED" volume status)                 || err_exit "serviced not returning volume status"
 echo "$svc_vol_status" | grep -qE "Driver:\s+devicemapper"  || ok_exit  "serviced not running on devicemapper"
-line=($(echo "$svc_vol_status" | grep -E "^PoolName:"))     || err_exit "cannot find pool name"
-pool_name=${line[1]}
+line=($(echo "$svc_vol_status" | grep -E "^Logical Volume:")) || err_exit "cannot find pool name"
+pool_name=${line[2]}
 [ -n $pool_name ]  || err_exit "cannot find pool name"
 
 # fstrim only the mounted serviced volumes


### PR DESCRIPTION
Motivation for change: this script is looking for [this](https://github.com/control-center/serviced/blob/76e980ab36d2f3262e3c7ca2690241a6a9f9b098/volume/status.go#L154) line so there wouldn't be a match while searching for `PoolName: `