### PR TITLE
CC-2442: Allow exclusion of volumes from backups via the command line

### DIFF
--- a/cli/api/apimocks/API.go
+++ b/cli/api/apimocks/API.go
@@ -924,8 +924,8 @@ func (_m *API) DeployServiceTemplate(_a0 api.DeployTemplateConfig) ([]service.Se
 
 	return r0, r1
 }
-func (_m *API) Backup(_a0 string) (string, error) {
-	ret := _m.Called(_a0)
+func (_m *API) Backup(_a0 string, _a1 []string) (string, error) {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 string
 	if rf, ok := ret.Get(0).(func(string) string); ok {

--- a/cli/api/backup.go
+++ b/cli/api/backup.go
@@ -16,13 +16,14 @@ package api
 import (
 	"fmt"
 	"path/filepath"
+
 	"github.com/control-center/serviced/dao"
 )
 
 // Dump all templates and services to a tgz file.
 // This includes a snapshot of all shared file systems
 // and exports all docker images the services depend on.
-func (a *api) Backup(dirpath string) (string, error) {
+func (a *api) Backup(dirpath string, excludes []string) (string, error) {
 	client, err := a.connectDAO()
 	if err != nil {
 		return "", err
@@ -30,8 +31,9 @@ func (a *api) Backup(dirpath string) (string, error) {
 
 	var path string
 	req := dao.BackupRequest{
-		Dirpath: 		dirpath,
-		SnapshotSpacePercent: 	options.SnapshotSpacePercent,
+		Dirpath:              dirpath,
+		SnapshotSpacePercent: options.SnapshotSpacePercent,
+		Excludes:             excludes,
 	}
 	if err := client.Backup(req, &path); err != nil {
 		return "", err

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -100,7 +100,7 @@ type API interface {
 	DeployServiceTemplate(DeployTemplateConfig) ([]service.Service, error)
 
 	// Backup & Restore
-	Backup(string) (string, error)
+	Backup(string, []string) (string, error)
 	Restore(string) error
 
 	// Docker

--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -29,6 +29,13 @@ func (c *ServicedCli) initBackup() {
 			Usage:       "Dump all templates and services to a tgz file",
 			Description: "serviced backup DIRPATH",
 			Action:      c.cmdBackup,
+			Flags: []cli.Flag{
+				cli.StringSliceFlag{
+					Name:  "exclude",
+					Value: &cli.StringSlice{},
+					Usage: "Subdirectory of the tenant volume to exclude from backup",
+				},
+			},
 		},
 		cli.Command{
 			Name:        "restore",
@@ -47,8 +54,7 @@ func (c *ServicedCli) cmdBackup(ctx *cli.Context) {
 		cli.ShowCommandHelp(ctx, "backup")
 		return
 	}
-
-	if path, err := c.driver.Backup(args[0]); err != nil {
+	if path, err := c.driver.Backup(args[0], ctx.StringSlice("exclude")); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	} else if path == "" {
 		fmt.Fprintln(os.Stderr, "received nil path to backup file")

--- a/cli/cmd/backup_test.go
+++ b/cli/cmd/backup_test.go
@@ -44,7 +44,7 @@ func InitBackupAPITest(args ...string) {
 	New(DefaultBackupAPITest, utils.TestConfigReader{}).Run(args)
 }
 
-func (t BackupAPITest) Backup(dirpath string) (string, error) {
+func (t BackupAPITest) Backup(dirpath string, excludes []string) (string, error) {
 	switch dirpath {
 	case PathNotFound:
 		return "", ErrBackupFailed
@@ -92,6 +92,8 @@ func ExampleServicedCLI_CmdBackup_usage() {
 	//    serviced backup DIRPATH
 	//
 	// OPTIONS:
+	//    --exclude '--exclude option --exclude option'	Subdirectory of the tenant volume to exclude from backup
+	//
 }
 
 func ExampleServicedCli_cmdRestore() {

--- a/dao/elasticsearch/filesystem.go
+++ b/dao/elasticsearch/filesystem.go
@@ -122,7 +122,7 @@ func (dao *ControlPlaneDao) Backup(backupRequest model.BackupRequest, filename *
 	// Smaller blocks will allow other goroutines to get time more frequently.
 	w.SetConcurrency(100000, 2)
 	defer w.Close()
-	err = dao.facade.Backup(ctx, w, backupRequest.SnapshotSpacePercent)
+	err = dao.facade.Backup(ctx, w, backupRequest.Excludes, backupRequest.SnapshotSpacePercent)
 	return
 }
 

--- a/dao/model.go
+++ b/dao/model.go
@@ -163,6 +163,7 @@ type HealthStatusRequest struct {
 }
 
 type BackupRequest struct {
-	Dirpath			string
-	SnapshotSpacePercent	int
+	Dirpath              string
+	SnapshotSpacePercent int
+	Excludes             []string
 }

--- a/facade/dfs.go
+++ b/facade/dfs.go
@@ -61,7 +61,7 @@ var registryVersionInfos = map[int]registryVersionInfo{
 }
 
 // Backup takes a backup of all installed applications
-func (f *Facade) Backup(ctx datastore.Context, w io.Writer, snapshotSpacePercent int) error {
+func (f *Facade) Backup(ctx datastore.Context, w io.Writer, excludes []string, snapshotSpacePercent int) error {
 	// Do not DFSLock here, ControlPlaneDao does that
 
 	stime := time.Now()
@@ -95,7 +95,7 @@ func (f *Facade) Backup(ctx datastore.Context, w io.Writer, snapshotSpacePercent
 		}
 		defer f.DeleteSnapshot(ctx, snapshot)
 		snapshots[i] = snapshot
-		snapshotExcludes[snapshot] = f.getExcludedVolumes(ctx, tenant)
+		snapshotExcludes[snapshot] = append(excludes, f.getExcludedVolumes(ctx, tenant)...)
 		glog.Infof("Created a snapshot for tenant %s at %s", tenant, snapshot)
 	}
 	glog.Infof("Loaded tenants")


### PR DESCRIPTION
This permits `serviced backup --exclude mariadb --exclude hbase-master /path/to/backups`