### PR TITLE
host state listener

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -728,6 +728,7 @@ func (d *daemon) startAgent() error {
 		}
 
 		agentOptions := node.AgentOptions{
+			IPAddress:            agentIP,
 			PoolID:               thisHost.PoolID,
 			Master:               options.Endpoint,
 			UIPort:               options.UIPort,

--- a/node/agent.go
+++ b/node/agent.go
@@ -74,6 +74,7 @@ const (
 
 // HostAgent is an instance of the control center Agent.
 type HostAgent struct {
+	ipaddress            string
 	poolID               string
 	master               string               // the connection string to the master agent
 	uiport               string               // the port to the ui (legacy was port 8787, now default 443)
@@ -111,6 +112,7 @@ func getZkDSN(zookeepers []string, timeout int) string {
 }
 
 type AgentOptions struct {
+	IPAddress            string
 	PoolID               string
 	Master               string
 	UIPort               string
@@ -136,6 +138,7 @@ type AgentOptions struct {
 func NewHostAgent(options AgentOptions, reg registry.Registry) (*HostAgent, error) {
 	// save off the arguments
 	agent := &HostAgent{}
+	agent.ipaddress = options.IPAddress
 	agent.poolID = options.PoolID
 	agent.master = options.Master
 	agent.uiport = options.UIPort

--- a/node/container.go
+++ b/node/container.go
@@ -1,0 +1,367 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/control-center/serviced/commons/docker"
+	"github.com/control-center/serviced/dfs/registry"
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/zzk"
+	zkservice "github.com/control-center/serviced/zzk/service2"
+	dockerclient "github.com/fsouza/go-dockerclient"
+)
+
+// StopContainer stops running container or returns nil if the container does
+// not exist or has already stopped.
+func (a *HostAgent) StopContainer(serviceID string, instanceID int) error {
+	logger := plog.WithFields(log.Fields{
+		"serviceid":  serviceID,
+		"instanceid": instanceID,
+	})
+
+	// find the container by name
+	ctrName := fmt.Sprintf("%s-%d", serviceID, instanceID)
+	ctr, err := docker.FindContainer(ctrName)
+	if err == docker.ErrNoSuchContainer {
+		logger.Debug("Could not stop, container not found")
+		return nil
+	} else if err != nil {
+		logger.WithError(err).Debug("Could not look up container")
+		return err
+	}
+
+	err = ctr.Stop(45 * time.Second)
+	if _, ok := err.(*dockerclient.ContainerNotRunning); ok {
+		logger.Debug("Container already stopped")
+		return nil
+	} else if err != nil {
+		logger.WithError(err).Debug("Could not stop container")
+		return err
+	}
+
+	return nil
+}
+
+// AttachContainer returns a channel that monitors the run state of a given
+// container.
+func (a *HostAgent) AttachContainer(containerID, serviceID string, instanceID int) (<-chan time.Time, error) {
+	logger := plog.WithFields(log.Fields{
+		"serviceid":   serviceID,
+		"instanceid":  instanceID,
+		"containerid": containerID,
+	})
+
+	// find the container by name
+	ctrName := fmt.Sprintf("%s-%d", serviceID, instanceID)
+	ctr, err := docker.FindContainer(ctrName)
+	if err == docker.ErrNoSuchContainer {
+		return nil, nil
+	} else if err != nil {
+		logger.WithError(err).Debug("Could not look up container")
+		return nil, err
+	}
+
+	// verify that the container ids match, otherwise delete
+	// the container.
+	if ctr.ID != containerID {
+		ctr.Kill()
+		if err := ctr.Delete(true); err != nil {
+			logger.WithError(err).Debug("Could not delete orphaned container")
+			return nil, err
+		}
+		logger.WithField("currentcontainerid", ctr.ID).Warn("Removed orphaned container")
+		return nil, nil
+	}
+
+	// monitor the container
+	ev := a.monitorContainer(logger, ctr)
+
+	// make sure the container is running at the time this event is set
+	if !ctr.IsRunning() {
+		logger.Debug("Could not capture event, container not running")
+		ctr.CancelOnEvent(docker.Die)
+		return nil, nil
+	}
+	return ev, nil
+}
+
+// StartContainer creates a new container and starts.  It returns info about
+// the container, and an event monitor to track the running state of the
+// service.
+func (a *HostAgent) StartContainer(cancel <-chan interface{}, svc *service.Service, instanceID int) (*zkservice.ServiceState, <-chan time.Time, error) {
+	logger := plog.WithFields(log.Fields{
+		"serviceid":   svc.ID,
+		"servicename": svc.Name,
+		"imageid":     svc.ImageID,
+		"instanceid":  instanceID,
+	})
+
+	// pull the service image
+	imageUUID, imageName, err := a.pullImage(logger, cancel, svc.ImageID)
+	if err != nil {
+		logger.WithError(err).Debug("Could not pull the service image")
+		return nil, nil, err
+	}
+	svc.ImageID = imageName
+
+	// Establish a connection to the master
+	// TODO: use the new rpc calls instead
+	client, err := NewControlClient(a.master)
+	if err != nil {
+		logger.WithField("client", a.master).WithError(err).Debug("Could not connect to the master")
+		return nil, nil, err
+	}
+	defer client.Close()
+
+	// get the container configs
+	conf, hostConf, err := a.setupContainer(client, svc, instanceID)
+	if err != nil {
+		logger.WithError(err).Debug("Could not setup container")
+		return nil, nil, err
+	}
+
+	// create the container
+	opts := dockerclient.CreateContainerOptions{
+		Name:       fmt.Sprintf("%s-%d", svc.ID, instanceID),
+		Config:     conf,
+		HostConfig: hostConf,
+	}
+
+	ctr, err := docker.NewContainer(&opts, false, 10*time.Second, nil, nil)
+	if err != nil {
+		logger.WithError(err).Debug("Could not create container")
+		return nil, nil, err
+	}
+	logger = logger.WithField("containerid", ctr.ID)
+	logger.Debug("Created a new container")
+
+	// start the container
+	ev := a.monitorContainer(logger, ctr)
+
+	if err := ctr.Start(); err != nil {
+		logger.WithError(err).Debug("Could not start container")
+		ctr.CancelOnEvent(docker.Die)
+		return nil, nil, err
+	}
+	logger.Debug("Started container")
+
+	dctr, err := ctr.Inspect()
+	if err != nil {
+		logger.WithError(err).Debug("Could not inspect container")
+		ctr.CancelOnEvent(docker.Die)
+		return nil, nil, err
+	}
+
+	state := &zkservice.ServiceState{
+		ContainerID: ctr.ID,
+		ImageID:     imageUUID,
+		Paused:      false,
+		PrivateIP:   ctr.NetworkSettings.IPAddress,
+		HostIP:      a.ipaddress,
+		Started:     dctr.State.StartedAt,
+	}
+
+	for _, ep := range svc.Endpoints {
+		if ep.Purpose == "export" {
+			state.Exports = append(state.Exports, zkservice.ExportBinding{
+				Application: ep.Application,
+				Protocol:    ep.Protocol,
+				PortNumber:  ep.PortNumber,
+			})
+		} else {
+			state.Imports = append(state.Imports, zkservice.ImportBinding{
+				Application:    ep.Application,
+				Purpose:        ep.Purpose,
+				PortNumber:     ep.PortNumber,
+				PortTemplate:   ep.PortTemplate,
+				VirtualAddress: ep.VirtualAddress,
+			})
+		}
+	}
+
+	return state, ev, nil
+}
+
+// ResumeContainer resumes a paused container
+func (a *HostAgent) ResumeContainer(svc *service.Service, instanceID int) error {
+	logger := plog.WithFields(log.Fields{
+		"serviceid":     svc.ID,
+		"servicename":   svc.Name,
+		"resumecommand": svc.Snapshot.Resume,
+		"instanceid":    instanceID,
+	})
+	ctrName := fmt.Sprintf("%s-%d", svc.ID, instanceID)
+
+	// check to see if the container exists and is running
+	ctr, err := docker.FindContainer(ctrName)
+	if err == docker.ErrNoSuchContainer {
+		// container has been deleted and the event monitor should catch this
+		logger.Debug("Container not found")
+		return nil
+	}
+	if !ctr.IsRunning() {
+		// container has stopped and the event monitor should catch this
+		logger.Debug("Container stopped")
+		return nil
+	}
+
+	// resume the paused container
+	if err := attachAndRun(ctrName, svc.Snapshot.Resume); err != nil {
+		logger.WithError(err).Debug("Could not resume paused container")
+		return err
+	}
+	logger.Debug("Resumed paused container")
+
+	return nil
+}
+
+// PauseContainer pauses a running container
+func (a *HostAgent) PauseContainer(svc *service.Service, instanceID int) error {
+	logger := plog.WithFields(log.Fields{
+		"serviceid":    svc.ID,
+		"servicename":  svc.Name,
+		"pausecommand": svc.Snapshot.Pause,
+		"instanceid":   instanceID,
+	})
+	ctrName := fmt.Sprintf("%s-%d", svc.ID, instanceID)
+
+	// check to see if the container exists and is running
+	ctr, err := docker.FindContainer(ctrName)
+	if err == docker.ErrNoSuchContainer {
+		// container has been deleted and the event monitor should catch this
+		logger.Debug("Container not found")
+		return nil
+	}
+	if !ctr.IsRunning() {
+		// container has stopped and the event monitor should catch this
+		logger.Debug("Container stopped")
+		return nil
+	}
+
+	// pause the running container
+	if err := attachAndRun(ctrName, svc.Snapshot.Pause); err != nil {
+		logger.WithError(err).Debug("Could not pause running container")
+		return err
+	}
+	logger.Debug("Paused running container")
+	return nil
+}
+
+// pullImage pulls the service image and returns the uuid string
+// of the image and the fully qualified image name.
+func (a *HostAgent) pullImage(logger *log.Entry, cancel <-chan interface{}, imageID string) (string, string, error) {
+	conn, err := zzk.GetLocalConnection("/")
+	if err != nil {
+		logger.WithError(err).Debug("Could not connect to coordinator")
+
+		// TODO: wrap error?
+		return "", "", err
+	}
+
+	timeoutC := make(chan time.Time)
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-done:
+		case <-cancel:
+			select {
+			case <-done:
+			case timeoutC <- time.Now():
+			}
+		}
+	}()
+
+	a.pullreg.SetConnection(conn)
+	if err := a.pullreg.PullImage(timeoutC, imageID); err != nil {
+		logger.WithError(err).Debug("Could not pull image")
+
+		// TODO: wrap error?
+		return "", "", err
+	}
+	logger.Debug("Pulled image")
+
+	uuid, err := registry.GetImageUUID(conn, imageID)
+	if err != nil {
+		logger.WithError(err).Debug("Could not load image id")
+
+		// TODO: wrap error?
+		return "", "", err
+	}
+	logger.Debug("Found image uuid")
+
+	name, err := a.pullreg.ImagePath(imageID)
+	if err != nil {
+		logger.WithError(err).Debug("Could not get full image name")
+
+		// TODO: wrap error?
+		return "", "", err
+	}
+
+	return uuid, name, nil
+}
+
+// monitorContainer tracks the running state of the container.
+func (a *HostAgent) monitorContainer(logger *log.Entry, ctr *docker.Container) <-chan time.Time {
+	ev := make(chan time.Time, 1)
+	ctr.OnEvent(docker.Die, func(_ string) {
+		defer close(ev)
+		dctr, err := ctr.Inspect()
+		if err != nil {
+			logger.WithError(err).Error("Could not look up container")
+			ev <- time.Now()
+			return
+		}
+
+		logger.WithFields(log.Fields{
+			"terminated": dctr.State.FinishedAt,
+			"exitcode":   dctr.State.ExitCode,
+		}).Debug("Container exited")
+
+		if dctr.State.ExitCode != 0 || log.GetLevel() == log.DebugLevel {
+			// TODO: need to get logs from api
+			output, err := exec.Command("docker", "logs", "--tail", "10000", ctr.ID).CombinedOutput()
+			if err != nil {
+				logger.WithField("output", string(output)).WithError(err).Warn("Could not get container logs")
+			} else {
+				prefix := fmt.Sprintf("ctr-%s: ", ctr.ID[0:5])
+				split := strings.Split(string(output), "\n")
+				for i, s := range split {
+					split[i] = prefix + s
+				}
+				final := strings.Join(split, "\n")
+				logger.WithField("output", string(final)).Info("Last 10000 lines of container")
+			}
+		}
+
+		if err := ctr.Delete(true); err != nil {
+			logger.WithError(err).Warn("Could not delete container")
+		}
+
+		// just in case something unusual happened
+		if !dctr.State.FinishedAt.IsZero() {
+			ev <- dctr.State.FinishedAt
+		} else {
+			ev <- time.Now()
+		}
+		return
+	})
+	return ev
+}

--- a/node/init.go
+++ b/node/init.go
@@ -1,0 +1,18 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import "github.com/control-center/serviced/logging"
+
+var plog = logging.PackageLogger()

--- a/zzk/service2/hoststate.go
+++ b/zzk/service2/hoststate.go
@@ -1,0 +1,290 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"path"
+	"time"
+
+	"github.com/control-center/serviced/coordinator/client"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/control-center/serviced/domain/service"
+)
+
+// HostStateHandler is the handler for running the HostListener
+type HostStateHandler interface {
+
+	// StopsContainer stops the container if the container exists and isn't
+	// already stopped.
+	StopContainer(serviceID string, instanceID int) error
+
+	// AttachContainer attaches to an existing container for the service
+	// instance. Returns nil channel if the container id doesn't match or if
+	// the container has stopped. Channel reports the time that the container
+	// has stopped.
+	AttachContainer(dockerID, serviceID string, instanceID int) (<-chan time.Time, error)
+
+	// StartContainer creates and starts a new container for the given service
+	// instance.  It returns relevant information about the container and a
+	// channel that triggers when the container has stopped.
+	StartContainer(cancel <-chan interface{}, svc *service.Service, instanceID int) (*ServiceState, <-chan time.Time, error)
+
+	// ResumeContainer resumes a paused container.  Returns nil if the
+	// container has stopped or if it doesn't exist.
+	ResumeContainer(svc *service.Service, instanceID int) error
+
+	// PauseContainer pauses a running container.  Returns nil if the container
+	// has stopped or if it doesn't exist.
+	PauseContainer(svc *service.Service, instanceID int) error
+}
+
+// HostStateListener is the listener for monitoring service instances
+type HostStateListener struct {
+	conn    client.Connection
+	handler HostStateHandler
+	hostID  string
+}
+
+// NewHostListener instantiates a HostListener object
+func NewHostStateListener(handler HostStateHandler, hostID string) *HostStateListener {
+	return &HostStateListener{
+		handler: handler,
+		hostID:  hostID,
+	}
+}
+
+// GetConnection implements zzk.Listener
+func (l *HostStateListener) SetConnection(conn client.Connection) { l.conn = conn }
+
+// GetPath implements zzk.Listener
+func (l *HostStateListener) GetPath(nodes ...string) string {
+	parts := append([]string{"/hosts", l.hostID, "instances"}, nodes...)
+	return path.Join(parts...)
+}
+
+// Ready implements zzk.Listener
+func (l *HostStateListener) Ready() error {
+	return nil
+}
+
+// Done removes the ephemeral node from the host registry
+func (l *HostStateListener) Done() {
+}
+
+// PostProcess implements zzk.Listener
+func (l *HostStateListener) PostProcess(p map[string]struct{}) {}
+
+// Spawn listens for changes in the host state and manages running instances
+func (l *HostStateListener) Spawn(shutdown <-chan interface{}, stateID string) {
+	logger := plog.WithFields(log.Fields{
+		"hostid":  l.hostID,
+		"stateid": stateID,
+	})
+
+	// check if the state id is valid
+	hostID, serviceID, instanceID, err := ParseStateID(stateID)
+	if err != nil || hostID != l.hostID {
+
+		logger.WithField("hostidmatch", hostID == l.hostID).WithError(err).Warn("Invalid state id, deleting")
+
+		// clean up the bad node
+		if err := l.conn.Delete(l.GetPath(stateID)); err != nil && err != client.ErrNoNode {
+			logger.WithError(err).Error("Could not delete host state")
+		}
+		return
+	}
+
+	logger = logger.WithFields(log.Fields{
+		"serviceid":  serviceID,
+		"instanceid": instanceID,
+	})
+
+	// set up the request object for updates
+	req := StateRequest{
+		PoolID:     "",
+		HostID:     hostID,
+		ServiceID:  serviceID,
+		InstanceID: instanceID,
+	}
+
+	var containerExit <-chan time.Time
+	defer func() {
+
+		// stop the container
+		if err := l.handler.StopContainer(serviceID, instanceID); err != nil {
+			logger.WithError(err).Error("Could not stop container")
+		} else if containerExit != nil {
+			// wait for the container to exit
+			time := <-containerExit
+			logger.WithField("terminated", time).Debug("Container exited")
+		}
+
+		// delete the state from the coordinator
+		if err := DeleteState(l.conn, req); err != nil {
+			logger.WithError(err).Warn("Could not delete state")
+		}
+	}()
+
+	done := make(chan struct{})
+	defer func() { close(done) }()
+	for {
+
+		// set up a listener on the host state node
+		hspth := l.GetPath(stateID)
+		hsdat := &HostState{}
+		hsevt, err := l.conn.GetW(hspth, hsdat, done)
+		if err == client.ErrNoNode {
+
+			logger.Debug("Host state was removed, exiting")
+			return
+		} else if err != nil {
+
+			logger.WithError(err).Error("Could not watch host state")
+			return
+		}
+
+		// load the service state node
+		sspth := path.Join("/services", serviceID, stateID)
+		ssdat := &ServiceState{}
+		if err := l.conn.Get(sspth, ssdat); err == client.ErrNoNode {
+
+			logger.Debug("Service state was removed, exiting")
+			return
+		} else if err != nil {
+
+			logger.WithError(err).Error("Could not load service state")
+			return
+		}
+
+		// load the service
+		spth := path.Join("/services", serviceID)
+		sdat := &ServiceNode{Service: &service.Service{}}
+		if err := l.conn.Get(spth, sdat); err != nil {
+
+			logger.WithError(err).Error("Could not load service")
+			return
+		}
+
+		// attach to the container if not already attached
+		if containerExit == nil {
+			containerExit, err = l.handler.AttachContainer(ssdat.ContainerID, serviceID, instanceID)
+			if err != nil {
+
+				logger.WithError(err).Error("Could not attach to container")
+				return
+			}
+		}
+
+		// set the state of this instance
+		switch hsdat.DesiredState {
+		case service.SVCRun:
+			if containerExit == nil {
+
+				// container is detached because it doesn't exist
+				ssdat, containerExit, err = l.handler.StartContainer(shutdown, sdat.Service, instanceID)
+				if err != nil {
+
+					logger.WithError(err).Error("Could not start container")
+					return
+				}
+
+				// set the service state in zookeeper
+				if err := UpdateState(l.conn, req, func(s *State) bool {
+					s.ServiceState = *ssdat
+					return true
+				}); err != nil {
+
+					logger.WithError(err).Error("Could not set state for started container")
+					return
+				}
+
+				logger.Debug("Started container")
+			} else if ssdat.Paused {
+
+				// resume paused container
+				if err := l.handler.ResumeContainer(sdat.Service, instanceID); err != nil {
+
+					logger.WithError(err).Error("Could not resume container")
+					return
+				}
+
+				// set the service state in zookeeper
+				if err := UpdateState(l.conn, req, func(s *State) bool {
+					s.Paused = false
+					return true
+				}); err != nil {
+
+					logger.WithError(err).Error("Could not set state for resumed container")
+					return
+				}
+
+				logger.Debug("Resumed paused container")
+			}
+
+		case service.SVCPause:
+			if containerExit != nil && !ssdat.Paused {
+
+				// container is attached and not paused, so pause the container
+				if err := l.handler.PauseContainer(sdat.Service, instanceID); err != nil {
+
+					logger.WithError(err).Error("Could not pause container")
+					return
+				}
+
+				// set the service state in zookeeper
+				if err := UpdateState(l.conn, req, func(s *State) bool {
+					s.Paused = true
+					return true
+				}); err != nil {
+
+					logger.WithError(err).Error("Could not set state for paused container")
+					return
+				}
+
+				logger.Debug("Paused running container")
+			}
+		case service.SVCStop:
+
+			logger.Debug("Stopping running container")
+			return
+		default:
+
+			logger.Debug("Could not process desired state for instance")
+		}
+
+		select {
+		case <-hsevt:
+		case time := <-containerExit:
+
+			logger.WithField("terminated", time).Warn("Container exited unexpectedly, restarting")
+			containerExit = nil
+			if err := UpdateState(l.conn, req, func(s *State) bool {
+				s.Terminated = time
+				return true
+			}); err != nil {
+
+				logger.WithError(err).Error("Could not update state for stopped container")
+				return
+			}
+		case <-shutdown:
+
+			logger.Debug("Host state listener received signal to shut down")
+			return
+		}
+
+		close(done)
+		done = make(chan struct{})
+	}
+}

--- a/zzk/service2/hoststate_test.go
+++ b/zzk/service2/hoststate_test.go
@@ -573,6 +573,8 @@ func (t *ZZKTest) TestHostStateListener_Spawn_AttachRestart(c *C) {
 		ssdat2.SetVersion(nil)
 		c.Check(ssdat2.Terminated.IsZero(), Equals, true)
 		ssdat2.Terminated = ssdat.Terminated
+		c.Check(ssdat2.Started.Equal(ssdat.Started), Equals, true)
+		ssdat2.Started = ssdat.Started
 		c.Check(ssdat2, DeepEquals, ssdat)
 	case <-done:
 		c.Fatalf("Listener shutdown")

--- a/zzk/service2/hoststate_test.go
+++ b/zzk/service2/hoststate_test.go
@@ -344,7 +344,7 @@ func (t *ZZKTest) TestHostStateListener_Spawn_AttachRun(c *C) {
 	select {
 	case e := <-ev:
 		c.Assert(e.Type, Equals, client.EventNodeDeleted)
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		c.Fatalf("state not deleted")
 	}
 	handler.AssertExpectations(c)

--- a/zzk/service2/hoststate_test.go
+++ b/zzk/service2/hoststate_test.go
@@ -1,0 +1,945 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build integration,!quick
+
+package service_test
+
+import (
+	"errors"
+	"time"
+
+	"github.com/control-center/serviced/coordinator/client"
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/zzk"
+	. "github.com/control-center/serviced/zzk/service2"
+	"github.com/control-center/serviced/zzk/service2/mocks"
+	"github.com/stretchr/testify/mock"
+
+	. "gopkg.in/check.v1"
+)
+
+var (
+	ErrTestNoAttach = errors.New("could not attach to container")
+)
+
+// Test Case: Bad state id
+func (t *ZZKTest) TestHostStateListener_Spawn_BadStateID(c *C) {
+	// Pre-requisites
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+	handler := &mocks.HostStateHandler{}
+
+	// Basic set up
+	svc := &service.Service{
+		ID:     "serviceid",
+		Name:   "serviceA",
+		PoolID: "poolid",
+	}
+	spth := "/services/serviceid"
+	sdat := &ServiceNode{Service: svc}
+	err = conn.Create(spth, sdat)
+	c.Assert(err, IsNil)
+	err = conn.CreateDir("/hosts/hostid")
+	c.Assert(err, IsNil)
+
+	listener := NewHostStateListener(handler, "hostid")
+	listener.SetConnection(conn)
+
+	shutdown := make(chan interface{})
+
+	done := make(chan struct{})
+	go func() {
+		listener.Spawn(shutdown, "badstateid")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		close(shutdown)
+		c.Fatalf("Listener did not shut down")
+	}
+	handler.AssertExpectations(c)
+}
+
+// Test Case: Missing host state
+func (t *ZZKTest) TestHostStateListener_Spawn_ErrHostState(c *C) {
+	// Pre-requisites
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+	handler := &mocks.HostStateHandler{}
+
+	// Basic set up
+	svc := &service.Service{
+		ID:     "serviceid",
+		Name:   "serviceA",
+		PoolID: "poolid",
+	}
+	spth := "/services/serviceid"
+	sdat := &ServiceNode{Service: svc}
+	err = conn.Create(spth, sdat)
+	c.Assert(err, IsNil)
+	err = conn.CreateDir("/hosts/hostid")
+	c.Assert(err, IsNil)
+
+	req := StateRequest{
+		HostID:     "hostid",
+		ServiceID:  "serviceid",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	// delete the host state
+	handler.On("StopContainer", "serviceid", 1).Return(nil)
+	err = conn.Delete("/hosts/hostid/instances/" + req.StateID())
+	c.Assert(err, IsNil)
+
+	listener := NewHostStateListener(handler, "hostid")
+	listener.SetConnection(conn)
+
+	shutdown := make(chan interface{})
+
+	done := make(chan struct{})
+	ok, ev, err := conn.ExistsW("/services/serviceid/"+req.StateID(), done)
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, true)
+
+	go func() {
+		listener.Spawn(shutdown, req.StateID())
+		close(done)
+	}()
+
+	timer := time.NewTimer(time.Second)
+	select {
+	case <-ev:
+		c.Logf("Listener cleaned up orphaned node")
+		timer.Reset(time.Second)
+
+		select {
+		case <-done:
+			c.Logf("Listener shut down")
+		case <-timer.C:
+			c.Fatalf("Listener did not shut down")
+		}
+
+	case <-timer.C:
+		close(shutdown)
+		c.Fatalf("Listener did not shut down")
+	}
+	handler.AssertExpectations(c)
+}
+
+// Test Case: Missing service state
+func (t *ZZKTest) TestHostStateListener_Spawn_ErrServiceState(c *C) {
+	// Pre-requisites
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+	handler := &mocks.HostStateHandler{}
+
+	// Basic set up
+	svc := &service.Service{
+		ID:     "serviceid",
+		Name:   "serviceA",
+		PoolID: "poolid",
+	}
+	spth := "/services/serviceid"
+	sdat := &ServiceNode{Service: svc}
+	err = conn.Create(spth, sdat)
+	c.Assert(err, IsNil)
+	err = conn.CreateDir("/hosts/hostid")
+	c.Assert(err, IsNil)
+
+	req := StateRequest{
+		HostID:     "hostid",
+		ServiceID:  "serviceid",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	// delete the service state
+	handler.On("StopContainer", "serviceid", 1).Return(nil)
+	err = conn.Delete("/services/serviceid/" + req.StateID())
+	c.Assert(err, IsNil)
+
+	listener := NewHostStateListener(handler, "hostid")
+	listener.SetConnection(conn)
+
+	shutdown := make(chan interface{})
+
+	done := make(chan struct{})
+	ok, ev, err := conn.ExistsW("/hosts/hostid/instances/"+req.StateID(), done)
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, true)
+
+	go func() {
+		listener.Spawn(shutdown, req.StateID())
+		close(done)
+	}()
+
+	timer := time.NewTimer(time.Second)
+	select {
+	case <-ev:
+		c.Logf("Listener cleaned up orphaned node")
+		timer.Reset(time.Second)
+
+		select {
+		case <-done:
+			c.Logf("Listener shut down")
+		case <-timer.C:
+			c.Fatalf("Listener did not shut down")
+		}
+
+	case <-timer.C:
+		close(shutdown)
+		c.Fatalf("Listener did not shut down")
+	}
+	handler.AssertExpectations(c)
+}
+
+// Test Case: Error on attach
+func (t *ZZKTest) TestHostStateListener_Spawn_ErrAttach(c *C) {
+	// Pre-requisites
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+	handler := &mocks.HostStateHandler{}
+
+	// Basic set up
+	svc := &service.Service{
+		ID:     "serviceid",
+		Name:   "serviceA",
+		PoolID: "poolid",
+	}
+	spth := "/services/serviceid"
+	sdat := &ServiceNode{Service: svc}
+	err = conn.Create(spth, sdat)
+	c.Assert(err, IsNil)
+	err = conn.CreateDir("/hosts/hostid")
+	c.Assert(err, IsNil)
+
+	req := StateRequest{
+		HostID:     "hostid",
+		ServiceID:  "serviceid",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	shutdown := make(chan interface{})
+
+	handler.On("StopContainer", "serviceid", 1).Return(nil)
+	handler.On("AttachContainer", "", "serviceid", 1).Return(nil, ErrTestNoAttach)
+
+	listener := NewHostStateListener(handler, "hostid")
+	listener.SetConnection(conn)
+
+	done := make(chan struct{})
+	ok, ev, err := conn.ExistsW("/hosts/hostid/instances/"+req.StateID(), done)
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, true)
+
+	go func() {
+		listener.Spawn(shutdown, req.StateID())
+		close(done)
+	}()
+
+	timer := time.NewTimer(time.Second)
+	select {
+	case <-ev:
+		c.Logf("Listener cleaned up orphaned node")
+		timer.Reset(time.Second)
+
+		select {
+		case <-done:
+			c.Logf("Listener shut down")
+		case <-timer.C:
+			c.Fatalf("Listener did not shut down")
+		}
+
+	case <-timer.C:
+		close(shutdown)
+		c.Fatalf("Listener did not shut down")
+	}
+	handler.AssertExpectations(c)
+}
+
+// Test Case: Listener attaches to a running container
+func (t *ZZKTest) TestHostStateListener_Spawn_AttachRun(c *C) {
+	// Pre-requisites
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+	handler := &mocks.HostStateHandler{}
+
+	// Basic set up
+	svc := &service.Service{
+		ID:     "serviceid",
+		Name:   "serviceA",
+		PoolID: "poolid",
+	}
+	spth := "/services/serviceid"
+	sdat := &ServiceNode{Service: svc}
+	err = conn.Create(spth, sdat)
+	c.Assert(err, IsNil)
+	err = conn.CreateDir("/hosts/hostid")
+	c.Assert(err, IsNil)
+
+	req := StateRequest{
+		HostID:     "hostid",
+		ServiceID:  "serviceid",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	// attached, run, no change
+	ssdat := ServiceState{
+		ContainerID: "containerid",
+		ImageID:     "imageid",
+		Paused:      false,
+		Started:     time.Now(),
+	}
+	err = UpdateState(conn, req, func(s *State) bool {
+		s.ServiceState = ssdat
+		return true
+	})
+	c.Assert(err, IsNil)
+	containerExit := make(chan time.Time, 1)
+	var retExit <-chan time.Time = containerExit
+	handler.On("AttachContainer", "containerid", "serviceid", 1).Return(retExit, nil).Once()
+	handler.On("StopContainer", "serviceid", 1).Return(nil).Run(func(_ mock.Arguments) {
+		containerExit <- time.Now()
+	})
+	listener := NewHostStateListener(handler, "hostid")
+	listener.SetConnection(conn)
+
+	done := make(chan struct{})
+	sspth := "/services/serviceid/" + req.StateID()
+	ev, err := conn.GetW(sspth, &ServiceState{}, done)
+	c.Assert(err, IsNil)
+
+	shutdown := make(chan interface{})
+	go func() {
+		listener.Spawn(shutdown, req.StateID())
+		close(done)
+	}()
+
+	select {
+	case <-ev:
+		c.Errorf("service state changed unexpectedly")
+	case <-time.After(time.Second):
+	}
+	close(shutdown)
+	select {
+	case e := <-ev:
+		c.Assert(e.Type, Equals, client.EventNodeDeleted)
+	case <-time.After(time.Second):
+		c.Fatalf("state not deleted")
+	}
+	handler.AssertExpectations(c)
+}
+
+// Test Case: Listener attaches to a paused running container
+func (t *ZZKTest) TestHostStateListener_Spawn_AttachResume(c *C) {
+	// Pre-requisites
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+	handler := &mocks.HostStateHandler{}
+
+	// Basic set up
+	svc := &service.Service{
+		ID:     "serviceid",
+		Name:   "serviceA",
+		PoolID: "poolid",
+	}
+	spth := "/services/serviceid"
+	sdat := &ServiceNode{Service: svc}
+	err = conn.Create(spth, sdat)
+	c.Assert(err, IsNil)
+	err = conn.CreateDir("/hosts/hostid")
+	c.Assert(err, IsNil)
+
+	req := StateRequest{
+		HostID:     "hostid",
+		ServiceID:  "serviceid",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	shutdown := make(chan interface{})
+	listener := NewHostStateListener(handler, "hostid")
+	listener.SetConnection(conn)
+
+	// set up a running container
+	ssdat := &ServiceState{
+		ContainerID: "containerid",
+		ImageID:     "imageid",
+		Paused:      true,
+		Started:     time.Now(),
+	}
+	err = UpdateState(conn, req, func(s *State) bool {
+		s.DesiredState = service.SVCPause
+		s.ServiceState = *ssdat
+		return true
+	})
+	c.Assert(err, IsNil)
+
+	containerExit := make(chan time.Time, 1)
+	var retExit <-chan time.Time = containerExit
+	handler.On("AttachContainer", "containerid", "serviceid", 1).Return(retExit, nil).Once()
+
+	done := make(chan struct{})
+	ev, err := conn.GetW("/services/serviceid/"+req.StateID(), ssdat, done)
+	c.Assert(err, IsNil)
+	go func() {
+		listener.Spawn(shutdown, req.StateID())
+		close(done)
+	}()
+
+	timer := time.NewTimer(time.Second)
+	select {
+	case <-ev:
+		c.Fatalf("Unexpected event from service state")
+	case <-done:
+		c.Fatalf("Listener shutdown")
+	case <-timer.C:
+	}
+
+	// resume container
+	handler.On("ResumeContainer", mock.AnythingOfType("*service.Service"), 1).Return(nil)
+	err = UpdateState(conn, req, func(s *State) bool {
+		s.DesiredState = service.SVCRun
+		return true
+	})
+	c.Assert(err, IsNil)
+	timer.Reset(time.Second)
+	select {
+	case <-ev:
+		// make sure the state is paused
+		ev, err = conn.GetW("/services/serviceid/"+req.StateID(), ssdat, done)
+		c.Assert(err, IsNil)
+
+		// may have been triggered by event to update desired state
+		if ssdat.Paused {
+			timer.Reset(time.Second)
+			select {
+			case <-ev:
+				ev, err = conn.GetW("/services/serviceid/"+req.StateID(), ssdat, done)
+				c.Assert(err, IsNil)
+			case <-done:
+				c.Fatalf("Listener shutdown")
+			case <-timer.C:
+				c.Fatalf("Listener took too long")
+			}
+		}
+
+		c.Check(ssdat.Paused, Equals, false)
+	case <-done:
+		c.Fatalf("Listener shutdown")
+	case <-timer.C:
+		c.Fatalf("Listener took too long")
+	}
+
+	// shutdown
+	handler.On("StopContainer", "serviceid", 1).Return(nil).Run(func(_ mock.Arguments) {
+		containerExit <- time.Now()
+	})
+	close(shutdown)
+	timer.Reset(time.Second)
+	select {
+	case e := <-ev:
+		c.Check(e.Type, Equals, client.EventNodeDeleted)
+	case <-done:
+		c.Logf("Listener shutdown")
+	case <-timer.C:
+		c.Fatalf("Listener took too long")
+	}
+	handler.AssertExpectations(c)
+}
+
+// Test Case: Listener attaches to a running container and is triggered to
+// restart it.
+func (t *ZZKTest) TestHostStateListener_Spawn_AttachRestart(c *C) {
+	// Pre-requisites
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+	handler := &mocks.HostStateHandler{}
+
+	// Basic set up
+	svc := &service.Service{
+		ID:     "serviceid",
+		Name:   "serviceA",
+		PoolID: "poolid",
+	}
+	spth := "/services/serviceid"
+	sdat := &ServiceNode{Service: svc}
+	err = conn.Create(spth, sdat)
+	c.Assert(err, IsNil)
+	err = conn.CreateDir("/hosts/hostid")
+	c.Assert(err, IsNil)
+
+	req := StateRequest{
+		HostID:     "hostid",
+		ServiceID:  "serviceid",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	shutdown := make(chan interface{})
+	listener := NewHostStateListener(handler, "hostid")
+	listener.SetConnection(conn)
+
+	// set up a running container
+	ssdat := &ServiceState{
+		ContainerID: "containerid",
+		ImageID:     "imageid",
+		Paused:      false,
+		Started:     time.Now(),
+	}
+	err = UpdateState(conn, req, func(s *State) bool {
+		s.ServiceState = *ssdat
+		return true
+	})
+	c.Assert(err, IsNil)
+
+	containerExit := make(chan time.Time, 1)
+	var retExit <-chan time.Time = containerExit
+	handler.On("AttachContainer", "containerid", "serviceid", 1).Return(retExit, nil).Once()
+
+	done := make(chan struct{})
+
+	ev, err := conn.GetW("/services/serviceid/"+req.StateID(), ssdat, done)
+	c.Assert(err, IsNil)
+	go func() {
+		listener.Spawn(shutdown, req.StateID())
+		close(done)
+	}()
+
+	timer := time.NewTimer(time.Second)
+	select {
+	case <-ev:
+		c.Fatalf("Unexpected event from service state")
+	case <-done:
+		c.Fatalf("Listener shutdown")
+	case <-timer.C:
+	}
+
+	ssdat = &ServiceState{
+		ContainerID: "containerid2",
+		ImageID:     "imageid",
+		Paused:      false,
+		Started:     time.Now(),
+	}
+	var retShutdown <-chan interface{} = shutdown
+	handler.On("AttachContainer", "containerid", "serviceid", 1).Return(nil, nil).Once()
+	handler.On("StartContainer", retShutdown, mock.AnythingOfType("*service.Service"), 1).Return(ssdat, retExit, nil)
+
+	containerExit <- time.Now()
+	timer.Reset(time.Second)
+	select {
+	case <-ev:
+		// state is either terminated or overwritten
+		ssdat2 := &ServiceState{}
+		ev, err = conn.GetW("/services/serviceid/"+req.StateID(), ssdat2, done)
+		c.Assert(err, IsNil)
+
+		if ssdat2.ContainerID == "containerid" {
+			timer.Reset(time.Second)
+			c.Check(ssdat2.Terminated.IsZero(), Equals, false)
+
+			select {
+			case <-ev:
+				ev, err = conn.GetW("/services/serviceid/"+req.StateID(), ssdat2, done)
+				c.Assert(err, IsNil)
+			case <-done:
+				c.Fatalf("Listener shutdown")
+			case <-timer.C:
+				c.Fatalf("Listener took too long")
+			}
+		}
+		ssdat2.SetVersion(nil)
+		c.Check(ssdat2.Terminated.IsZero(), Equals, true)
+		ssdat2.Terminated = ssdat.Terminated
+		c.Check(ssdat2, DeepEquals, ssdat)
+	case <-done:
+		c.Fatalf("Listener shutdown")
+	case <-timer.C:
+		c.Fatalf("Listener took too long")
+	}
+
+	handler.On("StopContainer", "serviceid", 1).Return(nil).Run(func(_ mock.Arguments) {
+		containerExit <- time.Now()
+	})
+
+	close(shutdown)
+	timer.Reset(time.Second)
+	select {
+	case e := <-ev:
+		c.Check(e.Type, Equals, client.EventNodeDeleted)
+	case <-done:
+		c.Logf("Listener shutdown")
+	case <-timer.C:
+		c.Fatalf("Listener took too long")
+	}
+	handler.AssertExpectations(c)
+}
+
+// Test Case: Listener attaches to a running container and pauses the state
+func (t *ZZKTest) TestHostStateListener_Spawn_AttachPause(c *C) {
+	// Pre-requisites
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+	handler := &mocks.HostStateHandler{}
+
+	// Basic set up
+	svc := &service.Service{
+		ID:     "serviceid",
+		Name:   "serviceA",
+		PoolID: "poolid",
+	}
+	spth := "/services/serviceid"
+	sdat := &ServiceNode{Service: svc}
+	err = conn.Create(spth, sdat)
+	c.Assert(err, IsNil)
+	err = conn.CreateDir("/hosts/hostid")
+	c.Assert(err, IsNil)
+
+	req := StateRequest{
+		HostID:     "hostid",
+		ServiceID:  "serviceid",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	shutdown := make(chan interface{})
+	listener := NewHostStateListener(handler, "hostid")
+	listener.SetConnection(conn)
+
+	// set up a running container
+	ssdat := &ServiceState{
+		ContainerID: "containerid",
+		ImageID:     "imageid",
+		Paused:      false,
+		Started:     time.Now(),
+	}
+	err = UpdateState(conn, req, func(s *State) bool {
+		s.ServiceState = *ssdat
+		return true
+	})
+	c.Assert(err, IsNil)
+
+	containerExit := make(chan time.Time, 1)
+	var retExit <-chan time.Time = containerExit
+	handler.On("AttachContainer", "containerid", "serviceid", 1).Return(retExit, nil).Once()
+
+	done := make(chan struct{})
+	ev, err := conn.GetW("/services/serviceid/"+req.StateID(), ssdat, done)
+	c.Assert(err, IsNil)
+	go func() {
+		listener.Spawn(shutdown, req.StateID())
+		close(done)
+	}()
+
+	timer := time.NewTimer(time.Second)
+	select {
+	case <-ev:
+		c.Fatalf("Unexpected event from service state")
+	case <-done:
+		c.Fatalf("Listener shutdown")
+	case <-timer.C:
+	}
+
+	// pause container
+	handler.On("PauseContainer", mock.AnythingOfType("*service.Service"), 1).Return(nil)
+	err = UpdateState(conn, req, func(s *State) bool {
+		s.DesiredState = service.SVCPause
+		return true
+	})
+	c.Assert(err, IsNil)
+	timer.Reset(time.Second)
+	select {
+	case <-ev:
+		// make sure the state is paused
+		ev, err = conn.GetW("/services/serviceid/"+req.StateID(), ssdat, done)
+		c.Assert(err, IsNil)
+
+		// may have been triggered by event to update desired state
+		if !ssdat.Paused {
+			timer.Reset(time.Second)
+			select {
+			case <-ev:
+				ev, err = conn.GetW("/services/serviceid/"+req.StateID(), ssdat, done)
+				c.Assert(err, IsNil)
+			case <-done:
+				c.Fatalf("Listener shutdown")
+			case <-timer.C:
+				c.Fatalf("Listener took too long")
+			}
+		}
+
+		c.Check(ssdat.Paused, Equals, true)
+	case <-done:
+		c.Fatalf("Listener shutdown")
+	case <-timer.C:
+		c.Fatalf("Listener took too long")
+	}
+
+	// shutdown
+	handler.On("StopContainer", "serviceid", 1).Return(nil).Run(func(_ mock.Arguments) {
+		containerExit <- time.Now()
+	})
+	close(shutdown)
+	timer.Reset(time.Second)
+	select {
+	case e := <-ev:
+		c.Check(e.Type, Equals, client.EventNodeDeleted)
+	case <-done:
+		c.Logf("Listener shutdown")
+	case <-timer.C:
+		c.Fatalf("Listener took too long")
+	}
+	handler.AssertExpectations(c)
+}
+
+// Test Case: Listener attaches to a paused running container (no change)
+func (t *ZZKTest) TestHostStateListener_Spawn_AttachPausePaused(c *C) {
+	// Pre-requisites
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+	handler := &mocks.HostStateHandler{}
+
+	// Basic set up
+	svc := &service.Service{
+		ID:     "serviceid",
+		Name:   "serviceA",
+		PoolID: "poolid",
+	}
+	spth := "/services/serviceid"
+	sdat := &ServiceNode{Service: svc}
+	err = conn.Create(spth, sdat)
+	c.Assert(err, IsNil)
+	err = conn.CreateDir("/hosts/hostid")
+	c.Assert(err, IsNil)
+
+	req := StateRequest{
+		HostID:     "hostid",
+		ServiceID:  "serviceid",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	shutdown := make(chan interface{})
+	listener := NewHostStateListener(handler, "hostid")
+	listener.SetConnection(conn)
+
+	// set up a paused running container
+	ssdat := &ServiceState{
+		ContainerID: "containerid",
+		ImageID:     "imageid",
+		Paused:      true,
+		Started:     time.Now(),
+	}
+	err = UpdateState(conn, req, func(s *State) bool {
+		s.DesiredState = service.SVCPause
+		s.ServiceState = *ssdat
+		return true
+	})
+	c.Assert(err, IsNil)
+
+	containerExit := make(chan time.Time, 1)
+	var retExit <-chan time.Time = containerExit
+	handler.On("AttachContainer", "containerid", "serviceid", 1).Return(retExit, nil).Once()
+
+	done := make(chan struct{})
+	ev, err := conn.GetW("/services/serviceid/"+req.StateID(), ssdat, done)
+	c.Assert(err, IsNil)
+	go func() {
+		listener.Spawn(shutdown, req.StateID())
+		close(done)
+	}()
+
+	timer := time.NewTimer(time.Second)
+	select {
+	case <-ev:
+		c.Fatalf("Unexpected event from service state")
+	case <-done:
+		c.Fatalf("Listener shutdown")
+	case <-timer.C:
+	}
+
+	// shutdown
+	handler.On("StopContainer", "serviceid", 1).Return(nil).Run(func(_ mock.Arguments) {
+		containerExit <- time.Now()
+	})
+	close(shutdown)
+	timer.Reset(time.Second)
+	select {
+	case e := <-ev:
+		c.Check(e.Type, Equals, client.EventNodeDeleted)
+	case <-done:
+		c.Logf("Listener shutdown")
+	case <-timer.C:
+		c.Fatalf("Listener took too long")
+	}
+	handler.AssertExpectations(c)
+}
+
+// Test Case: Listener to pause a stopped container (no change)
+func (t *ZZKTest) TestHostStateListener_Spawn_DetachPause(c *C) {
+	// Pre-requisites
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+	handler := &mocks.HostStateHandler{}
+
+	// Basic set up
+	svc := &service.Service{
+		ID:     "serviceid",
+		Name:   "serviceA",
+		PoolID: "poolid",
+	}
+	spth := "/services/serviceid"
+	sdat := &ServiceNode{Service: svc}
+	err = conn.Create(spth, sdat)
+	c.Assert(err, IsNil)
+	err = conn.CreateDir("/hosts/hostid")
+	c.Assert(err, IsNil)
+
+	req := StateRequest{
+		HostID:     "hostid",
+		ServiceID:  "serviceid",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	shutdown := make(chan interface{})
+	listener := NewHostStateListener(handler, "hostid")
+	listener.SetConnection(conn)
+
+	err = UpdateState(conn, req, func(s *State) bool {
+		s.DesiredState = service.SVCPause
+		return true
+	})
+	c.Assert(err, IsNil)
+	handler.On("AttachContainer", "", "serviceid", 1).Return(nil, nil).Once()
+
+	done := make(chan struct{})
+	ev, err := conn.GetW("/services/serviceid/"+req.StateID(), &ServiceState{}, done)
+	c.Assert(err, IsNil)
+	go func() {
+		listener.Spawn(shutdown, req.StateID())
+		close(done)
+	}()
+
+	timer := time.NewTimer(time.Second)
+	select {
+	case <-ev:
+		c.Fatalf("Unexpected event from service state")
+	case <-done:
+		c.Fatalf("Listener shutdown")
+	case <-timer.C:
+	}
+
+	// shutdown
+	handler.On("StopContainer", "serviceid", 1).Return(nil)
+	close(shutdown)
+	timer.Reset(time.Second)
+	select {
+	case e := <-ev:
+		c.Check(e.Type, Equals, client.EventNodeDeleted)
+	case <-done:
+		c.Logf("Listener shutdown")
+	case <-timer.C:
+		c.Fatalf("Listener took too long")
+	}
+	handler.AssertExpectations(c)
+}
+
+// Test Case: Listener attaches to a running container and stops
+func (t *ZZKTest) TestHostStateListener_Spawn_AttachStop(c *C) {
+	// Pre-requisites
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+	handler := &mocks.HostStateHandler{}
+
+	// Basic set up
+	svc := &service.Service{
+		ID:     "serviceid",
+		Name:   "serviceA",
+		PoolID: "poolid",
+	}
+	spth := "/services/serviceid"
+	sdat := &ServiceNode{Service: svc}
+	err = conn.Create(spth, sdat)
+	c.Assert(err, IsNil)
+	err = conn.CreateDir("/hosts/hostid")
+	c.Assert(err, IsNil)
+
+	req := StateRequest{
+		HostID:     "hostid",
+		ServiceID:  "serviceid",
+		InstanceID: 1,
+	}
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	shutdown := make(chan interface{})
+	listener := NewHostStateListener(handler, "hostid")
+	listener.SetConnection(conn)
+
+	// set up a running container
+	ssdat := &ServiceState{
+		ContainerID: "containerid",
+		ImageID:     "imageid",
+		Paused:      false,
+		Started:     time.Now(),
+	}
+	err = UpdateState(conn, req, func(s *State) bool {
+		s.DesiredState = service.SVCStop
+		s.ServiceState = *ssdat
+		return true
+	})
+	c.Assert(err, IsNil)
+
+	containerExit := make(chan time.Time, 1)
+	var retExit <-chan time.Time = containerExit
+	handler.On("AttachContainer", "containerid", "serviceid", 1).Return(retExit, nil).Once()
+
+	done := make(chan struct{})
+
+	ev, err := conn.GetW("/services/serviceid/"+req.StateID(), ssdat, done)
+	c.Assert(err, IsNil)
+	go func() {
+		listener.Spawn(shutdown, req.StateID())
+		close(done)
+	}()
+
+	handler.On("StopContainer", "serviceid", 1).Return(nil).Run(func(_ mock.Arguments) {
+		containerExit <- time.Now()
+	})
+	timer := time.NewTimer(time.Second)
+	select {
+	case e := <-ev:
+		c.Check(e.Type, Equals, client.EventNodeDeleted)
+	case <-done:
+		c.Logf("Listener shutdown")
+	case <-timer.C:
+		c.Fatalf("Listener took too long")
+	}
+	handler.AssertExpectations(c)
+}

--- a/zzk/service2/mocks/HostStateHandler.go
+++ b/zzk/service2/mocks/HostStateHandler.go
@@ -1,0 +1,100 @@
+package mocks
+
+import zk "github.com/control-center/serviced/zzk/service2"
+import "github.com/stretchr/testify/mock"
+
+import "time"
+
+import "github.com/control-center/serviced/domain/service"
+
+type HostStateHandler struct {
+	mock.Mock
+}
+
+func (_m *HostStateHandler) StopContainer(serviceID string, instanceID int) error {
+	ret := _m.Called(serviceID, instanceID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, int) error); ok {
+		r0 = rf(serviceID, instanceID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *HostStateHandler) AttachContainer(dockerID string, serviceID string, instanceID int) (<-chan time.Time, error) {
+	ret := _m.Called(dockerID, serviceID, instanceID)
+
+	var r0 <-chan time.Time
+	if rf, ok := ret.Get(0).(func(string, string, int) <-chan time.Time); ok {
+		r0 = rf(dockerID, serviceID, instanceID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(<-chan time.Time)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, int) error); ok {
+		r1 = rf(dockerID, serviceID, instanceID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *HostStateHandler) StartContainer(cancel <-chan interface{}, svc *service.Service, instanceID int) (*zk.ServiceState, <-chan time.Time, error) {
+	ret := _m.Called(cancel, svc, instanceID)
+
+	var r0 *zk.ServiceState
+	if rf, ok := ret.Get(0).(func(<-chan interface{}, *service.Service, int) *zk.ServiceState); ok {
+		r0 = rf(cancel, svc, instanceID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*zk.ServiceState)
+		}
+	}
+
+	var r1 <-chan time.Time
+	if rf, ok := ret.Get(1).(func(<-chan interface{}, *service.Service, int) <-chan time.Time); ok {
+		r1 = rf(cancel, svc, instanceID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(<-chan time.Time)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(<-chan interface{}, *service.Service, int) error); ok {
+		r2 = rf(cancel, svc, instanceID)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+func (_m *HostStateHandler) ResumeContainer(svc *service.Service, instanceID int) error {
+	ret := _m.Called(svc, instanceID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*service.Service, int) error); ok {
+		r0 = rf(svc, instanceID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *HostStateHandler) PauseContainer(svc *service.Service, instanceID int) error {
+	ret := _m.Called(svc, instanceID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*service.Service, int) error); ok {
+		r0 = rf(svc, instanceID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}


### PR DESCRIPTION
Includes:
New calls on the host side to manipulate host containers
Using new state ids on the host state listener (see https://github.com/control-center/serviced/blob/develop/zzk/service/hoststate.go if you need a point of reference)