### PR TITLE
fixes to import endpoint listener

### DIFF
--- a/zzk/registry2/import.go
+++ b/zzk/registry2/import.go
@@ -1,0 +1,121 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"path"
+	"sync"
+
+	"github.com/control-center/serviced/coordinator/client"
+)
+
+// StringMatcher is for matching applications
+type StringMatcher interface {
+	MatchString(string) bool
+}
+
+// Term describes a what applications it is looking for and then sends the
+// response.
+type Term struct {
+	matcher StringMatcher
+	send    chan<- string
+}
+
+// ImportListener passes matching endpoints to its respective receiver channel
+type ImportListener struct {
+	tenantID string
+	terms    []Term
+	apps     map[string]struct{}
+	mu       *sync.Mutex
+}
+
+// NewImportListener instantiates a new listener for a given tenant id.
+func NewImportListener(tenantID string) *ImportListener {
+	return &ImportListener{
+		tenantID: tenantID,
+		apps:     make(map[string]struct{}),
+	}
+}
+
+// AddTerm adds a search term to the listener and returns a channel receiever
+// with the applicable matches.
+func (l *ImportListener) AddTerm(matcher StringMatcher) <-chan string {
+	send := make(chan string)
+	t := Term{
+		matcher: matcher,
+		send:    send,
+	}
+	l.terms = append(l.terms, t)
+
+	return send
+}
+
+// Run starts the export listener for the given tenant
+func (l *ImportListener) Run(cancel <-chan struct{}, conn client.Connection) {
+	logger := plog.WithField("tenantid", l.tenantID)
+
+	pth := path.Join("/net/export", l.tenantID)
+
+	done := make(chan struct{})
+	defer func() { close(done) }()
+	for {
+
+		// set a watcher to alert when the path is available
+		ok, ev, err := conn.ExistsW(pth, done)
+		if err != nil {
+			logger.WithError(err).Error("Could not listen for exports on tenant")
+			return
+		}
+
+		var ch []string
+		if ok {
+			// the path is available, so set the listener on the change in the
+			// number of children
+			ch, ev, err = conn.ChildrenW(pth, done)
+			if err == client.ErrNoNode {
+				continue
+			} else if err != nil {
+				logger.WithError(err).Error("Could not listen for exports on tenant")
+				return
+			}
+		}
+
+		// for each new application found, send the matches to the respective
+		// term channels.
+		for _, app := range ch {
+			if _, ok := l.apps[app]; !ok {
+				for _, t := range l.terms {
+					if t.matcher.MatchString(app) {
+						select {
+						case t.send <- app:
+						case <-cancel:
+							return
+						}
+					}
+				}
+				l.apps[app] = struct{}{}
+			}
+		}
+
+		// wait for something to happen
+		select {
+		case <-ev:
+		case <-cancel:
+			return
+		}
+
+		close(done)
+		done = make(chan struct{})
+	}
+}

