### PR TITLE
feature/CC-2491

### DIFF
--- a/domain/service/instance.go
+++ b/domain/service/instance.go
@@ -31,24 +31,6 @@ const (
 	Stopped               = "stopped"
 )
 
-// UintUsage reports usage information as unsigned integers
-type UintUsage struct {
-	Max      uint64
-	Avg      uint64
-	Last     uint64
-	LastHour []uint64
-	LastDay  []uint64
-}
-
-// FloatUsage reports usage information as floating point values
-type FloatUsage struct {
-	Max      float64
-	Avg      float64
-	Last     float64
-	LastHour []float64
-	LastDay  []float64
-}
-
 // Instance describes an instance of a service
 type Instance struct {
 	ID           int
@@ -61,8 +43,6 @@ type Instance struct {
 	DesiredState DesiredState
 	CurrentState CurrentState
 	HealthStatus map[string]health.Status
-	MemoryUsage  UintUsage
-	CPUUsage     FloatUsage
 	Scheduled    time.Time
 	Started      time.Time
 	Terminated   time.Time

--- a/facade/instance.go
+++ b/facade/instance.go
@@ -1,0 +1,170 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package facade
+
+import (
+	"github.com/control-center/serviced/commons"
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/dfs/docker"
+	"github.com/control-center/serviced/domain/host"
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/health"
+	zkservice "github.com/control-center/serviced/zzk/service"
+)
+
+// GetServiceInstances returns the state of all instances for a particular
+// service.
+func (f *Facade) GetServiceInstances(ctx datastore.Context, serviceID string) ([]service.Instance, error) {
+	svc, err := f.serviceStore.Get(ctx, serviceID)
+	if err != nil {
+		// TODO: error on loading service
+		return nil, err
+	}
+	states, err := f.zzk.GetServiceStates2(svc.PoolID, svc.ID)
+	if err != nil {
+		// TODO: error on loading states
+		return nil, err
+	}
+	insts := make([]service.Instance, len(states))
+	for i, state := range states {
+		inst, err := f.getInstance(ctx, state)
+		if err != nil {
+			// TODO: error on loading state
+			return nil, err
+		}
+		insts[i] = *inst
+	}
+
+	return insts, nil
+}
+
+// GetHostInstances returns the state of all instances for a particular host.
+func (f *Facade) GetHostInstances(ctx datastore.Context, hostID string) ([]service.Instance, error) {
+	var hst host.Host
+	err := f.hostStore.Get(ctx, host.HostKey(hostID), &hst)
+	if err != nil {
+		// TODO: error on loading host
+		return nil, err
+	}
+	states, err := f.zzk.GetHostStates(hst.PoolID, hst.ID)
+	if err != nil {
+		// TODO: error on loading states
+		return nil, err
+	}
+	insts := make([]service.Instance, len(states))
+	for i, state := range states {
+		inst, err := f.getInstance(ctx, state)
+		if err != nil {
+			// TODO: error on loading state
+			return nil, err
+		}
+		insts[i] = *inst
+	}
+
+	return insts, nil
+}
+
+// getInstance calculates the fields of the service instance object.
+func (f *Facade) getInstance(ctx datastore.Context, state zkservice.State) (*service.Instance, error) {
+	// get the service
+	svc, err := f.serviceStore.Get(ctx, state.ServiceID)
+	if err != nil {
+		// TODO: error on loading service
+		return nil, err
+	}
+
+	// get the image
+	imageID, err := commons.ParseImageID(svc.ImageID)
+	if err != nil {
+		// TODO: error on loading image
+		return nil, err
+	}
+	imageID.Tag = docker.Latest
+	img, err := f.registryStore.Get(ctx, imageID.String())
+	if err != nil {
+		// TODO: error on searching image registry
+		return nil, err
+	}
+
+	// get the host
+	var hst host.Host
+	err = f.hostStore.Get(ctx, host.HostKey(state.HostID), &hst)
+	if err != nil {
+		// TODO: error on loading host
+		return nil, err
+	}
+
+	// get the current state
+	var curState service.CurrentState
+	switch state.DesiredState {
+	case service.SVCStop:
+		if state.Terminated.After(state.Started) {
+			curState = service.Stopped
+		} else {
+			curState = service.Stopping
+		}
+	case service.SVCRun:
+		if state.Started.After(state.Terminated) && !state.Paused {
+			curState = service.Running
+		} else {
+			curState = service.Starting
+		}
+	case service.SVCPause:
+		if state.Started.After(state.Terminated) {
+			if state.Paused {
+				curState = service.Paused
+			} else {
+				curState = service.Pausing
+			}
+		} else {
+			curState = service.Stopped
+		}
+	default:
+		curState = ""
+	}
+
+	// get the health status
+	hstats := make(map[string]health.Status)
+	for name := range svc.HealthChecks {
+		key := health.HealthStatusKey{
+			ServiceID:       svc.ID,
+			InstanceID:      state.InstanceID,
+			HealthCheckName: name,
+		}
+		result, ok := f.hcache.Get(key)
+		if ok {
+			hstats[name] = result.Status
+		} else {
+			hstats[name] = health.Unknown
+		}
+	}
+
+	// TODO: get memory stats
+	// TODO: get cpu stats
+
+	inst := &service.Instance{
+		ID:           state.InstanceID,
+		HostID:       hst.ID,
+		HostName:     hst.Name,
+		ServiceID:    svc.ID,
+		ServiceName:  svc.Name,
+		DockerID:     state.DockerID,
+		ImageSynced:  img.UUID == state.ImageID,
+		DesiredState: state.DesiredState,
+		CurrentState: curState,
+		HealthStatus: hstats,
+	}
+
+	return inst, nil
+}

--- a/facade/instance_test.go
+++ b/facade/instance_test.go
@@ -1,0 +1,337 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package facade_test
+
+import (
+	"errors"
+	"time"
+
+	"github.com/control-center/serviced/domain/host"
+	"github.com/control-center/serviced/domain/registry"
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/facade"
+	"github.com/control-center/serviced/health"
+	zkservice "github.com/control-center/serviced/zzk/service"
+	"github.com/stretchr/testify/mock"
+	. "gopkg.in/check.v1"
+)
+
+var (
+	ErrTestZK         = errors.New("mock zookeeper error")
+	ErrTestHostStore  = errors.New("mock host store error")
+	ErrTestImageStore = errors.New("mock image store error")
+)
+
+func (ft *FacadeUnitTest) TestGetServiceInstances_ServiceNotFound(c *C) {
+	ft.serviceStore.On("Get", ft.ctx, "badservice").Return(nil, facade.ErrServiceDoesNotExist)
+	inst, err := ft.Facade.GetServiceInstances(ft.ctx, "badservice")
+	c.Assert(err, Equals, facade.ErrServiceDoesNotExist)
+	c.Assert(inst, IsNil)
+}
+
+func (ft *FacadeUnitTest) TestGetServiceInstances_StatesError(c *C) {
+	svc := &service.Service{
+		ID:           "testservice",
+		PoolID:       "default",
+		Name:         "serviceA",
+		ImageID:      "testtenant/image",
+		DesiredState: int(service.SVCRun),
+	}
+
+	ft.serviceStore.On("Get", ft.ctx, "testservice").Return(svc, nil)
+	ft.zzk.On("GetServiceStates2", "default", "testservice").Return(nil, ErrTestZK)
+	inst, err := ft.Facade.GetServiceInstances(ft.ctx, "testservice")
+	c.Assert(err, Equals, ErrTestZK)
+	c.Assert(inst, IsNil)
+}
+
+func (ft *FacadeUnitTest) TestGetServiceInstances_HostNotFound(c *C) {
+	svc := &service.Service{
+		ID:           "testservice",
+		PoolID:       "default",
+		Name:         "serviceA",
+		ImageID:      "testtenant/image",
+		DesiredState: int(service.SVCRun),
+	}
+	ft.serviceStore.On("Get", ft.ctx, "testservice").Return(svc, nil)
+
+	states := []zkservice.State{
+		{
+			HostID:     "testhost",
+			ServiceID:  "testservice",
+			InstanceID: 1,
+			HostState2: zkservice.HostState2{
+				DesiredState: service.SVCRun,
+				Scheduled:    time.Now(),
+			},
+			ServiceState: zkservice.ServiceState{
+				ImageID:  "someimageuuid",
+				Started:  time.Now(),
+				Paused:   false,
+				DockerID: "somecontainerid",
+			},
+		},
+	}
+	ft.zzk.On("GetServiceStates2", "default", "testservice").Return(states, nil)
+
+	ft.hostStore.On("Get", ft.ctx, host.HostKey("testhost"), mock.AnythingOfType("*host.Host")).Return(ErrTestHostStore)
+	inst, err := ft.Facade.GetServiceInstances(ft.ctx, "testservice")
+	c.Assert(err, Equals, ErrTestHostStore)
+	c.Assert(inst, IsNil)
+}
+
+func (ft *FacadeUnitTest) TestGetServiceInstances_BadImage(c *C) {
+	svc := &service.Service{
+		ID:           "testservice",
+		PoolID:       "default",
+		Name:         "serviceA",
+		ImageID:      "testtenant/image",
+		DesiredState: int(service.SVCRun),
+	}
+	ft.serviceStore.On("Get", ft.ctx, "testservice").Return(svc, nil)
+
+	states := []zkservice.State{
+		{
+			HostID:     "testhost",
+			ServiceID:  "testservice",
+			InstanceID: 1,
+			HostState2: zkservice.HostState2{
+				DesiredState: service.SVCRun,
+				Scheduled:    time.Now(),
+			},
+			ServiceState: zkservice.ServiceState{
+				ImageID:  "someimageuuid",
+				Started:  time.Now(),
+				Paused:   false,
+				DockerID: "somecontainerid",
+			},
+		},
+	}
+	ft.zzk.On("GetServiceStates2", "default", "testservice").Return(states, nil)
+
+	hst := &host.Host{
+		ID:     "testhost",
+		Name:   "sometest.host.org",
+		PoolID: "default",
+	}
+	ft.hostStore.On("Get", ft.ctx, host.HostKey("testhost"), mock.AnythingOfType("*host.Host")).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*host.Host)
+		*arg = *hst
+	})
+
+	ft.registryStore.On("Get", ft.ctx, "testtenant/image:latest").Return(nil, ErrTestImageStore)
+	inst, err := ft.Facade.GetServiceInstances(ft.ctx, "testservice")
+	c.Assert(err, Equals, ErrTestImageStore)
+	c.Assert(inst, IsNil)
+}
+
+func (ft *FacadeUnitTest) TestGetServiceInstances_Success(c *C) {
+	svc := &service.Service{
+		ID:           "testservice",
+		PoolID:       "default",
+		Name:         "serviceA",
+		ImageID:      "testtenant/image",
+		DesiredState: int(service.SVCRun),
+	}
+	ft.serviceStore.On("Get", ft.ctx, "testservice").Return(svc, nil)
+
+	states := []zkservice.State{
+		{
+			HostID:     "testhost",
+			ServiceID:  "testservice",
+			InstanceID: 1,
+			HostState2: zkservice.HostState2{
+				DesiredState: service.SVCRun,
+				Scheduled:    time.Now(),
+			},
+			ServiceState: zkservice.ServiceState{
+				ImageID:  "someimageuuid",
+				Started:  time.Now(),
+				Paused:   false,
+				DockerID: "somecontainerid",
+			},
+		},
+	}
+	ft.zzk.On("GetServiceStates2", "default", "testservice").Return(states, nil)
+
+	hst := &host.Host{
+		ID:     "testhost",
+		Name:   "sometest.host.org",
+		PoolID: "default",
+	}
+	ft.hostStore.On("Get", ft.ctx, host.HostKey("testhost"), mock.AnythingOfType("*host.Host")).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*host.Host)
+		*arg = *hst
+	})
+
+	img := &registry.Image{
+		Library: "testtenant",
+		Repo:    "image",
+		Tag:     "latest",
+		UUID:    "someimageuuid",
+	}
+	ft.registryStore.On("Get", ft.ctx, "testtenant/image:latest").Return(img, nil)
+
+	expected := []service.Instance{
+		{
+			ID:           1,
+			HostID:       "testhost",
+			HostName:     "sometest.host.org",
+			ServiceID:    "testservice",
+			ServiceName:  "serviceA",
+			DockerID:     "somecontainerid",
+			ImageSynced:  true,
+			DesiredState: service.SVCRun,
+			CurrentState: service.Running,
+			HealthStatus: make(map[string]health.Status),
+			Scheduled:    states[0].Scheduled,
+			Started:      states[0].Started,
+			Terminated:   states[0].Terminated,
+		},
+	}
+	actual, err := ft.Facade.GetServiceInstances(ft.ctx, "testservice")
+	c.Assert(err, IsNil)
+	c.Assert(actual, DeepEquals, expected)
+}
+
+func (ft *FacadeUnitTest) TestGetHostInstances_HostNotFound(c *C) {
+	ft.hostStore.On("Get", ft.ctx, host.HostKey("testhost"), mock.AnythingOfType("*host.Host")).Return(ErrTestHostStore)
+	inst, err := ft.Facade.GetHostInstances(ft.ctx, "testhost")
+	c.Assert(err, Equals, ErrTestHostStore)
+	c.Assert(inst, IsNil)
+}
+
+func (ft *FacadeUnitTest) TestGetHostInstances_StatesError(c *C) {
+	hst := &host.Host{
+		ID:     "testhost",
+		Name:   "sometest.host.org",
+		PoolID: "default",
+	}
+	ft.hostStore.On("Get", ft.ctx, host.HostKey("testhost"), mock.AnythingOfType("*host.Host")).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*host.Host)
+		*arg = *hst
+	})
+
+	ft.zzk.On("GetHostStates", "default", "testhost").Return(nil, ErrTestZK)
+	inst, err := ft.Facade.GetHostInstances(ft.ctx, "testhost")
+	c.Assert(err, Equals, ErrTestZK)
+	c.Assert(inst, IsNil)
+}
+
+func (ft *FacadeUnitTest) TestGetHostInstances_ServiceNotFound(c *C) {
+	hst := &host.Host{
+		ID:     "testhost",
+		Name:   "sometest.host.org",
+		PoolID: "default",
+	}
+	ft.hostStore.On("Get", ft.ctx, host.HostKey("testhost"), mock.AnythingOfType("*host.Host")).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*host.Host)
+		*arg = *hst
+	})
+
+	states := []zkservice.State{
+		{
+			HostID:     "testhost",
+			ServiceID:  "testservice",
+			InstanceID: 1,
+			HostState2: zkservice.HostState2{
+				DesiredState: service.SVCRun,
+				Scheduled:    time.Now(),
+			},
+			ServiceState: zkservice.ServiceState{
+				ImageID:  "someimageuuid",
+				Started:  time.Now(),
+				Paused:   false,
+				DockerID: "somecontainerid",
+			},
+		},
+	}
+	ft.zzk.On("GetHostStates", "default", "testhost").Return(states, nil)
+
+	ft.serviceStore.On("Get", ft.ctx, "testservice").Return(nil, facade.ErrServiceDoesNotExist)
+	inst, err := ft.Facade.GetHostInstances(ft.ctx, "testhost")
+	c.Assert(err, Equals, facade.ErrServiceDoesNotExist)
+	c.Assert(inst, IsNil)
+}
+
+func (ft *FacadeUnitTest) TestGetHostInstances_Success(c *C) {
+	hst := &host.Host{
+		ID:     "testhost",
+		Name:   "sometest.host.org",
+		PoolID: "default",
+	}
+	ft.hostStore.On("Get", ft.ctx, host.HostKey("testhost"), mock.AnythingOfType("*host.Host")).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*host.Host)
+		*arg = *hst
+	})
+
+	states := []zkservice.State{
+		{
+			HostID:     "testhost",
+			ServiceID:  "testservice",
+			InstanceID: 1,
+			HostState2: zkservice.HostState2{
+				DesiredState: service.SVCRun,
+				Scheduled:    time.Now(),
+			},
+			ServiceState: zkservice.ServiceState{
+				ImageID:  "someimageuuid",
+				Started:  time.Now(),
+				Paused:   false,
+				DockerID: "somecontainerid",
+			},
+		},
+	}
+	ft.zzk.On("GetHostStates", "default", "testhost").Return(states, nil)
+
+	svc := &service.Service{
+		ID:           "testservice",
+		PoolID:       "default",
+		Name:         "serviceA",
+		ImageID:      "testtenant/image",
+		DesiredState: int(service.SVCRun),
+	}
+	ft.serviceStore.On("Get", ft.ctx, "testservice").Return(svc, nil)
+
+	img := &registry.Image{
+		Library: "testtenant",
+		Repo:    "image",
+		Tag:     "latest",
+		UUID:    "someimageuuid",
+	}
+	ft.registryStore.On("Get", ft.ctx, "testtenant/image:latest").Return(img, nil)
+
+	expected := []service.Instance{
+		{
+			ID:           1,
+			HostID:       "testhost",
+			HostName:     "sometest.host.org",
+			ServiceID:    "testservice",
+			ServiceName:  "serviceA",
+			DockerID:     "somecontainerid",
+			ImageSynced:  true,
+			DesiredState: service.SVCRun,
+			CurrentState: service.Running,
+			HealthStatus: make(map[string]health.Status),
+			Scheduled:    states[0].Scheduled,
+			Started:      states[0].Started,
+			Terminated:   states[0].Terminated,
+		},
+	}
+	actual, err := ft.Facade.GetHostInstances(ft.ctx, "testhost")
+	c.Assert(err, IsNil)
+	c.Assert(actual, DeepEquals, expected)
+}

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -110,4 +110,8 @@ type FacadeInterface interface {
 	RemovePublicEndpointVHost(ctx datastore.Context, serviceid, endpointName, vhost string) error
 
 	EnablePublicEndpointVHost(ctx datastore.Context, serviceid, endpointName, vhost string, isEnabled bool) error
+
+	GetHostInstances(ctx datastore.Context, hostid string) ([]service.Instance, error)
+
+	GetServiceInstances(ctx datastore.Context, serviceid string) ([]service.Instance, error)
 }

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -1,177 +1,287 @@
-// Copyright 2015 The Serviced Authors.
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package mocks
 
