### PR TITLE
built monitors for registering and tracking exported endpoints

### DIFF
--- a/zzk/service/exportdetails.go
+++ b/zzk/service/exportdetails.go
@@ -1,0 +1,196 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"fmt"
+	"path"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/control-center/serviced/coordinator/client"
+)
+
+// ExportDetails describes a port binding for an endpoint as it is
+// presented on the coordinator.
+type ExportDetails struct {
+	ExportBinding
+	PrivateIP  string
+	InstanceID int
+	version    interface{}
+}
+
+// Version implements client.Node
+func (node *ExportDetails) Version() interface{} {
+	return node.version
+}
+
+// SetVersion implements client.Node
+func (node *ExportDetails) SetVersion(version interface{}) {
+	node.version = version
+}
+
+// RegisterExport exposes an exported endpoint
+func RegisterExport(shutdown <-chan struct{}, conn client.Connection, tenantID string, export ExportDetails) {
+	logger := log.WithFields(log.Fields{
+		"TenantID":    tenantID,
+		"Application": export.Application,
+		"InstanceID":  export.InstanceID,
+	})
+
+	basepth := path.Join("/net", tenantID, export.Application, fmt.Sprintf("%d", export.InstanceID))
+	pth := basepth
+	defer func() {
+		if err := conn.Delete(pth); err != nil {
+			logger.WithFields(log.Fields{
+				"Error": err,
+			}).Debug("Could not remove endpoint")
+		}
+	}()
+
+	done := make(chan struct{})
+	defer func() { close(done) }()
+	for {
+		epLogger := logger.WithFields(log.Fields{
+			"ExportPath": pth,
+		})
+
+		// check the export endpoint path
+		ok, ev, err := conn.ExistsW(pth, done)
+		if err != nil {
+			epLogger.WithFields(log.Fields{
+				"Error": err,
+			}).Error("Could not look up endpoint")
+			return
+		}
+
+		// if the path doesn't exist, create it
+		if !ok {
+			epLogger.Debug("Registering endpoint")
+			pth, err = conn.CreateEphemeral(basepth, &export)
+			if err != nil {
+				epLogger.WithFields(log.Fields{
+					"Error": err,
+				}).Error("Could not create endpoint")
+				return
+			}
+			continue
+		}
+
+		epLogger.Debug("Watching endpoint")
+
+		select {
+		case <-ev:
+		case <-shutdown:
+			epLogger.Debug("Listener shutting down")
+			return
+		}
+		close(done)
+		done = make(chan struct{})
+	}
+}
+
+// TrackExports keeps track of changes to the list of exports for given import
+func TrackExports(shutdown <-chan struct{}, conn client.Connection, tenantID, application string) <-chan map[int]ExportDetails {
+	exportsChan := make(chan map[int]ExportDetails)
+	go func() {
+		defer close(exportsChan)
+
+		// lets keep track of the binds that we have already looked up
+		exportMap := make(map[string]ExportDetails)
+
+		// get the path to the export
+		pth := path.Join("/net", tenantID, application)
+
+		// set up the logger
+		logger := log.WithFields(log.Fields{
+			"TenantID":    tenantID,
+			"Application": application,
+		})
+		logger.Debug("Starting listener for export")
+
+		done := make(chan struct{})
+		defer func() { close(done) }()
+		for {
+
+			// check if the path exists
+			ok, ev, err := conn.ExistsW(pth, done)
+			if err != nil {
+				logger.WithFields(log.Fields{
+					"Error": err,
+				}).Error("Could not monitor application")
+				return
+			}
+
+			// watch the path for children
+			var ch []string
+			if ok {
+				ch, ev, err = conn.ChildrenW(pth, done)
+				if err == client.ErrNoNode {
+					continue
+				} else if err != nil {
+					logger.WithFields(log.Fields{
+						"Error": err,
+					}).Error("Could not monitor application ports")
+					return
+				}
+			}
+
+			// get the data and make sure it is in sync
+			exports := make(map[int]ExportDetails)
+			chMap := make(map[string]ExportDetails)
+			for _, name := range ch {
+				export, ok := exportMap[name]
+
+				if !ok {
+					err := conn.Get(path.Join(pth, name), &export)
+					if err == client.ErrNoNode {
+						continue
+					} else if err != nil {
+						logger.WithFields(log.Fields{
+							"Name":  name,
+							"Error": err,
+						}).Error("Could not look up export binding")
+						return
+					}
+					logger.WithFields(log.Fields{
+						"Name": name,
+					}).Debug("New record added")
+				}
+
+				exports[export.InstanceID] = export
+				chMap[name] = export
+			}
+			exportMap = chMap
+
+			// send the exports and wait for the next event
+			select {
+			case exportsChan <- exports:
+				// exports received, wait for event
+				select {
+				case <-ev:
+				case <-shutdown:
+					return
+				}
+			case <-ev:
+				logger.Debug("Exports updated, getting latest")
+			case <-shutdown:
+				return
+			}
+			close(done)
+			done = make(chan struct{})
+		}
+	}()
+
+	return exportsChan
+}

