### PR TITLE
Use json.Number instead of string

### DIFF
--- a/cli/api/logs.go
+++ b/cli/api/logs.go
@@ -532,7 +532,7 @@ type logSingleLine struct {
 	ContainerID string    `json:"host"`
 	File        string    `json:"file"`
 	Timestamp   time.Time `json:"@timestamp"`
-	Offset      string    `json:"offset"`
+	Offset      json.Number `json:"offset"`
 	Message     string    `json:"message"`
 	ServiceID   string    `json:"service"`
 }
@@ -641,7 +641,7 @@ func parseLogSource(source []byte) (*parsedMessage, error) {
 		offset := uint64(0)
 		if len(line.Offset) != 0 {
 			var e error
-			offset, e = strconv.ParseUint(line.Offset, 10, 64)
+			offset, e = strconv.ParseUint(string(line.Offset), 10, 64)
 			if e != nil {
 				return nil, fmt.Errorf("failed to parse offset \"%s\" in \"%s\": %s", line.Offset, source, e)
 			}


### PR DESCRIPTION
To avoid an error while unmarshalling an int value to string, use the json.Number type for that field and then convert it to string.