-import (
-	"time"
+import "github.com/stretchr/testify/mock"
 
-	"github.com/control-center/serviced/dao"
-	"github.com/control-center/serviced/datastore"
-	"github.com/control-center/serviced/domain/addressassignment"
-	"github.com/control-center/serviced/domain/host"
-	"github.com/control-center/serviced/domain/pool"
-	"github.com/control-center/serviced/domain/service"
-	"github.com/control-center/serviced/domain/servicedefinition"
-	"github.com/control-center/serviced/domain/servicestate"
-	"github.com/control-center/serviced/domain/servicetemplate"
-	"github.com/control-center/serviced/health"
-	"github.com/stretchr/testify/mock"
-)
+import "time"
+import "github.com/control-center/serviced/dao"
+import "github.com/control-center/serviced/datastore"
+import "github.com/control-center/serviced/health"
+import "github.com/control-center/serviced/domain/addressassignment"
+import "github.com/control-center/serviced/domain/host"
+import "github.com/control-center/serviced/domain/pool"
+import "github.com/control-center/serviced/domain/service"
+import "github.com/control-center/serviced/domain/servicedefinition"
+import "github.com/control-center/serviced/domain/servicestate"
+import "github.com/control-center/serviced/domain/servicetemplate"
 
 type FacadeInterface struct {
 	mock.Mock
 }
 
