### PR TITLE
Increase CC startup timeouts for smoke and acceptance tests

### DIFF
--- a/acceptance.sh
+++ b/acceptance.sh
@@ -12,6 +12,7 @@
 #
 #######################################################
 
+START_TIMEOUT=300
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 SERVICED=$(which serviced)
 if [ -z "${SERVICED}" ]; then
@@ -79,8 +80,8 @@ start_serviced() {
     mkdir -p ${SERVICED_VARPATH}
     sudo GOPATH=${GOPATH} PATH=${PATH} SERVICED_VARPATH=${SERVICED_VARPATH} SERVICED_MASTER=1 ${SERVICED} --allow-loop-back=true --agent server &
 
-    echo "Waiting 180 seconds for serviced to become the leader..."
-    retry 180 wget --no-check-certificate http://${HOSTNAME}:443 -O- &>/dev/null
+    echo "Waiting $START_TIMEOUT seconds for serviced to become the leader..."
+    retry $START_TIMEOUT  wget --no-check-certificate http://${HOSTNAME}:443 -O- &>/dev/null
     return $?
 }
 
@@ -146,7 +147,7 @@ echo "Pre-test cleanup complete"
 install_prereqs
 add_to_etc_hosts
 
-start_serviced             && succeed "Serviced became leader within timeout"    || fail "serviced failed to become the leader within 120 seconds."
+start_serviced             && succeed "Serviced started within timeout"    || fail "serviced failed to start within $START_TIMEOUT seconds."
 
 # build/start mock agents
 cd ${DIR}

--- a/smoke.sh
+++ b/smoke.sh
@@ -6,6 +6,7 @@
 #
 #######################################################
 
+START_TIMEOUT=300
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 SERVICED=$(which serviced)
 if [ -z "${SERVICED}" ]; then
@@ -99,8 +100,8 @@ start_serviced() {
     mkdir -p ${SERVICED_VARPATH}
     sudo GOPATH=${GOPATH} PATH=${PATH} SERVICED_VARPATH=${SERVICED_VARPATH} SERVICED_MASTER=1 ${SERVICED} --allow-loop-back=true --agent server &
 
-    echo "Waiting 120 seconds for serviced to become the leader..."
-    retry 180 wget --no-check-certificate http://${HOSTNAME}:443 -O- &>/dev/null
+    echo "Waiting $START_TIMEOUT seconds for serviced to start..."
+    retry $START_TIMEOUT wget --no-check-certificate http://${HOSTNAME}:443 -O- &>/dev/null
     return $?
 }
 
@@ -329,7 +330,7 @@ install_prereqs
 add_to_etc_hosts
 
 # Run all the tests
-start_serviced             && succeed "Serviced became leader within timeout"    || fail "serviced failed to become the leader within 120 seconds."
+start_serviced             && succeed "Serviced has started within timeout"      || fail "serviced failed to start within $START_TIMEOUT seconds."
 retry 20 add_host          && succeed "Added host successfully"                  || fail "Unable to add host"
 add_template               && succeed "Added template successfully"              || fail "Unable to add template"
 deploy_service             && succeed "Deployed service successfully"            || fail "Unable to deploy service"


### PR DESCRIPTION
Sometimes CC takes just over 3 minutes to startup, which can cause the tests to fail prematurely.