### PR TITLE
update cc ui shrinkwrap not to point at nexus.zendev

### DIFF
--- a/web/ui/npm-shrinkwrap.json
+++ b/web/ui/npm-shrinkwrap.json
@@ -5,7 +5,7 @@
     "gulp": {
       "version": "3.8.11",
       "from": "gulp@~3.8.10",
-      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/gulp/-/gulp-3.8.11.tgz",
+      "resolved": "http://registry.npmjs.org/gulp/-/gulp-3.8.11.tgz",
       "dependencies": {
         "archy": {
           "version": "1.0.0",
@@ -25,7 +25,7 @@
             "escape-string-regexp": {
               "version": "1.0.5",
               "from": "escape-string-regexp@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
@@ -71,22 +71,22 @@
         "liftoff": {
           "version": "2.2.1",
           "from": "liftoff@^2.0.1",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/liftoff/-/liftoff-2.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/liftoff/-/liftoff-2.2.1.tgz",
           "dependencies": {
             "extend": {
               "version": "2.0.1",
               "from": "extend@^2.0.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/extend/-/extend-2.0.1.tgz"
+              "resolved": "http://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
             },
             "findup-sync": {
               "version": "0.3.0",
               "from": "findup-sync@^0.3.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/findup-sync/-/findup-sync-0.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
               "dependencies": {
                 "glob": {
                   "version": "5.0.15",
                   "from": "glob@~5.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/glob/-/glob-5.0.15.tgz",
+                  "resolved": "http://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
@@ -108,22 +108,22 @@
                     "minimatch": {
                       "version": "3.0.0",
                       "from": "minimatch@2 || 3",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/minimatch/-/minimatch-3.0.0.tgz",
+                      "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
                           "from": "brace-expansion@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
                               "from": "balanced-match@^0.3.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/balanced-match/-/balanced-match-0.3.0.tgz"
+                              "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
                               "from": "concat-map@0.0.1",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/concat-map/-/concat-map-0.0.1.tgz"
+                              "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
                         }
@@ -132,7 +132,7 @@
                     "once": {
                       "version": "1.3.3",
                       "from": "once@^1.3.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/once/-/once-1.3.3.tgz",
+                      "resolved": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
@@ -144,7 +144,7 @@
                     "path-is-absolute": {
                       "version": "1.0.0",
                       "from": "path-is-absolute@^1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
                 }
@@ -153,24 +153,24 @@
             "flagged-respawn": {
               "version": "0.3.2",
               "from": "flagged-respawn@^0.3.2",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/flagged-respawn/-/flagged-respawn-0.3.2.tgz"
+              "resolved": "http://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz"
             },
             "rechoir": {
               "version": "0.6.2",
               "from": "rechoir@^0.6.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/rechoir/-/rechoir-0.6.2.tgz"
+              "resolved": "http://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
             },
             "resolve": {
               "version": "1.1.7",
               "from": "resolve@^1.1.6",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/resolve/-/resolve-1.1.7.tgz"
+              "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
             }
           }
         },
         "minimist": {
           "version": "1.2.0",
           "from": "minimist@^1.1.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/minimist/-/minimist-1.2.0.tgz"
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "orchestrator": {
           "version": "0.3.7",
@@ -185,7 +185,7 @@
                 "once": {
                   "version": "1.3.3",
                   "from": "once@^1.3.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/once/-/once-1.3.3.tgz",
+                  "resolved": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
@@ -221,19 +221,19 @@
         "tildify": {
           "version": "1.2.0",
           "from": "tildify@^1.0.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/tildify/-/tildify-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
               "from": "os-homedir@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/os-homedir/-/os-homedir-1.0.1.tgz"
+              "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
             }
           }
         },
         "v8flags": {
           "version": "2.0.11",
           "from": "v8flags@^2.0.2",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/v8flags/-/v8flags-2.0.11.tgz",
+          "resolved": "http://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
           "dependencies": {
             "user-home": {
               "version": "1.1.1",
@@ -245,17 +245,17 @@
         "vinyl-fs": {
           "version": "0.3.14",
           "from": "vinyl-fs@^0.3.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+          "resolved": "http://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
           "dependencies": {
             "defaults": {
               "version": "1.0.3",
               "from": "defaults@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/defaults/-/defaults-1.0.3.tgz",
+              "resolved": "http://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
               "dependencies": {
                 "clone": {
                   "version": "1.0.2",
                   "from": "clone@^1.0.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/clone/-/clone-1.0.2.tgz"
+                  "resolved": "http://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
                 }
               }
             },
@@ -289,7 +289,7 @@
                     "once": {
                       "version": "1.3.3",
                       "from": "once@^1.3.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/once/-/once-1.3.3.tgz",
+                      "resolved": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
@@ -303,22 +303,22 @@
                 "minimatch": {
                   "version": "2.0.10",
                   "from": "minimatch@^2.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/minimatch/-/minimatch-2.0.10.tgz",
+                  "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.3",
                       "from": "brace-expansion@^1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
                           "from": "balanced-match@^0.3.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/balanced-match/-/balanced-match-0.3.0.tgz"
+                          "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
                           "from": "concat-map@0.0.1",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/concat-map/-/concat-map-0.0.1.tgz"
+                          "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
                     }
@@ -356,7 +356,7 @@
                 "gaze": {
                   "version": "0.5.2",
                   "from": "gaze@^0.5.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/gaze/-/gaze-0.5.2.tgz",
+                  "resolved": "http://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
                   "dependencies": {
                     "globule": {
                       "version": "0.1.0",
@@ -381,7 +381,7 @@
                             "inherits": {
                               "version": "1.0.2",
                               "from": "inherits@1",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/inherits/-/inherits-1.0.2.tgz"
+                              "resolved": "http://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                             }
                           }
                         },
@@ -393,7 +393,7 @@
                             "lru-cache": {
                               "version": "2.7.3",
                               "from": "lru-cache@2",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lru-cache/-/lru-cache-2.7.3.tgz"
+                              "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                             },
                             "sigmund": {
                               "version": "1.0.1",
@@ -438,7 +438,7 @@
                 "is-utf8": {
                   "version": "0.2.1",
                   "from": "is-utf8@^0.2.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-utf8/-/is-utf8-0.2.1.tgz"
+                  "resolved": "http://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                 }
               }
             },
@@ -450,17 +450,17 @@
                 "readable-stream": {
                   "version": "1.0.34",
                   "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@~1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -477,7 +477,7 @@
                 "xtend": {
                   "version": "4.0.1",
                   "from": "xtend@>=4.0.0 <4.1.0-0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/xtend/-/xtend-4.0.1.tgz"
+                  "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
@@ -515,7 +515,7 @@
             "acorn-6to5": {
               "version": "0.11.1-18",
               "from": "acorn-6to5@0.11.1-18",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/acorn-6to5/-/acorn-6to5-0.11.1-18.tgz"
+              "resolved": "http://registry.npmjs.org/acorn-6to5/-/acorn-6to5-0.11.1-18.tgz"
             },
             "ast-types": {
               "version": "0.6.16",
@@ -525,27 +525,27 @@
             "commander": {
               "version": "2.6.0",
               "from": "commander@2.6.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/commander/-/commander-2.6.0.tgz"
+              "resolved": "http://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
             },
             "core-js": {
               "version": "0.4.5",
               "from": "core-js@0.4.5",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-js/-/core-js-0.4.5.tgz"
+              "resolved": "http://registry.npmjs.org/core-js/-/core-js-0.4.5.tgz"
             },
             "estraverse": {
               "version": "1.9.1",
               "from": "estraverse@1.9.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/estraverse/-/estraverse-1.9.1.tgz"
+              "resolved": "http://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
             },
             "esutils": {
               "version": "1.1.6",
               "from": "esutils@1.1.6",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esutils/-/esutils-1.1.6.tgz"
+              "resolved": "http://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
             },
             "esvalid": {
               "version": "1.1.0",
               "from": "esvalid@1.1.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esvalid/-/esvalid-1.1.0.tgz",
+              "resolved": "http://registry.npmjs.org/esvalid/-/esvalid-1.1.0.tgz",
               "dependencies": {
                 "object-assign": {
                   "version": "0.3.1",
@@ -557,7 +557,7 @@
             "fs-readdir-recursive": {
               "version": "0.1.0",
               "from": "fs-readdir-recursive@0.1.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/fs-readdir-recursive/-/fs-readdir-recursive-0.1.0.tgz"
+              "resolved": "http://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.0.tgz"
             },
             "jshint": {
               "version": "2.5.11",
@@ -587,7 +587,7 @@
                             "lru-cache": {
                               "version": "2.7.3",
                               "from": "lru-cache@2",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lru-cache/-/lru-cache-2.7.3.tgz"
+                              "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                             },
                             "sigmund": {
                               "version": "1.0.1",
@@ -659,17 +659,17 @@
                     "readable-stream": {
                       "version": "1.1.14",
                       "from": "readable-stream@1.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
                           "from": "core-util-is@~1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                          "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "isarray@0.0.1",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-0.0.1.tgz"
+                          "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
@@ -698,7 +698,7 @@
                     "lru-cache": {
                       "version": "2.7.3",
                       "from": "lru-cache@2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lru-cache/-/lru-cache-2.7.3.tgz"
+                      "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
@@ -715,7 +715,7 @@
                 "strip-json-comments": {
                   "version": "1.0.4",
                   "from": "strip-json-comments@1.0.x",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                  "resolved": "http://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                 },
                 "underscore": {
                   "version": "1.6.0",
@@ -732,7 +732,7 @@
             "output-file-sync": {
               "version": "1.1.1",
               "from": "output-file-sync@^1.1.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/output-file-sync/-/output-file-sync-1.1.1.tgz",
+              "resolved": "http://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.1",
@@ -749,46 +749,46 @@
                 "xtend": {
                   "version": "4.0.1",
                   "from": "xtend@^4.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/xtend/-/xtend-4.0.1.tgz"
+                  "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "private": {
               "version": "0.1.6",
               "from": "private@0.1.6",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/private/-/private-0.1.6.tgz"
+              "resolved": "http://registry.npmjs.org/private/-/private-0.1.6.tgz"
             },
             "regenerator": {
               "version": "0.8.9",
               "from": "regenerator@0.8.9",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/regenerator/-/regenerator-0.8.9.tgz",
+              "resolved": "http://registry.npmjs.org/regenerator/-/regenerator-0.8.9.tgz",
               "dependencies": {
                 "commoner": {
                   "version": "0.10.4",
                   "from": "commoner@~0.10.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/commoner/-/commoner-0.10.4.tgz",
+                  "resolved": "http://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
                   "dependencies": {
                     "detective": {
                       "version": "4.3.1",
                       "from": "detective@^4.3.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/detective/-/detective-4.3.1.tgz",
+                      "resolved": "http://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "1.2.2",
                           "from": "acorn@^1.0.3",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/acorn/-/acorn-1.2.2.tgz"
+                          "resolved": "http://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                         },
                         "defined": {
                           "version": "1.0.0",
                           "from": "defined@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/defined/-/defined-1.0.0.tgz"
+                          "resolved": "http://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
                         }
                       }
                     },
                     "glob": {
                       "version": "5.0.15",
                       "from": "glob@^5.0.15",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/glob/-/glob-5.0.15.tgz",
+                      "resolved": "http://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
@@ -810,22 +810,22 @@
                         "minimatch": {
                           "version": "3.0.0",
                           "from": "minimatch@2 || 3",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.3",
                               "from": "brace-expansion@^1.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.3.0",
                                   "from": "balanced-match@^0.3.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/balanced-match/-/balanced-match-0.3.0.tgz"
+                                  "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
                                   "from": "concat-map@0.0.1",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/concat-map/-/concat-map-0.0.1.tgz"
+                                  "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
                             }
@@ -834,7 +834,7 @@
                         "once": {
                           "version": "1.3.3",
                           "from": "once@^1.3.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/once/-/once-1.3.3.tgz",
+                          "resolved": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
@@ -846,19 +846,19 @@
                         "path-is-absolute": {
                           "version": "1.0.0",
                           "from": "path-is-absolute@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                          "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                         }
                       }
                     },
                     "graceful-fs": {
                       "version": "4.1.3",
                       "from": "graceful-fs@^4.1.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                      "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                     },
                     "iconv-lite": {
                       "version": "0.4.13",
                       "from": "iconv-lite@^0.4.5",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                      "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
@@ -875,27 +875,27 @@
                     "q": {
                       "version": "1.4.1",
                       "from": "q@^1.1.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/q/-/q-1.4.1.tgz"
+                      "resolved": "http://registry.npmjs.org/q/-/q-1.4.1.tgz"
                     },
                     "recast": {
                       "version": "0.10.43",
                       "from": "recast@^0.10.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/recast/-/recast-0.10.43.tgz",
+                      "resolved": "http://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
                       "dependencies": {
                         "esprima-fb": {
                           "version": "15001.1001.0-dev-harmony-fb",
                           "from": "esprima-fb@~15001.1001.0-dev-harmony-fb",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                          "resolved": "http://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
                         },
                         "source-map": {
                           "version": "0.5.3",
                           "from": "source-map@~0.5.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.5.3.tgz"
+                          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
                         },
                         "ast-types": {
                           "version": "0.8.15",
                           "from": "ast-types@0.8.15",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ast-types/-/ast-types-0.8.15.tgz"
+                          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
                         }
                       }
                     }
@@ -914,12 +914,12 @@
                 "through": {
                   "version": "2.3.8",
                   "from": "through@~2.3.6",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/through/-/through-2.3.8.tgz"
+                  "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 },
                 "defs": {
                   "version": "1.1.1",
                   "from": "defs@~1.1.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/defs/-/defs-1.1.1.tgz",
+                  "resolved": "http://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
                   "dependencies": {
                     "alter": {
                       "version": "0.2.0",
@@ -946,7 +946,7 @@
                     "esprima-fb": {
                       "version": "15001.1001.0-dev-harmony-fb",
                       "from": "esprima-fb@~15001.1001.0-dev-harmony-fb",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                      "resolved": "http://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
                     },
                     "simple-fmt": {
                       "version": "0.1.0",
@@ -976,90 +976,90 @@
                     "yargs": {
                       "version": "3.27.0",
                       "from": "yargs@~3.27.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/yargs/-/yargs-3.27.0.tgz",
+                      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
                           "from": "camelcase@^1.2.1",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/camelcase/-/camelcase-1.2.1.tgz"
+                          "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "cliui": {
                           "version": "2.1.0",
                           "from": "cliui@^2.1.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/cliui/-/cliui-2.1.0.tgz",
+                          "resolved": "http://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                           "dependencies": {
                             "center-align": {
                               "version": "0.1.3",
                               "from": "center-align@^0.1.1",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/center-align/-/center-align-0.1.3.tgz",
+                              "resolved": "http://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
                                   "from": "align-text@^0.1.1",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/align-text/-/align-text-0.1.4.tgz",
+                                  "resolved": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.2",
                                       "from": "kind-of@^3.0.2",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/kind-of/-/kind-of-3.0.2.tgz",
+                                      "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
                                           "from": "is-buffer@^1.0.2",
-                                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-buffer/-/is-buffer-1.1.3.tgz"
+                                          "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                         }
                                       }
                                     },
                                     "longest": {
                                       "version": "1.0.1",
                                       "from": "longest@^1.0.1",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/longest/-/longest-1.0.1.tgz"
+                                      "resolved": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
                                       "from": "repeat-string@^1.5.2",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/repeat-string/-/repeat-string-1.5.4.tgz"
+                                      "resolved": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                     }
                                   }
                                 },
                                 "lazy-cache": {
                                   "version": "1.0.3",
                                   "from": "lazy-cache@^1.0.3",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                                  "resolved": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
                                 }
                               }
                             },
                             "right-align": {
                               "version": "0.1.3",
                               "from": "right-align@^0.1.1",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/right-align/-/right-align-0.1.3.tgz",
+                              "resolved": "http://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
                                   "from": "align-text@^0.1.1",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/align-text/-/align-text-0.1.4.tgz",
+                                  "resolved": "http://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.2",
                                       "from": "kind-of@^3.0.2",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/kind-of/-/kind-of-3.0.2.tgz",
+                                      "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
                                           "from": "is-buffer@^1.0.2",
-                                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-buffer/-/is-buffer-1.1.3.tgz"
+                                          "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                         }
                                       }
                                     },
                                     "longest": {
                                       "version": "1.0.1",
                                       "from": "longest@^1.0.1",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/longest/-/longest-1.0.1.tgz"
+                                      "resolved": "http://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
                                       "from": "repeat-string@^1.5.2",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/repeat-string/-/repeat-string-1.5.4.tgz"
+                                      "resolved": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                     }
                                   }
                                 }
@@ -1068,29 +1068,29 @@
                             "wordwrap": {
                               "version": "0.0.2",
                               "from": "wordwrap@0.0.2",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/wordwrap/-/wordwrap-0.0.2.tgz"
+                              "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             }
                           }
                         },
                         "decamelize": {
                           "version": "1.2.0",
                           "from": "decamelize@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/decamelize/-/decamelize-1.2.0.tgz"
+                          "resolved": "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "os-locale": {
                           "version": "1.4.0",
                           "from": "os-locale@^1.4.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/os-locale/-/os-locale-1.4.0.tgz",
+                          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                           "dependencies": {
                             "lcid": {
                               "version": "1.0.0",
                               "from": "lcid@^1.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lcid/-/lcid-1.0.0.tgz",
+                              "resolved": "http://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                               "dependencies": {
                                 "invert-kv": {
                                   "version": "1.0.0",
                                   "from": "invert-kv@^1.0.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/invert-kv/-/invert-kv-1.0.0.tgz"
+                                  "resolved": "http://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
                                 }
                               }
                             }
@@ -1099,12 +1099,12 @@
                         "window-size": {
                           "version": "0.1.4",
                           "from": "window-size@^0.1.2",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/window-size/-/window-size-0.1.4.tgz"
+                          "resolved": "http://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
                         },
                         "y18n": {
                           "version": "3.2.1",
                           "from": "y18n@^3.2.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/y18n/-/y18n-3.2.1.tgz"
+                          "resolved": "http://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
                         }
                       }
                     }
@@ -1115,7 +1115,7 @@
             "regexpu": {
               "version": "1.0.0",
               "from": "regexpu@1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/regexpu/-/regexpu-1.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/regexpu/-/regexpu-1.0.0.tgz",
               "dependencies": {
                 "recast": {
                   "version": "0.9.18",
@@ -1142,7 +1142,7 @@
                 "regjsparser": {
                   "version": "0.1.5",
                   "from": "regjsparser@^0.1.3",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/regjsparser/-/regjsparser-0.1.5.tgz",
+                  "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
                   "dependencies": {
                     "jsesc": {
                       "version": "0.5.0",
@@ -1156,24 +1156,24 @@
             "roadrunner": {
               "version": "1.0.4",
               "from": "roadrunner@1.0.4",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/roadrunner/-/roadrunner-1.0.4.tgz"
+              "resolved": "http://registry.npmjs.org/roadrunner/-/roadrunner-1.0.4.tgz"
             },
             "source-map": {
               "version": "0.1.43",
               "from": "source-map@^0.1.39",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.1.43.tgz",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
                   "from": "amdefine@>=0.0.4",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/amdefine/-/amdefine-1.0.0.tgz"
+                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             },
             "source-map-support": {
               "version": "0.2.9",
               "from": "source-map-support@0.2.9",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map-support/-/source-map-support-0.2.9.tgz",
+              "resolved": "http://registry.npmjs.org/source-map-support/-/source-map-support-0.2.9.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.32",
@@ -1183,7 +1183,7 @@
                     "amdefine": {
                       "version": "1.0.0",
                       "from": "amdefine@>=0.0.4",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/amdefine/-/amdefine-1.0.0.tgz"
+                      "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 }
@@ -1204,17 +1204,17 @@
             "readable-stream": {
               "version": "1.0.34",
               "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
                   "from": "core-util-is@~1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -1231,7 +1231,7 @@
             "xtend": {
               "version": "4.0.1",
               "from": "xtend@~4.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
@@ -1243,12 +1243,12 @@
             "source-map": {
               "version": "0.1.43",
               "from": "source-map@^0.1.39",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.1.43.tgz",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
                   "from": "amdefine@>=0.0.4",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/amdefine/-/amdefine-1.0.0.tgz"
+                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             }
@@ -1264,31 +1264,31 @@
         "concat-with-sourcemaps": {
           "version": "1.0.4",
           "from": "concat-with-sourcemaps@^1.0.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
               "from": "source-map@^0.5.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             }
           }
         },
         "through": {
           "version": "2.3.8",
           "from": "through@^2.3.4",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/through/-/through-2.3.8.tgz"
+          "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz"
         }
       }
     },
     "gulp-jshint": {
       "version": "1.9.4",
       "from": "gulp-jshint@~1.9.0",
-      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/gulp-jshint/-/gulp-jshint-1.9.4.tgz",
+      "resolved": "http://registry.npmjs.org/gulp-jshint/-/gulp-jshint-1.9.4.tgz",
       "dependencies": {
         "jshint": {
           "version": "2.9.2",
           "from": "jshint@^2.5.6",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/jshint/-/jshint-2.9.2.tgz",
+          "resolved": "http://registry.npmjs.org/jshint/-/jshint-2.9.2.tgz",
           "dependencies": {
             "cli": {
               "version": "0.6.6",
@@ -1313,7 +1313,7 @@
                         "lru-cache": {
                           "version": "2.7.3",
                           "from": "lru-cache@2",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lru-cache/-/lru-cache-2.7.3.tgz"
+                          "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
@@ -1385,17 +1385,17 @@
                 "readable-stream": {
                   "version": "1.1.14",
                   "from": "readable-stream@1.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@~1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -1424,39 +1424,39 @@
             "strip-json-comments": {
               "version": "1.0.4",
               "from": "strip-json-comments@1.0.x",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+              "resolved": "http://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "lodash": {
               "version": "3.7.0",
               "from": "lodash@3.7.x",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lodash/-/lodash-3.7.0.tgz"
+              "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
             }
           }
         },
         "lodash": {
           "version": "3.10.1",
           "from": "lodash@^3.0.1",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lodash/-/lodash-3.10.1.tgz"
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "minimatch": {
           "version": "2.0.10",
           "from": "minimatch@^2.0.1",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/minimatch/-/minimatch-2.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.3",
               "from": "brace-expansion@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/brace-expansion/-/brace-expansion-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.3.0",
                   "from": "balanced-match@^0.3.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/balanced-match/-/balanced-match-0.3.0.tgz"
+                  "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
                   "from": "concat-map@0.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/concat-map/-/concat-map-0.0.1.tgz"
+                  "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
             }
@@ -1465,7 +1465,7 @@
         "rcloader": {
           "version": "0.1.2",
           "from": "rcloader@0.1.2",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/rcloader/-/rcloader-0.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
           "dependencies": {
             "rcfinder": {
               "version": "0.1.8",
@@ -1487,17 +1487,17 @@
             "readable-stream": {
               "version": "1.0.34",
               "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
                   "from": "core-util-is@~1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -1514,7 +1514,7 @@
             "xtend": {
               "version": "4.0.1",
               "from": "xtend@~4.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         }
@@ -1538,17 +1538,17 @@
             "readable-stream": {
               "version": "1.0.34",
               "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
                   "from": "core-util-is@~1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -1565,7 +1565,7 @@
             "xtend": {
               "version": "4.0.1",
               "from": "xtend@~4.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
@@ -1601,7 +1601,7 @@
         "deepmerge": {
           "version": "0.2.10",
           "from": "deepmerge@>=0.2.7 <0.3.0-0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/deepmerge/-/deepmerge-0.2.10.tgz"
+          "resolved": "http://registry.npmjs.org/deepmerge/-/deepmerge-0.2.10.tgz"
         },
         "through2": {
           "version": "0.6.5",
@@ -1611,17 +1611,17 @@
             "readable-stream": {
               "version": "1.0.34",
               "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
                   "from": "core-util-is@~1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -1638,14 +1638,14 @@
             "xtend": {
               "version": "4.0.1",
               "from": "xtend@~4.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.4.15",
           "from": "uglify-js@2.4.15",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/uglify-js/-/uglify-js-2.4.15.tgz",
+          "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.4.15.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
@@ -1660,7 +1660,7 @@
                 "amdefine": {
                   "version": "1.0.0",
                   "from": "amdefine@>=0.0.4",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/amdefine/-/amdefine-1.0.0.tgz"
+                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             },
@@ -1672,7 +1672,7 @@
                 "wordwrap": {
                   "version": "0.0.3",
                   "from": "wordwrap@~0.0.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/wordwrap/-/wordwrap-0.0.3.tgz"
+                  "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 }
               }
             },
@@ -1691,12 +1691,12 @@
             "source-map": {
               "version": "0.1.43",
               "from": "source-map@^0.1.39",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.1.43.tgz",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
                   "from": "amdefine@>=0.0.4",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/amdefine/-/amdefine-1.0.0.tgz"
+                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             }
@@ -1707,7 +1707,7 @@
     "gulp-util": {
       "version": "3.0.7",
       "from": "gulp-util@^3.0.2",
-      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/gulp-util/-/gulp-util-3.0.7.tgz",
+      "resolved": "http://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "dependencies": {
         "array-differ": {
           "version": "1.0.0",
@@ -1727,53 +1727,53 @@
         "chalk": {
           "version": "1.1.3",
           "from": "chalk@*",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
               "from": "ansi-styles@^2.2.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ansi-styles/-/ansi-styles-2.2.1.tgz"
+              "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
               "from": "escape-string-regexp@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
               "from": "has-ansi@^2.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/has-ansi/-/has-ansi-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
                   "from": "ansi-regex@^2.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
               "from": "strip-ansi@^3.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
                   "from": "ansi-regex@^2.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
               "from": "supports-color@^2.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/supports-color/-/supports-color-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "dateformat": {
           "version": "1.0.12",
           "from": "dateformat@^1.0.11",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/dateformat/-/dateformat-1.0.12.tgz",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
@@ -1783,39 +1783,39 @@
             "meow": {
               "version": "3.7.0",
               "from": "meow@^3.3.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/meow/-/meow-3.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "2.1.0",
                   "from": "camelcase-keys@^2.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "2.1.1",
                       "from": "camelcase@^2.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/camelcase/-/camelcase-2.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.2.0",
                   "from": "decamelize@^1.1.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/decamelize/-/decamelize-1.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "loud-rejection": {
                   "version": "1.3.0",
                   "from": "loud-rejection@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/loud-rejection/-/loud-rejection-1.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                   "dependencies": {
                     "array-find-index": {
                       "version": "1.0.1",
                       "from": "array-find-index@^1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/array-find-index/-/array-find-index-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
                     },
                     "signal-exit": {
                       "version": "2.1.2",
                       "from": "signal-exit@^2.1.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/signal-exit/-/signal-exit-2.1.2.tgz"
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                     }
                   }
                 },
@@ -1827,61 +1827,61 @@
                 "normalize-package-data": {
                   "version": "2.3.5",
                   "from": "normalize-package-data@^2.3.4",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                  "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.4",
                       "from": "hosted-git-info@^2.1.4",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
                       "from": "is-builtin-module@^1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.1",
                           "from": "builtin-modules@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/builtin-modules/-/builtin-modules-1.1.1.tgz"
+                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                         }
                       }
                     },
                     "semver": {
                       "version": "5.1.0",
                       "from": "semver@2 || 3 || 4 || 5",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/semver/-/semver-5.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
                       "from": "validate-npm-package-license@^3.0.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
                           "from": "spdx-correct@~1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.2.1",
                               "from": "spdx-license-ids@^1.0.2",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.2",
                           "from": "spdx-expression-parse@~1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.4",
                               "from": "spdx-exceptions@^1.0.4",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                             },
                             "spdx-license-ids": {
                               "version": "1.2.1",
                               "from": "spdx-license-ids@^1.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
                         }
@@ -1892,32 +1892,32 @@
                 "object-assign": {
                   "version": "4.0.1",
                   "from": "object-assign@^4.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/object-assign/-/object-assign-4.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                 },
                 "read-pkg-up": {
                   "version": "1.0.1",
                   "from": "read-pkg-up@^1.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
                       "version": "1.1.2",
                       "from": "find-up@^1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/find-up/-/find-up-1.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
                           "from": "path-exists@^2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/path-exists/-/path-exists-2.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
                           "from": "pinkie-promise@^2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
                               "from": "pinkie@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie/-/pinkie-2.0.4.tgz"
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
                         }
@@ -1926,32 +1926,32 @@
                     "read-pkg": {
                       "version": "1.1.0",
                       "from": "read-pkg@^1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/read-pkg/-/read-pkg-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "dependencies": {
                         "load-json-file": {
                           "version": "1.1.0",
                           "from": "load-json-file@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/load-json-file/-/load-json-file-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.3",
                               "from": "graceful-fs@^4.1.2",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
                               "from": "parse-json@^2.2.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/parse-json/-/parse-json-2.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.3.0",
                                   "from": "error-ex@^1.2.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/error-ex/-/error-ex-1.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                   "dependencies": {
                                     "is-arrayish": {
                                       "version": "0.2.1",
                                       "from": "is-arrayish@^0.2.1",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                     }
                                   }
                                 }
@@ -1960,29 +1960,29 @@
                             "pify": {
                               "version": "2.3.0",
                               "from": "pify@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pify/-/pify-2.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
                               "from": "pinkie-promise@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
                                   "from": "pinkie@^2.0.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie/-/pinkie-2.0.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
                             },
                             "strip-bom": {
                               "version": "2.0.0",
                               "from": "strip-bom@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/strip-bom/-/strip-bom-2.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "dependencies": {
                                 "is-utf8": {
                                   "version": "0.2.1",
                                   "from": "is-utf8@^0.2.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-utf8/-/is-utf8-0.2.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                                 }
                               }
                             }
@@ -1991,27 +1991,27 @@
                         "path-type": {
                           "version": "1.1.0",
                           "from": "path-type@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/path-type/-/path-type-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.3",
                               "from": "graceful-fs@^4.1.2",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                             },
                             "pify": {
                               "version": "2.3.0",
                               "from": "pify@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pify/-/pify-2.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
                               "from": "pinkie-promise@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
                                   "from": "pinkie@^2.0.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie/-/pinkie-2.0.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
                             }
@@ -2024,17 +2024,17 @@
                 "redent": {
                   "version": "1.0.0",
                   "from": "redent@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/redent/-/redent-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
                       "from": "indent-string@^2.1.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/indent-string/-/indent-string-2.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.1",
                           "from": "repeating@^2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/repeating/-/repeating-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
@@ -2055,14 +2055,14 @@
                     "strip-indent": {
                       "version": "1.0.1",
                       "from": "strip-indent@^1.0.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/strip-indent/-/strip-indent-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                     }
                   }
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
                   "from": "trim-newlines@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                 }
               }
             }
@@ -2071,29 +2071,29 @@
         "fancy-log": {
           "version": "1.2.0",
           "from": "fancy-log@^1.1.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/fancy-log/-/fancy-log-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
           "dependencies": {
             "time-stamp": {
               "version": "1.0.1",
               "from": "time-stamp@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/time-stamp/-/time-stamp-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz"
             }
           }
         },
         "gulplog": {
           "version": "1.0.0",
           "from": "gulplog@^1.0.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/gulplog/-/gulplog-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
           "dependencies": {
             "glogg": {
               "version": "1.0.0",
               "from": "glogg@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/glogg/-/glogg-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
               "dependencies": {
                 "sparkles": {
                   "version": "1.0.0",
                   "from": "sparkles@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/sparkles/-/sparkles-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
                 }
               }
             }
@@ -2102,12 +2102,12 @@
         "has-gulplog": {
           "version": "0.1.0",
           "from": "has-gulplog@^0.1.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/has-gulplog/-/has-gulplog-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
           "dependencies": {
             "sparkles": {
               "version": "1.0.0",
               "from": "sparkles@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/sparkles/-/sparkles-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
             }
           }
         },
@@ -2129,7 +2129,7 @@
         "lodash.template": {
           "version": "3.6.2",
           "from": "lodash.template@^3.0.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lodash.template/-/lodash.template-3.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
           "dependencies": {
             "lodash._basecopy": {
               "version": "3.0.1",
@@ -2139,7 +2139,7 @@
             "lodash._basetostring": {
               "version": "3.0.1",
               "from": "lodash._basetostring@^3.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
             },
             "lodash._basevalues": {
               "version": "3.0.0",
@@ -2154,34 +2154,34 @@
             "lodash.escape": {
               "version": "3.2.0",
               "from": "lodash.escape@^3.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lodash.escape/-/lodash.escape-3.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
               "dependencies": {
                 "lodash._root": {
                   "version": "3.0.1",
                   "from": "lodash._root@^3.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lodash._root/-/lodash._root-3.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
                 }
               }
             },
             "lodash.keys": {
               "version": "3.1.2",
               "from": "lodash.keys@^3.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "dependencies": {
                 "lodash._getnative": {
                   "version": "3.9.1",
                   "from": "lodash._getnative@^3.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                 },
                 "lodash.isarguments": {
                   "version": "3.0.8",
                   "from": "lodash.isarguments@^3.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
                   "from": "lodash.isarray@^3.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 }
               }
             },
@@ -2193,14 +2193,14 @@
             "lodash.templatesettings": {
               "version": "3.1.1",
               "from": "lodash.templatesettings@^3.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
             }
           }
         },
         "minimist": {
           "version": "1.2.0",
           "from": "minimist@^1.1.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/minimist/-/minimist-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "multipipe": {
           "version": "0.1.2",
@@ -2210,22 +2210,22 @@
             "duplexer2": {
               "version": "0.0.2",
               "from": "duplexer2@0.0.2",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/duplexer2/-/duplexer2-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
                   "from": "readable-stream@1.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@~1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -2246,27 +2246,27 @@
         "object-assign": {
           "version": "3.0.0",
           "from": "object-assign@^3.0.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/object-assign/-/object-assign-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
         },
         "replace-ext": {
           "version": "0.0.1",
           "from": "replace-ext@0.0.1",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/replace-ext/-/replace-ext-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
         },
         "through2": {
           "version": "2.0.1",
           "from": "through2@^2.0.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/through2/-/through2-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.6",
               "from": "readable-stream@~2.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-2.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
                   "from": "core-util-is@~1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
@@ -2276,12 +2276,12 @@
                 "isarray": {
                   "version": "1.0.0",
                   "from": "isarray@~1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
                   "from": "process-nextick-args@~1.0.6",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -2291,26 +2291,26 @@
                 "util-deprecate": {
                   "version": "1.0.2",
                   "from": "util-deprecate@~1.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
               "from": "xtend@~4.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "vinyl": {
           "version": "0.5.3",
           "from": "vinyl@^0.5.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/vinyl/-/vinyl-0.5.3.tgz",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "dependencies": {
             "clone": {
               "version": "1.0.2",
               "from": "clone@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/clone/-/clone-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
             },
             "clone-stats": {
               "version": "0.0.1",
@@ -2324,78 +2324,78 @@
     "jasmine-core": {
       "version": "2.4.1",
       "from": "jasmine-core@^2.1.3",
-      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/jasmine-core/-/jasmine-core-2.4.1.tgz"
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz"
     },
     "jshint-stylish": {
       "version": "1.0.2",
       "from": "jshint-stylish@~1.0.0",
-      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/jshint-stylish/-/jshint-stylish-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-1.0.2.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "from": "chalk@*",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
               "from": "ansi-styles@^2.2.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ansi-styles/-/ansi-styles-2.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
               "from": "escape-string-regexp@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
               "from": "has-ansi@^2.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/has-ansi/-/has-ansi-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
                   "from": "ansi-regex@^2.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
               "from": "strip-ansi@^3.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
                   "from": "ansi-regex@^2.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
               "from": "supports-color@^2.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/supports-color/-/supports-color-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "log-symbols": {
           "version": "1.0.2",
           "from": "log-symbols@^1.0.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/log-symbols/-/log-symbols-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
         },
         "string-length": {
           "version": "1.0.1",
           "from": "string-length@^1.0.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/string-length/-/string-length-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
               "from": "strip-ansi@^3.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
                   "from": "ansi-regex@^2.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             }
@@ -2411,86 +2411,86 @@
     "karma": {
       "version": "0.12.37",
       "from": "karma@^0.12.1",
-      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/karma/-/karma-0.12.37.tgz",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-0.12.37.tgz",
       "dependencies": {
         "chokidar": {
           "version": "1.4.3",
           "from": "chokidar@^1.0.1",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/chokidar/-/chokidar-1.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
               "from": "anymatch@^1.3.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/anymatch/-/anymatch-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "arrify": {
                   "version": "1.0.1",
                   "from": "arrify@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/arrify/-/arrify-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                 },
                 "micromatch": {
                   "version": "2.3.7",
                   "from": "micromatch@^2.1.5",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/micromatch/-/micromatch-2.3.7.tgz",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "2.0.0",
                       "from": "arr-diff@^2.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/arr-diff/-/arr-diff-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                       "dependencies": {
                         "arr-flatten": {
                           "version": "1.0.1",
                           "from": "arr-flatten@^1.0.1",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
                         }
                       }
                     },
                     "array-unique": {
                       "version": "0.2.1",
                       "from": "array-unique@^0.2.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/array-unique/-/array-unique-0.2.1.tgz"
+                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                     },
                     "braces": {
                       "version": "1.8.4",
                       "from": "braces@^1.8.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/braces/-/braces-1.8.4.tgz",
+                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.4.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
                           "from": "expand-range@^1.8.1",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/expand-range/-/expand-range-1.8.1.tgz",
+                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.3",
                               "from": "fill-range@^2.1.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/fill-range/-/fill-range-2.2.3.tgz",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "2.1.0",
                                   "from": "is-number@^2.1.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-number/-/is-number-2.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                                 },
                                 "isobject": {
                                   "version": "2.0.0",
                                   "from": "isobject@^2.0.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isobject/-/isobject-2.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
                                   "dependencies": {
                                     "isarray": {
                                       "version": "0.0.1",
                                       "from": "isarray@0.0.1",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-0.0.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                     }
                                   }
                                 },
                                 "randomatic": {
                                   "version": "1.1.5",
                                   "from": "randomatic@^1.1.3",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/randomatic/-/randomatic-1.1.5.tgz"
+                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.4",
                                   "from": "repeat-string@^1.5.2",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/repeat-string/-/repeat-string-1.5.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
                             }
@@ -2499,114 +2499,114 @@
                         "preserve": {
                           "version": "0.2.0",
                           "from": "preserve@^0.2.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/preserve/-/preserve-0.2.0.tgz"
+                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
                           "from": "repeat-element@^1.1.2",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/repeat-element/-/repeat-element-1.1.2.tgz"
+                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.5",
                       "from": "expand-brackets@^0.1.4",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                       "dependencies": {
                         "is-posix-bracket": {
                           "version": "0.1.1",
                           "from": "is-posix-bracket@^0.1.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
                         }
                       }
                     },
                     "extglob": {
                       "version": "0.3.2",
                       "from": "extglob@^0.3.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/extglob/-/extglob-0.3.2.tgz"
+                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
                       "from": "filename-regex@^2.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/filename-regex/-/filename-regex-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "is-extglob": {
                       "version": "1.0.0",
                       "from": "is-extglob@^1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-extglob/-/is-extglob-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "3.0.2",
                       "from": "kind-of@^3.0.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/kind-of/-/kind-of-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                       "dependencies": {
                         "is-buffer": {
                           "version": "1.1.3",
                           "from": "is-buffer@^1.0.2",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-buffer/-/is-buffer-1.1.3.tgz"
+                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                         }
                       }
                     },
                     "normalize-path": {
                       "version": "2.0.1",
                       "from": "normalize-path@^2.0.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/normalize-path/-/normalize-path-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                     },
                     "object.omit": {
                       "version": "2.0.0",
                       "from": "object.omit@^2.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/object.omit/-/object.omit-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.4",
                           "from": "for-own@^0.1.3",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/for-own/-/for-own-0.1.4.tgz",
+                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.5",
                               "from": "for-in@^0.1.5",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/for-in/-/for-in-0.1.5.tgz"
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
                             }
                           }
                         },
                         "is-extendable": {
                           "version": "0.1.1",
                           "from": "is-extendable@^0.1.1",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-extendable/-/is-extendable-0.1.1.tgz"
+                          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.4",
                       "from": "parse-glob@^3.0.4",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/parse-glob/-/parse-glob-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.3.0",
                           "from": "glob-base@^0.3.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/glob-base/-/glob-base-0.3.0.tgz"
+                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.2",
                           "from": "is-dotfile@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.3",
                       "from": "regex-cache@^0.4.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/regex-cache/-/regex-cache-0.4.3.tgz",
+                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
                           "from": "is-equal-shallow@^0.1.3",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
                         "is-primitive": {
                           "version": "2.0.0",
                           "from": "is-primitive@^2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-primitive/-/is-primitive-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
                     }
@@ -2617,12 +2617,12 @@
             "async-each": {
               "version": "1.0.0",
               "from": "async-each@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/async-each/-/async-each-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
             },
             "glob-parent": {
               "version": "2.0.0",
               "from": "glob-parent@^2.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/glob-parent/-/glob-parent-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
             },
             "inherits": {
               "version": "2.0.1",
@@ -2632,81 +2632,81 @@
             "is-binary-path": {
               "version": "1.0.1",
               "from": "is-binary-path@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.4.0",
                   "from": "binary-extensions@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/binary-extensions/-/binary-extensions-1.4.0.tgz"
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "2.0.1",
               "from": "is-glob@^2.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-glob/-/is-glob-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "dependencies": {
                 "is-extglob": {
                   "version": "1.0.0",
                   "from": "is-extglob@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-extglob/-/is-extglob-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
               "from": "path-is-absolute@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "readdirp": {
               "version": "2.0.0",
               "from": "readdirp@^2.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readdirp/-/readdirp-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.3",
                   "from": "graceful-fs@^4.1.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "2.1.0",
                   "from": "readable-stream@^2.0.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@~1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inline-process-browser": {
                       "version": "2.0.1",
                       "from": "inline-process-browser@~2.0.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
                       "dependencies": {
                         "falafel": {
                           "version": "1.2.0",
                           "from": "falafel@^1.0.1",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/falafel/-/falafel-1.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                           "dependencies": {
                             "acorn": {
                               "version": "1.2.2",
                               "from": "acorn@^1.0.3",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/acorn/-/acorn-1.2.2.tgz"
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                             },
                             "foreach": {
                               "version": "2.0.5",
                               "from": "foreach@^2.0.5",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/foreach/-/foreach-2.0.5.tgz"
+                              "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
                               "from": "isarray@0.0.1",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-0.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "object-keys": {
                               "version": "1.0.9",
                               "from": "object-keys@^1.0.6",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/object-keys/-/object-keys-1.0.9.tgz"
+                              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
                             }
                           }
                         },
@@ -2718,19 +2718,19 @@
                             "readable-stream": {
                               "version": "1.0.34",
                               "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-1.0.34.tgz",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                               "dependencies": {
                                 "isarray": {
                                   "version": "0.0.1",
                                   "from": "isarray@0.0.1",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-0.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 }
                               }
                             },
                             "xtend": {
                               "version": "4.0.1",
                               "from": "xtend@>=4.0.0 <4.1.0-0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/xtend/-/xtend-4.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                             }
                           }
                         }
@@ -2739,12 +2739,12 @@
                     "isarray": {
                       "version": "1.0.0",
                       "from": "isarray@~1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
                       "from": "process-nextick-args@~1.0.6",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -2754,37 +2754,37 @@
                     "unreachable-branch-transform": {
                       "version": "0.5.1",
                       "from": "unreachable-branch-transform@~0.5.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
+                      "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
                       "dependencies": {
                         "esmangle-evaluator": {
                           "version": "1.0.0",
                           "from": "esmangle-evaluator@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
                         },
                         "recast": {
                           "version": "0.11.5",
                           "from": "recast@^0.11.4",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/recast/-/recast-0.11.5.tgz",
+                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
                           "dependencies": {
                             "ast-types": {
                               "version": "0.8.16",
                               "from": "ast-types@0.8.16",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ast-types/-/ast-types-0.8.16.tgz"
+                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
                             },
                             "esprima": {
                               "version": "2.7.2",
                               "from": "esprima@~2.7.1",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esprima/-/esprima-2.7.2.tgz"
+                              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                             },
                             "private": {
                               "version": "0.1.6",
                               "from": "private@~0.1.5",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/private/-/private-0.1.6.tgz"
+                              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
                             },
                             "source-map": {
                               "version": "0.5.3",
                               "from": "source-map@~0.5.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.5.3.tgz"
+                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
                             }
                           }
                         }
@@ -2793,7 +2793,7 @@
                     "util-deprecate": {
                       "version": "1.0.2",
                       "from": "util-deprecate@~1.0.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 }
@@ -2804,59 +2804,59 @@
         "colors": {
           "version": "1.1.2",
           "from": "colors@^1.1.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/colors/-/colors-1.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
         },
         "connect": {
           "version": "2.30.2",
           "from": "connect@^2.29.2",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/connect/-/connect-2.30.2.tgz",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
           "dependencies": {
             "basic-auth-connect": {
               "version": "1.0.0",
               "from": "basic-auth-connect@1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
             },
             "body-parser": {
               "version": "1.13.3",
               "from": "body-parser@~1.13.3",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/body-parser/-/body-parser-1.13.3.tgz",
+              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
               "dependencies": {
                 "iconv-lite": {
                   "version": "0.4.11",
                   "from": "iconv-lite@0.4.11",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/iconv-lite/-/iconv-lite-0.4.11.tgz"
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
                 },
                 "on-finished": {
                   "version": "2.3.0",
                   "from": "on-finished@~2.3.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/on-finished/-/on-finished-2.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.1",
                       "from": "ee-first@1.1.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ee-first/-/ee-first-1.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                     }
                   }
                 },
                 "raw-body": {
                   "version": "2.1.6",
                   "from": "raw-body@~2.1.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/raw-body/-/raw-body-2.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
                   "dependencies": {
                     "bytes": {
                       "version": "2.3.0",
                       "from": "bytes@2.3.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/bytes/-/bytes-2.3.0.tgz"
+                      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
                     },
                     "iconv-lite": {
                       "version": "0.4.13",
                       "from": "iconv-lite@^0.4.5",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                     },
                     "unpipe": {
                       "version": "1.0.0",
                       "from": "unpipe@1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/unpipe/-/unpipe-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                     }
                   }
                 }
@@ -2865,122 +2865,122 @@
             "bytes": {
               "version": "2.1.0",
               "from": "bytes@2.1.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/bytes/-/bytes-2.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
             },
             "cookie": {
               "version": "0.1.3",
               "from": "cookie@0.1.3",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/cookie/-/cookie-0.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
             },
             "cookie-parser": {
               "version": "1.3.5",
               "from": "cookie-parser@~1.3.5",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/cookie-parser/-/cookie-parser-1.3.5.tgz"
+              "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz"
             },
             "cookie-signature": {
               "version": "1.0.6",
               "from": "cookie-signature@1.0.6",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/cookie-signature/-/cookie-signature-1.0.6.tgz"
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
             },
             "compression": {
               "version": "1.5.2",
               "from": "compression@~1.5.2",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/compression/-/compression-1.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.2.13",
                   "from": "accepts@~1.2.13",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/accepts/-/accepts-1.2.13.tgz",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.1.10",
                       "from": "mime-types@~2.1.10",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/mime-types/-/mime-types-2.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.22.0",
                           "from": "mime-db@~1.22.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/mime-db/-/mime-db-1.22.0.tgz"
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.5.3",
                       "from": "negotiator@0.5.3",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/negotiator/-/negotiator-0.5.3.tgz"
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
                     }
                   }
                 },
                 "compressible": {
                   "version": "2.0.7",
                   "from": "compressible@~2.0.5",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/compressible/-/compressible-2.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.7.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.22.0",
                       "from": "mime-db@>= 1.21.0 < 2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/mime-db/-/mime-db-1.22.0.tgz"
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                     }
                   }
                 },
                 "vary": {
                   "version": "1.0.1",
                   "from": "vary@~1.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/vary/-/vary-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
                 }
               }
             },
             "connect-timeout": {
               "version": "1.6.2",
               "from": "connect-timeout@~1.6.2",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/connect-timeout/-/connect-timeout-1.6.2.tgz",
+              "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
                   "from": "ms@0.7.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ms/-/ms-0.7.1.tgz"
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "content-type": {
               "version": "1.0.1",
               "from": "content-type@~1.0.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/content-type/-/content-type-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
             },
             "csurf": {
               "version": "1.8.3",
               "from": "csurf@~1.8.3",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/csurf/-/csurf-1.8.3.tgz",
+              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
               "dependencies": {
                 "csrf": {
                   "version": "3.0.1",
                   "from": "csrf@~3.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/csrf/-/csrf-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.1.tgz",
                   "dependencies": {
                     "base64-url": {
                       "version": "1.2.1",
                       "from": "base64-url@1.2.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/base64-url/-/base64-url-1.2.1.tgz"
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                     },
                     "rndm": {
                       "version": "1.2.0",
                       "from": "rndm@1.2.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/rndm/-/rndm-1.2.0.tgz"
+                      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz"
                     },
                     "scmp": {
                       "version": "1.0.0",
                       "from": "scmp@1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/scmp/-/scmp-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
                     },
                     "uid-safe": {
                       "version": "2.1.0",
                       "from": "uid-safe@2.1.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/uid-safe/-/uid-safe-2.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.0.tgz",
                       "dependencies": {
                         "random-bytes": {
                           "version": "1.0.0",
                           "from": "random-bytes@~1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/random-bytes/-/random-bytes-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz"
                         }
                       }
                     }
@@ -2991,75 +2991,75 @@
             "debug": {
               "version": "2.2.0",
               "from": "debug@~2.2.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/debug/-/debug-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
                   "from": "ms@0.7.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ms/-/ms-0.7.1.tgz"
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "depd": {
               "version": "1.0.1",
               "from": "depd@~1.0.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/depd/-/depd-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
             },
             "errorhandler": {
               "version": "1.4.3",
               "from": "errorhandler@~1.4.2",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/errorhandler/-/errorhandler-1.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.3.2",
                   "from": "accepts@~1.3.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/accepts/-/accepts-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.2.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.1.10",
                       "from": "mime-types@~2.1.10",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/mime-types/-/mime-types-2.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.22.0",
                           "from": "mime-db@~1.22.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/mime-db/-/mime-db-1.22.0.tgz"
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.6.0",
                       "from": "negotiator@0.6.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/negotiator/-/negotiator-0.6.0.tgz"
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz"
                     }
                   }
                 },
                 "escape-html": {
                   "version": "1.0.3",
                   "from": "escape-html@~1.0.3",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escape-html/-/escape-html-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
                 }
               }
             },
             "express-session": {
               "version": "1.11.3",
               "from": "express-session@~1.11.3",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/express-session/-/express-session-1.11.3.tgz",
+              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
               "dependencies": {
                 "crc": {
                   "version": "3.3.0",
                   "from": "crc@3.3.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/crc/-/crc-3.3.0.tgz"
+                  "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz"
                 },
                 "uid-safe": {
                   "version": "2.0.0",
                   "from": "uid-safe@~2.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/uid-safe/-/uid-safe-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
                   "dependencies": {
                     "base64-url": {
                       "version": "1.2.1",
                       "from": "base64-url@1.2.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/base64-url/-/base64-url-1.2.1.tgz"
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                     }
                   }
                 }
@@ -3068,41 +3068,41 @@
             "finalhandler": {
               "version": "0.4.0",
               "from": "finalhandler@0.4.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/finalhandler/-/finalhandler-0.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
               "dependencies": {
                 "escape-html": {
                   "version": "1.0.2",
                   "from": "escape-html@1.0.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escape-html/-/escape-html-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
                 },
                 "on-finished": {
                   "version": "2.3.0",
                   "from": "on-finished@~2.3.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/on-finished/-/on-finished-2.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.1",
                       "from": "ee-first@1.1.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ee-first/-/ee-first-1.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                     }
                   }
                 },
                 "unpipe": {
                   "version": "1.0.0",
                   "from": "unpipe@~1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/unpipe/-/unpipe-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
             },
             "fresh": {
               "version": "0.3.0",
               "from": "fresh@0.3.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/fresh/-/fresh-0.3.0.tgz"
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
             },
             "http-errors": {
               "version": "1.3.1",
               "from": "http-errors@~1.3.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/http-errors/-/http-errors-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
@@ -3112,46 +3112,46 @@
                 "statuses": {
                   "version": "1.2.1",
                   "from": "statuses@1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/statuses/-/statuses-1.2.1.tgz"
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                 }
               }
             },
             "method-override": {
               "version": "2.3.5",
               "from": "method-override@~2.3.5",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/method-override/-/method-override-2.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.5.tgz",
               "dependencies": {
                 "methods": {
                   "version": "1.1.2",
                   "from": "methods@~1.1.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/methods/-/methods-1.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
                 },
                 "vary": {
                   "version": "1.0.1",
                   "from": "vary@~1.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/vary/-/vary-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
                 }
               }
             },
             "morgan": {
               "version": "1.6.1",
               "from": "morgan@~1.6.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/morgan/-/morgan-1.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
               "dependencies": {
                 "basic-auth": {
                   "version": "1.0.3",
                   "from": "basic-auth@~1.0.3",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/basic-auth/-/basic-auth-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz"
                 },
                 "on-finished": {
                   "version": "2.3.0",
                   "from": "on-finished@~2.3.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/on-finished/-/on-finished-2.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.1",
                       "from": "ee-first@1.1.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ee-first/-/ee-first-1.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                     }
                   }
                 }
@@ -3160,22 +3160,22 @@
             "multiparty": {
               "version": "3.3.2",
               "from": "multiparty@3.3.2",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/multiparty/-/multiparty-3.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
                   "from": "readable-stream@1.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@~1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -3199,81 +3199,81 @@
             "on-headers": {
               "version": "1.0.1",
               "from": "on-headers@~1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/on-headers/-/on-headers-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
             },
             "parseurl": {
               "version": "1.3.1",
               "from": "parseurl@~1.3.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/parseurl/-/parseurl-1.3.1.tgz"
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
             },
             "pause": {
               "version": "0.1.0",
               "from": "pause@0.1.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pause/-/pause-0.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz"
             },
             "qs": {
               "version": "4.0.0",
               "from": "qs@4.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/qs/-/qs-4.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
             },
             "response-time": {
               "version": "2.3.1",
               "from": "response-time@~2.3.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/response-time/-/response-time-2.3.1.tgz"
+              "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.1.tgz"
             },
             "serve-favicon": {
               "version": "2.3.0",
               "from": "serve-favicon@~2.3.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/serve-favicon/-/serve-favicon-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz",
               "dependencies": {
                 "etag": {
                   "version": "1.7.0",
                   "from": "etag@~1.7.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/etag/-/etag-1.7.0.tgz"
+                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
                 },
                 "ms": {
                   "version": "0.7.1",
                   "from": "ms@0.7.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ms/-/ms-0.7.1.tgz"
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "serve-index": {
               "version": "1.7.3",
               "from": "serve-index@~1.7.2",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/serve-index/-/serve-index-1.7.3.tgz",
+              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.2.13",
                   "from": "accepts@~1.2.13",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/accepts/-/accepts-1.2.13.tgz",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
                   "dependencies": {
                     "negotiator": {
                       "version": "0.5.3",
                       "from": "negotiator@0.5.3",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/negotiator/-/negotiator-0.5.3.tgz"
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
                     }
                   }
                 },
                 "batch": {
                   "version": "0.5.3",
                   "from": "batch@0.5.3",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/batch/-/batch-0.5.3.tgz"
+                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
                 },
                 "escape-html": {
                   "version": "1.0.3",
                   "from": "escape-html@~1.0.3",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escape-html/-/escape-html-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.10",
                   "from": "mime-types@~2.1.10",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/mime-types/-/mime-types-2.1.10.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.22.0",
                       "from": "mime-db@~1.22.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/mime-db/-/mime-db-1.22.0.tgz"
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                     }
                   }
                 }
@@ -3282,59 +3282,59 @@
             "serve-static": {
               "version": "1.10.2",
               "from": "serve-static@~1.10.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/serve-static/-/serve-static-1.10.2.tgz",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz",
               "dependencies": {
                 "escape-html": {
                   "version": "1.0.3",
                   "from": "escape-html@~1.0.3",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escape-html/-/escape-html-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
                 },
                 "send": {
                   "version": "0.13.1",
                   "from": "send@0.13.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/send/-/send-0.13.1.tgz",
+                  "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
                   "dependencies": {
                     "depd": {
                       "version": "1.1.0",
                       "from": "depd@~1.1.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/depd/-/depd-1.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
                     },
                     "destroy": {
                       "version": "1.0.4",
                       "from": "destroy@~1.0.4",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/destroy/-/destroy-1.0.4.tgz"
+                      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                     },
                     "etag": {
                       "version": "1.7.0",
                       "from": "etag@~1.7.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/etag/-/etag-1.7.0.tgz"
+                      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
                     },
                     "ms": {
                       "version": "0.7.1",
                       "from": "ms@0.7.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ms/-/ms-0.7.1.tgz"
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
                     "on-finished": {
                       "version": "2.3.0",
                       "from": "on-finished@~2.3.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/on-finished/-/on-finished-2.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                       "dependencies": {
                         "ee-first": {
                           "version": "1.1.1",
                           "from": "ee-first@1.1.1",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ee-first/-/ee-first-1.1.1.tgz"
+                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                         }
                       }
                     },
                     "range-parser": {
                       "version": "1.0.3",
                       "from": "range-parser@~1.0.3",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/range-parser/-/range-parser-1.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
                     },
                     "statuses": {
                       "version": "1.2.1",
                       "from": "statuses@~1.2.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/statuses/-/statuses-1.2.1.tgz"
+                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                     }
                   }
                 }
@@ -3343,22 +3343,22 @@
             "type-is": {
               "version": "1.6.12",
               "from": "type-is@~1.6.6",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/type-is/-/type-is-1.6.12.tgz",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
                   "from": "media-typer@0.3.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/media-typer/-/media-typer-0.3.0.tgz"
+                  "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.10",
                   "from": "mime-types@~2.1.10",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/mime-types/-/mime-types-2.1.10.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.22.0",
                       "from": "mime-db@>= 1.21.0 < 2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/mime-db/-/mime-db-1.22.0.tgz"
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                     }
                   }
                 }
@@ -3367,12 +3367,12 @@
             "utils-merge": {
               "version": "1.0.0",
               "from": "utils-merge@1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/utils-merge/-/utils-merge-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
             },
             "vhost": {
               "version": "3.0.2",
               "from": "vhost@~3.0.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/vhost/-/vhost-3.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz"
             }
           }
         },
@@ -3384,7 +3384,7 @@
         "glob": {
           "version": "5.0.15",
           "from": "glob@^5.0.6",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/glob/-/glob-5.0.15.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
@@ -3406,7 +3406,7 @@
             "once": {
               "version": "1.3.3",
               "from": "once@^1.3.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/once/-/once-1.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
@@ -3418,7 +3418,7 @@
             "path-is-absolute": {
               "version": "1.0.0",
               "from": "path-is-absolute@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
@@ -3440,7 +3440,7 @@
             "pkginfo": {
               "version": "0.3.1",
               "from": "pkginfo@0.3.x",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pkginfo/-/pkginfo-0.3.1.tgz"
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
             },
             "utile": {
               "version": "0.2.1",
@@ -3455,12 +3455,12 @@
                 "deep-equal": {
                   "version": "1.0.1",
                   "from": "deep-equal@*",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/deep-equal/-/deep-equal-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
                 },
                 "i": {
                   "version": "0.3.4",
                   "from": "i@0.3.x",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/i/-/i-0.3.4.tgz"
+                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.4.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.1",
@@ -3470,7 +3470,7 @@
                     "minimist": {
                       "version": "0.0.8",
                       "from": "minimist@0.0.8",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/minimist/-/minimist-0.0.8.tgz"
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
@@ -3486,27 +3486,27 @@
         "lodash": {
           "version": "3.10.1",
           "from": "lodash@^3.8.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lodash/-/lodash-3.10.1.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "log4js": {
           "version": "0.6.35",
           "from": "log4js@^0.6.25",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/log4js/-/log4js-0.6.35.tgz",
+          "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.35.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.34",
               "from": "readable-stream@~1.0.2",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
                   "from": "core-util-is@~1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -3530,27 +3530,27 @@
         "mime": {
           "version": "1.3.4",
           "from": "mime@^1.3.4",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/mime/-/mime-1.3.4.tgz"
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "minimatch": {
           "version": "2.0.10",
           "from": "minimatch@^2.0.7",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/minimatch/-/minimatch-2.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.3",
               "from": "brace-expansion@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/brace-expansion/-/brace-expansion-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.3.0",
                   "from": "balanced-match@^0.3.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/balanced-match/-/balanced-match-0.3.0.tgz"
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
                   "from": "concat-map@0.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/concat-map/-/concat-map-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
             }
@@ -3564,7 +3564,7 @@
             "wordwrap": {
               "version": "0.0.3",
               "from": "wordwrap@~0.0.2",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/wordwrap/-/wordwrap-0.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
@@ -3576,17 +3576,17 @@
         "q": {
           "version": "1.4.1",
           "from": "q@^1.4.1",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/q/-/q-1.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
         },
         "rimraf": {
           "version": "2.5.2",
           "from": "rimraf@^2.3.3",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/rimraf/-/rimraf-2.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
           "dependencies": {
             "glob": {
               "version": "7.0.3",
               "from": "glob@^7.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/glob/-/glob-7.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
@@ -3608,7 +3608,7 @@
                 "once": {
                   "version": "1.3.3",
                   "from": "once@^1.3.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/once/-/once-1.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
@@ -3620,7 +3620,7 @@
                 "path-is-absolute": {
                   "version": "1.0.0",
                   "from": "path-is-absolute@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             }
@@ -3629,12 +3629,12 @@
         "socket.io": {
           "version": "0.9.16",
           "from": "socket.io@0.9.16",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/socket.io/-/socket.io-0.9.16.tgz",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
           "dependencies": {
             "socket.io-client": {
               "version": "0.9.16",
               "from": "socket.io-client@0.9.16",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/socket.io-client/-/socket.io-client-0.9.16.tgz",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "1.2.5",
@@ -3671,17 +3671,17 @@
                 "xmlhttprequest": {
                   "version": "1.4.2",
                   "from": "xmlhttprequest@1.4.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
+                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
                 },
                 "active-x-obfuscator": {
                   "version": "0.0.1",
                   "from": "active-x-obfuscator@0.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "dependencies": {
                     "zeparser": {
                       "version": "0.0.5",
                       "from": "zeparser@0.0.5",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/zeparser/-/zeparser-0.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
                     }
                   }
                 }
@@ -3690,36 +3690,36 @@
             "policyfile": {
               "version": "0.0.4",
               "from": "policyfile@0.0.4",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/policyfile/-/policyfile-0.0.4.tgz"
+              "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
             },
             "base64id": {
               "version": "0.1.0",
               "from": "base64id@0.1.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/base64id/-/base64id-0.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
             },
             "redis": {
               "version": "0.7.3",
               "from": "redis@0.7.3",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/redis/-/redis-0.7.3.tgz"
+              "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
             }
           }
         },
         "source-map": {
           "version": "0.4.4",
           "from": "source-map@^0.4.2",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
               "from": "amdefine@>=0.0.4",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/amdefine/-/amdefine-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
         },
         "useragent": {
           "version": "2.1.9",
           "from": "useragent@^2.1.6",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/useragent/-/useragent-2.1.9.tgz",
+          "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.2.4",
@@ -3733,17 +3733,17 @@
     "karma-6to5-preprocessor": {
       "version": "3.0.1",
       "from": "karma-6to5-preprocessor@~3.0.0",
-      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/karma-6to5-preprocessor/-/karma-6to5-preprocessor-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/karma-6to5-preprocessor/-/karma-6to5-preprocessor-3.0.1.tgz",
       "dependencies": {
         "6to5-core": {
           "version": "3.6.5",
           "from": "6to5-core@^3.0.0",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/6to5-core/-/6to5-core-3.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/6to5-core/-/6to5-core-3.6.5.tgz",
           "dependencies": {
             "acorn-6to5": {
               "version": "0.11.1-31",
               "from": "acorn-6to5@0.11.1-31",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/acorn-6to5/-/acorn-6to5-0.11.1-31.tgz"
+              "resolved": "https://registry.npmjs.org/acorn-6to5/-/acorn-6to5-0.11.1-31.tgz"
             },
             "ast-types": {
               "version": "0.6.16",
@@ -3763,7 +3763,7 @@
                 "escape-string-regexp": {
                   "version": "1.0.5",
                   "from": "escape-string-regexp@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
@@ -3799,29 +3799,29 @@
             "commander": {
               "version": "2.6.0",
               "from": "commander@2.6.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/commander/-/commander-2.6.0.tgz"
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
             },
             "core-js": {
               "version": "0.5.4",
               "from": "core-js@^0.5.3",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-js/-/core-js-0.5.4.tgz"
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.5.4.tgz"
             },
             "debug": {
               "version": "2.2.0",
               "from": "debug@~2.2.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/debug/-/debug-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
                   "from": "ms@0.7.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ms/-/ms-0.7.1.tgz"
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "detect-indent": {
               "version": "3.0.0",
               "from": "detect-indent@3.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/detect-indent/-/detect-indent-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.0.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "3.0.2",
@@ -3831,7 +3831,7 @@
                 "minimist": {
                   "version": "1.2.0",
                   "from": "minimist@^1.1.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/minimist/-/minimist-1.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "repeating": {
                   "version": "1.1.3",
@@ -3857,17 +3857,17 @@
             "estraverse": {
               "version": "1.9.1",
               "from": "estraverse@1.9.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/estraverse/-/estraverse-1.9.1.tgz"
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
             },
             "esutils": {
               "version": "1.1.6",
               "from": "esutils@1.1.6",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esutils/-/esutils-1.1.6.tgz"
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
             },
             "fs-readdir-recursive": {
               "version": "0.1.0",
               "from": "fs-readdir-recursive@0.1.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/fs-readdir-recursive/-/fs-readdir-recursive-0.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.0.tgz"
             },
             "globals": {
               "version": "5.1.0",
@@ -3877,7 +3877,7 @@
             "js-tokenizer": {
               "version": "1.3.3",
               "from": "js-tokenizer@1.3.3",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/js-tokenizer/-/js-tokenizer-1.3.3.tgz"
+              "resolved": "https://registry.npmjs.org/js-tokenizer/-/js-tokenizer-1.3.3.tgz"
             },
             "lodash": {
               "version": "3.0.0",
@@ -3887,7 +3887,7 @@
             "output-file-sync": {
               "version": "1.1.0",
               "from": "output-file-sync@1.1.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/output-file-sync/-/output-file-sync-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.0.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.1",
@@ -3904,46 +3904,46 @@
                 "xtend": {
                   "version": "4.0.1",
                   "from": "xtend@^4.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/xtend/-/xtend-4.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "private": {
               "version": "0.1.6",
               "from": "private@0.1.6",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/private/-/private-0.1.6.tgz"
+              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
             },
             "regenerator-6to5": {
               "version": "0.8.10-1",
               "from": "regenerator-6to5@0.8.10-1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/regenerator-6to5/-/regenerator-6to5-0.8.10-1.tgz",
+              "resolved": "https://registry.npmjs.org/regenerator-6to5/-/regenerator-6to5-0.8.10-1.tgz",
               "dependencies": {
                 "commoner": {
                   "version": "0.10.4",
                   "from": "commoner@~0.10.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/commoner/-/commoner-0.10.4.tgz",
+                  "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
                   "dependencies": {
                     "detective": {
                       "version": "4.3.1",
                       "from": "detective@^4.3.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/detective/-/detective-4.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "1.2.2",
                           "from": "acorn@^1.0.3",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/acorn/-/acorn-1.2.2.tgz"
+                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                         },
                         "defined": {
                           "version": "1.0.0",
                           "from": "defined@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/defined/-/defined-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
                         }
                       }
                     },
                     "glob": {
                       "version": "5.0.15",
                       "from": "glob@^5.0.15",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/glob/-/glob-5.0.15.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
@@ -3965,22 +3965,22 @@
                         "minimatch": {
                           "version": "3.0.0",
                           "from": "minimatch@2 || 3",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.3",
                               "from": "brace-expansion@^1.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.3.0",
                                   "from": "balanced-match@^0.3.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/balanced-match/-/balanced-match-0.3.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
                                   "from": "concat-map@0.0.1",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/concat-map/-/concat-map-0.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
                             }
@@ -3989,7 +3989,7 @@
                         "once": {
                           "version": "1.3.3",
                           "from": "once@^1.3.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
@@ -4001,19 +4001,19 @@
                         "path-is-absolute": {
                           "version": "1.0.0",
                           "from": "path-is-absolute@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                         }
                       }
                     },
                     "graceful-fs": {
                       "version": "4.1.3",
                       "from": "graceful-fs@^4.1.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                     },
                     "iconv-lite": {
                       "version": "0.4.13",
                       "from": "iconv-lite@^0.4.5",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
@@ -4030,27 +4030,27 @@
                     "q": {
                       "version": "1.4.1",
                       "from": "q@^1.1.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/q/-/q-1.4.1.tgz"
+                      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                     },
                     "recast": {
                       "version": "0.10.43",
                       "from": "recast@^0.10.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/recast/-/recast-0.10.43.tgz",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
                       "dependencies": {
                         "esprima-fb": {
                           "version": "15001.1001.0-dev-harmony-fb",
                           "from": "esprima-fb@~15001.1001.0-dev-harmony-fb",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
                         },
                         "source-map": {
                           "version": "0.5.3",
                           "from": "source-map@~0.5.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.5.3.tgz"
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
                         },
                         "ast-types": {
                           "version": "0.8.15",
                           "from": "ast-types@0.8.15",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ast-types/-/ast-types-0.8.15.tgz"
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
                         }
                       }
                     }
@@ -4059,14 +4059,14 @@
                 "through": {
                   "version": "2.3.8",
                   "from": "through@~2.3.6",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/through/-/through-2.3.8.tgz"
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "regexpu": {
               "version": "1.1.0",
               "from": "regexpu@1.1.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/regexpu/-/regexpu-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.1.0.tgz",
               "dependencies": {
                 "recast": {
                   "version": "0.9.18",
@@ -4093,7 +4093,7 @@
                 "regjsparser": {
                   "version": "0.1.5",
                   "from": "regjsparser@^0.1.3",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/regjsparser/-/regjsparser-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
                   "dependencies": {
                     "jsesc": {
                       "version": "0.5.0",
@@ -4107,24 +4107,24 @@
             "roadrunner": {
               "version": "1.0.4",
               "from": "roadrunner@1.0.4",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/roadrunner/-/roadrunner-1.0.4.tgz"
+              "resolved": "https://registry.npmjs.org/roadrunner/-/roadrunner-1.0.4.tgz"
             },
             "source-map": {
               "version": "0.1.43",
               "from": "source-map@^0.1.39",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.1.43.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
                   "from": "amdefine@>=0.0.4",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/amdefine/-/amdefine-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             },
             "source-map-support": {
               "version": "0.2.9",
               "from": "source-map-support@0.2.9",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map-support/-/source-map-support-0.2.9.tgz",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.9.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.32",
@@ -4134,7 +4134,7 @@
                     "amdefine": {
                       "version": "1.0.0",
                       "from": "amdefine@>=0.0.4",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/amdefine/-/amdefine-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 }
@@ -4143,12 +4143,12 @@
             "supports-color": {
               "version": "1.2.0",
               "from": "supports-color@1.2.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/supports-color/-/supports-color-1.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
             },
             "useragent": {
               "version": "2.1.9",
               "from": "useragent@^2.1.5",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/useragent/-/useragent-2.1.9.tgz",
+              "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.2.4",
@@ -4164,29 +4164,29 @@
     "karma-chrome-launcher": {
       "version": "0.1.12",
       "from": "karma-chrome-launcher@^0.1.7",
-      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/karma-chrome-launcher/-/karma-chrome-launcher-0.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.12.tgz",
       "dependencies": {
         "which": {
           "version": "1.2.4",
           "from": "which@~1.2.2",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/which/-/which-1.2.4.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
               "from": "is-absolute@^0.1.7",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-absolute/-/is-absolute-0.1.7.tgz",
+              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
               "dependencies": {
                 "is-relative": {
                   "version": "0.1.3",
                   "from": "is-relative@^0.1.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-relative/-/is-relative-0.1.3.tgz"
+                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                 }
               }
             },
             "isexe": {
               "version": "1.1.2",
               "from": "isexe@^1.1.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isexe/-/isexe-1.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
             }
           }
         }
@@ -4210,7 +4210,7 @@
             "escodegen": {
               "version": "0.0.23",
               "from": "escodegen@0.0.23",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escodegen/-/escodegen-0.0.23.tgz",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.23.tgz",
               "dependencies": {
                 "estraverse": {
                   "version": "0.0.4",
@@ -4220,7 +4220,7 @@
                 "source-map": {
                   "version": "0.5.3",
                   "from": "source-map@>= 0.1.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.5.3.tgz"
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
                 }
               }
             },
@@ -4242,12 +4242,12 @@
                     "source-map": {
                       "version": "0.1.43",
                       "from": "source-map@~0.1.7",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.1.43.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "1.0.0",
                           "from": "amdefine@>=0.0.4",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/amdefine/-/amdefine-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                         }
                       }
                     }
@@ -4268,7 +4268,7 @@
             "fileset": {
               "version": "0.1.8",
               "from": "fileset@0.1.x",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/fileset/-/fileset-0.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.4.0",
@@ -4278,7 +4278,7 @@
                     "lru-cache": {
                       "version": "2.7.3",
                       "from": "lru-cache@2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lru-cache/-/lru-cache-2.7.3.tgz"
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
@@ -4305,7 +4305,7 @@
                         "lru-cache": {
                           "version": "2.7.3",
                           "from": "lru-cache@2",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lru-cache/-/lru-cache-2.7.3.tgz"
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
@@ -4321,7 +4321,7 @@
             "which": {
               "version": "1.0.9",
               "from": "which@1.0.x",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/which/-/which-1.0.9.tgz"
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
             },
             "async": {
               "version": "0.2.10",
@@ -4331,12 +4331,12 @@
             "abbrev": {
               "version": "1.0.7",
               "from": "abbrev@1.0.x",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/abbrev/-/abbrev-1.0.7.tgz"
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             },
             "wordwrap": {
               "version": "0.0.3",
               "from": "wordwrap@~0.0.2",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/wordwrap/-/wordwrap-0.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "resolve": {
               "version": "0.5.1",
@@ -4378,12 +4378,12 @@
                     "escope": {
                       "version": "1.0.3",
                       "from": "escope@~ 1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escope/-/escope-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/escope/-/escope-1.0.3.tgz",
                       "dependencies": {
                         "estraverse": {
                           "version": "2.0.0",
                           "from": "estraverse@^2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/estraverse/-/estraverse-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz"
                         }
                       }
                     },
@@ -4409,12 +4409,12 @@
                 "source-map": {
                   "version": "0.1.43",
                   "from": "source-map@~0.1.7",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.1.43.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
                       "from": "amdefine@>=0.0.4",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/amdefine/-/amdefine-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 },
@@ -4450,7 +4450,7 @@
                 "wordwrap": {
                   "version": "0.0.3",
                   "from": "wordwrap@~0.0.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/wordwrap/-/wordwrap-0.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
@@ -4462,32 +4462,32 @@
             "escodegen": {
               "version": "1.8.0",
               "from": "escodegen@*",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escodegen/-/escodegen-1.8.0.tgz",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
               "dependencies": {
                 "estraverse": {
                   "version": "1.9.3",
                   "from": "estraverse@^1.9.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/estraverse/-/estraverse-1.9.3.tgz"
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                 },
                 "esutils": {
                   "version": "2.0.2",
                   "from": "esutils@^2.0.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esutils/-/esutils-2.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "esprima": {
                   "version": "2.7.2",
                   "from": "esprima@^2.7.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esprima/-/esprima-2.7.2.tgz"
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                 },
                 "optionator": {
                   "version": "0.8.1",
                   "from": "optionator@^0.8.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/optionator/-/optionator-0.8.1.tgz",
+                  "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
                   "dependencies": {
                     "prelude-ls": {
                       "version": "1.1.2",
                       "from": "prelude-ls@~1.1.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                     },
                     "deep-is": {
                       "version": "0.1.3",
@@ -4497,22 +4497,22 @@
                     "wordwrap": {
                       "version": "1.0.0",
                       "from": "wordwrap@~1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/wordwrap/-/wordwrap-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
                     },
                     "type-check": {
                       "version": "0.3.2",
                       "from": "type-check@~0.3.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/type-check/-/type-check-0.3.2.tgz"
+                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
                     },
                     "levn": {
                       "version": "0.3.0",
                       "from": "levn@~0.3.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/levn/-/levn-0.3.0.tgz"
+                      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
                     },
                     "fast-levenshtein": {
                       "version": "1.1.3",
                       "from": "fast-levenshtein@^1.1.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
                     }
                   }
                 },
@@ -4524,7 +4524,7 @@
                     "amdefine": {
                       "version": "1.0.0",
                       "from": "amdefine@>=0.0.4",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/amdefine/-/amdefine-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 }
@@ -4545,38 +4545,38 @@
             "which": {
               "version": "1.2.4",
               "from": "which@^1.1.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/which/-/which-1.2.4.tgz",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
                   "from": "is-absolute@^0.1.7",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-absolute/-/is-absolute-0.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
                       "version": "0.1.3",
                       "from": "is-relative@^0.1.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-relative/-/is-relative-0.1.3.tgz"
+                      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                     }
                   }
                 },
                 "isexe": {
                   "version": "1.1.2",
                   "from": "isexe@^1.1.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isexe/-/isexe-1.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
                 }
               }
             },
             "estraverse": {
               "version": "4.2.0",
               "from": "estraverse@*",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/estraverse/-/estraverse-4.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
             }
           }
         },
         "dateformat": {
           "version": "1.0.12",
           "from": "dateformat@~1.0.6",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/dateformat/-/dateformat-1.0.12.tgz",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
@@ -4586,39 +4586,39 @@
             "meow": {
               "version": "3.7.0",
               "from": "meow@^3.3.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/meow/-/meow-3.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "2.1.0",
                   "from": "camelcase-keys@^2.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "2.1.1",
                       "from": "camelcase@^2.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/camelcase/-/camelcase-2.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.2.0",
                   "from": "decamelize@^1.1.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/decamelize/-/decamelize-1.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "loud-rejection": {
                   "version": "1.3.0",
                   "from": "loud-rejection@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/loud-rejection/-/loud-rejection-1.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                   "dependencies": {
                     "array-find-index": {
                       "version": "1.0.1",
                       "from": "array-find-index@^1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/array-find-index/-/array-find-index-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
                     },
                     "signal-exit": {
                       "version": "2.1.2",
                       "from": "signal-exit@^2.1.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/signal-exit/-/signal-exit-2.1.2.tgz"
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                     }
                   }
                 },
@@ -4630,66 +4630,66 @@
                 "minimist": {
                   "version": "1.2.0",
                   "from": "minimist@^1.1.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/minimist/-/minimist-1.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
                   "from": "normalize-package-data@^2.3.4",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                  "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.4",
                       "from": "hosted-git-info@^2.1.4",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
                       "from": "is-builtin-module@^1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.1",
                           "from": "builtin-modules@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/builtin-modules/-/builtin-modules-1.1.1.tgz"
+                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                         }
                       }
                     },
                     "semver": {
                       "version": "5.1.0",
                       "from": "semver@2 || 3 || 4 || 5",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/semver/-/semver-5.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
                       "from": "validate-npm-package-license@^3.0.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
                           "from": "spdx-correct@~1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.2.1",
                               "from": "spdx-license-ids@^1.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.2",
                           "from": "spdx-expression-parse@~1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.4",
                               "from": "spdx-exceptions@^1.0.4",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                             },
                             "spdx-license-ids": {
                               "version": "1.2.1",
                               "from": "spdx-license-ids@^1.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
                         }
@@ -4700,32 +4700,32 @@
                 "object-assign": {
                   "version": "4.0.1",
                   "from": "object-assign@^4.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/object-assign/-/object-assign-4.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                 },
                 "read-pkg-up": {
                   "version": "1.0.1",
                   "from": "read-pkg-up@^1.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
                       "version": "1.1.2",
                       "from": "find-up@^1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/find-up/-/find-up-1.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
                           "from": "path-exists@^2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/path-exists/-/path-exists-2.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
                           "from": "pinkie-promise@^2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
                               "from": "pinkie@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie/-/pinkie-2.0.4.tgz"
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
                         }
@@ -4734,32 +4734,32 @@
                     "read-pkg": {
                       "version": "1.1.0",
                       "from": "read-pkg@^1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/read-pkg/-/read-pkg-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "dependencies": {
                         "load-json-file": {
                           "version": "1.1.0",
                           "from": "load-json-file@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/load-json-file/-/load-json-file-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.3",
                               "from": "graceful-fs@^4.1.2",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
                               "from": "parse-json@^2.2.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/parse-json/-/parse-json-2.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.3.0",
                                   "from": "error-ex@^1.2.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/error-ex/-/error-ex-1.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                   "dependencies": {
                                     "is-arrayish": {
                                       "version": "0.2.1",
                                       "from": "is-arrayish@^0.2.1",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                     }
                                   }
                                 }
@@ -4768,29 +4768,29 @@
                             "pify": {
                               "version": "2.3.0",
                               "from": "pify@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pify/-/pify-2.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
                               "from": "pinkie-promise@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
                                   "from": "pinkie@^2.0.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie/-/pinkie-2.0.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
                             },
                             "strip-bom": {
                               "version": "2.0.0",
                               "from": "strip-bom@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/strip-bom/-/strip-bom-2.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "dependencies": {
                                 "is-utf8": {
                                   "version": "0.2.1",
                                   "from": "is-utf8@^0.2.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-utf8/-/is-utf8-0.2.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                                 }
                               }
                             }
@@ -4799,27 +4799,27 @@
                         "path-type": {
                           "version": "1.1.0",
                           "from": "path-type@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/path-type/-/path-type-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.3",
                               "from": "graceful-fs@^4.1.2",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                             },
                             "pify": {
                               "version": "2.3.0",
                               "from": "pify@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pify/-/pify-2.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
                               "from": "pinkie-promise@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
                                   "from": "pinkie@^2.0.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie/-/pinkie-2.0.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
                             }
@@ -4832,17 +4832,17 @@
                 "redent": {
                   "version": "1.0.0",
                   "from": "redent@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/redent/-/redent-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
                       "from": "indent-string@^2.1.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/indent-string/-/indent-string-2.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.1",
                           "from": "repeating@^2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/repeating/-/repeating-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
@@ -4863,14 +4863,14 @@
                     "strip-indent": {
                       "version": "1.0.1",
                       "from": "strip-indent@^1.0.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/strip-indent/-/strip-indent-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                     }
                   }
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
                   "from": "trim-newlines@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                 }
               }
             }
@@ -4881,17 +4881,17 @@
     "karma-firefox-launcher": {
       "version": "0.1.7",
       "from": "karma-firefox-launcher@^0.1.4",
-      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/karma-firefox-launcher/-/karma-firefox-launcher-0.1.7.tgz"
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-0.1.7.tgz"
     },
     "karma-jasmine": {
       "version": "0.3.8",
       "from": "karma-jasmine@^0.3.5",
-      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/karma-jasmine/-/karma-jasmine-0.3.8.tgz"
+      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.8.tgz"
     },
     "karma-jasmine-html-reporter": {
       "version": "0.1.8",
       "from": "karma-jasmine-html-reporter@~0.1",
-      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-0.1.8.tgz",
       "dependencies": {
         "karma-jasmine": {
           "version": "0.2.3",
@@ -4908,7 +4908,7 @@
         "xmlbuilder": {
           "version": "0.4.2",
           "from": "xmlbuilder@0.4.2",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
         }
       }
     },
@@ -4920,17 +4920,17 @@
         "phantomjs": {
           "version": "1.9.20",
           "from": "phantomjs@~1.9",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/phantomjs/-/phantomjs-1.9.20.tgz",
+          "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.20.tgz",
           "dependencies": {
             "extract-zip": {
               "version": "1.5.0",
               "from": "extract-zip@~1.5.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/extract-zip/-/extract-zip-1.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.0",
                   "from": "concat-stream@1.5.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/concat-stream/-/concat-stream-1.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
@@ -4940,27 +4940,27 @@
                     "typedarray": {
                       "version": "0.0.6",
                       "from": "typedarray@~0.0.5",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/typedarray/-/typedarray-0.0.6.tgz"
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "2.0.6",
                       "from": "readable-stream@~2.0.5",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
                           "from": "core-util-is@~1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "1.0.0",
                           "from": "isarray@~1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
                           "from": "process-nextick-args@~1.0.6",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
@@ -4970,7 +4970,7 @@
                         "util-deprecate": {
                           "version": "1.0.2",
                           "from": "util-deprecate@~1.0.1",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
                     }
@@ -4979,7 +4979,7 @@
                 "debug": {
                   "version": "0.7.4",
                   "from": "debug@0.7.4",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/debug/-/debug-0.7.4.tgz"
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.0",
@@ -4996,17 +4996,17 @@
                 "yauzl": {
                   "version": "2.4.1",
                   "from": "yauzl@2.4.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/yauzl/-/yauzl-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
                   "dependencies": {
                     "fd-slicer": {
                       "version": "1.0.1",
                       "from": "fd-slicer@~1.0.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/fd-slicer/-/fd-slicer-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
                       "dependencies": {
                         "pend": {
                           "version": "1.2.0",
                           "from": "pend@~1.2.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pend/-/pend-1.2.0.tgz"
+                          "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
                         }
                       }
                     }
@@ -5017,37 +5017,37 @@
             "fs-extra": {
               "version": "0.26.7",
               "from": "fs-extra@~0.26.4",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/fs-extra/-/fs-extra-0.26.7.tgz",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.3",
                   "from": "graceful-fs@^4.1.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                 },
                 "jsonfile": {
                   "version": "2.3.0",
                   "from": "jsonfile@^2.1.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/jsonfile/-/jsonfile-2.3.0.tgz"
+                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.0.tgz"
                 },
                 "klaw": {
                   "version": "1.2.0",
                   "from": "klaw@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/klaw/-/klaw-1.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.2.0.tgz"
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
                   "from": "path-is-absolute@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 },
                 "rimraf": {
                   "version": "2.5.2",
                   "from": "rimraf@^2.2.8",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/rimraf/-/rimraf-2.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "7.0.3",
                       "from": "glob@^7.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/glob/-/glob-7.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
@@ -5069,22 +5069,22 @@
                         "minimatch": {
                           "version": "3.0.0",
                           "from": "minimatch@2 || 3",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.3",
                               "from": "brace-expansion@^1.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.3.0",
                                   "from": "balanced-match@^0.3.0",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/balanced-match/-/balanced-match-0.3.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
                                   "from": "concat-map@0.0.1",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/concat-map/-/concat-map-0.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
                             }
@@ -5093,7 +5093,7 @@
                         "once": {
                           "version": "1.3.3",
                           "from": "once@^1.3.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
@@ -5111,22 +5111,22 @@
             "hasha": {
               "version": "2.2.0",
               "from": "hasha@^2.2.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/hasha/-/hasha-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
               "dependencies": {
                 "is-stream": {
                   "version": "1.1.0",
                   "from": "is-stream@^1.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-stream/-/is-stream-1.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
                   "from": "pinkie-promise@^2.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
                       "from": "pinkie@^2.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie/-/pinkie-2.0.4.tgz"
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
                 }
@@ -5135,7 +5135,7 @@
             "kew": {
               "version": "0.7.0",
               "from": "kew@~0.7.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/kew/-/kew-0.7.0.tgz"
+              "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz"
             },
             "progress": {
               "version": "1.1.8",
@@ -5145,22 +5145,22 @@
             "request": {
               "version": "2.67.0",
               "from": "request@~2.67.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/request/-/request-2.67.0.tgz",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "1.0.3",
                   "from": "bl@~1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/bl/-/bl-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.6",
                       "from": "readable-stream@~2.0.5",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
                           "from": "core-util-is@~1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/core-util-is/-/core-util-is-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
@@ -5170,12 +5170,12 @@
                         "isarray": {
                           "version": "1.0.0",
                           "from": "isarray@~1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isarray/-/isarray-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
                           "from": "process-nextick-args@~1.0.6",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
@@ -5185,7 +5185,7 @@
                         "util-deprecate": {
                           "version": "1.0.2",
                           "from": "util-deprecate@~1.0.1",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
                     }
@@ -5194,140 +5194,140 @@
                 "caseless": {
                   "version": "0.11.0",
                   "from": "caseless@~0.11.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/caseless/-/caseless-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
                 "extend": {
                   "version": "3.0.0",
                   "from": "extend@~3.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/extend/-/extend-3.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.6.1",
                   "from": "forever-agent@~0.6.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/forever-agent/-/forever-agent-0.6.1.tgz"
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
                   "version": "1.0.0-rc4",
                   "from": "form-data@~1.0.0-rc3",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/form-data/-/form-data-1.0.0-rc4.tgz",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
                   "dependencies": {
                     "async": {
                       "version": "1.5.2",
                       "from": "async@^1.5.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/async/-/async-1.5.2.tgz"
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
                   "from": "json-stringify-safe@~5.0.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.10",
                   "from": "mime-types@~2.1.10",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/mime-types/-/mime-types-2.1.10.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.22.0",
                       "from": "mime-db@>= 1.21.0 < 2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/mime-db/-/mime-db-1.22.0.tgz"
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.7",
                   "from": "node-uuid@~1.4.7",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/node-uuid/-/node-uuid-1.4.7.tgz"
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "qs": {
                   "version": "5.2.0",
                   "from": "qs@~5.2.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/qs/-/qs-5.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.2",
                   "from": "tunnel-agent@~0.4.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.2.2",
                   "from": "tough-cookie@~2.2.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/tough-cookie/-/tough-cookie-2.2.2.tgz"
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
                 },
                 "http-signature": {
                   "version": "1.1.1",
                   "from": "http-signature@~1.1.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/http-signature/-/http-signature-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
                       "from": "assert-plus@^0.2.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/assert-plus/-/assert-plus-0.2.0.tgz"
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                     },
                     "jsprim": {
                       "version": "1.2.2",
                       "from": "jsprim@^1.2.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/jsprim/-/jsprim-1.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
                       "dependencies": {
                         "extsprintf": {
                           "version": "1.0.2",
                           "from": "extsprintf@1.0.2",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/extsprintf/-/extsprintf-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                         },
                         "json-schema": {
                           "version": "0.2.2",
                           "from": "json-schema@0.2.2",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/json-schema/-/json-schema-0.2.2.tgz"
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                         },
                         "verror": {
                           "version": "1.3.6",
                           "from": "verror@1.3.6",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/verror/-/verror-1.3.6.tgz"
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                         }
                       }
                     },
                     "sshpk": {
                       "version": "1.7.4",
                       "from": "sshpk@^1.7.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/sshpk/-/sshpk-1.7.4.tgz",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
                           "from": "asn1@>=0.2.3 <0.3.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/asn1/-/asn1-0.2.3.tgz"
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                         },
                         "dashdash": {
                           "version": "1.13.0",
                           "from": "dashdash@>=1.10.1 <2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/dashdash/-/dashdash-1.13.0.tgz",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
                           "dependencies": {
                             "assert-plus": {
                               "version": "1.0.0",
                               "from": "assert-plus@^1.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/assert-plus/-/assert-plus-1.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                             }
                           }
                         },
                         "jsbn": {
                           "version": "0.1.0",
                           "from": "jsbn@>=0.1.0 <0.2.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/jsbn/-/jsbn-0.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                         },
                         "tweetnacl": {
                           "version": "0.14.3",
                           "from": "tweetnacl@>=0.13.0 <1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
                         },
                         "jodid25519": {
                           "version": "1.0.2",
                           "from": "jodid25519@>=1.0.0 <2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/jodid25519/-/jodid25519-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
                           "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                         }
                       }
                     }
@@ -5336,173 +5336,173 @@
                 "oauth-sign": {
                   "version": "0.8.1",
                   "from": "oauth-sign@~0.8.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/oauth-sign/-/oauth-sign-0.8.1.tgz"
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
                 },
                 "hawk": {
                   "version": "3.1.3",
                   "from": "hawk@~3.1.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/hawk/-/hawk-3.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.16.3",
                       "from": "hoek@2.x.x",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/hoek/-/hoek-2.16.3.tgz"
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
                     "boom": {
                       "version": "2.10.1",
                       "from": "boom@2.x.x",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/boom/-/boom-2.10.1.tgz"
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.5",
                       "from": "cryptiles@2.x.x",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/cryptiles/-/cryptiles-2.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
                       "from": "sntp@1.x.x",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/sntp/-/sntp-1.0.9.tgz"
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.6.0",
                   "from": "aws-sign2@~0.6.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.5",
                   "from": "stringstream@~0.0.4",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/stringstream/-/stringstream-0.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
                   "from": "combined-stream@~1.0.5",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
                       "from": "delayed-stream@~1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     }
                   }
                 },
                 "isstream": {
                   "version": "0.1.2",
                   "from": "isstream@~0.1.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isstream/-/isstream-0.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
                   "from": "is-typedarray@~1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                 },
                 "har-validator": {
                   "version": "2.0.6",
                   "from": "har-validator@~2.0.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/har-validator/-/har-validator-2.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
                       "from": "chalk@^1.1.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/chalk/-/chalk-1.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
                           "from": "ansi-styles@^2.2.1",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
                           "from": "escape-string-regexp@^1.0.2",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
                           "from": "has-ansi@^2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
                               "from": "ansi-regex@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
                           "from": "strip-ansi@^3.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
                               "from": "ansi-regex@^2.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
                           "from": "supports-color@^2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/supports-color/-/supports-color-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "commander": {
                       "version": "2.9.0",
                       "from": "commander@^2.9.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/commander/-/commander-2.9.0.tgz",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
                           "from": "graceful-readlink@>= 1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.13.1",
                       "from": "is-my-json-valid@^2.12.4",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
                           "from": "generate-function@^2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/generate-function/-/generate-function-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
                           "from": "generate-object-property@^1.1.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
                               "from": "is-property@^1.0.0",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-property/-/is-property-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "2.0.0",
                           "from": "jsonpointer@2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                         },
                         "xtend": {
                           "version": "4.0.1",
                           "from": "xtend@^4.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/xtend/-/xtend-4.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                         }
                       }
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
                       "from": "pinkie-promise@^2.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
                           "from": "pinkie@^2.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/pinkie/-/pinkie-2.0.4.tgz"
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
                     }
@@ -5513,36 +5513,36 @@
             "request-progress": {
               "version": "2.0.1",
               "from": "request-progress@~2.0.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/request-progress/-/request-progress-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
               "dependencies": {
                 "throttleit": {
                   "version": "1.0.0",
                   "from": "throttleit@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/throttleit/-/throttleit-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz"
                 }
               }
             },
             "which": {
               "version": "1.2.4",
               "from": "which@~1.2.2",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/which/-/which-1.2.4.tgz",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
                   "from": "is-absolute@^0.1.7",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-absolute/-/is-absolute-0.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
                       "version": "0.1.3",
                       "from": "is-relative@^0.1.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-relative/-/is-relative-0.1.3.tgz"
+                      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                     }
                   }
                 },
                 "isexe": {
                   "version": "1.1.2",
                   "from": "isexe@^1.1.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isexe/-/isexe-1.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
                 }
               }
             }
@@ -5553,42 +5553,42 @@
     "karma-threshold-reporter": {
       "version": "0.1.15",
       "from": "karma-threshold-reporter@~0.1.7",
-      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/karma-threshold-reporter/-/karma-threshold-reporter-0.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/karma-threshold-reporter/-/karma-threshold-reporter-0.1.15.tgz",
       "dependencies": {
         "istanbul": {
           "version": "0.3.22",
           "from": "istanbul@~0.3.2",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/istanbul/-/istanbul-0.3.22.tgz",
+          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
               "from": "abbrev@1.0.x",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/abbrev/-/abbrev-1.0.7.tgz"
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             },
             "async": {
               "version": "1.5.2",
               "from": "async@1.x",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/async/-/async-1.5.2.tgz"
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             },
             "escodegen": {
               "version": "1.7.1",
               "from": "escodegen@1.7.x",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escodegen/-/escodegen-1.7.1.tgz",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
               "dependencies": {
                 "estraverse": {
                   "version": "1.9.3",
                   "from": "estraverse@^1.9.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/estraverse/-/estraverse-1.9.3.tgz"
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                 },
                 "esutils": {
                   "version": "2.0.2",
                   "from": "esutils@^2.0.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esutils/-/esutils-2.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "esprima": {
                   "version": "1.2.5",
                   "from": "esprima@^1.2.2",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esprima/-/esprima-1.2.5.tgz"
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                 },
                 "optionator": {
                   "version": "0.5.0",
@@ -5598,7 +5598,7 @@
                     "prelude-ls": {
                       "version": "1.1.2",
                       "from": "prelude-ls@~1.1.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                     },
                     "deep-is": {
                       "version": "0.1.3",
@@ -5608,12 +5608,12 @@
                     "wordwrap": {
                       "version": "0.0.3",
                       "from": "wordwrap@~0.0.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/wordwrap/-/wordwrap-0.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     },
                     "type-check": {
                       "version": "0.3.2",
                       "from": "type-check@~0.3.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/type-check/-/type-check-0.3.2.tgz"
+                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
                     },
                     "levn": {
                       "version": "0.2.5",
@@ -5623,7 +5623,7 @@
                     "fast-levenshtein": {
                       "version": "1.0.7",
                       "from": "fast-levenshtein@~1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
                     }
                   }
                 },
@@ -5635,7 +5635,7 @@
                     "amdefine": {
                       "version": "1.0.0",
                       "from": "amdefine@>=0.0.4",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/amdefine/-/amdefine-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 }
@@ -5644,32 +5644,32 @@
             "esprima": {
               "version": "2.5.0",
               "from": "esprima@2.5.x",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esprima/-/esprima-2.5.0.tgz"
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz"
             },
             "fileset": {
               "version": "0.2.1",
               "from": "fileset@0.2.x",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/fileset/-/fileset-0.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "2.0.10",
                   "from": "minimatch@2.x",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/minimatch/-/minimatch-2.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.3",
                       "from": "brace-expansion@^1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
                           "from": "balanced-match@^0.3.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/balanced-match/-/balanced-match-0.3.0.tgz"
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
                           "from": "concat-map@0.0.1",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/concat-map/-/concat-map-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
                     }
@@ -5678,7 +5678,7 @@
                 "glob": {
                   "version": "5.0.15",
                   "from": "glob@5.x",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/glob/-/glob-5.0.15.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
@@ -5700,7 +5700,7 @@
                     "path-is-absolute": {
                       "version": "1.0.0",
                       "from": "path-is-absolute@^1.0.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
                 }
@@ -5709,7 +5709,7 @@
             "handlebars": {
               "version": "4.0.5",
               "from": "handlebars@^4.0.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/handlebars/-/handlebars-4.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
               "dependencies": {
                 "optimist": {
                   "version": "0.6.1",
@@ -5719,7 +5719,7 @@
                     "wordwrap": {
                       "version": "0.0.3",
                       "from": "wordwrap@~0.0.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/wordwrap/-/wordwrap-0.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     },
                     "minimist": {
                       "version": "0.0.10",
@@ -5731,19 +5731,19 @@
                 "source-map": {
                   "version": "0.4.4",
                   "from": "source-map@^0.4.4",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.4.4.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
                       "from": "amdefine@>=0.0.4",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/amdefine/-/amdefine-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 },
                 "uglify-js": {
                   "version": "2.6.2",
                   "from": "uglify-js@^2.6",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/uglify-js/-/uglify-js-2.6.2.tgz",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
@@ -5753,7 +5753,7 @@
                     "source-map": {
                       "version": "0.5.3",
                       "from": "source-map@~0.5.1",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/source-map/-/source-map-0.5.3.tgz"
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
                     },
                     "uglify-to-browserify": {
                       "version": "1.0.2",
@@ -5763,90 +5763,90 @@
                     "yargs": {
                       "version": "3.10.0",
                       "from": "yargs@~3.10.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/yargs/-/yargs-3.10.0.tgz",
+                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
                           "from": "camelcase@^1.0.2",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/camelcase/-/camelcase-1.2.1.tgz"
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "cliui": {
                           "version": "2.1.0",
                           "from": "cliui@^2.1.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/cliui/-/cliui-2.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                           "dependencies": {
                             "center-align": {
                               "version": "0.1.3",
                               "from": "center-align@^0.1.1",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/center-align/-/center-align-0.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
                                   "from": "align-text@^0.1.3",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/align-text/-/align-text-0.1.4.tgz",
+                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.2",
                                       "from": "kind-of@^3.0.2",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/kind-of/-/kind-of-3.0.2.tgz",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
                                           "from": "is-buffer@^1.0.2",
-                                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-buffer/-/is-buffer-1.1.3.tgz"
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                         }
                                       }
                                     },
                                     "longest": {
                                       "version": "1.0.1",
                                       "from": "longest@^1.0.1",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/longest/-/longest-1.0.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
                                       "from": "repeat-string@^1.5.2",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/repeat-string/-/repeat-string-1.5.4.tgz"
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                     }
                                   }
                                 },
                                 "lazy-cache": {
                                   "version": "1.0.3",
                                   "from": "lazy-cache@^1.0.3",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
                                 }
                               }
                             },
                             "right-align": {
                               "version": "0.1.3",
                               "from": "right-align@^0.1.1",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/right-align/-/right-align-0.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
                                   "from": "align-text@^0.1.3",
-                                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/align-text/-/align-text-0.1.4.tgz",
+                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.2",
                                       "from": "kind-of@^3.0.2",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/kind-of/-/kind-of-3.0.2.tgz",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
                                           "from": "is-buffer@^1.0.2",
-                                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-buffer/-/is-buffer-1.1.3.tgz"
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                         }
                                       }
                                     },
                                     "longest": {
                                       "version": "1.0.1",
                                       "from": "longest@^1.0.1",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/longest/-/longest-1.0.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
                                       "from": "repeat-string@^1.5.2",
-                                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/repeat-string/-/repeat-string-1.5.4.tgz"
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                     }
                                   }
                                 }
@@ -5855,19 +5855,19 @@
                             "wordwrap": {
                               "version": "0.0.2",
                               "from": "wordwrap@0.0.2",
-                              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/wordwrap/-/wordwrap-0.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             }
                           }
                         },
                         "decamelize": {
                           "version": "1.2.0",
                           "from": "decamelize@^1.0.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/decamelize/-/decamelize-1.2.0.tgz"
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "window-size": {
                           "version": "0.1.0",
                           "from": "window-size@0.1.0",
-                          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/window-size/-/window-size-0.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                         }
                       }
                     }
@@ -5878,24 +5878,24 @@
             "js-yaml": {
               "version": "3.6.0",
               "from": "js-yaml@3.x",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/js-yaml/-/js-yaml-3.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.7",
                   "from": "argparse@^1.0.7",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/argparse/-/argparse-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
                   "dependencies": {
                     "sprintf-js": {
                       "version": "1.0.3",
                       "from": "sprintf-js@~1.0.2",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "2.7.2",
                   "from": "esprima@^2.7.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/esprima/-/esprima-2.7.2.tgz"
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                 }
               }
             },
@@ -5914,12 +5914,12 @@
             "nopt": {
               "version": "3.0.6",
               "from": "nopt@3.x",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/nopt/-/nopt-3.0.6.tgz"
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
             },
             "once": {
               "version": "1.3.3",
               "from": "once@^1.3.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/once/-/once-1.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
@@ -5931,48 +5931,48 @@
             "resolve": {
               "version": "1.1.7",
               "from": "resolve@^1.1.6",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/resolve/-/resolve-1.1.7.tgz"
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
             },
             "supports-color": {
               "version": "3.1.2",
               "from": "supports-color@^3.1.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/supports-color/-/supports-color-3.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "dependencies": {
                 "has-flag": {
                   "version": "1.0.0",
                   "from": "has-flag@^1.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/has-flag/-/has-flag-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
                 }
               }
             },
             "which": {
               "version": "1.2.4",
               "from": "which@^1.1.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/which/-/which-1.2.4.tgz",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
                   "from": "is-absolute@^0.1.7",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-absolute/-/is-absolute-0.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
                       "version": "0.1.3",
                       "from": "is-relative@^0.1.0",
-                      "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/is-relative/-/is-relative-0.1.3.tgz"
+                      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                     }
                   }
                 },
                 "isexe": {
                   "version": "1.1.2",
                   "from": "isexe@^1.1.1",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/isexe/-/isexe-1.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
                 }
               }
             },
             "wordwrap": {
               "version": "1.0.0",
               "from": "wordwrap@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/wordwrap/-/wordwrap-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
             }
           }
         }
@@ -5986,46 +5986,46 @@
         "chalk": {
           "version": "1.1.3",
           "from": "chalk@*",
-          "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
               "from": "ansi-styles@^2.2.1",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ansi-styles/-/ansi-styles-2.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
               "from": "escape-string-regexp@^1.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
               "from": "has-ansi@^2.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/has-ansi/-/has-ansi-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
                   "from": "ansi-regex@^2.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
               "from": "strip-ansi@^3.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
                   "from": "ansi-regex@^2.0.0",
-                  "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
               "from": "supports-color@^2.0.0",
-              "resolved": "http://nexus.zendev.org:8081/nexus/content/repositories/npm/supports-color/-/supports-color-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         }


### PR DESCRIPTION
the last shrinkwrap update pointed many packages to our internal npm cache. This points them back to the public npm registry.