-func (m *FacadeInterface) AddService(ctx datastore.Context, svc service.Service) error {
-	ret := m.Called(ctx, svc)
+func (_m *FacadeInterface) AddService(ctx datastore.Context, svc service.Service) error {
+	ret := _m.Called(ctx, svc)
 
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, service.Service) error); ok {
+		r0 = rf(ctx, svc)
+	} else {
+		r0 = ret.Error(0)
+	}
 
 	return r0
 }
-func (m *FacadeInterface) GetService(ctx datastore.Context, id string) (*service.Service, error) {
-	ret := m.Called(ctx, id)
+func (_m *FacadeInterface) GetService(ctx datastore.Context, id string) (*service.Service, error) {
+	ret := _m.Called(ctx, id)
 
 	var r0 *service.Service
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(*service.Service)
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) *service.Service); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*service.Service)
+		}
 	}
-	r1 := ret.Error(1)
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
-func (m *FacadeInterface) GetServices(ctx datastore.Context, request dao.EntityRequest) ([]service.Service, error) {
-	ret := m.Called(ctx, request)
+func (_m *FacadeInterface) GetServices(ctx datastore.Context, request dao.EntityRequest) ([]service.Service, error) {
+	ret := _m.Called(ctx, request)
 
 	var r0 []service.Service
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]service.Service)
+	if rf, ok := ret.Get(0).(func(datastore.Context, dao.EntityRequest) []service.Service); ok {
+		r0 = rf(ctx, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]service.Service)
+		}
 	}
