### PR TITLE
feature/CC-2474: Adding endpoint for hosts with reduced payload.

### DIFF
--- a/domain/host/host.go
+++ b/domain/host/host.go
@@ -82,12 +82,12 @@ type ReadHost struct {
 	RAMLimit      string
 	KernelVersion string
 	KernelRelease string
-	ServiceD      ReadServiceD
+	ServiceD      ReadServiced
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 }
 
-type ReadServiceD struct {
+type ReadServiced struct {
 	Version string
 	Date    string
 	Release string

--- a/domain/host/host.go
+++ b/domain/host/host.go
@@ -72,6 +72,27 @@ type Host struct {
 	datastore.VersionedEntity
 }
 
+//ReadHost is a minimal representation of hosts.
+type ReadHost struct {
+	ID            string
+	Name          string
+	PoolID        string
+	Cores         int
+	Memory        uint64
+	RAMLimit      string
+	KernelVersion string
+	KernelRelease string
+	ServiceD      ReadServiceD
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+type ReadServiceD struct {
+	Version string
+	Date    string
+	Release string
+}
+
 func (a *Host) TotalRAM() (mem uint64) {
 	if a.RAMLimit != "" {
 		mem, _ = GetRAMLimit(a.RAMLimit, a.Memory)

--- a/facade/host.go
+++ b/facade/host.go
@@ -259,7 +259,7 @@ func (f *Facade) GetReadHosts(ctx datastore.Context) ([]host.ReadHost, error) {
 			RAMLimit:      h.RAMLimit,
 			KernelVersion: h.KernelVersion,
 			KernelRelease: h.KernelRelease,
-			ServiceD: host.ReadServiceD{
+			ServiceD: host.ReadServiced{
 				Version: h.ServiceD.Version,
 				Date:    h.ServiceD.Date,
 				Release: h.ServiceD.Release,

--- a/facade/host.go
+++ b/facade/host.go
@@ -240,3 +240,34 @@ func (f *Facade) FindHostsInPool(ctx datastore.Context, poolID string) ([]host.H
 func (f *Facade) GetHostByIP(ctx datastore.Context, hostIP string) (*host.Host, error) {
 	return f.hostStore.GetHostByIP(ctx, hostIP)
 }
+
+func (f *Facade) GetReadHosts(ctx datastore.Context) ([]host.ReadHost, error) {
+	readHosts := []host.ReadHost{}
+
+	hosts, err := f.hostStore.GetN(ctx, 20000)
+	if err != nil {
+		return readHosts, err
+	}
+
+	for _, h := range hosts {
+		readHosts = append(readHosts, host.ReadHost{
+			ID:            h.ID,
+			Name:          h.Name,
+			PoolID:        h.PoolID,
+			Cores:         h.Cores,
+			Memory:        h.Memory,
+			RAMLimit:      h.RAMLimit,
+			KernelVersion: h.KernelVersion,
+			KernelRelease: h.KernelRelease,
+			ServiceD: host.ReadServiceD{
+				Version: h.ServiceD.Version,
+				Date:    h.ServiceD.Date,
+				Release: h.ServiceD.Release,
+			},
+			CreatedAt: h.CreatedAt,
+			UpdatedAt: h.UpdatedAt,
+		})
+	}
+
+	return readHosts, nil
+}

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -116,4 +116,6 @@ type FacadeInterface interface {
 	GetServiceInstances(ctx datastore.Context, serviceid string) ([]service.Instance, error)
 
 	GetReadPools(ctx datastore.Context) ([]pool.ReadPool, error)
+
+	GetReadHosts(ctx datastore.Context) ([]host.ReadHost, error)
 }

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -749,3 +749,24 @@ func (_m *FacadeInterface) GetReadPools(ctx datastore.Context) ([]pool.ReadPool,
 
 	return r0, r1
 }
+func (_m *FacadeInterface) GetReadHosts(ctx datastore.Context) ([]host.ReadHost, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []host.ReadHost
+	if rf, ok := ret.Get(0).(func(datastore.Context) []host.ReadHost); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]host.ReadHost)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/web/api_hosts.go
+++ b/web/api_hosts.go
@@ -1,3 +1,15 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package web
 
 import (

--- a/web/api_hosts.go
+++ b/web/api_hosts.go
@@ -1,0 +1,36 @@
+package web
+
+import (
+	"github.com/control-center/serviced/domain/host"
+	"github.com/zenoss/go-json-rest"
+)
+
+// getPools returns the list of pools requested.  This call supports paging.
+func getHosts(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
+	facade := ctx.getFacade()
+	dataCtx := ctx.getDatastoreContext()
+
+	hosts, err := facade.GetReadHosts(dataCtx)
+	if err != nil {
+		restServerError(w, err)
+		return
+	}
+
+	response := hostsResponse{
+		Results: hosts,
+		Total:   len(hosts),
+		Links: []APILink{APILink{
+			Rel:    "self",
+			HRef:   r.URL.Path,
+			Method: "GET",
+		}},
+	}
+
+	w.WriteJson(response)
+}
+
+type hostsResponse struct {
+	Results []host.ReadHost `json:"results"`
+	Total   int             `json:"total"`
+	Links   []APILink       `json:"links"`
+}

--- a/web/api_hosts_test.go
+++ b/web/api_hosts_test.go
@@ -1,0 +1,153 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package web
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/control-center/serviced/domain/host"
+	. "gopkg.in/check.v1"
+)
+
+type apiHostsTestData struct {
+	firstHost  host.ReadHost
+	secondHost host.ReadHost
+	selfLink   APILink
+}
+
+func newAPIHostsTestData() apiHostsTestData {
+	return apiHostsTestData{
+		firstHost: host.ReadHost{
+			ID:            "firstHost",
+			Name:          "FirstHost",
+			PoolID:        "Pool",
+			Cores:         12,
+			Memory:        15000,
+			RAMLimit:      "50%",
+			KernelVersion: "1.1.1",
+			KernelRelease: "1.2.3",
+			ServiceD: host.ReadServiceD{
+				Version: "1.2.3.4.5",
+				Date:    "1/1/1999",
+				Release: "Release",
+			},
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+
+		secondHost: host.ReadHost{
+			ID:            "secondHost",
+			Name:          "SecondHost",
+			PoolID:        "Pool",
+			Cores:         7,
+			Memory:        10000,
+			RAMLimit:      "70%",
+			KernelVersion: "1.1.1",
+			KernelRelease: "1.2.3",
+			ServiceD: host.ReadServiceD{
+				Version: "1.2.3.4.5",
+				Date:    "1/1/1999",
+				Release: "Release",
+			},
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+
+		selfLink: APILink{
+			HRef:   "/hosts",
+			Rel:    "self",
+			Method: "GET",
+		},
+	}
+}
+
+func (s *TestWebSuite) TestRestGetHostsShouldReturnStatusOK(c *C) {
+	data := newAPIHostsTestData()
+	request := s.buildRequest("GET", "http://www.example.com/hosts", "")
+
+	s.mockFacade.
+		On("GetReadHosts", s.ctx.getDatastoreContext()).
+		Return([]host.ReadHost{data.firstHost}, nil)
+
+	getHosts(&(s.writer), &request, s.ctx)
+
+	c.Assert(s.recorder.Code, Equals, http.StatusOK)
+}
+
+func (s *TestWebSuite) TestRestGetHostsShouldReturnCorrectValuesForReadPool(c *C) {
+	data := newAPIHostsTestData()
+	request := s.buildRequest("GET", "http://www.example.com/hosts", "")
+
+	s.mockFacade.
+		On("GetReadHosts", s.ctx.getDatastoreContext()).
+		Return([]host.ReadHost{data.firstHost}, nil)
+
+	getHosts(&(s.writer), &request, s.ctx)
+
+	response := hostsResponse{}
+	s.getResult(c, &response)
+
+	host := response.Results[0]
+
+	c.Assert(host.ID, Equals, data.firstHost.ID)
+	c.Assert(host.Name, Equals, data.firstHost.Name)
+	c.Assert(host.PoolID, Equals, data.firstHost.PoolID)
+	c.Assert(host.Cores, Equals, data.firstHost.Cores)
+	c.Assert(host.Memory, Equals, data.firstHost.Memory)
+	c.Assert(host.RAMLimit, Equals, data.firstHost.RAMLimit)
+	c.Assert(host.KernelVersion, Equals, data.firstHost.KernelVersion)
+	c.Assert(host.KernelRelease, Equals, data.firstHost.KernelRelease)
+	c.Assert(host.ServiceD.Date, Equals, data.firstHost.ServiceD.Date)
+	c.Assert(host.ServiceD.Release, Equals, data.firstHost.ServiceD.Release)
+	c.Assert(host.ServiceD.Version, Equals, data.firstHost.ServiceD.Version)
+	c.Assert(host.CreatedAt, Equals, data.firstHost.CreatedAt)
+	c.Assert(host.UpdatedAt, Equals, data.firstHost.UpdatedAt)
+}
+
+func (s *TestWebSuite) TestRestGetHostsShouldReturnCorrectValueForTotal(c *C) {
+	data := newAPIHostsTestData()
+	request := s.buildRequest("GET", "http://www.example.com/hosts", "")
+
+	s.mockFacade.
+		On("GetReadHosts", s.ctx.getDatastoreContext()).
+		Return([]host.ReadHost{data.firstHost, data.secondHost}, nil)
+
+	getHosts(&(s.writer), &request, s.ctx)
+
+	response := hostsResponse{}
+	s.getResult(c, &response)
+
+	c.Assert(response.Total, Equals, 2)
+}
+
+func (s *TestWebSuite) TestRestGetHostsShouldReturnCorrectLinkValues(c *C) {
+	data := newAPIHostsTestData()
+	request := s.buildRequest("GET", "http://www.example.com/hosts", "")
+
+	s.mockFacade.
+		On("GetReadHosts", s.ctx.getDatastoreContext()).
+		Return([]host.ReadHost{data.firstHost, data.secondHost}, nil)
+
+	getHosts(&(s.writer), &request, s.ctx)
+
+	response := hostsResponse{}
+	s.getResult(c, &response)
+
+	c.Assert(response.Links[0].HRef, Equals, data.selfLink.HRef)
+	c.Assert(response.Links[0].Rel, Equals, data.selfLink.Rel)
+	c.Assert(response.Links[0].Method, Equals, data.selfLink.Method)
+}

--- a/web/api_hosts_test.go
+++ b/web/api_hosts_test.go
@@ -114,8 +114,12 @@ func (s *TestWebSuite) TestRestGetHostsShouldReturnCorrectValuesForReadPool(c *C
 	c.Assert(host.ServiceD.Date, Equals, data.firstHost.ServiceD.Date)
 	c.Assert(host.ServiceD.Release, Equals, data.firstHost.ServiceD.Release)
 	c.Assert(host.ServiceD.Version, Equals, data.firstHost.ServiceD.Version)
-	c.Assert(host.CreatedAt, Equals, data.firstHost.CreatedAt)
-	c.Assert(host.UpdatedAt, Equals, data.firstHost.UpdatedAt)
+
+	createdEquals := host.CreatedAt.Equal(data.firstPool.CreatedAt)
+	c.Assert(createdEquals, Equals, true)
+
+	updateEquals := host.UpdatedAt.Equal(data.firstPool.UpdatedAt)
+	c.Assert(updateEquals, Equals, true)
 }
 
 func (s *TestWebSuite) TestRestGetHostsShouldReturnCorrectValueForTotal(c *C) {

--- a/web/api_hosts_test.go
+++ b/web/api_hosts_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Serviced Authors.
+// Copyright 2016 The Serviced Authors.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -40,7 +40,7 @@ func newAPIHostsTestData() apiHostsTestData {
 			RAMLimit:      "50%",
 			KernelVersion: "1.1.1",
 			KernelRelease: "1.2.3",
-			ServiceD: host.ReadServiceD{
+			ServiceD: host.ReadServiced{
 				Version: "1.2.3.4.5",
 				Date:    "1/1/1999",
 				Release: "Release",
@@ -58,7 +58,7 @@ func newAPIHostsTestData() apiHostsTestData {
 			RAMLimit:      "70%",
 			KernelVersion: "1.1.1",
 			KernelRelease: "1.2.3",
-			ServiceD: host.ReadServiceD{
+			ServiceD: host.ReadServiced{
 				Version: "1.2.3.4.5",
 				Date:    "1/1/1999",
 				Release: "Release",

--- a/web/api_hosts_test.go
+++ b/web/api_hosts_test.go
@@ -115,10 +115,10 @@ func (s *TestWebSuite) TestRestGetHostsShouldReturnCorrectValuesForReadPool(c *C
 	c.Assert(host.ServiceD.Release, Equals, data.firstHost.ServiceD.Release)
 	c.Assert(host.ServiceD.Version, Equals, data.firstHost.ServiceD.Version)
 
-	createdEquals := host.CreatedAt.Equal(data.firstPool.CreatedAt)
+	createdEquals := host.CreatedAt.Equal(data.firstHost.CreatedAt)
 	c.Assert(createdEquals, Equals, true)
 
-	updateEquals := host.UpdatedAt.Equal(data.firstPool.UpdatedAt)
+	updateEquals := host.UpdatedAt.Equal(data.firstHost.UpdatedAt)
 	c.Assert(updateEquals, Equals, true)
 }
 

--- a/web/routes.go
+++ b/web/routes.go
@@ -42,9 +42,6 @@ func (sc *ServiceConfig) getRoutes() []rest.Route {
 		rest.Route{"DELETE", "/hosts/:hostId/:serviceStateId", gz(sc.authorizedClient(restKillRunning))},
 		rest.Route{"GET", "/hosts/:hostId/instances", gz(sc.checkAuth(restGetHostInstances))},
 
-		// API Pools
-		rest.Route{"GET", "/api/v2/pools", gz(sc.checkAuth(getPools))},
-
 		// Pools
 		rest.Route{"GET", "/pools/:poolId", gz(sc.checkAuth(restGetPool))},
 		rest.Route{"DELETE", "/pools/:poolId", gz(sc.checkAuth(restRemovePool))},
@@ -124,6 +121,10 @@ func (sc *ServiceConfig) getRoutes() []rest.Route {
 		rest.Route{"GET", "/stats", gz(sc.isCollectingStats())},
 		rest.Route{"GET", "/version", gz(sc.authorizedClient(restGetServicedVersion))},
 		rest.Route{"GET", "/storage", gz(sc.authorizedClient(restGetStorage))},
+
+		// V2 API
+		rest.Route{"GET", "/api/v2/pools", gz(sc.checkAuth(getPools))},
+		rest.Route{"GET", "/api/v2/hosts", gz(sc.checkAuth(getHosts))},
 	}
 
 	// Hardcoding these target URLs for now.


### PR DESCRIPTION
Adding a new v2 endpoint for hosts.  The endpoint returns hosts with only the properties necessary for the hosts page.  Reducing the payload (for example, monitoring profile is not included) to only those properties should help make the hosts page faster for sites with large amounts of hosts.