### PR TITLE
Feature/cc 2486

### DIFF
--- a/zzk/service/hoststate_test.go
+++ b/zzk/service/hoststate_test.go
@@ -389,6 +389,11 @@ func (t *ZZKTest) TestHostStateListener_Spawn_StartAndStop(c *C) {
 
 	c.Logf("Stopping service instance")
 	err = StopServiceInstance(conn, "", "test-host-1", stateID)
+	if err != nil {
+		c.Logf("could not stop, trying again")
+		err = StopServiceInstance(conn, "", "test-host-1", stateID)
+		c.Assert(err, IsNil)
+	}
 	wait(svc.ID, service.SVCStop)
 }
 

--- a/zzk/service/state.go
+++ b/zzk/service/state.go
@@ -51,10 +51,12 @@ type ServiceState struct {
 	version    interface{}
 }
 
+// Version implements client.Node
 func (s *ServiceState) Version() interface{} {
 	return s.version
 }
 
+// SetVersion implements client.Node
 func (s *ServiceState) SetVersion(version interface{}) {
 	s.version = version
 }
@@ -68,10 +70,12 @@ type HostState2 struct {
 	version      interface{}
 }
 
+// Version implements client.Node
 func (s *HostState2) Version() interface{} {
 	return s.version
 }
 
+// SetVersion implements client.Node
 func (s *HostState2) SetVersion(version interface{}) {
 	s.version = version
 }
@@ -149,7 +153,7 @@ func GetState(conn client.Connection, req StateRequest) (*State, error) {
 
 		logger.WithFields(log.Fields{
 			"Error": err,
-		}).Error("Could not look up service state")
+		}).Debug("Could not look up service state")
 
 		return nil, &StateError{
 			Request:   req,
@@ -188,7 +192,7 @@ func GetServiceStates2(conn client.Connection, poolID, serviceID string) ([]Stat
 		// TODO: wrap the error?
 		logger.WithFields(log.Fields{
 			"Error": err,
-		}).Error("Could not look up instances on service")
+		}).Debug("Could not look up instances on service")
 
 		return nil, err
 	}
@@ -246,7 +250,7 @@ func GetHostStates(conn client.Connection, poolID, hostID string) ([]State, erro
 		// TODO: wrap the error?
 		logger.WithFields(log.Fields{
 			"Error": err,
-		}).Error("Could not look up instances on host")
+		}).Debug("Could not look up instances on host")
 
 		return nil, err
 	}
@@ -403,6 +407,8 @@ func UpdateState(conn client.Connection, req StateRequest, mutate func(*State)) 
 		InstanceID:   req.InstanceID,
 	}
 	mutate(state)
+
+	// set the version object on the respective states
 	*hsdat = state.HostState2
 	hsdat.SetVersion(hsver)
 	*ssdat = state.ServiceState
@@ -458,7 +464,7 @@ func DeleteState(conn client.Connection, req StateRequest) error {
 	} else if ok {
 		t.Delete(hspth)
 	} else {
-		logger.Warn("No state to delete on host")
+		logger.Debug("No state to delete on host")
 	}
 
 	// Delete the service instance
