### PR TITLE
use new isvcs image with java 8 support

### DIFF
--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -25,7 +25,7 @@ var Mgr *Manager
 
 const (
 	IMAGE_REPO    = "zenoss/serviced-isvcs"
-	IMAGE_TAG     = "v43"
+	IMAGE_TAG     = "v44"
 	ZK_IMAGE_REPO = "zenoss/isvcs-zookeeper"
 	ZK_IMAGE_TAG  = "v4"
 )


### PR DESCRIPTION
For ZEN-23915: use zenoss/serviced-isvcs:v44 to pick up java 8 changes.