-	r1 := ret.Error(1)
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, dao.EntityRequest) error); ok {
+		r1 = rf(ctx, request)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
-func (m *FacadeInterface) GetServicesByImage(ctx datastore.Context, imageID string) ([]service.Service, error) {
-	ret := m.Called(ctx, imageID)
+func (_m *FacadeInterface) GetServicesByImage(ctx datastore.Context, imageID string) ([]service.Service, error) {
+	ret := _m.Called(ctx, imageID)
 
 	var r0 []service.Service
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]service.Service)
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) []service.Service); ok {
+		r0 = rf(ctx, imageID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]service.Service)
+		}
 	}
-	r1 := ret.Error(1)
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, imageID)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
-func (m *FacadeInterface) GetServiceStates(ctx datastore.Context, serviceID string) ([]servicestate.ServiceState, error) {
-	ret := m.Called(ctx, serviceID)
+func (_m *FacadeInterface) GetServiceStates(ctx datastore.Context, serviceID string) ([]servicestate.ServiceState, error) {
+	ret := _m.Called(ctx, serviceID)
 
 	var r0 []servicestate.ServiceState
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]servicestate.ServiceState)
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) []servicestate.ServiceState); ok {
+		r0 = rf(ctx, serviceID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]servicestate.ServiceState)
+		}
 	}
-	r1 := ret.Error(1)
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, serviceID)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
-func (m *FacadeInterface) GetTenantID(ctx datastore.Context, serviceID string) (string, error) {
-	ret := m.Called(ctx, serviceID)
+func (_m *FacadeInterface) GetTenantID(ctx datastore.Context, serviceID string) (string, error) {
+	ret := _m.Called(ctx, serviceID)
 
-	r0 := ret.Get(0).(string)
-	r1 := ret.Error(1)
+	var r0 string
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) string); ok {
+		r0 = rf(ctx, serviceID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
 
-	return r0, r1
-}
-func (m *FacadeInterface) MigrateServices(ctx datastore.Context, request dao.ServiceMigrationRequest) error {
-	ret := m.Called(ctx, request)
-
-	r0 := ret.Error(0)
-
-	return r0
-}
-func (m *FacadeInterface) RemoveService(ctx datastore.Context, id string) error {
-	ret := m.Called(ctx, id)
-
-	r0 := ret.Error(0)
-
-	return r0
-}
-func (m *FacadeInterface) ScheduleService(ctx datastore.Context, serviceID string, autoLaunch bool, desiredState service.DesiredState) (int, error) {
-	ret := m.Called(ctx, serviceID, autoLaunch, desiredState)
-
-	r0 := ret.Get(0).(int)
-	r1 := ret.Error(1)
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, serviceID)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
-func (m *FacadeInterface) UpdateService(ctx datastore.Context, svc service.Service) error {
-	ret := m.Called(ctx, svc)
+func (_m *FacadeInterface) MigrateServices(ctx datastore.Context, request dao.ServiceMigrationRequest) error {
+	ret := _m.Called(ctx, request)
 
-	r0 := ret.Error(0)
-
-	return r0
-}
-func (m *FacadeInterface) WaitService(ctx datastore.Context, dstate service.DesiredState, timeout time.Duration, recursive bool, serviceIDs ...string) error {
-	ret := m.Called(ctx, dstate, timeout, recursive, serviceIDs)
-
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, dao.ServiceMigrationRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
 
 	return r0
 }
-func (m *FacadeInterface) AssignIPs(ctx datastore.Context, assignmentRequest addressassignment.AssignmentRequest) (err error) {
-	ret := m.Called(ctx, assignmentRequest)
+func (_m *FacadeInterface) RemoveService(ctx datastore.Context, id string) error {
+	ret := _m.Called(ctx, id)
 
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
 
 	return r0
 }
-func (m *FacadeInterface) AddServiceTemplate(ctx datastore.Context, serviceTemplate servicetemplate.ServiceTemplate) (string, error) {
-	ret := m.Called(ctx, serviceTemplate)
+func (_m *FacadeInterface) ScheduleService(ctx datastore.Context, serviceID string, autoLaunch bool, desiredState service.DesiredState) (int, error) {
+	ret := _m.Called(ctx, serviceID, autoLaunch, desiredState)
 
-	r0 := ret.Get(0).(string)
-	r1 := ret.Error(1)
+	var r0 int
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, bool, service.DesiredState) int); ok {
+		r0 = rf(ctx, serviceID, autoLaunch, desiredState)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string, bool, service.DesiredState) error); ok {
+		r1 = rf(ctx, serviceID, autoLaunch, desiredState)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
-func (m *FacadeInterface) GetServiceTemplates(ctx datastore.Context) (map[string]servicetemplate.ServiceTemplate, error) {
-	ret := m.Called(ctx)
+func (_m *FacadeInterface) UpdateService(ctx datastore.Context, svc service.Service) error {
+	ret := _m.Called(ctx, svc)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, service.Service) error); ok {
+		r0 = rf(ctx, svc)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *FacadeInterface) WaitService(ctx datastore.Context, dstate service.DesiredState, timeout time.Duration, recursive bool, serviceIDs ...string) error {
+	ret := _m.Called(ctx, dstate, timeout, recursive, serviceIDs)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, service.DesiredState, time.Duration, bool, ...string) error); ok {
+		r0 = rf(ctx, dstate, timeout, recursive, serviceIDs...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *FacadeInterface) AssignIPs(ctx datastore.Context, assignmentRequest addressassignment.AssignmentRequest) error {
+	ret := _m.Called(ctx, assignmentRequest)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, addressassignment.AssignmentRequest) error); ok {
+		r0 = rf(ctx, assignmentRequest)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *FacadeInterface) AddServiceTemplate(ctx datastore.Context, serviceTemplate servicetemplate.ServiceTemplate) (string, error) {
+	ret := _m.Called(ctx, serviceTemplate)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(datastore.Context, servicetemplate.ServiceTemplate) string); ok {
+		r0 = rf(ctx, serviceTemplate)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, servicetemplate.ServiceTemplate) error); ok {
+		r1 = rf(ctx, serviceTemplate)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *FacadeInterface) GetServiceTemplates(ctx datastore.Context) (map[string]servicetemplate.ServiceTemplate, error) {
+	ret := _m.Called(ctx)
 
 	var r0 map[string]servicetemplate.ServiceTemplate
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(map[string]servicetemplate.ServiceTemplate)
+	if rf, ok := ret.Get(0).(func(datastore.Context) map[string]servicetemplate.ServiceTemplate); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]servicetemplate.ServiceTemplate)
+		}
 	}