--- a/zzk/registry2/import_test.go
+++ b/zzk/registry2/import_test.go
@@ -1,0 +1,135 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build integration,!quick
+
+package registry_test
+
+import (
+	"time"
+
+	"github.com/control-center/serviced/zzk"
+	. "github.com/control-center/serviced/zzk/registry2"
+	"github.com/control-center/serviced/zzk/registry2/mocks"
+	. "gopkg.in/check.v1"
+)
+
+func (t *ZZKTest) TestImportListener(c *C) {
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+
+	err = conn.CreateDir("/net/export/tenantid/app1")
+	c.Assert(err, IsNil)
+
+	listener := NewImportListener("tenantid")
+	term := &mocks.StringMatcher{}
+	term.On("MatchString", "app1").Return(true)
+	ev := listener.AddTerm(term)
+
+	shutdown := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		listener.Run(shutdown, conn)
+		close(done)
+	}()
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case app := <-ev:
+		c.Check(app, Equals, "app1")
+	case <-done:
+		c.Fatalf("Listener exited unexpectedly")
+	case <-timer.C:
+		close(shutdown)
+		c.Fatalf("Timed out waiting for listener")
+	}
+
+	// add another match
+	term.On("MatchString", "app2").Return(true)
+	err = conn.CreateDir("/net/export/tenantid/app2")
+	c.Assert(err, IsNil)
+
+	timer.Reset(time.Second)
+	select {
+	case app := <-ev:
+		c.Check(app, Equals, "app2")
+	case <-done:
+		c.Fatalf("Listener exited unexpectedly")
+	case <-timer.C:
+		close(shutdown)
+		c.Fatalf("Timed out waiting for listener")
+	}
+
+	// add a mismatch
+	term.On("MatchString", "app3").Return(false)
+	err = conn.CreateDir("/net/export/tenantid/app3")
+	c.Assert(err, IsNil)
+
+	timer.Reset(time.Second)
+	select {
+	case app := <-ev:
+		c.Errorf("Unexpected event receieved from listener: %s", app)
+	case <-done:
+		c.Fatalf("Listener exited unexpectedly")
+	case <-timer.C:
+	}
+
+	// shutdown
+	close(shutdown)
+
+	timer.Reset(time.Second)
+	select {
+	case app := <-ev:
+		c.Errorf("Unexpected event receieved from listener: %s", app)
+	case <-done:
+	case <-timer.C:
+		c.Fatalf("Timed out waiting for listener")
+	}
+
+	// add another node and restart
+	term.On("MatchString", "app4").Return(true)
+	err = conn.CreateDir("/net/export/tenantid/app4")
+	c.Assert(err, IsNil)
+
+	shutdown = make(chan struct{})
+	done = make(chan struct{})
+	go func() {
+		listener.Run(shutdown, conn)
+		close(done)
+	}()
+
+	timer = time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case app := <-ev:
+		c.Check(app, Equals, "app4")
+	case <-done:
+		c.Fatalf("Listener exited unexpectedly")
+	case <-timer.C:
+		close(shutdown)
+		c.Fatalf("Timed out waiting for listener")
+	}
+
+	// shutdown again
+	close(shutdown)
+
+	timer.Reset(time.Second)
+	select {
+	case app := <-ev:
+		c.Errorf("Unexpected event receieved from listener: %s", app)
+	case <-done:
+	case <-timer.C:
+		c.Fatalf("Timed out waiting for listener")
+	}
+}

--- a/zzk/registry2/mocks/StringMatcher.go
+++ b/zzk/registry2/mocks/StringMatcher.go
@@ -1,0 +1,20 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+type StringMatcher struct {
+	mock.Mock
+}
+
+func (_m *StringMatcher) MatchString(_a0 string) bool {
+	ret := _m.Called(_a0)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}

--- a/zzk/service2/binding.go
+++ b/zzk/service2/binding.go
@@ -65,21 +65,21 @@ func (i ImportBinding) GetPortNumber(instanceID int) (uint16, error) {
 				Field:       i.PortTemplate,
 				Message:     "port value is not an integer",
 			}
-		} else if portNumber <= 0 {
+		} else if portNumber < 0 {
 			return 0, &TemplateError{
 				Application: i.Application,
 				Field:       i.PortTemplate,
-				Message:     "port value must be greater than zero",
+				Message:     "port value must be gte zero",
 			}
 		}
 		return uint16(portNumber), nil
 	}
 
-	if i.PortNumber == 0 {
+	if i.PortNumber < 0 {
 		return 0, &TemplateError{
 			Application: i.Application,
 			Field:       fmt.Sprintf("%d", i.PortNumber),
-			Message:     "port value must be greater than zero",
+			Message:     "port value must be gte zero",
 		}
 	}
 


### PR DESCRIPTION
* Hostname is not a proxy for ContainerID and can only be treated as such for a shell
* As a result, to verify that a service instance node has non-stale data, monitor the node and wait for the start time to be greater than the finish time.
* for import_all endpoints, if a port template is not available, default to the PortNumber + instanceID
* Removed unnecessary ":" when RegisteringVirtualAddress
* Passed useTLS into the endpoint proxy
* Sometimes, the application of an import may be a regular expression to match one or more exports, so I added an import listener to track whenever a new matching export is added.  Note that exports do not get deleted unless the top-level service is removed.