### PR TITLE
Add PEMFromRSAKey routines

### DIFF
--- a/auth/rsa.go
+++ b/auth/rsa.go
@@ -165,6 +165,33 @@ func RSAVerifierFromPEM(key []byte) (Verifier, error) {
 	return RSAVerifier(pkey)
 }
 
+// PEMFromRSAPublicKey creates a PEM block from an RSA public key
+func PEMFromRSAPublicKey(key *rsa.PublicKey, headers map[string]string) ([]byte, error) {
+	marshalled, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		return []byte{}, err
+	}
+	block := pem.Block{
+		Type:    "PUBLIC KEY",
+		Headers: headers,
+		Bytes:   marshalled,
+	}
+	bytes := pem.EncodeToMemory(&block)
+	return bytes, nil
+}
+
+// PEMFromRSAPublicKey creates a PEM block from an RSA public key
+func PEMFromRSAPrivateKey(key *rsa.PrivateKey, headers map[string]string) ([]byte, error) {
+	marshalled := x509.MarshalPKCS1PrivateKey(key)
+	block := pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: headers,
+		Bytes:   marshalled,
+	}
+	bytes := pem.EncodeToMemory(&block)
+	return bytes, nil
+}
+
 // DevRSASigner returns a dev signer for dev purposes
 func DevRSASigner() Signer {
 	signer, _ := RSASignerFromPEM(DevPrivKeyPEM)

--- a/auth/rsa_test.go
+++ b/auth/rsa_test.go
@@ -18,6 +18,7 @@ package auth_test
 import (
 	"bytes"
 	"crypto/rsa"
+	"strings"
 
 	"github.com/control-center/serviced/auth"
 	. "gopkg.in/check.v1"
@@ -69,7 +70,7 @@ func (s *TestAuthSuite) TestRSAPublicKeyFromPEM(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(key, FitsTypeOf, sample)
 
-	// Test a public key
+	// Test a private key
 	key, err = auth.RSAPublicKeyFromPEM(auth.DevPrivKeyPEM)
 	c.Assert(err, Equals, auth.ErrNotRSAPublicKey)
 	c.Assert(key, IsNil)
@@ -125,4 +126,28 @@ func (s *TestAuthSuite) TestRSASignAndVerify(c *C) {
 	// Verify the signature
 	err = verifier.Verify(message, sig)
 	c.Assert(err, IsNil)
+}
+
+func (s *TestAuthSuite) TestPEMFromRSAPPublicKey(c *C) {
+	pem := auth.DevPubKeyPEM
+	expected := strings.TrimSpace(string(pem[:]))
+	pub, err := auth.RSAPublicKeyFromPEM(pem)
+
+	// Get a PEM from the public key
+	out, err := auth.PEMFromRSAPublicKey(pub, nil)
+	c.Assert(err, IsNil)
+	actual := strings.TrimSpace(string(out[:]))
+	c.Assert(actual, Equals, expected)
+}
+
+func (s *TestAuthSuite) TestPEMFromRSAPrivateKey(c *C) {
+	pem := auth.DevPrivKeyPEM
+	expected := strings.TrimSpace(string(pem[:]))
+	priv, err := auth.RSAPrivateKeyFromPEM(pem)
+
+	// Get a PEM from the private key
+	out, err := auth.PEMFromRSAPrivateKey(priv, nil)
+	c.Assert(err, IsNil)
+	actual := strings.TrimSpace(string(out[:]))
+	c.Assert(actual, Equals, expected)
 }


### PR DESCRIPTION
Add routines to get a PEM block from an RSA public or private key.