-	r1 := ret.Error(1)
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
-func (m *FacadeInterface) RemoveServiceTemplate(ctx datastore.Context, templateID string) error {
-	ret := m.Called(ctx, templateID)
+func (_m *FacadeInterface) RemoveServiceTemplate(ctx datastore.Context, templateID string) error {
+	ret := _m.Called(ctx, templateID)
 
-	return ret.Error(0)
-}
-func (m *FacadeInterface) UpdateServiceTemplate(ctx datastore.Context, template servicetemplate.ServiceTemplate) error {
-	ret := m.Called(ctx, template)
-
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) error); ok {
+		r0 = rf(ctx, templateID)
+	} else {
+		r0 = ret.Error(0)
+	}
 
 	return r0
 }
-func (m *FacadeInterface) DeployTemplate(ctx datastore.Context, poolID string, templateID string, deploymentID string) ([]string, error) {
-	ret := m.Called(ctx, poolID, templateID, deploymentID)
+func (_m *FacadeInterface) UpdateServiceTemplate(ctx datastore.Context, template servicetemplate.ServiceTemplate) error {
+	ret := _m.Called(ctx, template)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, servicetemplate.ServiceTemplate) error); ok {
+		r0 = rf(ctx, template)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *FacadeInterface) DeployTemplate(ctx datastore.Context, poolID string, templateID string, deploymentID string) ([]string, error) {
+	ret := _m.Called(ctx, poolID, templateID, deploymentID)
 
 	var r0 []string
-	if rf, ok := ret.Get(0).(func() []string); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string, string) []string); ok {
+		r0 = rf(ctx, poolID, templateID, deploymentID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -179,16 +289,16 @@ func (m *FacadeInterface) DeployTemplate(ctx datastore.Context, poolID string, t
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(datastore.Context, string, string, string) error); ok {
+		r1 = rf(ctx, poolID, templateID, deploymentID)
 	} else {
 		r1 = ret.Error(1)
 	}
 
 	return r0, r1
 }
-func (m *FacadeInterface) DeployTemplateActive() (active []map[string]string, err error) {
-	ret := m.Called()
+func (_m *FacadeInterface) DeployTemplateActive() ([]map[string]string, error) {
+	ret := _m.Called()
 
 	var r0 []map[string]string
 	if rf, ok := ret.Get(0).(func() []map[string]string); ok {
@@ -208,222 +318,413 @@ func (m *FacadeInterface) DeployTemplateActive() (active []map[string]string, er
 
 	return r0, r1
 }
-func (m *FacadeInterface) DeployTemplateStatus(deploymentID string) (status string, err error) {
-	ret := m.Called(deploymentID)
+func (_m *FacadeInterface) DeployTemplateStatus(deploymentID string) (string, error) {
+	ret := _m.Called(deploymentID)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(deploymentID)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(string)
-		}
+		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(deploymentID)
 	} else {
 		r1 = ret.Error(1)
 	}
 
 	return r0, r1
 }
-func (m *FacadeInterface) AddHost(ctx datastore.Context, entity *host.Host) error {
-	ret := m.Called(ctx, entity)
-
-	r0 := ret.Error(0)
-
-	return r0
-}
-func (m *FacadeInterface) GetHost(ctx datastore.Context, hostID string) (*host.Host, error) {
-	ret := m.Called(ctx, hostID)
-
-	var r0 *host.Host
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(*host.Host)
-	}
-	r1 := ret.Error(1)
-
-	return r0, r1
-}
-func (m *FacadeInterface) GetHosts(ctx datastore.Context) ([]host.Host, error) {
-	ret := m.Called(ctx)
-
-	var r0 []host.Host
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]host.Host)
-	}
-	r1 := ret.Error(1)
-
-	return r0, r1
-}
-func (m *FacadeInterface) GetActiveHostIDs(ctx datastore.Context) ([]string, error) {
-	ret := m.Called(ctx)
-
-	var r0 []string
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]string)
-	}
-	r1 := ret.Error(1)
-
-	return r0, r1
-}
-func (m *FacadeInterface) UpdateHost(ctx datastore.Context, entity *host.Host) error {
-	ret := m.Called(ctx, entity)
-
-	r0 := ret.Error(0)
-
-	return r0
-}
-func (m *FacadeInterface) RemoveHost(ctx datastore.Context, hostID string) error {
-	ret := m.Called(ctx, hostID)
-
-	r0 := ret.Error(0)
-
-	return r0
-}
-func (m *FacadeInterface) FindHostsInPool(ctx datastore.Context, poolID string) ([]host.Host, error) {
-	ret := m.Called(ctx, poolID)
-
-	var r0 []host.Host
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]host.Host)
-	}
-	r1 := ret.Error(1)
-
-	return r0, r1
-}
-func (m *FacadeInterface) AddResourcePool(ctx datastore.Context, entity *pool.ResourcePool) error {
-	ret := m.Called(ctx, entity)
-
-	r0 := ret.Error(0)
-
-	return r0
-}
-func (m *FacadeInterface) GetResourcePool(ctx datastore.Context, poolID string) (*pool.ResourcePool, error) {
-	ret := m.Called(ctx, poolID)
-
-	var r0 *pool.ResourcePool
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(*pool.ResourcePool)
-	}
-	r1 := ret.Error(1)
-
-	return r0, r1
-}
-func (m *FacadeInterface) GetResourcePools(ctx datastore.Context) ([]pool.ResourcePool, error) {
-	ret := m.Called(ctx)
-
-	var r0 []pool.ResourcePool
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]pool.ResourcePool)
-	}
-	r1 := ret.Error(1)
-
-	return r0, r1
-}
-func (m *FacadeInterface) GetPoolIPs(ctx datastore.Context, poolID string) (*pool.PoolIPs, error) {
-	ret := m.Called(ctx, poolID)
-
-	var r0 *pool.PoolIPs
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(*pool.PoolIPs)
-	}
-	r1 := ret.Error(1)
-
-	return r0, r1
-}
-func (m *FacadeInterface) HasIP(ctx datastore.Context, poolID string, ipAddr string) (bool, error) {
-	ret := m.Called(ctx, poolID, ipAddr)
-
-	r0 := ret.Get(0).(bool)
-	r1 := ret.Error(1)
-
-	return r0, r1
-}
-func (m *FacadeInterface) RemoveResourcePool(ctx datastore.Context, id string) error {
-	ret := m.Called(ctx, id)
-
-	r0 := ret.Error(0)
-
-	return r0
-}
-func (m *FacadeInterface) UpdateResourcePool(ctx datastore.Context, entity *pool.ResourcePool) error {
-	ret := m.Called(ctx, entity)
-
-	r0 := ret.Error(0)
-
-	return r0
-}
-func (m *FacadeInterface) GetHealthChecksForService(ctx datastore.Context, id string) (map[string]health.HealthCheck, error) {
-	ret := m.Called(ctx, id)
-
-	var r0 map[string]health.HealthCheck
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(map[string]health.HealthCheck)
-	}
-	r1 := ret.Error(1)
-
-	return r0, r1
-}
-func (_m *FacadeInterface) UpgradeRegistry(ctx datastore.Context, fromRegistryHost string, force bool) error {
-	ret := _m.Called(ctx, fromRegistryHost, force)
+func (_m *FacadeInterface) AddHost(ctx datastore.Context, entity *host.Host) error {
+	ret := _m.Called(ctx, entity)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(datastore.Context, string, bool) error); ok {
-		r0 = rf(ctx, fromRegistryHost, force)
+	if rf, ok := ret.Get(0).(func(datastore.Context, *host.Host) error); ok {
+		r0 = rf(ctx, entity)
 	} else {
 		r0 = ret.Error(0)
 	}
 
 	return r0
 }
+func (_m *FacadeInterface) GetHost(ctx datastore.Context, hostID string) (*host.Host, error) {
+	ret := _m.Called(ctx, hostID)
 
-func (m *FacadeInterface) AddPublicEndpointPort(ctx datastore.Context, serviceid, endpointName, portAddr string, usetls bool, protocol string, isEnabled, restart bool) (*servicedefinition.Port, error) {
-	ret := m.Called(ctx, serviceid, endpointName, portAddr, usetls, protocol, isEnabled, restart)
+	var r0 *host.Host
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) *host.Host); ok {
+		r0 = rf(ctx, hostID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*host.Host)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, hostID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *FacadeInterface) GetHosts(ctx datastore.Context) ([]host.Host, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []host.Host
+	if rf, ok := ret.Get(0).(func(datastore.Context) []host.Host); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]host.Host)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *FacadeInterface) GetActiveHostIDs(ctx datastore.Context) ([]string, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(datastore.Context) []string); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *FacadeInterface) UpdateHost(ctx datastore.Context, entity *host.Host) error {
+	ret := _m.Called(ctx, entity)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, *host.Host) error); ok {
+		r0 = rf(ctx, entity)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *FacadeInterface) RemoveHost(ctx datastore.Context, hostID string) error {
+	ret := _m.Called(ctx, hostID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) error); ok {
+		r0 = rf(ctx, hostID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *FacadeInterface) FindHostsInPool(ctx datastore.Context, poolID string) ([]host.Host, error) {
+	ret := _m.Called(ctx, poolID)
+
+	var r0 []host.Host
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) []host.Host); ok {
+		r0 = rf(ctx, poolID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]host.Host)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, poolID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *FacadeInterface) AddResourcePool(ctx datastore.Context, entity *pool.ResourcePool) error {
+	ret := _m.Called(ctx, entity)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, *pool.ResourcePool) error); ok {
+		r0 = rf(ctx, entity)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *FacadeInterface) GetResourcePool(ctx datastore.Context, poolID string) (*pool.ResourcePool, error) {
+	ret := _m.Called(ctx, poolID)
+
+	var r0 *pool.ResourcePool
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) *pool.ResourcePool); ok {
+		r0 = rf(ctx, poolID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pool.ResourcePool)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, poolID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *FacadeInterface) GetResourcePools(ctx datastore.Context) ([]pool.ResourcePool, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []pool.ResourcePool
+	if rf, ok := ret.Get(0).(func(datastore.Context) []pool.ResourcePool); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]pool.ResourcePool)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *FacadeInterface) GetPoolIPs(ctx datastore.Context, poolID string) (*pool.PoolIPs, error) {
+	ret := _m.Called(ctx, poolID)
+
+	var r0 *pool.PoolIPs
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) *pool.PoolIPs); ok {
+		r0 = rf(ctx, poolID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pool.PoolIPs)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, poolID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *FacadeInterface) HasIP(ctx datastore.Context, poolID string, ipAddr string) (bool, error) {
+	ret := _m.Called(ctx, poolID, ipAddr)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string) bool); ok {
+		r0 = rf(ctx, poolID, ipAddr)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string, string) error); ok {
+		r1 = rf(ctx, poolID, ipAddr)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *FacadeInterface) RemoveResourcePool(ctx datastore.Context, id string) error {
+	ret := _m.Called(ctx, id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *FacadeInterface) UpdateResourcePool(ctx datastore.Context, entity *pool.ResourcePool) error {
+	ret := _m.Called(ctx, entity)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, *pool.ResourcePool) error); ok {
+		r0 = rf(ctx, entity)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *FacadeInterface) GetHealthChecksForService(ctx datastore.Context, id string) (map[string]health.HealthCheck, error) {
+	ret := _m.Called(ctx, id)
+
+	var r0 map[string]health.HealthCheck
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) map[string]health.HealthCheck); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]health.HealthCheck)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *FacadeInterface) AddPublicEndpointPort(ctx datastore.Context, serviceid string, endpointName string, portAddr string, usetls bool, protocol string, isEnabled bool, restart bool) (*servicedefinition.Port, error) {
+	ret := _m.Called(ctx, serviceid, endpointName, portAddr, usetls, protocol, isEnabled, restart)
 
 	var r0 *servicedefinition.Port
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(*servicedefinition.Port)
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string, string, bool, string, bool, bool) *servicedefinition.Port); ok {
+		r0 = rf(ctx, serviceid, endpointName, portAddr, usetls, protocol, isEnabled, restart)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*servicedefinition.Port)
+		}
 	}
