### PR TITLE
CC-2417: Disable block analysis of volume status

### DIFF
--- a/volume/status.go
+++ b/volume/status.go
@@ -160,9 +160,6 @@ Data (total/used/avail):	{{bytes .PoolDataTotal}}	/ {{bytes .PoolDataUsed}}	({{p
 Volume Mount Point:	{{.VolumePath}}
 Filesystem (total/used/avail):	{{bytes .FilesystemTotal}} / {{bytes .FilesystemUsed}}	({{percent .FilesystemUsed .FilesystemTotal}}) / {{bytes .FilesystemAvailable}}	({{percent .FilesystemAvailable .FilesystemTotal}})
 Virtual device size:	{{blocksToBytes .DeviceTotalBlocks}}
-Pool space allocated to virtual device:	{{blocksToBytes .DeviceAllocatedBlocks}} ({{percent .DeviceAllocatedBlocks (bytesToBlocks $parent.PoolDataTotal)}} of pool)
-Pool space allocated to {{.NumberSnapshots}} snapshots:	{{blocksToBytes .SnapshotAllocatedBlocks}}
-Virtual device unallocated space:	{{blocksToBytes .DeviceUnallocatedBlocks}} (vs. {{bytes $parent.PoolDataAvailable}} available in pool)
 {{range .Errors}}
 {{.}}
 {{end -}}


### PR DESCRIPTION
Now it looks like this:
```
Status for volume /home/ian/src/metis/var/serviced/volumes:

Driver:      devicemapper
Driver Type: direct-lvm
Volume Path: /home/ian/src/metis/var/serviced/volumes

Thin Pool
---------
Logical Volume:               devian-serviced--pool
Metadata (total/used/avail):  28 MiB / 1.02 MiB  (3.6%) / 26.98 MiB (96%)
Data (total/used/avail):      25 GiB / 1.696 GiB (6.8%) / 23.3 GiB  (93%)

c8ujbyojmjvp50jxbee6ytyc2 Application Data
-----------------------------------------
Volume Mount Point:            /home/ian/src/metis/var/serviced/volumes/c8ujbyojmjvp50jxbee6ytyc2
Filesystem (total/used/avail): 100 GiB / 1.752 GiB (1.8%) / 98.25 GiB (98%)
Virtual device size:           100 GiB
```