### PR TITLE
Create a better mux protocol wherein the header has a non-variable size

### DIFF
--- a/proxy/mux_test.go
+++ b/proxy/mux_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/control-center/serviced/utils"
 )
 
 type echoListener struct {
@@ -123,8 +125,11 @@ func TestTCPMux(t *testing.T) {
 	testMsg := "\nhello\n"
 
 	conn := mux.testConnect(t)
-	header := fmt.Sprintf("127.0.0.1:%s\n", listenerToPort(target.listener))
-	conn.Write([]byte(header))
+	header, err := utils.PackTCPAddressString(fmt.Sprintf("127.0.0.1:%s", listenerToPort(target.listener)))
+	if err != nil {
+		t.Fail()
+	}
+	conn.Write(header)
 	conn.Write([]byte(testMsg))
 	buffer := make([]byte, 4096)
 	n, err := conn.Read(buffer)

--- a/utils/tcp.go
+++ b/utils/tcp.go
@@ -1,0 +1,89 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+var (
+	endian = binary.BigEndian
+	// ErrInvalidTCPAddress is thrown when a specified address can't be packed
+	ErrInvalidTCPAddress = errors.New("Invalid TCP address")
+)
+
+// PackTCPAddress packs a TCP address (IP and port) to 6 bytes
+func PackTCPAddress(ip string, port uint16) ([]byte, error) {
+	var result bytes.Buffer
+
+	// Pack the port to 2 bytes
+	portBuf := make([]byte, 2)
+	endian.PutUint16(portBuf, port)
+	result.Write(portBuf)
+
+	// Pack the ip address to 4 bytes
+	ipaddr := net.ParseIP(ip)
+	if ipaddr == nil {
+		return nil, ErrInvalidTCPAddress
+	}
+	ipbytes := ipaddr.To4()
+	result.Write(ipbytes)
+
+	return result.Bytes(), nil
+}
+
+// PackTCPAddressString packs a TCP address represented as a string ("IP:port")
+// to 6 bytes
+func PackTCPAddressString(address string) ([]byte, error) {
+	parts := strings.Split(address, ":")
+	if len(parts) != 2 {
+		return nil, ErrInvalidTCPAddress
+	}
+	ip := parts[0]
+	intport, err := strconv.Atoi(parts[1])
+	if err != nil || uint16(intport) == 0 {
+		return nil, ErrInvalidTCPAddress
+	}
+	port := uint16(intport)
+	return PackTCPAddress(ip, port)
+}
+
+// UnpackTCPAddress unpacks a 6-byte representation of a TCP address produced
+// by PackTCPAddress into an IP and port
+func UnpackTCPAddress(packed []byte) (ip string, port uint16) {
+
+	// Read off the port
+	buf := bytes.NewBuffer(packed)
+	binary.Read(buf, endian, &port)
+
+	// Read off the IP
+	ipbytes := make([]byte, 4)
+	buf.Read(ipbytes)
+	ip = net.IP(ipbytes).String()
+
+	return
+}
+
+// UnpackTCPAddressToString unpacks a 6-byte representation of a TCP address
+// produced by PackTCPAddress into a string of the format "IP:port"
+func UnpackTCPAddressToString(packed []byte) string {
+	ip, port := UnpackTCPAddress(packed)
+	return fmt.Sprintf("%s:%d", ip, port)
+}

--- a/utils/tcp_test.go
+++ b/utils/tcp_test.go
@@ -1,0 +1,65 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"testing"
+
+	. "github.com/control-center/serviced/utils"
+)
+
+func TestPackTCPAddresses(t *testing.T) {
+	var (
+		ip   string = "172.12.0.1"
+		port uint16 = 11211
+		addr string = "172.12.0.1:11211"
+	)
+	packed, err := PackTCPAddress(ip, port)
+	if len(packed) != 6 {
+		t.Fail()
+	}
+	if err != nil {
+		t.Fail()
+	}
+	ip2, port2 := UnpackTCPAddress(packed)
+	if ip != ip2 {
+		t.Fail()
+	}
+	if port != port2 {
+		t.Fail()
+	}
+	spacked, err := PackTCPAddressString(addr)
+	if err != nil {
+		t.Fail()
+	}
+	if string(packed) != string(spacked) {
+		t.Fail()
+	}
+	addr2 := UnpackTCPAddressToString(spacked)
+	if addr2 != addr {
+		t.Fail()
+	}
+
+	for _, invalidaddr := range []string{
+		"1.2.3.4:abc",
+		"1.2.3.4:65536",
+		"not an address",
+		"666.666.666.666:123",
+	} {
+		if _, err := PackTCPAddressString(invalidaddr); err != ErrInvalidTCPAddress {
+			t.Logf("Invalid address didn't produce an error: %s", invalidaddr)
+			t.Fail()
+		}
+	}
+}

--- a/web/publicendpoint.go
+++ b/web/publicendpoint.go
@@ -17,7 +17,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -29,6 +28,7 @@ import (
 	"github.com/zenoss/glog"
 
 	"github.com/control-center/serviced/coordinator/client"
+	"github.com/control-center/serviced/utils"
 	"github.com/control-center/serviced/zzk"
 	"github.com/control-center/serviced/zzk/registry"
 )
@@ -383,10 +383,11 @@ func (sc *ServiceConfig) getRemoteConnection(remoteAddr string, isLocalContainer
 		if len(privateIP) == 0 {
 			return nil, fmt.Errorf("missing endpoint")
 		}
-		muxAddr := fmt.Sprintf("%s:%d\n", privateIP, privatePort)
-		glog.V(1).Infof("public endpoint muxing to %s", muxAddr)
-		io.WriteString(remote, muxAddr)
-
+		muxHeader, err := utils.PackTCPAddress(privateIP, privatePort)
+		if err != nil {
+			return nil, err
+		}
+		remote.Write(muxHeader)
 	}
 	return remote, nil
 }


### PR DESCRIPTION
This prevents weirdness in scenarios where the message being sent was being
read into the buffer with the mux header, and then somehow failing to be
written down the pipe to the receiving service. This only occurred when TLS was disabled.

This is the first PR to allow CC-2496 to be fixed.