-	r1 := ret.Error(1)
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string, string, string, bool, string, bool, bool) error); ok {
+		r1 = rf(ctx, serviceid, endpointName, portAddr, usetls, protocol, isEnabled, restart)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
+func (_m *FacadeInterface) RemovePublicEndpointPort(ctx datastore.Context, serviceid string, endpointName string, portAddr string) error {
+	ret := _m.Called(ctx, serviceid, endpointName, portAddr)
 
-func (m *FacadeInterface) RemovePublicEndpointPort(ctx datastore.Context, serviceid, endpointName, portAddr string) error {
-	ret := m.Called(ctx, serviceid, endpointName, portAddr)
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string, string) error); ok {
+		r0 = rf(ctx, serviceid, endpointName, portAddr)
+	} else {
+		r0 = ret.Error(0)
+	}
+
 	return r0
 }
+func (_m *FacadeInterface) EnablePublicEndpointPort(ctx datastore.Context, serviceid string, endpointName string, portAddr string, isEnabled bool) error {
+	ret := _m.Called(ctx, serviceid, endpointName, portAddr, isEnabled)
 
-func (m *FacadeInterface) EnablePublicEndpointPort(ctx datastore.Context, serviceid, endpointName, portAddr string, isEnabled bool) error {
-	ret := m.Called(ctx, serviceid, endpointName, portAddr, isEnabled)
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string, string, bool) error); ok {
+		r0 = rf(ctx, serviceid, endpointName, portAddr, isEnabled)
+	} else {
+		r0 = ret.Error(0)
+	}
+
 	return r0
 }
