### PR TITLE
Added methods to encode/decode mux header

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -62,3 +62,8 @@ type Identity interface {
 	HasDFSAccess() bool
 	Verifier() (Verifier, error)
 }
+
+// TODO: Placeholder until we have the token available
+func AuthToken() string {
+	return "my super fake token"
+}

--- a/auth/mux.go
+++ b/auth/mux.go
@@ -78,11 +78,11 @@ func BuildMuxHeader(address []byte) ([]byte, error) {
 	return headerBuf.Bytes(), nil
 }
 
-func errorExtractingHeader(err error) (string, Identity, error) {
-	return "", nil, err
+func errorExtractingHeader(err error) ([]byte, Identity, error) {
+	return nil, nil, err
 }
 
-func ExtractMuxHeader(rawHeader []byte) (string, Identity, error) {
+func ExtractMuxHeader(rawHeader []byte) ([]byte, Identity, error) {
 	var offset uint32 = 0
 
 	if len(rawHeader) <= TOKEN_LEN_BYTES+ADDRESS_BYTES {
@@ -108,7 +108,7 @@ func ExtractMuxHeader(rawHeader []byte) (string, Identity, error) {
 	}
 
 	// Next six bytes is going to be the address
-	address := string(rawHeader[offset : offset+ADDRESS_BYTES])
+	address := rawHeader[offset : offset+ADDRESS_BYTES]
 	offset += ADDRESS_BYTES
 
 	// get the part of the header that has been signed
@@ -121,11 +121,10 @@ func ExtractMuxHeader(rawHeader []byte) (string, Identity, error) {
 	senderVerifier, err := senderIdentity.Verifier()
 	if err != nil {
 		return errorExtractingHeader(err)
-	} else {
-		err := senderVerifier.Verify(signed_message, signature)
-		if err != nil {
-			return errorExtractingHeader(err)
-		}
+	}
+	err := senderVerifier.Verify(signed_message, signature)
+	if err != nil {
+		return errorExtractingHeader(err)
 	}
 
 	return address, senderIdentity, nil

--- a/auth/mux.go
+++ b/auth/mux.go
@@ -1,0 +1,132 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+)
+
+/*
+   When establishing a connection to the mux, in addition to the address of the receiver,
+   the sender sends an authentication token and signs the whole message. The token determines
+   if the sender is authorized to send data to the receiver or not
+
+   ----------------------------------------------------------------------------------------------
+   | Auth Token length (4 bytes)  |     Auth Token (N bytes)  | Address (6 bytes) |  Signature  |
+   ----------------------------------------------------------------------------------------------
+*/
+
+var (
+	endian           = binary.BigEndian
+	ErrBadMuxAddress = errors.New("Bad mux address")
+	ErrBadMuxHeader  = errors.New("Bad mux header")
+)
+
+const (
+	ADDRESS_BYTES   = 6
+	TOKEN_LEN_BYTES = 4
+)
+
+func BuildMuxHeader(address []byte) ([]byte, error) {
+	headerBuf := new(bytes.Buffer)
+
+	if len(address) != ADDRESS_BYTES {
+		return nil, ErrBadMuxAddress
+	}
+
+	//get current host token
+	token := AuthToken()
+
+	// add token length
+	var tokenLen uint32 = uint32(len(token))
+	tokenLenBuf := make([]byte, 4)
+	endian.PutUint32(tokenLenBuf, tokenLen)
+	headerBuf.Write(tokenLenBuf)
+
+	// add token
+	headerBuf.Write([]byte(token))
+
+	// add address
+	headerBuf.Write([]byte(address))
+
+	// Sign what we have so far
+	myPrivateKey := LocalPrivateKey()
+	signer, err := RSASigner(myPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	signature, err := signer.Sign(headerBuf.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	// add signature to header
+	headerBuf.Write(signature)
+
+	return headerBuf.Bytes(), nil
+}
+
+func errorExtractingHeader(err error) (string, Identity, error) {
+	return "", nil, err
+}
+
+func ExtractMuxHeader(rawHeader []byte) (string, Identity, error) {
+	var offset uint32 = 0
+
+	if len(rawHeader) <= TOKEN_LEN_BYTES+ADDRESS_BYTES {
+		return errorExtractingHeader(ErrBadMuxHeader)
+	}
+
+	// First four bytes represents the token length
+	tokenLen := endian.Uint32(rawHeader[offset : offset+TOKEN_LEN_BYTES])
+	offset += TOKEN_LEN_BYTES
+	if len(rawHeader) <= TOKEN_LEN_BYTES+int(tokenLen)+ADDRESS_BYTES {
+		return errorExtractingHeader(ErrBadMuxHeader)
+	}
+
+	// Next tokeLen bytes contain the token
+	token := string(rawHeader[offset : offset+tokenLen])
+	offset += tokenLen
+
+	// Validate the token can be parsed
+	masterPublicKey := MasterPublicKey()
+	senderIdentity, err := ParseJWTIdentity(token, &masterPublicKey)
+	if err != nil {
+		return errorExtractingHeader(err)
+	}
+
+	// Next six bytes is going to be the address
+	address := string(rawHeader[offset : offset+ADDRESS_BYTES])
+	offset += ADDRESS_BYTES
+
+	// get the part of the header that has been signed
+	signed_message := rawHeader[:offset]
+
+	// Whatever is left is the signature
+	signature := rawHeader[offset:]
+
+	// Verify the identity of the signed message
+	senderVerifier, err := senderIdentity.Verifier()
+	if err != nil {
+		return errorExtractingHeader(err)
+	} else {
+		err := senderVerifier.Verify(signed_message, signature)
+		if err != nil {
+			return errorExtractingHeader(err)
+		}
+	}
+
+	return address, senderIdentity, nil
+}

--- a/auth/mux_test.go
+++ b/auth/mux_test.go
@@ -1,0 +1,78 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package auth_test
+
+import (
+	"crypto"
+	"github.com/control-center/serviced/auth"
+	. "gopkg.in/check.v1"
+	"time"
+)
+
+var (
+	mockPublicKey  crypto.PublicKey
+	mockPrivateKey crypto.PrivateKey
+	hostId         = "MyHost"
+	poolId         = "MyPool"
+	admin          = false
+	dfs            = true
+	fakeSigner     auth.Signer
+	fakeToken      string
+)
+
+func init() {
+	// For simplicity we will sign the token and header with the same private key
+	mockPublicKey, _ = auth.RSAPublicKeyFromPEM(auth.DevPubKeyPEM)
+	mockPrivateKey, _ = auth.RSAPrivateKeyFromPEM(auth.DevPrivKeyPEM)
+	// Build a fake token
+	fakeToken, _ = auth.CreateJWTIdentity(hostId, poolId, admin, dfs, mockPublicKey, time.Hour, mockPrivateKey)
+	// Build a fake signer
+	fakeSigner, _ = auth.RSASigner(mockPrivateKey)
+}
+
+func (s *TestAuthSuite) TestBuildHeaderBadAddr(c *C) {
+	c.Assert(fakeToken, NotNil)
+	c.Assert(fakeSigner, NotNil)
+	addr := "this is more than 6 bytes"
+	_, err := auth.BuildAuthMuxHeader([]byte(addr), fakeToken, fakeSigner)
+	c.Assert(err, Equals, auth.ErrBadMuxAddress)
+}
+
+func (s *TestAuthSuite) TestExtractBadHeader(c *C) {
+	mockHeader := []byte{0, 0, 0, 19, 109, 121, 32, 115, 117, 112, 101, 114, 32, 102}
+	_, _, err := auth.ExtractMuxHeader(mockHeader)
+	c.Assert(err, Equals, auth.ErrBadMuxHeader)
+}
+
+func (s *TestAuthSuite) TestBuildAndExtractHeader(c *C) {
+	c.Assert(fakeToken, NotNil)
+	c.Assert(fakeSigner, NotNil)
+	addr := "zenoss"
+	// build header
+	header, err := auth.BuildAuthMuxHeader([]byte(addr), fakeToken, fakeSigner)
+	c.Assert(err, Equals, nil)
+	c.Assert(header, NotNil)
+	// extract header
+	extractedAddr, ident, err := auth.ExtractAuthMuxHeader(header, mockPublicKey)
+	// check the address is correctly decoded
+	c.Assert(err, IsNil)
+	c.Assert(string(extractedAddr), DeepEquals, addr)
+	// check the identity has been correctly extracted
+	c.Assert(hostId, DeepEquals, ident.HostID())
+	c.Assert(poolId, DeepEquals, ident.PoolID())
+	c.Assert(admin, Equals, ident.HasAdminAccess())
+	c.Assert(dfs, Equals, ident.HasDFSAccess())
+}

--- a/auth/rsa.go
+++ b/auth/rsa.go
@@ -230,3 +230,21 @@ func DevRSAVerifier() Verifier {
 	verifier, _ := RSAVerifierFromPEM(DevPubKeyPEM)
 	return verifier
 }
+
+// TODO: LocalPrivateKey, LocalPublicKey, MasterPublicKey
+// are just a placeholder until we have the required keys loaded in memory somewhere
+
+func LocalPrivateKey() crypto.PrivateKey {
+	key, _ := RSAPrivateKeyFromPEM(DevPrivKeyPEM)
+	return key
+}
+
+func LocalPublicKey() crypto.PublicKey {
+	key, _ := RSAPublicKeyFromPEM(DevPubKeyPEM)
+	return key
+}
+
+func MasterPublicKey() crypto.PublicKey {
+	key, _ := RSAPublicKeyFromPEM(DevPubKeyPEM)
+	return key
+}


### PR DESCRIPTION
Added method to build/extract the mux auth header. This code is not yet wired to the mux bc we still need to have the JWT part implemented.

To wire it we will need to:

Build header: https://github.com/control-center/serviced/blob/develop/container/proxy.go#L261
Extract header: https://github.com/control-center/serviced/blob/develop/proxy/mux.go#L145 once we get the identity, drop the connection if Valid() return an error