--- a/zzk/service/exportdetails_test.go
+++ b/zzk/service/exportdetails_test.go
@@ -1,0 +1,180 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build integration,!quick
+
+package service
+
+import (
+	"time"
+
+	"github.com/control-center/serviced/zzk"
+	. "gopkg.in/check.v1"
+)
+
+func (t *ZZKTest) TestRegisterExport(c *C) {
+
+	// pre-requisites
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+
+	// watch the application path
+	done := make(chan struct{})
+	ok, ev, err := conn.ExistsW("/net/tenantid/app", done)
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, false)
+
+	// start
+	shutdown := make(chan struct{})
+	go func() {
+		RegisterExport(shutdown, conn, "tenantid", ExportDetails{
+			ExportBinding: ExportBinding{Application: "app"},
+			InstanceID:    1,
+		})
+		close(done)
+	}()
+
+	var ch []string
+
+	timer := time.NewTimer(time.Second)
+	select {
+	case <-ev:
+		ch, ev, err = conn.ChildrenW("/net/tenantid/app", done)
+		c.Assert(err, IsNil)
+		if len(ch) == 0 {
+			timer.Reset(time.Second)
+			select {
+			case <-ev:
+				ch, ev, err = conn.ChildrenW("/net/tenantid/app", done)
+				c.Assert(err, IsNil)
+			case <-done:
+				c.Fatalf("Listener exited unexpectedly")
+			case <-timer.C:
+				close(shutdown)
+				c.Fatalf("Listener timed out")
+			}
+		}
+	case <-done:
+		c.Fatalf("Listener exited unexpectedly")
+	case <-timer.C:
+		close(shutdown)
+		c.Fatalf("Listener timed out")
+	}
+	c.Assert(ch, HasLen, 1)
+	node := ch[0]
+
+	// delete
+	err = conn.Delete("/net/tenantid/app/" + node)
+	c.Assert(err, IsNil)
+
+	ch, ev, err = conn.ChildrenW("/net/tenantid/app", done)
+	c.Assert(err, IsNil)
+	if len(ch) == 0 {
+		timer.Reset(time.Second)
+		select {
+		case <-ev:
+			ch, err = conn.Children("/net/tenantid/app")
+			c.Assert(err, IsNil)
+		case <-done:
+			c.Fatalf("Listener exited unexpectedly")
+		case <-timer.C:
+			close(shutdown)
+			c.Fatalf("Listener timed out")
+		}
+	}
+	c.Assert(ch, HasLen, 1)
+	c.Assert(ch[0], Not(Equals), node)
+
+	// shutdown
+	close(shutdown)
+	timer.Reset(time.Second)
+	select {
+	case <-done:
+	case <-timer.C:
+		c.Fatalf("Listener timed out")
+	}
+	ch, err = conn.Children("/net/tenantid/app")
+	c.Assert(err, IsNil)
+	c.Assert(ch, HasLen, 0)
+}
+
+func (t *ZZKTest) TestTrackExports(c *C) {
+	// pre-requisites
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+
+	// start the listener
+	shutdown := make(chan struct{})
+	ev := TrackExports(shutdown, conn, "tenantid", "app")
+
+	// get empty list
+	timer := time.NewTimer(time.Second)
+	select {
+	case exports := <-ev:
+		c.Check(exports, HasLen, 0)
+	case <-timer.C:
+		close(shutdown)
+		c.Fatalf("Timed out waiting for exports")
+	}
+
+	// add an export
+	export := &ExportDetails{
+		ExportBinding: ExportBinding{Application: "app"},
+		InstanceID:    0,
+	}
+	err = conn.Create("/net/tenantid/app/0", export)
+	c.Assert(err, IsNil)
+
+	timer.Reset(time.Second)
+	select {
+	case exports := <-ev:
+		c.Check(exports, HasLen, 1)
+		c.Check(exports[0].InstanceID, Equals, export.InstanceID)
+	case <-timer.C:
+		close(shutdown)
+		c.Fatalf("Timed out waiting for exports")
+	}
+
+	// add an export and delete the other export
+	export = &ExportDetails{
+		ExportBinding: ExportBinding{Application: "app"},
+		InstanceID:    1,
+	}
+	err = conn.Create("/net/tenantid/app/1", export)
+	c.Assert(err, IsNil)
+	timer.Stop() // timer won't reset once it has triggered
+	time.Sleep(time.Second)
+	err = conn.Delete("/net/tenantid/app/0")
+	c.Assert(err, IsNil)
+
+	timer.Reset(time.Second)
+	select {
+	case exports := <-ev:
+		c.Check(exports, HasLen, 1)
+		c.Check(exports[1].InstanceID, Equals, export.InstanceID)
+	case <-timer.C:
+		close(shutdown)
+		c.Fatalf("Timed out waiting for exports")
+	}
+
+	// shutdown
+	close(shutdown)
+
+	timer.Reset(time.Second)
+	select {
+	case _, ok := <-ev:
+		c.Check(ok, Equals, false)
+	case <-timer.C:
+		c.Fatalf("Timed out waiting for exports")
+	}
+}


### PR DESCRIPTION
RegisterExport does its best to persist an ephemeral exported endpoint to zookeeper

TrackExports keeps track of the list of available exported endpoints from zookeeper.  Exported endpoints are ephemeral and they do not get modified, only added and deleted, so there is also a cache that keeps track of the number of available endpoints to reduce the number of calls to zookeeper to deserialize data.