-
-func (m *FacadeInterface) AddPublicEndpointVHost(ctx datastore.Context, serviceid, endpointName, vhost string, isEnabled, restart bool) (*servicedefinition.VHost, error) {
-	ret := m.Called(ctx, serviceid, endpointName, vhost, isEnabled, restart)
+func (_m *FacadeInterface) AddPublicEndpointVHost(ctx datastore.Context, serviceid string, endpointName string, vhost string, isEnabled bool, restart bool) (*servicedefinition.VHost, error) {
+	ret := _m.Called(ctx, serviceid, endpointName, vhost, isEnabled, restart)
 
 	var r0 *servicedefinition.VHost
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(*servicedefinition.VHost)
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string, string, bool, bool) *servicedefinition.VHost); ok {
+		r0 = rf(ctx, serviceid, endpointName, vhost, isEnabled, restart)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*servicedefinition.VHost)
+		}
 	}
-	r1 := ret.Error(1)
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string, string, string, bool, bool) error); ok {
+		r1 = rf(ctx, serviceid, endpointName, vhost, isEnabled, restart)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
+func (_m *FacadeInterface) RemovePublicEndpointVHost(ctx datastore.Context, serviceid string, endpointName string, vhost string) error {
+	ret := _m.Called(ctx, serviceid, endpointName, vhost)
 
-func (m *FacadeInterface) RemovePublicEndpointVHost(ctx datastore.Context, serviceid, endpointName, vhost string) error {
-	ret := m.Called(ctx, serviceid, endpointName, vhost)
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string, string) error); ok {
+		r0 = rf(ctx, serviceid, endpointName, vhost)
+	} else {
+		r0 = ret.Error(0)
+	}
+
 	return r0
 }
+func (_m *FacadeInterface) EnablePublicEndpointVHost(ctx datastore.Context, serviceid string, endpointName string, vhost string, isEnabled bool) error {
+	ret := _m.Called(ctx, serviceid, endpointName, vhost, isEnabled)
 
-func (m *FacadeInterface) EnablePublicEndpointVHost(ctx datastore.Context, serviceid, endpointName, vhost string, isEnabled bool) error {
-	ret := m.Called(ctx, serviceid, endpointName, vhost, isEnabled)
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string, string, bool) error); ok {
+		r0 = rf(ctx, serviceid, endpointName, vhost, isEnabled)
+	} else {
+		r0 = ret.Error(0)
+	}
+
 	return r0
+}
+func (_m *FacadeInterface) GetHostInstances(ctx datastore.Context, hostid string) ([]service.Instance, error) {
+	ret := _m.Called(ctx, hostid)
+
+	var r0 []service.Instance
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) []service.Instance); ok {
+		r0 = rf(ctx, hostid)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]service.Instance)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, hostid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *FacadeInterface) GetServiceInstances(ctx datastore.Context, serviceid string) ([]service.Instance, error) {
+	ret := _m.Called(ctx, serviceid)
+
+	var r0 []service.Instance
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) []service.Instance); ok {
+		r0 = rf(ctx, serviceid)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]service.Instance)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, serviceid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }

--- a/facade/mocks/ZZK.go
+++ b/facade/mocks/ZZK.go
@@ -9,12 +9,13 @@ import "github.com/control-center/serviced/domain/registry"
 import "github.com/control-center/serviced/domain/service"
 import "github.com/control-center/serviced/domain/servicestate"
 import zkregistry "github.com/control-center/serviced/zzk/registry"
+import zkservice "github.com/control-center/serviced/zzk/service"
 
 type ZZK struct {
 	mock.Mock
 }
 
