### PR TITLE
after host is added, show user the new host private key

### DIFF
--- a/web/ui/src/Hosts/HostsController.js
+++ b/web/ui/src/Hosts/HostsController.js
@@ -27,6 +27,7 @@
 
         $scope.modalAddHost = function() {
             areUIReady.lock();
+            $scope.resetNewHost();
             $modalService.create({
                 templateUrl: "add-host.html",
                 model: $scope,
@@ -34,13 +35,10 @@
                 actions: [
                     {
                         role: "cancel",
-                        action: function(){
-                            $scope.resetNewHost();
-                            this.close();
-                        }
                     },{
                         role: "ok",
-                        label: "add_host",
+                        label: "Next",
+                        icon: "glyphicon-chevron-right",
                         action: function(){
                             if(this.validate()){
                                 // disable ok button, and store the re-enable function
@@ -53,8 +51,7 @@
 
                                 resourcesFactory.addHost($scope.newHost)
                                     .success(function(data, status){
-                                        $notification.create("", data.Detail).success();
-                                        this.close();
+                                        $scope.modal_displayHostKeys(data.PrivateKey, $scope.newHost.host, data.Detail);
                                         update();
                                     }.bind(this))
                                     .error(function(data, status){
@@ -79,6 +76,52 @@
                 },
                 onShow: () => {
                     areUIReady.unlock();
+                }
+            });
+        };
+
+        $scope.modal_displayHostKeys = function(keys, name, message) {
+            let model = $scope.$new(true);
+            model.keys = keys;
+            model.name = name;
+
+            $modalService.create({
+                templateUrl: "display-host-keys.html",
+                model: model,
+                title: "Host Keys",
+                actions: [
+                    {
+                        label: "Download Keys",
+                        action: function(){
+                            utils.downloadText(name + ".keys", keys);
+                        },
+                        icon: "glyphicon-download"
+                    },{
+                        role: "ok"
+                    }
+                ],
+                onShow: function(){
+                    if(message){
+                        this.createNotification("", message).success();
+                    }
+
+                    // TODO - dont touch the DOM!
+                    let keysWrapEl = this.$el.find(".keys-wrap"),
+                        keysEl = keysWrapEl.find(".keys");
+                    keysWrapEl.on("click", e => {
+                        // TODO - if already selected, this deselects
+                        keysEl.select();
+                        try {
+                            let success = document.execCommand('copy');
+                            if(success){
+                                this.createNotification("", "Keys copied to clipboard").info();
+                            } else {
+                                this.createNotification("", "Press Ctrl+C or Cmd+C to copy keys").info();
+                            }
+                        } catch(e) {
+                            this.createNotification("", "Press Ctrl+C or Cmd+C to copy keys").info();
+                        }
+                    });
                 }
             });
         };

--- a/web/ui/src/Hosts/display-host-keys.html
+++ b/web/ui/src/Hosts/display-host-keys.html
@@ -1,0 +1,9 @@
+<p>Click the text area to copy the keys for host <strong>{{name}}</strong></p>
+
+<div class="keys-wrap" style="position: relative; height: 200px;">
+    <textarea class="keys" readonly style="height: 100%; max-width: 100%; background-color: #DDD;">{{keys}}</textarea>
+</div><br>
+
+<p>
+    These keys must be registered with the host machine <strong>{{name}}</strong> using the <span class="inline-code">serviced host register</span> command. If the keys are lost, new keys must be generated for the host.
+</p>

--- a/web/ui/src/Hosts/display-host-keys.html
+++ b/web/ui/src/Hosts/display-host-keys.html
@@ -4,6 +4,4 @@
     <textarea class="keys" readonly style="height: 100%; max-width: 100%; background-color: #DDD;">{{keys}}</textarea>
 </div><br>
 
-<p>
-    These keys must be registered with the host machine <strong>{{name}}</strong> using the <span class="inline-code">serviced host register</span> command. If the keys are lost, new keys must be generated for the host.
-</p>
+<p>These keys must be registered on the host machine <strong>{{name}}</strong> using the <span class="inline-code">serviced host register</span> command. If the keys are lost, new keys must be generated for the host.</p>

--- a/web/ui/src/common/miscUtils.js
+++ b/web/ui/src/common/miscUtils.js
@@ -48,6 +48,17 @@
                 window.location = url;
             },
 
+            // http://stackoverflow.com/a/18197341
+			downloadText(filename, text) {
+				var element = document.createElement('a');
+				element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+				element.setAttribute('download', filename);
+				element.style.display = 'none';
+				document.body.appendChild(element);
+				element.click();
+				document.body.removeChild(element);
+			},
+
             getModeFromFilename: function(filename){
                 var re = /(?:\.([^.]+))?$/;
                 var ext = re.exec(filename)[1];

--- a/web/ui/src/common/modalService.js
+++ b/web/ui/src/common/modalService.js
@@ -217,6 +217,11 @@
                     momo.destroy();
                 });
 
+                // if any existing modals, remove backdrop
+                if(modals.length){
+                    $(".modal-backdrop").remove();
+                }
+
                 var modal = new Modal(template, model, config);
                 modal.show();
 

--- a/web/ui/static/css/main.css
+++ b/web/ui/static/css/main.css
@@ -1936,3 +1936,7 @@ body.no-animation *:after {
     font-weight: normal;
     content: "\e031";
 }
+
+.instructions-block {
+    font-size: 1.1em;
+}


### PR DESCRIPTION
After new host is added, show a dialog with the hosts private key and some basic instructions on how to use it. Also easy to copy/pasta the key on click.

![image](https://cloud.githubusercontent.com/assets/1927558/18566767/c5155f9e-7b5a-11e6-9925-49d328ed462c.png)
