### PR TITLE
Increase smoke test timeout for CC startup

### DIFF
--- a/smoke.sh
+++ b/smoke.sh
@@ -6,6 +6,7 @@
 #
 #######################################################
 
+START_TIMEOUT=300
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 SERVICED=$(which serviced)
 if [ -z "${SERVICED}" ]; then
@@ -99,8 +100,8 @@ start_serviced() {
     mkdir -p ${SERVICED_VARPATH}
     sudo GOPATH=${GOPATH} PATH=${PATH} SERVICED_VARPATH=${SERVICED_VARPATH} SERVICED_MASTER=1 ${SERVICED} --allow-loop-back=true --agent server &
 
-    echo "Waiting 120 seconds for serviced to become the leader..."
-    retry 180 wget --no-check-certificate http://${HOSTNAME}:443 -O- &>/dev/null
+    echo "Waiting $START_TIMEOUT seconds for serviced to start..."
+    retry $START_TIMEOUT wget --no-check-certificate http://${HOSTNAME}:443 -O- &>/dev/null
     return $?
 }
 
@@ -329,7 +330,7 @@ install_prereqs
 add_to_etc_hosts
 
 # Run all the tests
-start_serviced             && succeed "Serviced became leader within timeout"    || fail "serviced failed to become the leader within 120 seconds."
+start_serviced             && succeed "Serviced has started within timeout"      || fail "serviced failed to start within $START_TIMEOUT seconds."
 retry 20 add_host          && succeed "Added host successfully"                  || fail "Unable to add host"
 add_template               && succeed "Added template successfully"              || fail "Unable to add template"
 deploy_service             && succeed "Deployed service successfully"            || fail "Unable to deploy service"


### PR DESCRIPTION
ES startup can take a couple of minutes, so a 3 minute timeout is too tight.

From http://jenkins.zendev.org/job/ControlCenter/job/1.1.x/job/serviced-1.1.x-merge-smoke/498,
note that the HTTP server for CC was only started a moment before the timeout expired:
```
I0906 18:52:58.626892 11621 api.go:52] Setting supported TLS ciphers for HTTP: [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA TLS_RSA_WITH_AES_256_CBC_SHA TLS_RSA_WITH_AES_128_CBC_SHA TLS_RSA_WITH_3DES_EDE_CBC_SHA]
...
====== FAIL ======
serviced failed to become the leader within 120 seconds.
==================
```