-func (_m *ZZK) UpdateService(svc *service.Service, setLockOnCreate, setLockOnUpdate bool) error {
+func (_m *ZZK) UpdateService(svc *service.Service, setLockOnCreate bool, setLockOnUpdate bool) error {
 	ret := _m.Called(svc, setLockOnCreate, setLockOnUpdate)
 
 	var r0 error
@@ -286,4 +287,46 @@ func (_m *ZZK) GetServiceEndpoints(tenantID string, serviceID string, endpoints 
 	}
 
 	return r0
+}
+func (_m *ZZK) GetServiceStates2(poolID string, serviceID string) ([]zkservice.State, error) {
+	ret := _m.Called(poolID, serviceID)
+
+	var r0 []zkservice.State
+	if rf, ok := ret.Get(0).(func(string, string) []zkservice.State); ok {
+		r0 = rf(poolID, serviceID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]zkservice.State)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(poolID, serviceID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *ZZK) GetHostStates(poolID string, hostID string) ([]zkservice.State, error) {
+	ret := _m.Called(poolID, hostID)
+
+	var r0 []zkservice.State
+	if rf, ok := ret.Get(0).(func(string, string) []zkservice.State); ok {
+		r0 = rf(poolID, hostID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]zkservice.State)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(poolID, hostID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }

--- a/facade/zkapi.go
+++ b/facade/zkapi.go
@@ -301,3 +301,26 @@ func (zk *zkf) GetServiceEndpoints(tenantID, serviceID string, result *[]applica
 	}
 	return nil
 }
+
+// GetServiceStates2 returns all running instances for a service
+// FIXME: update name when integration is complete
+func (zk *zkf) GetServiceStates2(poolID, serviceID string) ([]zkservice.State, error) {
+	conn, err := zzk.GetLocalConnection("/")
+	if err != nil {
+		glog.Errorf("Could not get connection to zookeeper: %s", err)
+		return nil, err
+	}
+
+	return zkservice.GetServiceStates2(conn, poolID, serviceID)
+}
+
+// GetHostStates returns all running instances for a host
+func (zk *zkf) GetHostStates(poolID, hostID string) ([]zkservice.State, error) {
+	conn, err := zzk.GetLocalConnection("/")
+	if err != nil {
+		glog.Errorf("Could not get connection to zookeeper: %s", err)
+		return nil, err
+	}
+
+	return zkservice.GetHostStates(conn, poolID, hostID)
+}

--- a/facade/zzk.go
+++ b/facade/zzk.go
@@ -21,6 +21,7 @@ import (
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/domain/servicestate"
 	zkregistry "github.com/control-center/serviced/zzk/registry"
+	zkservice "github.com/control-center/serviced/zzk/service"
 )
 
 type ZZK interface {
@@ -46,6 +47,8 @@ type ZZK interface {
 	LockServices(svcs []service.Service) error
 	UnlockServices(svcs []service.Service) error
 	GetServiceEndpoints(tenantID, serviceID string, endpoints *[]applicationendpoint.ApplicationEndpoint) error
+	GetServiceStates2(poolID, serviceID string) ([]zkservice.State, error) // FIXME: update when integration is complete
+	GetHostStates(poolID, hostID string) ([]zkservice.State, error)
 }
 
 func GetFacadeZZK(f *Facade) ZZK {

--- a/web/hostresource.go
+++ b/web/hostresource.go
@@ -51,6 +51,52 @@ func restGetHosts(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) 
 	w.WriteJson(&response)
 }
 
+func restGetHostInstances(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
+	hostID, err := url.QueryUnescape(r.PathParam("hostId"))
+	if err != nil {
+		restBadRequest(w, err)
+		return
+	} else if len(hostID) == 0 {
+		restBadRequest(w, fmt.Errorf("hostID must be specified for GET"))
+		return
+	}
+
+	facade := ctx.getFacade()
+	dataCtx := ctx.getDatastoreContext()
+	instances, err := facade.GetHostInstances(dataCtx, hostID)
+	if err != nil {
+		glog.Error("Could not get host instances:", err)
+		restServerError(w, err)
+		return
+	}
+
+	glog.V(4).Infof("restGetHostInstances: id %s, instances %#v", hostID, instances)
+	w.WriteJson(&instances)
+}
+
+func restGetServiceInstances(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
+	serviceID, err := url.QueryUnescape(r.PathParam("serviceId"))
+	if err != nil {
+		restBadRequest(w, err)
+		return
+	} else if len(serviceID) == 0 {
+		restBadRequest(w, fmt.Errorf("serviceID must be specified for GET"))
+		return
+	}
+
+	facade := ctx.getFacade()
+	dataCtx := ctx.getDatastoreContext()
+	instances, err := facade.GetServiceInstances(dataCtx, serviceID)
+	if err != nil {
+		glog.Error("Could not get service instances:", err)
+		restServerError(w, err)
+		return
+	}
+
+	glog.V(4).Infof("restGetServiceInstances: id %s, instances %#v", serviceID, instances)
+	w.WriteJson(&instances)
+}
+
 func restGetActiveHostIDs(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
 	facade := ctx.getFacade()
 	dataCtx := ctx.getDatastoreContext()

--- a/web/routes.go
+++ b/web/routes.go
@@ -40,6 +40,7 @@ func (sc *ServiceConfig) getRoutes() []rest.Route {
 		rest.Route{"PUT", "/hosts/:hostId", gz(sc.checkAuth(restUpdateHost))},
 		rest.Route{"GET", "/hosts/:hostId/running", gz(sc.authorizedClient(restGetRunningForHost))},
 		rest.Route{"DELETE", "/hosts/:hostId/:serviceStateId", gz(sc.authorizedClient(restKillRunning))},
+		rest.Route{"GET", "/hosts/:hostId/instances", gz(sc.checkAuth(restGetHostInstances))},
 
 		// Pools
 		rest.Route{"GET", "/pools/:poolId", gz(sc.checkAuth(restGetPool))},
@@ -75,6 +76,7 @@ func (sc *ServiceConfig) getRoutes() []rest.Route {
 		rest.Route{"PUT", "/services/:serviceId/startService", gz(sc.authorizedClient(restStartService))},
 		rest.Route{"PUT", "/services/:serviceId/stopService", gz(sc.authorizedClient(restStopService))},
 		rest.Route{"POST", "/services/:serviceId/migrate", sc.authorizedClient(restPostServicesForMigration)},
+		rest.Route{"GET", "/hosts/:serviceId/instances", gz(sc.checkAuth(restGetServiceInstances))},
 
 		// Services (Virtual Host)
 		rest.Route{"GET", "/services/vhosts", gz(sc.authorizedClient(restGetVirtualHosts))},

--- a/web/servicetemplateresource_test.go
+++ b/web/servicetemplateresource_test.go
@@ -232,7 +232,7 @@ func (s *TestWebSuite) TestRestDeployAppTemplateStatusFails(c *C) {
 	request := s.buildRequest("POST", "/templates/deploy/status", requestJSON)
 	s.mockFacade.
 		On("DeployTemplateStatus", deploymentID).
-		Return(nil, expectedError)
+		Return("", expectedError)
 
 	restDeployAppTemplateStatus(&(s.writer), &request, s.ctx)
 


### PR DESCRIPTION
This is for querying service instance data in the new format.  The new format is still not integrated into the code base.

* Added business logic to parse the zk state information and transform it into a service domain instance object
* Added rest endpoint at /services/:serviceId/instances to return instance info from a service
* Added rest endpoint at /hosts/:hostId/instances to return instance info from a host
* Regenerated facade mocks
* Logging on the facade instances