@@ -477,7 +483,7 @@ func DeleteState(conn client.Connection, req StateRequest) error {
 	} else if ok {
 		t.Delete(sspth)
 	} else {
-		logger.Warn("No state to delete on service")
+		logger.Debug("No state to delete on service")
 	}
 
 	if err := t.Commit(); err != nil {

--- a/zzk/service/state.go
+++ b/zzk/service/state.go
@@ -25,6 +25,8 @@ import (
 	"github.com/control-center/serviced/domain/service"
 )
 
+var ErrInvalidStateID = errors.New("invalid state id")
+
 // ServiceState provides information for a particular instance of a service
 type ServiceState struct {
 	DockerID   string
@@ -81,11 +83,11 @@ type StateRequest struct {
 func ParseStateID(stateID string) (string, int, error) {
 	parts := strings.SplitN(stateID, "-", 2)
 	if len(parts) != 2 {
-		return "", 0, errors.New("invalid state id")
+		return "", 0, ErrInvalidStateID
 	}
 	instanceID, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return "", 0, err
+		return "", 0, ErrInvalidStateID
 	}
 	return parts[0], instanceID, nil
 }
@@ -207,8 +209,8 @@ func GetHostStates(conn client.Connection, poolID, hostID string) ([]State, erro
 	return states, nil
 }
 
-// CreateInstance creates a new service state and host state
-func CreateInstance(conn client.Connection, req StateRequest) error {
+// CreateState creates a new service state and host state
+func CreateState(conn client.Connection, req StateRequest) error {
 	basepth := "/"
 	if req.PoolID != "" {
 		basepth = path.Join("/pools", req.PoolID)
@@ -244,8 +246,8 @@ func CreateInstance(conn client.Connection, req StateRequest) error {
 	return nil
 }
 
-// UpdateInstance updates the service state and host state
-func UpdateInstance(conn client.Connection, req StateRequest, mutate func(*HostState2, *ServiceState)) error {
+// UpdateState updates the service state and host state
+func UpdateState(conn client.Connection, req StateRequest, mutate func(*HostState2, *ServiceState)) error {
 	basepth := "/"
 	if req.PoolID != "" {
 		basepth = path.Join("/pools", req.PoolID)
@@ -279,8 +281,8 @@ func UpdateInstance(conn client.Connection, req StateRequest, mutate func(*HostS
 	return nil
 }
 
-// DeleteInstance removes the service state and host state
-func DeleteInstance(conn client.Connection, req StateRequest) error {
+// DeleteState removes the service state and host state
+func DeleteState(conn client.Connection, req StateRequest) error {
 	basepth := "/"
 	if req.PoolID != "" {
 		basepth = path.Join("/pools", req.PoolID)

--- a/zzk/service/state.go
+++ b/zzk/service/state.go
@@ -1,0 +1,320 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/control-center/serviced/coordinator/client"
+	"github.com/control-center/serviced/domain/service"
+)
+
+// ServiceState provides information for a particular instance of a service
+type ServiceState struct {
+	DockerID   string
+	ImageID    string
+	Paused     bool
+	Started    time.Time
+	Terminated time.Time
+	version    interface{}
+}
+
+func (s *ServiceState) Version() interface{} {
+	return s.version
+}
+
+func (s *ServiceState) SetVersion(version interface{}) {
+	s.version = version
+}
+
+// HostState2 provides information for a particular instance on host for a
+// service.
+// TODO: update name when the calls are swapped on the listeners
+type HostState2 struct {
+	DesiredState service.DesiredState
+	Scheduled    time.Time
+	version      interface{}
+}
+
+func (s *HostState2) Version() interface{} {
+	return s.version
+}
+
+func (s *HostState2) SetVersion(version interface{}) {
+	s.version = version
+}
+
+// State is a concatenation of the HostState and ServiceState objects
+type State struct {
+	HostState2
+	ServiceState
+	HostID     string
+	ServiceID  string
+	InstanceID int
+}
+
+// StateRequest provides information for service instance CRUD
+type StateRequest struct {
+	PoolID     string
+	HostID     string
+	ServiceID  string
+	InstanceID int
+}
+
+// ParseStateID returns the instance id from the given state id
+func ParseStateID(stateID string) (string, int, error) {
+	parts := strings.SplitN(stateID, "-", 2)
+	if len(parts) != 2 {
+		return "", 0, errors.New("invalid state id")
+	}
+	instanceID, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", 0, err
+	}
+	return parts[0], instanceID, nil
+}
+
+// GetState returns the service state and host state for a particular instance.
+func GetState(conn client.Connection, req StateRequest) (*State, error) {
+	basepth := "/"
+	if req.PoolID != "" {
+		basepth = path.Join("/pools", req.PoolID)
+	}
+
+	// Get the current host state
+	hsval := fmt.Sprintf("%s-%d", req.ServiceID, req.InstanceID)
+	hspth := path.Join(basepth, "/hosts", req.HostID, "instances", hsval)
+	hsdat := &HostState2{}
+	if err := conn.Get(hspth, hsdat); err != nil {
+		// TODO: error on could not get host instance
+		return nil, err
+	}
+
+	// Get the current service state
+	ssval := fmt.Sprintf("%s-%d", req.HostID, req.InstanceID)
+	sspth := path.Join(basepth, "/services", req.ServiceID, ssval)
+	ssdat := &ServiceState{}
+	if err := conn.Get(sspth, ssdat); err != nil {
+		// TODO: error on could not get service instance
+		return nil, err
+	}
+
+	return &State{
+		HostState2:   *hsdat,
+		ServiceState: *ssdat,
+		HostID:       req.HostID,
+		ServiceID:    req.ServiceID,
+		InstanceID:   req.InstanceID,
+	}, nil
+}
+
+// GetServiceStates2 returns the states of a running service
+// TODO: update name when calls are swapped
+func GetServiceStates2(conn client.Connection, poolID, serviceID string) ([]State, error) {
+	basepth := "/"
+	if poolID != "" {
+		basepth = path.Join("/pools", poolID)
+	}
+
+	spth := path.Join(basepth, "/services", serviceID)
+	ch, err := conn.Children(spth)
+	if err != nil && err != client.ErrNoNode {
+		// TODO: error on could not get instances of service
+		return nil, err
+	}
+
+	states := make([]State, len(ch))
+	for i, stateID := range ch {
+		hostID, instanceID, err := ParseStateID(stateID)
+		if err != nil {
+			// TODO: error on invalid state
+			return nil, err
+		}
+
+		req := StateRequest{
+			PoolID:     poolID,
+			HostID:     hostID,
+			ServiceID:  serviceID,
+			InstanceID: instanceID,
+		}
+
+		state, err := GetState(conn, req)
+		if err != nil {
+			// TODO: error on building state
+			return nil, err
+		}
+
+		states[i] = *state
+	}
+
+	return states, nil
+}
+
+// GetHostStates returns the states running on a host
+func GetHostStates(conn client.Connection, poolID, hostID string) ([]State, error) {
+	basepth := "/"
+	if poolID != "" {
+		basepth = path.Join("/pools", poolID)
+	}
+
+	hpth := path.Join(basepth, "/hosts", hostID, "instances")
+	ch, err := conn.Children(hpth)
+	if err != nil && err != client.ErrNoNode {
+		// TODO: error on could not get instances on host
+		return nil, err
+	}
+
+	states := make([]State, len(ch))
+	for i, stateID := range ch {
+		serviceID, instanceID, err := ParseStateID(stateID)
+		if err != nil {
+			// TODO: error on invalid state
+			return nil, err
+		}
+
+		req := StateRequest{
+			PoolID:     poolID,
+			HostID:     hostID,
+			ServiceID:  serviceID,
+			InstanceID: instanceID,
+		}
+
+		state, err := GetState(conn, req)
+		if err != nil {
+			// TODO: error on building state
+			return nil, err
+		}
+
+		states[i] = *state
+	}
+
+	return states, nil
+}
+
+// CreateInstance creates a new service state and host state
+func CreateInstance(conn client.Connection, req StateRequest) error {
+	basepth := "/"
+	if req.PoolID != "" {
+		basepth = path.Join("/pools", req.PoolID)
+	}
+
+	t := conn.NewTransaction()
+
+	// Prepare the host instance
+	hpth := path.Join(basepth, "/hosts", req.HostID, "instances")
+	err := conn.CreateIfExists(hpth, &client.Dir{})
+	if err != nil && err != client.ErrNodeExists {
+		// TODO: error on could not set up host instance
+		return err
+	}
+	hsval := fmt.Sprintf("%s-%d", req.ServiceID, req.InstanceID)
+	hspth := path.Join(hpth, hsval)
+	hsdat := &HostState2{
+		DesiredState: service.SVCRun,
+		Scheduled:    time.Now(),
+	}
+	t.Create(hspth, hsdat)
+
+	// Prepare the service instance
+	ssval := fmt.Sprintf("%s-%d", req.HostID, req.InstanceID)
+	sspth := path.Join(basepth, "/services", req.ServiceID, ssval)
+	ssdat := &ServiceState{}
+	t.Create(sspth, ssdat)
+
+	if err := t.Commit(); err != nil {
+		// TODO: error on create instance
+		return err
+	}
+	return nil
+}
+
+// UpdateInstance updates the service state and host state
+func UpdateInstance(conn client.Connection, req StateRequest, mutate func(*HostState2, *ServiceState)) error {
+	basepth := "/"
+	if req.PoolID != "" {
+		basepth = path.Join("/pools", req.PoolID)
+	}
+
+	// Get the current host state
+	hsval := fmt.Sprintf("%s-%d", req.ServiceID, req.InstanceID)
+	hspth := path.Join(basepth, "/hosts", req.HostID, "instances", hsval)
+	hsdat := &HostState2{}
+	if err := conn.Get(hspth, hsdat); err != nil {
+		// TODO: error on could not get host instance
+		return err
+	}
+
+	// Get the current service state
+	ssval := fmt.Sprintf("%s-%d", req.HostID, req.InstanceID)
+	sspth := path.Join(basepth, "/services", req.ServiceID, ssval)
+	ssdat := &ServiceState{}
+	if err := conn.Get(sspth, ssdat); err != nil {
+		// TODO: error on could not get service instance
+		return err
+	}
+
+	// mutate the states
+	mutate(hsdat, ssdat)
+
+	if err := conn.NewTransaction().Set(hspth, hsdat).Set(sspth, ssdat).Commit(); err != nil {
+		// TODO: error on update instance
+		return err
+	}
+	return nil
+}
+
+// DeleteInstance removes the service state and host state
+func DeleteInstance(conn client.Connection, req StateRequest) error {
+	basepth := "/"
+	if req.PoolID != "" {
+		basepth = path.Join("/pools", req.PoolID)
+	}
+
+	t := conn.NewTransaction()
+
+	// Delete the host instance
+	hsval := fmt.Sprintf("%s-%d", req.ServiceID, req.InstanceID)
+	hspth := path.Join(basepth, "/hosts", req.HostID, "instances", hsval)
+	if ok, err := conn.Exists(hspth); err != nil {
+		// TODO: error on could not check host instance
+		return err
+	} else if ok {
+		t.Delete(hspth)
+	} else {
+		// TODO: log on nothing to delete
+	}
+
+	// Delete the service instance
+	ssval := fmt.Sprintf("%s-%d", req.HostID, req.InstanceID)
+	sspth := path.Join(basepth, "/services", req.ServiceID, ssval)
+	if ok, err := conn.Exists(sspth); err != nil {
+		// TODO: error on could not check service instance
+		return err
+	} else if ok {
+		t.Delete(sspth)
+	} else {
+		// TODO: log on nothing to delete
+	}
+
+	if err := t.Commit(); err != nil {
+		// TODO: error on delete instance
+		return err
+	}
+	return nil
+}

--- a/zzk/service/state.go
+++ b/zzk/service/state.go
@@ -34,7 +34,7 @@ type StateError struct {
 }
 
 func (err StateError) Error() string {
-	return fmt.Sprintf("could not %s instance %s from service %s on host %s: %s", err.Operation, err.Request.InstanceID, err.Request.ServiceID, err.Request.ServiceID, err.Message)
+	return fmt.Sprintf("could not %s instance %d from service %s on host %s: %s", err.Operation, err.Request.InstanceID, err.Request.ServiceID, err.Request.ServiceID, err.Message)
 }
 
 // ErrInvalidStateID is an error that is returned when a state id value is not
@@ -338,7 +338,7 @@ func CreateState(conn client.Connection, req StateRequest) error {
 		return &StateError{
 			Request:   req,
 			Operation: "create",
-			Message:   fmt.Sprintf("could not commit transaction", err),
+			Message:   fmt.Sprintf("could not commit transaction"),
 		}
 	}
 

--- a/zzk/service/state_test.go
+++ b/zzk/service/state_test.go
@@ -72,10 +72,71 @@ func (t *ZZKTest) TestGetServiceStates2(c *C) {
 	err = conn.CreateDir("/pools/poolid/hosts/hostid2")
 	c.Assert(err, IsNil)
 
+	// create states
+	req := StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid1",
+		ServiceID:  "serviceid1",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	req = StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid1",
+		ServiceID:  "serviceid2",
+		InstanceID: 2,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	req = StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid2",
+		ServiceID:  "serviceid2",
+		InstanceID: 3,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
 	// 0 states
-	states, err := GetServiceStates2(conn, "poolid", "serviceid1")
+	states, err := GetServiceStates2(conn, "poolid", "serviceid0")
 	c.Assert(err, IsNil)
 	c.Assert(states, HasLen, 0)
+
+	// =1 state
+	states, err = GetServiceStates2(conn, "poolid", "serviceid1")
+	c.Assert(err, IsNil)
+	c.Assert(states, HasLen, 1)
+	c.Assert(states[0].InstanceID, Equals, 1)
+
+	// >1 state
+	states, err = GetServiceStates2(conn, "poolid", "serviceid2")
+	c.Assert(err, IsNil)
+	c.Assert(states, HasLen, 2)
+	actual := []int{states[0].InstanceID, states[1].InstanceID}
+	sort.Ints(actual)
+	c.Assert(actual, DeepEquals, []int{2, 3})
+}
+
+func (t *ZZKTest) TestDeleteServiceStates(c *C) {
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+
+	// add 2 services
+	err = conn.CreateDir("/pools/poolid/services/serviceid1")
+	c.Assert(err, IsNil)
+
+	err = conn.CreateDir("/pools/poolid/services/serviceid2")
+	c.Assert(err, IsNil)
+
+	// add 2 hosts
+	err = conn.CreateDir("/pools/poolid/hosts/hostid1")
+	c.Assert(err, IsNil)
+
+	err = conn.CreateDir("/pools/poolid/hosts/hostid2")
+	c.Assert(err, IsNil)
 
 	// create states
 	req := StateRequest{
@@ -105,19 +166,17 @@ func (t *ZZKTest) TestGetServiceStates2(c *C) {
 	err = CreateState(conn, req)
 	c.Assert(err, IsNil)
 
+	// 0 states
+	count := DeleteServiceStates(conn, "poolid", "serviceid0")
+	c.Check(count, Equals, 0)
+
 	// =1 state
-	states, err = GetServiceStates2(conn, "poolid", "serviceid1")
-	c.Assert(err, IsNil)
-	c.Assert(states, HasLen, 1)
-	c.Assert(states[0].InstanceID, Equals, 1)
+	count = DeleteServiceStates(conn, "poolid", "serviceid1")
+	c.Check(count, Equals, 1)
 
 	// >1 state
-	states, err = GetServiceStates2(conn, "poolid", "serviceid2")
-	c.Assert(err, IsNil)
-	c.Assert(states, HasLen, 2)
-	actual := []int{states[0].InstanceID, states[1].InstanceID}
-	sort.Ints(actual)
-	c.Assert(actual, DeepEquals, []int{2, 3})
+	count = DeleteServiceStates(conn, "poolid", "serviceid2")
+	c.Check(count, Equals, 2)
 }
 
 func (t *ZZKTest) TestGetHostStates(c *C) {
@@ -138,10 +197,71 @@ func (t *ZZKTest) TestGetHostStates(c *C) {
 	err = conn.CreateDir("/pools/poolid/hosts/hostid2")
 	c.Assert(err, IsNil)
 
+	// create states
+	req := StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid1",
+		ServiceID:  "serviceid1",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	req = StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid2",
+		ServiceID:  "serviceid1",
+		InstanceID: 2,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	req = StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid2",
+		ServiceID:  "serviceid2",
+		InstanceID: 3,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
 	// 0 states
-	states, err := GetHostStates(conn, "poolid", "hostid1")
+	states, err := GetHostStates(conn, "poolid", "hostid0")
 	c.Assert(err, IsNil)
 	c.Assert(states, HasLen, 0)
+
+	// =1 state
+	states, err = GetHostStates(conn, "poolid", "hostid1")
+	c.Assert(err, IsNil)
+	c.Assert(states, HasLen, 1)
+	c.Assert(states[0].InstanceID, Equals, 1)
+
+	// >1 state
+	states, err = GetHostStates(conn, "poolid", "hostid2")
+	c.Assert(err, IsNil)
+	c.Assert(states, HasLen, 2)
+	actual := []int{states[0].InstanceID, states[1].InstanceID}
+	sort.Ints(actual)
+	c.Assert(actual, DeepEquals, []int{2, 3})
+}
+
+func (t *ZZKTest) TestDeleteHostStates(c *C) {
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+
+	// add 2 services
+	err = conn.CreateDir("/pools/poolid/services/serviceid1")
+	c.Assert(err, IsNil)
+
+	err = conn.CreateDir("/pools/poolid/services/serviceid2")
+	c.Assert(err, IsNil)
+
+	// add 2 hosts
+	err = conn.CreateDir("/pools/poolid/hosts/hostid1")
+	c.Assert(err, IsNil)
+
+	err = conn.CreateDir("/pools/poolid/hosts/hostid2")
+	c.Assert(err, IsNil)
 
 	// create states
 	req := StateRequest{
@@ -171,19 +291,17 @@ func (t *ZZKTest) TestGetHostStates(c *C) {
 	err = CreateState(conn, req)
 	c.Assert(err, IsNil)
 
+	// 0 states
+	count := DeleteHostStates(conn, "poolid", "hostid0")
+	c.Check(count, Equals, 0)
+
 	// =1 state
-	states, err = GetHostStates(conn, "poolid", "hostid1")
-	c.Assert(err, IsNil)
-	c.Assert(states, HasLen, 1)
-	c.Assert(states[0].InstanceID, Equals, 1)
+	count = DeleteHostStates(conn, "poolid", "hostid1")
+	c.Check(count, Equals, 1)
 
 	// >1 state
-	states, err = GetHostStates(conn, "poolid", "hostid2")
-	c.Assert(err, IsNil)
-	c.Assert(states, HasLen, 2)
-	actual := []int{states[0].InstanceID, states[1].InstanceID}
-	sort.Ints(actual)
-	c.Assert(actual, DeepEquals, []int{2, 3})
+	count = DeleteHostStates(conn, "poolid", "hostid2")
+	c.Check(count, Equals, 2)
 }
 
 func (t *ZZKTest) TestCRUDState(c *C) {

--- a/zzk/service/state_test.go
+++ b/zzk/service/state_test.go
@@ -26,27 +26,31 @@ import (
 
 func (t *ZZKTest) TestParseStateID(c *C) {
 	// invalid id
-	owner, inst, err := ParseStateID("badaadadadafg")
+	hostID, serviceID, inst, err := ParseStateID("badaadadadafg")
 	c.Assert(err, Equals, ErrInvalidStateID)
-	c.Assert(owner, Equals, "")
+	c.Assert(hostID, Equals, "")
+	c.Assert(serviceID, Equals, "")
 	c.Assert(inst, Equals, 0)
 
 	// another invalid id
-	owner, inst, err = ParseStateID("fhfhfhfhgjjs-dfgsgsg-1")
+	hostID, serviceID, inst, err = ParseStateID("dfgsgsg-1")
 	c.Assert(err, Equals, ErrInvalidStateID)
-	c.Assert(owner, Equals, "")
+	c.Assert(hostID, Equals, "")
+	c.Assert(serviceID, Equals, "")
 	c.Assert(inst, Equals, 0)
 
 	// yet another invalid id
-	owner, inst, err = ParseStateID("dfrhedfbsd-de4")
+	hostID, serviceID, inst, err = ParseStateID("rg35g34-dfrhedfbsd-de4")
 	c.Assert(err, Equals, ErrInvalidStateID)
-	c.Assert(owner, Equals, "")
+	c.Assert(hostID, Equals, "")
+	c.Assert(serviceID, Equals, "")
 	c.Assert(inst, Equals, 0)
 
 	// an acceptable id
-	owner, inst, err = ParseStateID("fgrg43g5heefv-5")
+	hostID, serviceID, inst, err = ParseStateID("45grwg34-fgrg43g5heefv-5")
 	c.Assert(err, IsNil)
-	c.Assert(owner, Equals, "fgrg43g5heefv")
+	c.Assert(hostID, Equals, "45grwg34")
+	c.Assert(serviceID, Equals, "fgrg43g5heefv")
 	c.Assert(inst, Equals, 5)
 }
 
@@ -205,10 +209,10 @@ func (t *ZZKTest) TestCRUDState(c *C) {
 	startTime := time.Now()
 	err = CreateState(conn, req)
 	c.Assert(err, IsNil)
-	ok, err := conn.Exists("/pools/poolid/services/serviceid/hostid-3")
+	ok, err := conn.Exists("/pools/poolid/services/serviceid/hostid-serviceid-3")
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)
-	ok, err = conn.Exists("/pools/poolid/hosts/hostid/instances/serviceid-3")
+	ok, err = conn.Exists("/pools/poolid/hosts/hostid/instances/hostid-serviceid-3")
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)
 

--- a/zzk/service/state_test.go
+++ b/zzk/service/state_test.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/control-center/serviced/coordinator/client"
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/zzk"
 	. "gopkg.in/check.v1"
@@ -214,9 +213,11 @@ func (t *ZZKTest) TestCRUDState(c *C) {
 	c.Assert(ok, Equals, true)
 
 	// create duplicate state
-	// TODO: need more standard error here
 	err = CreateState(conn, req)
-	c.Assert(err, NotNil)
+	stateErr, ok := err.(*StateError)
+	c.Check(ok, Equals, true)
+	c.Check(stateErr.Request, DeepEquals, req)
+	c.Check(stateErr.Operation, Equals, "create")
 
 	// state exists
 	state, err := GetState(conn, req)
@@ -260,6 +261,9 @@ func (t *ZZKTest) TestCRUDState(c *C) {
 	c.Assert(err, IsNil)
 
 	state, err = GetState(conn, req)
-	c.Assert(err, Equals, client.ErrNoNode)
+	stateErr, ok = err.(*StateError)
+	c.Check(ok, Equals, true)
+	c.Check(stateErr.Request, DeepEquals, req)
+	c.Check(stateErr.Operation, Equals, "get")
 	c.Assert(state, IsNil)
 }

--- a/zzk/service/state_test.go
+++ b/zzk/service/state_test.go
@@ -356,12 +356,14 @@ func (t *ZZKTest) TestCRUDState(c *C) {
 	c.Check(state.InstanceID, Equals, 3)
 
 	// update state
-	err = UpdateState(conn, req, func(h *HostState2, s *ServiceState) {
-		h.DesiredState = service.SVCPause
-		s.DockerID = "dockerid"
-		s.ImageID = "imageid"
-		s.Paused = true
-		s.Started = time.Now()
+	err = UpdateState(conn, req, func(s *State) {
+		s.DesiredState = service.SVCPause
+		s.ServiceState = ServiceState{
+			DockerID: "dockerid",
+			ImageID:  "imageid",
+			Paused:   true,
+			Started:  time.Now(),
+		}
 	})
 	c.Assert(err, IsNil)
 

--- a/zzk/service/state_test.go
+++ b/zzk/service/state_test.go
@@ -1,0 +1,265 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build integration,!quick
+
+package service
+
+import (
+	"sort"
+	"time"
+
+	"github.com/control-center/serviced/coordinator/client"
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/zzk"
+	. "gopkg.in/check.v1"
+)
+
+func (t *ZZKTest) TestParseStateID(c *C) {
+	// invalid id
+	owner, inst, err := ParseStateID("badaadadadafg")
+	c.Assert(err, Equals, ErrInvalidStateID)
+	c.Assert(owner, Equals, "")
+	c.Assert(inst, Equals, 0)
+
+	// another invalid id
+	owner, inst, err = ParseStateID("fhfhfhfhgjjs-dfgsgsg-1")
+	c.Assert(err, Equals, ErrInvalidStateID)
+	c.Assert(owner, Equals, "")
+	c.Assert(inst, Equals, 0)
+
+	// yet another invalid id
+	owner, inst, err = ParseStateID("dfrhedfbsd-de4")
+	c.Assert(err, Equals, ErrInvalidStateID)
+	c.Assert(owner, Equals, "")
+	c.Assert(inst, Equals, 0)
+
+	// an acceptable id
+	owner, inst, err = ParseStateID("fgrg43g5heefv-5")
+	c.Assert(err, IsNil)
+	c.Assert(owner, Equals, "fgrg43g5heefv")
+	c.Assert(inst, Equals, 5)
+}
+
+func (t *ZZKTest) TestGetServiceStates2(c *C) {
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+
+	// add 2 services
+	err = conn.CreateDir("/pools/poolid/services/serviceid1")
+	c.Assert(err, IsNil)
+
+	err = conn.CreateDir("/pools/poolid/services/serviceid2")
+	c.Assert(err, IsNil)
+
+	// add 2 hosts
+	err = conn.CreateDir("/pools/poolid/hosts/hostid1")
+	c.Assert(err, IsNil)
+
+	err = conn.CreateDir("/pools/poolid/hosts/hostid2")
+	c.Assert(err, IsNil)
+
+	// 0 states
+	states, err := GetServiceStates2(conn, "poolid", "serviceid1")
+	c.Assert(err, IsNil)
+	c.Assert(states, HasLen, 0)
+
+	// create states
+	req := StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid1",
+		ServiceID:  "serviceid1",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	req = StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid1",
+		ServiceID:  "serviceid2",
+		InstanceID: 2,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	req = StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid2",
+		ServiceID:  "serviceid2",
+		InstanceID: 3,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	// =1 state
+	states, err = GetServiceStates2(conn, "poolid", "serviceid1")
+	c.Assert(err, IsNil)
+	c.Assert(states, HasLen, 1)
+	c.Assert(states[0].InstanceID, Equals, 1)
+
+	// >1 state
+	states, err = GetServiceStates2(conn, "poolid", "serviceid2")
+	c.Assert(err, IsNil)
+	c.Assert(states, HasLen, 2)
+	actual := []int{states[0].InstanceID, states[1].InstanceID}
+	sort.Ints(actual)
+	c.Assert(actual, DeepEquals, []int{2, 3})
+}
+
+func (t *ZZKTest) TestGetHostStates(c *C) {
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+
+	// add 2 services
+	err = conn.CreateDir("/pools/poolid/services/serviceid1")
+	c.Assert(err, IsNil)
+
+	err = conn.CreateDir("/pools/poolid/services/serviceid2")
+	c.Assert(err, IsNil)
+
+	// add 2 hosts
+	err = conn.CreateDir("/pools/poolid/hosts/hostid1")
+	c.Assert(err, IsNil)
+
+	err = conn.CreateDir("/pools/poolid/hosts/hostid2")
+	c.Assert(err, IsNil)
+
+	// 0 states
+	states, err := GetHostStates(conn, "poolid", "hostid1")
+	c.Assert(err, IsNil)
+	c.Assert(states, HasLen, 0)
+
+	// create states
+	req := StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid1",
+		ServiceID:  "serviceid1",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	req = StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid2",
+		ServiceID:  "serviceid1",
+		InstanceID: 2,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	req = StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid2",
+		ServiceID:  "serviceid2",
+		InstanceID: 3,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	// =1 state
+	states, err = GetHostStates(conn, "poolid", "hostid1")
+	c.Assert(err, IsNil)
+	c.Assert(states, HasLen, 1)
+	c.Assert(states[0].InstanceID, Equals, 1)
+
+	// >1 state
+	states, err = GetHostStates(conn, "poolid", "hostid2")
+	c.Assert(err, IsNil)
+	c.Assert(states, HasLen, 2)
+	actual := []int{states[0].InstanceID, states[1].InstanceID}
+	sort.Ints(actual)
+	c.Assert(actual, DeepEquals, []int{2, 3})
+}
+
+func (t *ZZKTest) TestCRUDState(c *C) {
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+
+	// add a service
+	err = conn.CreateDir("/pools/poolid/services/serviceid")
+	c.Assert(err, IsNil)
+
+	// add a host
+	err = conn.CreateDir("/pools/poolid/hosts/hostid")
+	c.Assert(err, IsNil)
+
+	req := StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid",
+		ServiceID:  "serviceid",
+		InstanceID: 3,
+	}
+
+	// create state
+	startTime := time.Now()
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+	ok, err := conn.Exists("/pools/poolid/services/serviceid/hostid-3")
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, true)
+	ok, err = conn.Exists("/pools/poolid/hosts/hostid/instances/serviceid-3")
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, true)
+
+	// create duplicate state
+	// TODO: need more standard error here
+	err = CreateState(conn, req)
+	c.Assert(err, NotNil)
+
+	// state exists
+	state, err := GetState(conn, req)
+	c.Assert(err, IsNil)
+	c.Check(state.DockerID, Equals, "")
+	c.Check(state.ImageID, Equals, "")
+	c.Check(state.Paused, Equals, false)
+	c.Check(startTime.Before(state.Started), Equals, false)
+	c.Check(startTime.Before(state.Terminated), Equals, false)
+	c.Check(state.DesiredState, Equals, service.SVCRun)
+	c.Check(startTime.Before(state.Scheduled), Equals, true)
+	c.Check(state.HostID, Equals, "hostid")
+	c.Check(state.ServiceID, Equals, "serviceid")
+	c.Check(state.InstanceID, Equals, 3)
+
+	// update state
+	err = UpdateState(conn, req, func(h *HostState2, s *ServiceState) {
+		h.DesiredState = service.SVCPause
+		s.DockerID = "dockerid"
+		s.ImageID = "imageid"
+		s.Paused = true
+		s.Started = time.Now()
+	})
+	c.Assert(err, IsNil)
+
+	state, err = GetState(conn, req)
+	c.Assert(err, IsNil)
+	c.Check(state.DockerID, Equals, "dockerid")
+	c.Check(state.ImageID, Equals, "imageid")
+	c.Check(state.Paused, Equals, true)
+	c.Check(startTime.Before(state.Started), Equals, true)
+	c.Check(startTime.Before(state.Terminated), Equals, false)
+	c.Check(state.DesiredState, Equals, service.SVCPause)
+	c.Check(startTime.Before(state.Scheduled), Equals, true)
+	c.Check(state.HostID, Equals, "hostid")
+	c.Check(state.ServiceID, Equals, "serviceid")
+	c.Check(state.InstanceID, Equals, 3)
+
+	// delete state
+	err = DeleteState(conn, req)
+	c.Assert(err, IsNil)
+
+	state, err = GetState(conn, req)
+	c.Assert(err, Equals, client.ErrNoNode)
+	c.Assert(state, IsNil)
+}


### PR DESCRIPTION
Note that these changes have not been integrated yet!

* Renamed state id to HOSTID-SERVICEID-INSTANCEID to reduce the number of calls made to zookeeper and the amount of deserialization to figure out which host and service has each instance

* Minimized the size of the respective objects to only include information that was most used and most relevant to the instance.

* Using new logger schema