### PR TITLE
Feature/rpc auth rebased

### DIFF
--- a/acceptance/mockAgent/daemon.go
+++ b/acceptance/mockAgent/daemon.go
@@ -90,7 +90,7 @@ func (d *daemon) startRPC() {
 			if err != nil {
 				glog.Fatalf("Error accepting connections: %s", err)
 			}
-			go d.rpcServer.ServeCodec(jsonrpc.NewServerCodec(conn))
+			go d.rpcServer.ServeCodec(rpcutils.NewDefaultAuthServerCodec(conn))
 		}
 	}()
 }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -21,7 +21,6 @@ import (
 )
 
 const (
-	ADDRESS_BYTES   = 6
 	TOKEN_LEN_BYTES = 4
 	SIGNATURE_BYTES = 256
 )

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -14,9 +14,16 @@
 package auth
 
 import (
+	"encoding/binary"
 	"errors"
 
 	"github.com/control-center/serviced/logging"
+)
+
+const (
+	ADDRESS_BYTES   = 6
+	TOKEN_LEN_BYTES = 4
+	SIGNATURE_BYTES = 256
 )
 
 var (
@@ -46,8 +53,11 @@ var (
 	ErrBadKeysFile = errors.New("Unable to read security keys file")
 	// ErrNotAuthenticated is thrown when there's no authentication token
 	ErrNotAuthenticated = errors.New("No authentication token available")
+	// ErrBadToken is thrown when there is a problem extracting a token from a data stream (e.g. mux, rpc, etc)
+	ErrBadToken = errors.New("Could not extract token")
 
-	log = logging.PackageLogger()
+	log    = logging.PackageLogger()
+	endian = binary.BigEndian
 )
 
 // Signer is used to sign a message

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -28,6 +28,10 @@ type TestAuthSuite struct {
 	masterPrivPEM   []byte
 	delegatePubPEM  []byte
 	delegatePrivPEM []byte
+	hostId          string
+	poolId          string
+	admin           bool
+	dfs             bool
 }
 
 var (
@@ -49,6 +53,11 @@ func (s *TestAuthSuite) SetUpTest(c *C) {
 
 	auth.LoadMasterKeysFromPEM(mPub, mPriv)
 	auth.LoadDelegateKeysFromPEM(mPub, dPriv)
+
+	s.hostId = "MyHost"
+	s.poolId = "MyPool"
+	s.admin = false
+	s.dfs = true
 }
 
 func (s *TestAuthSuite) TearDownTest(c *C) {

--- a/auth/localkeys.go
+++ b/auth/localkeys.go
@@ -119,13 +119,13 @@ func VerifyMasterSignature(message, signature []byte) error {
 func GetMasterPublicKey() (crypto.PublicKey, error) {
 	dKeyCond.L.Lock()
 	defer dKeyCond.L.Unlock()
-	if delegateKeys.masterPublic == nil {
-		if masterKeys.public == nil {
+	if masterKeys.public == nil {
+		if delegateKeys.masterPublic == nil {
 			return nil, ErrNoPublicKey
 		}
-		return masterKeys.public, nil
+		return delegateKeys.masterPublic, nil
 	}
-	return delegateKeys.masterPublic, nil
+	return masterKeys.public, nil
 }
 
 func getMasterPrivateKey() (crypto.PrivateKey, error) {

--- a/auth/mocks/Identity.go
+++ b/auth/mocks/Identity.go
@@ -1,0 +1,100 @@
+package mocks
+
+import "github.com/control-center/serviced/auth"
+import "github.com/stretchr/testify/mock"
+
+type Identity struct {
+	mock.Mock
+}
+
+func (_m *Identity) Valid() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Identity) Expired() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+func (_m *Identity) HostID() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+func (_m *Identity) PoolID() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+func (_m *Identity) HasAdminAccess() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+func (_m *Identity) HasDFSAccess() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+func (_m *Identity) Verifier() (auth.Verifier, error) {
+	ret := _m.Called()
+
+	var r0 auth.Verifier
+	if rf, ok := ret.Get(0).(func() auth.Verifier); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(auth.Verifier)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/auth/mocks/RPCHeaderBuilder.go
+++ b/auth/mocks/RPCHeaderBuilder.go
@@ -1,0 +1,29 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+type RPCHeaderBuilder struct {
+	mock.Mock
+}
+
+func (_m *RPCHeaderBuilder) BuildHeader() ([]byte, error) {
+	ret := _m.Called()
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func() []byte); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/auth/mocks/RPCHeaderParser.go
+++ b/auth/mocks/RPCHeaderParser.go
@@ -1,0 +1,28 @@
+package mocks
+
+import "github.com/control-center/serviced/auth"
+import "github.com/stretchr/testify/mock"
+
+type RPCHeaderParser struct {
+	mock.Mock
+}
+
+func (_m *RPCHeaderParser) ParseHeader(_a0 []byte) (auth.Identity, error) {
+	ret := _m.Called(_a0)
+
+	var r0 auth.Identity
+	if rf, ok := ret.Get(0).(func([]byte) auth.Identity); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(auth.Identity)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]byte) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/auth/mux.go
+++ b/auth/mux.go
@@ -29,6 +29,10 @@ import (
    ---------------------------------------------------------------------------------------------------------
 */
 
+const (
+	ADDRESS_BYTES = 6
+)
+
 var (
 	ErrBadMuxAddress = errors.New("Bad mux address")
 	ErrBadMuxHeader  = errors.New("Bad mux header")
@@ -92,11 +96,11 @@ func ExtractMuxHeader(rawHeader []byte) ([]byte, Identity, error) {
 
 	// Validate the token can be parsed
 	senderIdentity, err := ParseJWTIdentity(token)
-	if err != nil || senderIdentity == nil {
-		if err == nil || senderIdentity == nil {
-			err = ErrBadToken
-		}
+	if err != nil {
 		return errorExtractingHeader(err)
+	}
+	if senderIdentity == nil {
+		return errorExtractingHeader(ErrBadToken)
 	}
 
 	// Next six bytes is going to be the address

--- a/auth/mux.go
+++ b/auth/mux.go
@@ -15,7 +15,6 @@ package auth
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"net"
 )
@@ -31,16 +30,8 @@ import (
 */
 
 var (
-	endian           = binary.BigEndian
 	ErrBadMuxAddress = errors.New("Bad mux address")
 	ErrBadMuxHeader  = errors.New("Bad mux header")
-	ErrBadToken      = errors.New("Could not extract token")
-)
-
-const (
-	ADDRESS_BYTES   = 6
-	TOKEN_LEN_BYTES = 4
-	SIGNATURE_BYTES = 256
 )
 
 func BuildMuxHeader(address []byte) ([]byte, error) {

--- a/auth/mux_test.go
+++ b/auth/mux_test.go
@@ -22,15 +22,8 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-var (
-	hostId = "MyHost"
-	poolId = "MyPool"
-	admin  = false
-	dfs    = true
-)
-
 func (s *TestAuthSuite) TestBuildHeaderBadAddr(c *C) {
-	fakeToken, _, err := auth.CreateJWTIdentity(hostId, poolId, admin, dfs, s.delegatePubPEM, time.Hour)
+	fakeToken, _, err := auth.CreateJWTIdentity(s.hostId, s.poolId, s.admin, s.dfs, s.delegatePubPEM, time.Hour)
 	c.Assert(err, IsNil)
 	c.Assert(fakeToken, NotNil)
 	addr := "this is more than 6 bytes"
@@ -45,7 +38,7 @@ func (s *TestAuthSuite) TestExtractBadHeader(c *C) {
 }
 
 func (s *TestAuthSuite) TestBuildAndExtractHeader(c *C) {
-	fakeToken, _, err := auth.CreateJWTIdentity(hostId, poolId, admin, dfs, s.delegatePubPEM, time.Hour)
+	fakeToken, _, err := auth.CreateJWTIdentity(s.hostId, s.poolId, s.admin, s.dfs, s.delegatePubPEM, time.Hour)
 	c.Assert(err, IsNil)
 	c.Assert(fakeToken, NotNil)
 	addr := "zenoss"
@@ -59,8 +52,8 @@ func (s *TestAuthSuite) TestBuildAndExtractHeader(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(string(extractedAddr), DeepEquals, addr)
 	// check the identity has been correctly extracted
-	c.Assert(hostId, DeepEquals, ident.HostID())
-	c.Assert(poolId, DeepEquals, ident.PoolID())
-	c.Assert(admin, Equals, ident.HasAdminAccess())
-	c.Assert(dfs, Equals, ident.HasDFSAccess())
+	c.Assert(s.hostId, DeepEquals, ident.HostID())
+	c.Assert(s.poolId, DeepEquals, ident.PoolID())
+	c.Assert(s.admin, Equals, ident.HasAdminAccess())
+	c.Assert(s.dfs, Equals, ident.HasDFSAccess())
 }

--- a/auth/rpc.go
+++ b/auth/rpc.go
@@ -1,0 +1,114 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"bytes"
+	"errors"
+)
+
+/*
+   When sending an RPC request, if authentication is required, the client sends an authentication token as well
+   as its signature. The token determines if the sender is authorized to make the RPC request
+
+   ----------------------------------------------------------------------------------------
+   | Auth Token length (4 bytes)  |     Auth Token (N bytes)  | Signature (256 bytes) |
+   ----------------------------------------------------------------------------------------
+*/
+
+var (
+	ErrBadRPCHeader = errors.New("Bad rpc header")
+)
+
+func BuildRPCHeader() ([]byte, error) {
+	// get current host token
+	token, err := AuthTokenNonBlocking()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return BuildAuthRPCHeader(token)
+}
+
+func BuildAuthRPCHeader(token string) ([]byte, error) {
+	headerBuf := new(bytes.Buffer)
+
+	// add token length
+	var tokenLen uint32 = uint32(len(token))
+	tokenLenBuf := make([]byte, TOKEN_LEN_BYTES)
+	endian.PutUint32(tokenLenBuf, tokenLen)
+	headerBuf.Write(tokenLenBuf)
+
+	// add token
+	headerBuf.Write([]byte(token))
+
+	// Sign what we have so far
+	signature, err := SignAsDelegate(headerBuf.Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	// add signature to header
+	headerBuf.Write(signature)
+
+	return headerBuf.Bytes(), nil
+}
+
+func ExtractRPCHeader(rawHeader []byte) (Identity, error) {
+
+	if len(rawHeader) <= TOKEN_LEN_BYTES {
+		return nil, ErrBadRPCHeader
+	}
+
+	var offset uint32 = 0
+
+	// First four bytes represents the token length
+	tokenLen := endian.Uint32(rawHeader[offset : offset+TOKEN_LEN_BYTES])
+	offset += TOKEN_LEN_BYTES
+	if len(rawHeader) <= TOKEN_LEN_BYTES+int(tokenLen) {
+		return nil, ErrBadRPCHeader
+	}
+
+	// Next tokeLen bytes contain the token
+	token := string(rawHeader[offset : offset+tokenLen])
+	offset += tokenLen
+
+	// Validate the token can be parsed
+	senderIdentity, err := ParseJWTIdentity(token)
+	if err != nil || senderIdentity == nil {
+		if err == nil || senderIdentity == nil {
+			err = ErrBadToken
+		}
+		return nil, err
+	}
+
+	// get the part of the header that has been signed
+	signed_message := rawHeader[:offset]
+
+	// Whatever is left is the signature
+	signature := rawHeader[offset:]
+
+	// Verify the identity of the signed message
+	senderVerifier, err := senderIdentity.Verifier()
+	if err != nil {
+		return nil, err
+	}
+	err = senderVerifier.Verify(signed_message, signature)
+	if err != nil {
+		return nil, err
+	}
+
+	return senderIdentity, nil
+}

--- a/auth/rpc.go
+++ b/auth/rpc.go
@@ -52,6 +52,7 @@ func (r *RPCHeaderHandler) BuildHeader() ([]byte, error) {
 	signAsMaster = false
 	token, err = AuthTokenNonBlocking()
 	if err != nil {
+		log.WithError(err).Debug("Unable to retrieve delegate token")
 		// We may be an un-added master
 		token, err2 = MasterToken()
 		if err2 != nil {
@@ -115,11 +116,11 @@ func (r *RPCHeaderHandler) ParseHeader(rawHeader []byte) (Identity, error) {
 
 	// Validate the token can be parsed
 	senderIdentity, err := ParseJWTIdentity(token)
-	if err != nil || senderIdentity == nil {
-		if err == nil || senderIdentity == nil {
-			err = ErrBadToken
-		}
+	if err != nil {
 		return nil, err
+	}
+	if senderIdentity == nil {
+		return nil, ErrBadToken
 	}
 
 	// get the part of the header that has been signed

--- a/auth/rpc.go
+++ b/auth/rpc.go
@@ -31,7 +31,16 @@ var (
 	ErrBadRPCHeader = errors.New("Bad rpc header")
 )
 
-func BuildRPCHeader() ([]byte, error) {
+type RPCHeaderParser interface {
+	ParseHeader([]byte) (Identity, error)
+}
+type RPCHeaderBuilder interface {
+	BuildHeader() ([]byte, error)
+}
+
+type RPCHeaderHandler struct{}
+
+func (r *RPCHeaderHandler) BuildHeader() ([]byte, error) {
 	var (
 		token        string
 		err          error
@@ -53,10 +62,10 @@ func BuildRPCHeader() ([]byte, error) {
 		signAsMaster = true
 	}
 
-	return BuildAuthRPCHeader(token, signAsMaster)
+	return r.BuildAuthRPCHeader(token, signAsMaster)
 }
 
-func BuildAuthRPCHeader(token string, signAsMaster bool) ([]byte, error) {
+func (r *RPCHeaderHandler) BuildAuthRPCHeader(token string, signAsMaster bool) ([]byte, error) {
 	headerBuf := new(bytes.Buffer)
 
 	// add token length
@@ -85,7 +94,7 @@ func BuildAuthRPCHeader(token string, signAsMaster bool) ([]byte, error) {
 	return headerBuf.Bytes(), nil
 }
 
-func ExtractRPCHeader(rawHeader []byte) (Identity, error) {
+func (r *RPCHeaderHandler) ParseHeader(rawHeader []byte) (Identity, error) {
 
 	if len(rawHeader) <= TOKEN_LEN_BYTES {
 		return nil, ErrBadRPCHeader

--- a/auth/rpc_test.go
+++ b/auth/rpc_test.go
@@ -1,0 +1,77 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package auth_test
+
+import (
+	"crypto/rsa"
+	"encoding/binary"
+	"time"
+
+	"github.com/control-center/serviced/auth"
+	. "gopkg.in/check.v1"
+)
+
+var (
+	endian = binary.BigEndian
+)
+
+func (s *TestAuthSuite) TestExtractBadRPCHeader(c *C) {
+	mockHeader := []byte{0, 0, 0, 19, 109, 121, 32, 115, 117, 112, 101, 114, 32, 102}
+	_, err := auth.ExtractRPCHeader(mockHeader)
+	c.Assert(err, Equals, auth.ErrBadRPCHeader)
+}
+
+func (s *TestAuthSuite) TestExtractBadToken(c *C) {
+	badToken := []byte("This is not a token")
+	tokenLength := len(badToken)
+	mockHeaderLength := auth.TOKEN_LEN_BYTES + tokenLength + auth.SIGNATURE_BYTES
+	mockHeader := make([]byte, mockHeaderLength)
+	endian.PutUint32(mockHeader[:auth.TOKEN_LEN_BYTES], uint32(tokenLength))
+	_ = copy(mockHeader[auth.TOKEN_LEN_BYTES:auth.TOKEN_LEN_BYTES+tokenLength], badToken)
+	_, err := auth.ExtractRPCHeader(mockHeader)
+	c.Assert(err, Equals, auth.ErrBadToken)
+}
+
+func (s *TestAuthSuite) TestExtractBadSignature(c *C) {
+	fakeToken, _, err := auth.CreateJWTIdentity(s.hostId, s.poolId, s.admin, s.dfs, s.delegatePubPEM, time.Hour)
+	c.Assert(err, IsNil)
+	c.Assert(fakeToken, NotNil)
+	tokenLength := len(fakeToken)
+	mockHeaderLength := auth.TOKEN_LEN_BYTES + tokenLength + auth.SIGNATURE_BYTES
+	mockHeader := make([]byte, mockHeaderLength)
+	endian.PutUint32(mockHeader[:auth.TOKEN_LEN_BYTES], uint32(tokenLength))
+	_ = copy(mockHeader[auth.TOKEN_LEN_BYTES:auth.TOKEN_LEN_BYTES+tokenLength], fakeToken)
+	_, err = auth.ExtractRPCHeader(mockHeader)
+	c.Assert(err, Equals, rsa.ErrVerification)
+}
+
+func (s *TestAuthSuite) TestBuildAndExtractRPCHeader(c *C) {
+	fakeToken, _, err := auth.CreateJWTIdentity(s.hostId, s.poolId, s.admin, s.dfs, s.delegatePubPEM, time.Hour)
+	c.Assert(err, IsNil)
+	c.Assert(fakeToken, NotNil)
+	// build header
+	header, err := auth.BuildAuthRPCHeader(fakeToken)
+	c.Assert(err, Equals, nil)
+	c.Assert(header, NotNil)
+	// extract header
+	ident, err := auth.ExtractRPCHeader(header)
+	c.Assert(err, IsNil)
+	// check the identity has been correctly extracted
+	c.Assert(s.hostId, DeepEquals, ident.HostID())
+	c.Assert(s.poolId, DeepEquals, ident.PoolID())
+	c.Assert(s.admin, Equals, ident.HasAdminAccess())
+	c.Assert(s.dfs, Equals, ident.HasDFSAccess())
+}

--- a/auth/token.go
+++ b/auth/token.go
@@ -52,7 +52,7 @@ func RefreshToken(f TokenFunc, filename string) (int64, error) {
 		return 0, err
 	}
 	updateToken(token, time.Unix(expires, 0), filename)
-	log.WithField("expiration", expires).Info("Received new authentication token")
+	log.WithField("expiration", expires).Debug("Received new authentication token")
 	return expires, err
 }
 

--- a/auth/token.go
+++ b/auth/token.go
@@ -81,6 +81,27 @@ func AuthTokenNonBlocking() (string, error) {
 	return currentToken, nil
 }
 
+// MasterToken() generates a new token with an empty host and pool ID and the master's public key,
+//  signed by the master's private key.  This will return an error if there is no master private
+//  key available (i.e. if we are not the master)
+func MasterToken() (string, error) {
+	masterpublic, err := GetMasterPublicKey()
+	if err != nil {
+		return "", err
+	}
+	keypem, err := PEMFromRSAPublicKey(masterpublic, nil)
+	if err != nil {
+		return "", err
+	}
+
+	signed, _, err := CreateJWTIdentity("", "", true, true, keypem, time.Hour)
+	if err != nil {
+		return "", err
+	}
+
+	return signed, nil
+}
+
 // CurrentIdentity returns the identity represented by the currently-live token,
 // or nil if the token is not yet available
 func CurrentIdentity() Identity {

--- a/auth/token.go
+++ b/auth/token.go
@@ -67,6 +67,20 @@ func AuthToken() string {
 	return currentToken
 }
 
+// A non-blocking call to get an unexpired auth token.  Returns an error
+//  If no token exists or if the token is expired
+func AuthTokenNonBlocking() (string, error) {
+	if currentToken == "" {
+		return "", ErrNotAuthenticated
+	}
+
+	if expired() {
+		return "", ErrIdentityTokenExpired
+	}
+
+	return currentToken, nil
+}
+
 // CurrentIdentity returns the identity represented by the currently-live token,
 // or nil if the token is not yet available
 func CurrentIdentity() Identity {

--- a/cli/api/apimocks/API.go
+++ b/cli/api/apimocks/API.go
@@ -146,6 +146,36 @@ func (_m *API) AddHost(_a0 api.HostConfig) (*host.Host, []byte, error) {
 
 	return r0, r1, r2
 }
+func (_m *API) AuthenticateHost(_a0 string) (string, int64, error) {
+	ret := _m.Called(_a0)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(string)
+		}
+	}
+
+	var r1 int64
+	if rf, ok := ret.Get(1).(func(string) int64); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(int64)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(string) error); ok {
+		r2 = rf(_a0)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
 func (_m *API) RemoveHost(_a0 string) error {
 	ret := _m.Called(_a0)
 

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -66,7 +66,6 @@ import (
 	"net"
 	"net/http"
 	"net/rpc"
-	"net/rpc/jsonrpc"
 	"os"
 	"os/signal"
 	"path"
@@ -252,7 +251,7 @@ func (d *daemon) startRPC() {
 			if err != nil {
 				logger.WithError(err).Fatal("Error accepting RPC connection")
 			}
-			go d.rpcServer.ServeCodec(rpcutils.NewAuthServerCodec(jsonrpc.NewServerCodec(conn)))
+			go d.rpcServer.ServeCodec(rpcutils.NewDefaultAuthServerCodec(conn))
 		}
 	}()
 }

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -252,7 +252,7 @@ func (d *daemon) startRPC() {
 			if err != nil {
 				logger.WithError(err).Fatal("Error accepting RPC connection")
 			}
-			go d.rpcServer.ServeCodec(jsonrpc.NewServerCodec(conn))
+			go d.rpcServer.ServeCodec(rpcutils.NewAuthServerCodec(jsonrpc.NewServerCodec(conn)))
 		}
 	}()
 }

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -46,6 +46,7 @@ type API interface {
 	SetHostMemory(HostUpdateConfig) error
 	GetHostPublicKey(string) ([]byte, error)
 	RegisterHost([]byte) error
+	AuthenticateHost(string) (string, int64, error)
 
 	// Pools
 	GetResourcePools() ([]pool.ResourcePool, error)

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -17,17 +17,20 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
+	"github.com/control-center/serviced/auth"
 	"github.com/control-center/serviced/cli/api"
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/isvcs"
 	"github.com/control-center/serviced/logging"
 	"github.com/control-center/serviced/servicedversion"
 	"github.com/control-center/serviced/utils"
+	"github.com/control-center/serviced/validation"
 	"github.com/control-center/serviced/volume"
 	"github.com/control-center/serviced/volume/nfs"
 	"github.com/zenoss/glog"
@@ -183,6 +186,12 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 	}
 	api.LoadOptions(options)
 
+	// Try to authenticate this host
+	if err := c.authenticateHost(&options); err != nil {
+		// Not all commands require authentication
+		log.WithError(err).Debug("Unable to authenticate host")
+	}
+
 	// Set logging options
 	if err := setLogging(ctx); err != nil {
 		fmt.Printf("Unable to set logging options: %s\n", err)
@@ -194,6 +203,36 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 		fmt.Printf("Unable to set isvcs options: %s\n", err)
 		return err
 	}
+	return nil
+}
+
+// This will authenticate the host once to get a valid token for any CLI commands
+//  that require it.
+func (c *ServicedCli) authenticateHost(options *api.Options) error {
+	// Load the keys
+	delegateKeyFile := filepath.Join(options.EtcPath, auth.DelegateKeyFileName)
+	if err := auth.LoadDelegateKeysFromFile(delegateKeyFile); err != nil {
+		return err
+	}
+
+	// Get our host ID
+	myHostID, err := utils.HostID()
+	if err != nil {
+		return err
+	} else if err := validation.ValidHostID(myHostID); err != nil {
+		return err
+	}
+
+	// Load an auth token once
+	tokenFile := filepath.Join(options.EtcPath, auth.TokenFileName)
+	getToken := func() (string, int64, error) {
+		return c.driver.AuthenticateHost(myHostID)
+	}
+
+	if _, err := auth.RefreshToken(getToken, tokenFile); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -209,7 +209,15 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 // This will authenticate the host once to get a valid token for any CLI commands
 //  that require it.
 func (c *ServicedCli) authenticateHost(options *api.Options) error {
-	// Load the keys
+	// If we are the master, load the master keys
+	if options.Master {
+		masterKeyFile := filepath.Join(options.IsvcsPath, auth.MasterKeyFileName)
+		if err := auth.CreateOrLoadMasterKeys(masterKeyFile); err != nil {
+			return err
+		}
+	}
+
+	// Load the delegate keys
 	delegateKeyFile := filepath.Join(options.EtcPath, auth.DelegateKeyFileName)
 	if err := auth.LoadDelegateKeysFromFile(delegateKeyFile); err != nil {
 		return err

--- a/facade/service.go
+++ b/facade/service.go
@@ -738,7 +738,7 @@ func (f *Facade) GetService(ctx datastore.Context, id string) (*service.Service,
 // GetEvaluatedService returns a service where an evaluation has been executed against all templated properties.
 func (f *Facade) GetEvaluatedService(ctx datastore.Context, serviceID string, instanceID int) (*service.Service, error) {
 	logger := plog.WithFields(log.Fields{
-		"serviceID": serviceID,
+		"serviceID":  serviceID,
 		"instanceID": instanceID,
 	})
 	logger.Debug("Started Facade.GetEvaluatedService")
@@ -780,7 +780,6 @@ func (f *Facade) evaluateService(ctx datastore.Context, svc *service.Service, in
 
 	return svc.Evaluate(getService, getServiceChild, instanceID)
 }
-
 
 // GetServices looks up all services. Allows filtering by tenant ID, name (regular expression), and/or update time.
 func (f *Facade) GetServices(ctx datastore.Context, request dao.EntityRequest) ([]service.Service, error) {

--- a/rpc/master/hosts_server.go
+++ b/rpc/master/hosts_server.go
@@ -131,6 +131,9 @@ func (s *Server) AuthenticateHost(req HostAuthenticationRequest, resp *HostAuthe
 	if err != nil {
 		return err
 	}
+	if host == nil {
+		return errors.New("Host does not exist")
+	}
 	signed, expires, err := auth.CreateJWTIdentity(host.ID, host.PoolID, true, true, keypem, s.expiration)
 	if err != nil {
 		return err

--- a/rpc/rpcutils/authcodec.go
+++ b/rpc/rpcutils/authcodec.go
@@ -1,0 +1,78 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcutils
+
+import (
+	"net/rpc"
+)
+
+// Server Codec
+type AuthServerCodec struct {
+	wrappedcodec rpc.ServerCodec
+}
+
+func NewAuthServerCodec(codecToWrap rpc.ServerCodec) rpc.ServerCodec {
+	return AuthServerCodec{codecToWrap}
+}
+
+func (a AuthServerCodec) ReadRequestHeader(r *rpc.Request) error {
+	return a.wrappedcodec.ReadRequestHeader(r)
+}
+
+func (a AuthServerCodec) ReadRequestBody(body interface{}) error {
+	// TODO: Get the token out of the body and authenticate first
+
+	return a.wrappedcodec.ReadRequestBody(body)
+}
+
+func (a AuthServerCodec) WriteResponse(r *rpc.Response, body interface{}) error {
+	return a.wrappedcodec.WriteResponse(r, body)
+}
+
+func (a AuthServerCodec) Close() error {
+	return a.wrappedcodec.Close()
+}
+
+// Client Codec
+type AuthClientCodec struct {
+	wrappedcodec rpc.ClientCodec
+}
+
+func NewAuthClientCodec(codecToWrap rpc.ClientCodec) rpc.ClientCodec {
+	return AuthClientCodec{codecToWrap}
+}
+
+func (a AuthClientCodec) WriteRequest(r *rpc.Request, body interface{}) error {
+	// TODO: Wrap the body up with the token
+
+	return a.wrappedcodec.WriteRequest(r, body)
+}
+
+func (a AuthClientCodec) ReadResponseHeader(r *rpc.Response) error {
+	return a.wrappedcodec.ReadResponseHeader(r)
+}
+
+func (a AuthClientCodec) ReadResponseBody(body interface{}) error {
+	return a.wrappedcodec.ReadResponseBody(body)
+}
+
+func (a AuthClientCodec) Close() error {
+	return a.wrappedcodec.Close()
+}
+
+// NewClient returns a new rpc.Client to handle requests to the
+// set of services at the other end of the connection.
+func NewAuthClient(wrappedCodec rpc.ClientCodec) *rpc.Client {
+	return rpc.NewClientWithCodec(NewAuthClientCodec(wrappedCodec))
+}

--- a/rpc/rpcutils/authcodec.go
+++ b/rpc/rpcutils/authcodec.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	// RPC Calls that do not require authentication or who handle authentication separately
-	NonAuthenticatingCalls = []string{"Master.AuthenticateHost", "Master.AddHost", "Agent.BuildHost", "Master.GetHost"}
+	NonAuthenticatingCalls = []string{"Master.AuthenticateHost"}
 	// TODO: When we implement admin, switch this to a list that does NOT require admin, and update requiresAdmin appropriately
 	AdminRequiredCalls = []string{} // RPC calls that require admin access
 	endian             = binary.BigEndian

--- a/rpc/rpcutils/authcodec.go
+++ b/rpc/rpcutils/authcodec.go
@@ -14,65 +14,227 @@
 package rpcutils
 
 import (
+	"encoding/binary"
+	"errors"
+	"github.com/control-center/serviced/auth"
+	"io"
 	"net/rpc"
+	"net/rpc/jsonrpc"
+	"sync"
 )
 
+var (
+	// RPC Calls that do not require authentication or who handle authentication separately
+	NonAuthenticatingCalls = []string{"Master.AuthenticateHost", "Master.AddHost", "Agent.BuildHost", "Master.GetHost"}
+	// TODO: When we implement admin, switch this to a list that does NOT require admin, and update requiresAdmin appropriately
+	AdminRequiredCalls = []string{} // RPC calls that require admin access
+	endian             = binary.BigEndian
+)
+
+var (
+	ErrReadingHeader = errors.New("Unable to parse header from RPC request")
+)
+
+// Checks the RPC method name to see if authentication is required.
+//  If it is, calls on the client side will include a signed header, which will be
+//  Verified on the server side
+func requiresAuthentication(callName string) bool {
+	for _, name := range NonAuthenticatingCalls {
+		if name == callName {
+			return false
+		}
+	}
+	return true
+}
+
+// Checks the RPC method name to see if admin-level permissions are required.
+//  If they are, it will also check the "admin" attribute on the identity after validating it.
+func requiresAdmin(callName string) bool {
+	for _, name := range AdminRequiredCalls {
+		if name == callName {
+			return true
+		}
+	}
+	return false
+}
+
 // Server Codec
+type HeaderParserFunc func([]byte) (auth.Identity, error)
 type AuthServerCodec struct {
+	conn         io.ReadWriteCloser
 	wrappedcodec rpc.ServerCodec
+	parseHeader  HeaderParserFunc
+	mutex        sync.Mutex // Makes sure we read in order
 }
 
-func NewAuthServerCodec(codecToWrap rpc.ServerCodec) rpc.ServerCodec {
-	return AuthServerCodec{codecToWrap}
+func NewDefaultAuthServerCodec(conn io.ReadWriteCloser) rpc.ServerCodec {
+	return NewAuthServerCodec(conn, jsonrpc.NewServerCodec(conn), auth.ExtractRPCHeader)
 }
 
-func (a AuthServerCodec) ReadRequestHeader(r *rpc.Request) error {
-	return a.wrappedcodec.ReadRequestHeader(r)
+func NewAuthServerCodec(conn io.ReadWriteCloser, codecToWrap rpc.ServerCodec, parseHeader HeaderParserFunc) rpc.ServerCodec {
+	return &AuthServerCodec{
+		conn:         conn,
+		wrappedcodec: codecToWrap,
+		parseHeader:  parseHeader,
+	}
 }
 
-func (a AuthServerCodec) ReadRequestBody(body interface{}) error {
-	// TODO: Get the token out of the body and authenticate first
+// Reads the request header and populates the rpc.Request object.
+//  This implementation reads the auth header off the stream first, then
+//  lets the underlying codec read the rest.
+//  Finally, it validates the identity if necessary.
+func (a *AuthServerCodec) ReadRequestHeader(r *rpc.Request) error {
 
+	// Lock so we read both values back-to-back
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	// Read the header
+
+	// Read the first 4 bytes to get the length of the header
+	headerLenBuf := make([]byte, 4)
+	n, err := a.conn.Read(headerLenBuf)
+	if err != nil {
+		return err
+	}
+	if n != 4 {
+		return ErrReadingHeader
+	}
+
+	headerLength := endian.Uint32(headerLenBuf)
+
+	// Now read the header
+	var header []byte
+	if headerLength > 0 {
+		header = make([]byte, headerLength)
+		n, err = a.conn.Read(header)
+		if err != nil {
+			return err
+		}
+		if uint32(n) != headerLength {
+			return ErrReadingHeader
+		}
+	}
+
+	// Now let the underlying codec read the rest
+	if err := a.wrappedcodec.ReadRequestHeader(r); err != nil {
+		return err
+	}
+
+	// Now we can get the method name from r and authenticate if required
+	if requiresAuthentication(r.ServiceMethod) {
+		_, err := a.parseHeader(header)
+		if err != nil {
+			return err
+		}
+
+		//TODO:  Check Admin
+
+		//TODO: We need to get the identity into the request body or somehow check the pool ID
+	}
+	return nil
+}
+
+// Decodes the request and populates the body object with the body of the request
+//  We don't change anything here, just let the underlying codec handle it.
+//  This always gets called after ReadRequestHeader
+func (a *AuthServerCodec) ReadRequestBody(body interface{}) error {
+	// TODO: Use reflection and add the identity to the body if necessary
 	return a.wrappedcodec.ReadRequestBody(body)
 }
 
-func (a AuthServerCodec) WriteResponse(r *rpc.Response, body interface{}) error {
+//  Encodes the response before sending it back down to the client.
+//  We don't change anything here, just let the underlying codec handle it.
+func (a *AuthServerCodec) WriteResponse(r *rpc.Response, body interface{}) error {
 	return a.wrappedcodec.WriteResponse(r, body)
 }
 
-func (a AuthServerCodec) Close() error {
+// Closes the connection on the server side
+//  We don't change anything here, just let the underlying codec handle it.
+func (a *AuthServerCodec) Close() error {
 	return a.wrappedcodec.Close()
 }
 
 // Client Codec
+type BuildHeaderFunc func() ([]byte, error)
 type AuthClientCodec struct {
+	conn         io.ReadWriteCloser
 	wrappedcodec rpc.ClientCodec
+	getHeader    BuildHeaderFunc
+	mutex        sync.Mutex
 }
 
-func NewAuthClientCodec(codecToWrap rpc.ClientCodec) rpc.ClientCodec {
-	return AuthClientCodec{codecToWrap}
+func NewDefaultAuthClientCodec(conn io.ReadWriteCloser) rpc.ClientCodec {
+	return NewAuthClientCodec(conn, jsonrpc.NewClientCodec(conn), auth.BuildRPCHeader)
 }
 
-func (a AuthClientCodec) WriteRequest(r *rpc.Request, body interface{}) error {
-	// TODO: Wrap the body up with the token
-
-	return a.wrappedcodec.WriteRequest(r, body)
+func NewAuthClientCodec(conn io.ReadWriteCloser, codecToWrap rpc.ClientCodec, getHeader BuildHeaderFunc) rpc.ClientCodec {
+	return &AuthClientCodec{
+		conn:         conn,
+		wrappedcodec: codecToWrap,
+		getHeader:    getHeader,
+	}
 }
 
-func (a AuthClientCodec) ReadResponseHeader(r *rpc.Response) error {
+// Encodes the request and sends it to the server.
+// This implementation gets an auth header when appropriate, and writes it to the stream
+//  before letting the underlying codec send the rest of the request.
+func (a *AuthClientCodec) WriteRequest(r *rpc.Request, body interface{}) error {
+	var (
+		header []byte
+		err    error
+	)
+
+	if requiresAuthentication(r.ServiceMethod) {
+		header, err = a.getHeader()
+		if err != nil {
+			return err
+		}
+	}
+
+	// add header length
+	var headerLen uint32 = uint32(len(header))
+	headerLenBuf := make([]byte, 4)
+	endian.PutUint32(headerLenBuf, headerLen)
+
+	// Lock to ensure we write the header and the rest of the request back-to-back
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	a.conn.Write(headerLenBuf)
+	a.conn.Write(header)
+
+	// let the underlying codec write the rest of the request
+	if err := a.wrappedcodec.WriteRequest(r, body); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Decodes the response and reads the header, building the rpc.Response object
+//  We don't change anything here, just let the underlying codec handle it.
+func (a *AuthClientCodec) ReadResponseHeader(r *rpc.Response) error {
 	return a.wrappedcodec.ReadResponseHeader(r)
 }
 
-func (a AuthClientCodec) ReadResponseBody(body interface{}) error {
+// Decodes the body of the response and builds the body object.
+// We don't change anything here, just let the underlying codec handle it.
+func (a *AuthClientCodec) ReadResponseBody(body interface{}) error {
 	return a.wrappedcodec.ReadResponseBody(body)
 }
 
-func (a AuthClientCodec) Close() error {
+// Closes the connection on the client side
+//  We don't change anything here, just let the underlying codec handle it.
+func (a *AuthClientCodec) Close() error {
 	return a.wrappedcodec.Close()
 }
 
-// NewClient returns a new rpc.Client to handle requests to the
-// set of services at the other end of the connection.
-func NewAuthClient(wrappedCodec rpc.ClientCodec) *rpc.Client {
-	return rpc.NewClientWithCodec(NewAuthClientCodec(wrappedCodec))
+// NewClient returns a new rpc.Client that uses our client codec
+func NewAuthClient(conn io.ReadWriteCloser, codecToWrap rpc.ClientCodec) *rpc.Client {
+	return rpc.NewClientWithCodec(NewAuthClientCodec(conn, codecToWrap, auth.BuildRPCHeader))
+}
+
+func NewDefaultAuthClient(conn io.ReadWriteCloser) *rpc.Client {
+	return rpc.NewClientWithCodec(NewDefaultAuthClientCodec(conn))
 }

--- a/rpc/rpcutils/authcodec_test.go
+++ b/rpc/rpcutils/authcodec_test.go
@@ -1,0 +1,105 @@
+// +build unit
+
+package rpcutils
+
+import (
+	// "net"
+	"net/rpc"
+	// "net/rpc/jsonrpc"
+	// "sync"
+	"github.com/control-center/serviced/rpc/rpcutils/mocks"
+	. "gopkg.in/check.v1"
+	// "testing"
+	"errors"
+)
+
+var (
+	wrappedClientCodec = &mocks.ClientCodec{}
+	wrappedServerCodec = &mocks.ServerCodec{}
+	authClientCodec    = NewAuthClientCodec(wrappedClientCodec)
+	authServerCodec    = NewAuthServerCodec(wrappedServerCodec)
+
+	ErrTestCodec = errors.New("Error calling codec method")
+)
+
+// AuthServerCodec Tests
+func (s *MySuite) TestReadRequestHeader(c *C) {
+	req := &rpc.Request{}
+	wrappedServerCodec.On("ReadRequestHeader", req).Return(ErrTestCodec).Once()
+	err := authServerCodec.ReadRequestHeader(req)
+	c.Assert(err, Equals, ErrTestCodec)
+	wrappedServerCodec.On("ReadRequestHeader", req).Return(nil).Once()
+	err = authServerCodec.ReadRequestHeader(req)
+	c.Assert(err, IsNil)
+}
+
+func (s *MySuite) TestReadRequestBody(c *C) {
+	body := 0
+	wrappedServerCodec.On("ReadRequestBody", body).Return(ErrTestCodec).Once()
+	err := authServerCodec.ReadRequestBody(body)
+	c.Assert(err, Equals, ErrTestCodec)
+	wrappedServerCodec.On("ReadRequestBody", body).Return(nil).Once()
+	err = authServerCodec.ReadRequestBody(body)
+	c.Assert(err, IsNil)
+}
+
+func (s *MySuite) TestWriteResponse(c *C) {
+	body := 0
+	resp := &rpc.Response{}
+	wrappedServerCodec.On("WriteResponse", resp, body).Return(ErrTestCodec).Once()
+	err := authServerCodec.WriteResponse(resp, body)
+	c.Assert(err, Equals, ErrTestCodec)
+	wrappedServerCodec.On("WriteResponse", resp, body).Return(nil).Once()
+	err = authServerCodec.WriteResponse(resp, body)
+	c.Assert(err, IsNil)
+}
+
+func (s *MySuite) TestCloseServerCodec(c *C) {
+	wrappedServerCodec.On("Close").Return(ErrTestCodec).Once()
+	err := authServerCodec.Close()
+	c.Assert(err, Equals, ErrTestCodec)
+	wrappedServerCodec.On("Close").Return(nil).Once()
+	err = authServerCodec.Close()
+	c.Assert(err, IsNil)
+}
+
+// AuthClientCodec Tests
+func (s *MySuite) TestWriteRequest(c *C) {
+	req := &rpc.Request{}
+	body := 0
+	wrappedClientCodec.On("WriteRequest", req, body).Return(ErrTestCodec).Once()
+	err := authClientCodec.WriteRequest(req, body)
+	c.Assert(err, Equals, ErrTestCodec)
+	wrappedClientCodec.On("WriteRequest", req, body).Return(nil).Once()
+	err = authClientCodec.WriteRequest(req, body)
+	c.Assert(err, IsNil)
+}
+
+func (s *MySuite) TestReadResponseHeader(c *C) {
+	resp := &rpc.Response{}
+	wrappedClientCodec.On("ReadResponseHeader", resp).Return(ErrTestCodec).Once()
+	err := authClientCodec.ReadResponseHeader(resp)
+	c.Assert(err, Equals, ErrTestCodec)
+	wrappedClientCodec.On("ReadResponseHeader", resp).Return(nil).Once()
+	err = authClientCodec.ReadResponseHeader(resp)
+	c.Assert(err, IsNil)
+}
+
+func (s *MySuite) TestReadResponseBody(c *C) {
+	body := 0
+	wrappedClientCodec.On("ReadResponseBody", body).Return(ErrTestCodec).Once()
+	err := authClientCodec.ReadResponseBody(body)
+	c.Assert(err, Equals, ErrTestCodec)
+	wrappedClientCodec.On("ReadResponseBody", body).Return(nil).Once()
+	err = authClientCodec.ReadResponseBody(body)
+	c.Assert(err, IsNil)
+}
+
+func (s *MySuite) TestCloseClientCodec(c *C) {
+	wrappedClientCodec.On("Close").Return(ErrTestCodec).Once()
+	err := authClientCodec.Close()
+	c.Assert(err, Equals, ErrTestCodec)
+	wrappedClientCodec.On("Close").Return(nil).Once()
+	err = authClientCodec.Close()
+	c.Assert(err, IsNil)
+}

--- a/rpc/rpcutils/authcodec_test.go
+++ b/rpc/rpcutils/authcodec_test.go
@@ -3,103 +3,265 @@
 package rpcutils
 
 import (
-	// "net"
-	"net/rpc"
-	// "net/rpc/jsonrpc"
-	// "sync"
-	"github.com/control-center/serviced/rpc/rpcutils/mocks"
-	. "gopkg.in/check.v1"
-	// "testing"
+	"bytes"
 	"errors"
+	. "gopkg.in/check.v1"
+	"net/rpc"
+
+	"github.com/control-center/serviced/auth"
+	"github.com/control-center/serviced/rpc/rpcutils/mocks"
 )
 
-var (
-	wrappedClientCodec = &mocks.ClientCodec{}
-	wrappedServerCodec = &mocks.ServerCodec{}
-	authClientCodec    = NewAuthClientCodec(wrappedClientCodec)
-	authServerCodec    = NewAuthServerCodec(wrappedServerCodec)
+// AuthCodec Helpers
+// We need a ReadWriteCloser we can pass to our codecs
+type ByteBufferReadWriteCloser struct {
+	bytes.Buffer
+}
 
+func (b *ByteBufferReadWriteCloser) Close() error {
+	return nil
+}
+
+type AuthCodecTest struct {
+	headerPassed          []byte
+	headerToReturn        []byte
+	headerErrToReturn     error
+	identityToReturn      auth.Identity
+	identityErrorToReturn error
+	buff                  *ByteBufferReadWriteCloser
+	wrappedClientCodec    *mocks.ClientCodec
+	wrappedServerCodec    *mocks.ServerCodec
+	authClientCodec       rpc.ClientCodec
+	authServerCodec       rpc.ServerCodec
+}
+
+func NewAuthCodecTest() *AuthCodecTest {
+
+	buff := &ByteBufferReadWriteCloser{}
+	test := AuthCodecTest{
+		headerPassed:          []byte{},
+		headerToReturn:        []byte{},
+		headerErrToReturn:     nil,
+		identityToReturn:      nil,
+		identityErrorToReturn: nil,
+		buff: buff,
+	}
+
+	wrappedClientCodec := &mocks.ClientCodec{}
+	wrappedServerCodec := &mocks.ServerCodec{}
+	asc := NewAuthServerCodec(buff, wrappedServerCodec, test.ParseHeader)
+	acc := NewAuthClientCodec(buff, wrappedClientCodec, test.GetHeader)
+
+	test.wrappedClientCodec = wrappedClientCodec
+	test.wrappedServerCodec = wrappedServerCodec
+	test.authClientCodec = acc
+	test.authServerCodec = asc
+
+	return &test
+}
+
+func (a *AuthCodecTest) Reset() {
+	a.buff.Reset()
+	a.headerToReturn = []byte{}
+	a.headerErrToReturn = nil
+	a.headerPassed = []byte{}
+	a.identityToReturn = nil
+	a.identityErrorToReturn = nil
+}
+
+// We need a header getter
+func (a *AuthCodecTest) GetHeader() ([]byte, error) {
+	return a.headerToReturn, a.headerErrToReturn
+}
+
+func (a *AuthCodecTest) ParseHeader(h []byte) (auth.Identity, error) {
+	a.headerPassed = h
+	return a.identityToReturn, a.identityErrorToReturn
+}
+
+func (a *AuthCodecTest) WriteHeaderToBuffer(h []byte) {
+	headerLength := uint32(len(h))
+	headerLenBuf := make([]byte, 4)
+	endian.PutUint32(headerLenBuf, headerLength)
+	a.buff.Write(headerLenBuf)
+	a.buff.Write(h)
+}
+
+func (a *AuthCodecTest) ReadHeaderFromBuffer(length int) []byte {
+	return a.buff.Bytes()[4 : length+4]
+}
+
+var (
 	ErrTestCodec = errors.New("Error calling codec method")
+	act          = NewAuthCodecTest()
 )
 
 // AuthServerCodec Tests
 func (s *MySuite) TestReadRequestHeader(c *C) {
-	req := &rpc.Request{}
-	wrappedServerCodec.On("ReadRequestHeader", req).Return(ErrTestCodec).Once()
-	err := authServerCodec.ReadRequestHeader(req)
+
+	// Put a header onto the buffer
+	header := []byte("Header1")
+	act.WriteHeaderToBuffer(header)
+
+	req := &rpc.Request{ServiceMethod: "AuthenticatingCall"}
+	act.wrappedServerCodec.On("ReadRequestHeader", req).Return(ErrTestCodec).Once()
+	err := act.authServerCodec.ReadRequestHeader(req)
 	c.Assert(err, Equals, ErrTestCodec)
-	wrappedServerCodec.On("ReadRequestHeader", req).Return(nil).Once()
-	err = authServerCodec.ReadRequestHeader(req)
+
+	// Test with an authentication required method
+	act.Reset()
+	act.WriteHeaderToBuffer(header)
+
+	act.identityErrorToReturn = ErrTestCodec
+	act.wrappedServerCodec.On("ReadRequestHeader", req).Return(nil).Once()
+	err = act.authServerCodec.ReadRequestHeader(req)
+	c.Assert(err, Equals, ErrTestCodec)
+	c.Assert(act.headerPassed, DeepEquals, header)
+
+	act.Reset()
+	act.WriteHeaderToBuffer(header)
+
+	act.wrappedServerCodec.On("ReadRequestHeader", req).Return(nil).Once()
+	err = act.authServerCodec.ReadRequestHeader(req)
 	c.Assert(err, IsNil)
+	c.Assert(act.headerPassed, DeepEquals, header)
+
+	// Test with a non-authentication required method
+	act.Reset()
+	act.WriteHeaderToBuffer(header)
+
+	req = &rpc.Request{ServiceMethod: "NonAuthenticatingCall"}
+	act.wrappedServerCodec.On("ReadRequestHeader", req).Return(nil).Once()
+	err = act.authServerCodec.ReadRequestHeader(req)
+	c.Assert(err, IsNil)
+	c.Assert(act.headerPassed, DeepEquals, []byte{})
+
 }
 
 func (s *MySuite) TestReadRequestBody(c *C) {
 	body := 0
-	wrappedServerCodec.On("ReadRequestBody", body).Return(ErrTestCodec).Once()
-	err := authServerCodec.ReadRequestBody(body)
+	act.wrappedServerCodec.On("ReadRequestBody", body).Return(ErrTestCodec).Once()
+	err := act.authServerCodec.ReadRequestBody(body)
 	c.Assert(err, Equals, ErrTestCodec)
-	wrappedServerCodec.On("ReadRequestBody", body).Return(nil).Once()
-	err = authServerCodec.ReadRequestBody(body)
+	act.wrappedServerCodec.On("ReadRequestBody", body).Return(nil).Once()
+	err = act.authServerCodec.ReadRequestBody(body)
 	c.Assert(err, IsNil)
 }
 
 func (s *MySuite) TestWriteResponse(c *C) {
 	body := 0
 	resp := &rpc.Response{}
-	wrappedServerCodec.On("WriteResponse", resp, body).Return(ErrTestCodec).Once()
-	err := authServerCodec.WriteResponse(resp, body)
+	act.wrappedServerCodec.On("WriteResponse", resp, body).Return(ErrTestCodec).Once()
+	err := act.authServerCodec.WriteResponse(resp, body)
 	c.Assert(err, Equals, ErrTestCodec)
-	wrappedServerCodec.On("WriteResponse", resp, body).Return(nil).Once()
-	err = authServerCodec.WriteResponse(resp, body)
+	act.wrappedServerCodec.On("WriteResponse", resp, body).Return(nil).Once()
+	err = act.authServerCodec.WriteResponse(resp, body)
 	c.Assert(err, IsNil)
 }
 
 func (s *MySuite) TestCloseServerCodec(c *C) {
-	wrappedServerCodec.On("Close").Return(ErrTestCodec).Once()
-	err := authServerCodec.Close()
+	act.wrappedServerCodec.On("Close").Return(ErrTestCodec).Once()
+	err := act.authServerCodec.Close()
 	c.Assert(err, Equals, ErrTestCodec)
-	wrappedServerCodec.On("Close").Return(nil).Once()
-	err = authServerCodec.Close()
+	act.wrappedServerCodec.On("Close").Return(nil).Once()
+	err = act.authServerCodec.Close()
 	c.Assert(err, IsNil)
 }
 
 // AuthClientCodec Tests
 func (s *MySuite) TestWriteRequest(c *C) {
-	req := &rpc.Request{}
+	req := &rpc.Request{ServiceMethod: "AuthenticatingCall"}
 	body := 0
-	wrappedClientCodec.On("WriteRequest", req, body).Return(ErrTestCodec).Once()
-	err := authClientCodec.WriteRequest(req, body)
+
+	act.headerErrToReturn = ErrTestCodec
+	err := act.authClientCodec.WriteRequest(req, body)
 	c.Assert(err, Equals, ErrTestCodec)
-	wrappedClientCodec.On("WriteRequest", req, body).Return(nil).Once()
-	err = authClientCodec.WriteRequest(req, body)
+
+	act.headerErrToReturn = nil
+	act.wrappedClientCodec.On("WriteRequest", req, body).Return(ErrTestCodec).Once()
+	err = act.authClientCodec.WriteRequest(req, body)
+	c.Assert(err, Equals, ErrTestCodec)
+
+	act.Reset()
+	header := []byte("Header1")
+	act.headerToReturn = header
+	act.wrappedClientCodec.On("WriteRequest", req, body).Return(nil).Once()
+	err = act.authClientCodec.WriteRequest(req, body)
 	c.Assert(err, IsNil)
+	headerWritten := act.ReadHeaderFromBuffer(len(header))
+	c.Assert(headerWritten, DeepEquals, header)
+
+	// Try it with a non-authenticating call, and make sure the header is empty
+	act.Reset()
+	act.headerToReturn = header
+	req.ServiceMethod = "NonAuthenticatingCall"
+	act.wrappedClientCodec.On("WriteRequest", req, body).Return(nil).Once()
+	err = act.authClientCodec.WriteRequest(req, body)
+	c.Assert(err, IsNil)
+	// First 4 bytes of buffer should be 0s
+	bts := act.buff.Bytes()
+	c.Assert(bts[:4], DeepEquals, []byte{0, 0, 0, 0})
+
 }
 
 func (s *MySuite) TestReadResponseHeader(c *C) {
 	resp := &rpc.Response{}
-	wrappedClientCodec.On("ReadResponseHeader", resp).Return(ErrTestCodec).Once()
-	err := authClientCodec.ReadResponseHeader(resp)
+	act.wrappedClientCodec.On("ReadResponseHeader", resp).Return(ErrTestCodec).Once()
+	err := act.authClientCodec.ReadResponseHeader(resp)
 	c.Assert(err, Equals, ErrTestCodec)
-	wrappedClientCodec.On("ReadResponseHeader", resp).Return(nil).Once()
-	err = authClientCodec.ReadResponseHeader(resp)
+	act.wrappedClientCodec.On("ReadResponseHeader", resp).Return(nil).Once()
+	err = act.authClientCodec.ReadResponseHeader(resp)
 	c.Assert(err, IsNil)
 }
 
 func (s *MySuite) TestReadResponseBody(c *C) {
 	body := 0
-	wrappedClientCodec.On("ReadResponseBody", body).Return(ErrTestCodec).Once()
-	err := authClientCodec.ReadResponseBody(body)
+	act.wrappedClientCodec.On("ReadResponseBody", body).Return(ErrTestCodec).Once()
+	err := act.authClientCodec.ReadResponseBody(body)
 	c.Assert(err, Equals, ErrTestCodec)
-	wrappedClientCodec.On("ReadResponseBody", body).Return(nil).Once()
-	err = authClientCodec.ReadResponseBody(body)
+	act.wrappedClientCodec.On("ReadResponseBody", body).Return(nil).Once()
+	err = act.authClientCodec.ReadResponseBody(body)
 	c.Assert(err, IsNil)
 }
 
 func (s *MySuite) TestCloseClientCodec(c *C) {
-	wrappedClientCodec.On("Close").Return(ErrTestCodec).Once()
-	err := authClientCodec.Close()
+	act.wrappedClientCodec.On("Close").Return(ErrTestCodec).Once()
+	err := act.authClientCodec.Close()
 	c.Assert(err, Equals, ErrTestCodec)
-	wrappedClientCodec.On("Close").Return(nil).Once()
-	err = authClientCodec.Close()
+	act.wrappedClientCodec.On("Close").Return(nil).Once()
+	err = act.authClientCodec.Close()
 	c.Assert(err, IsNil)
+}
+
+// Make sure that the header written by the client can be read
+//  by the server
+func (s *MySuite) TestWriteAndRead(c *C) {
+	// Test for an authenticating call
+	req := &rpc.Request{ServiceMethod: "AuthenticatingCall"}
+	body := 0
+	header := []byte("Header1")
+	act.headerToReturn = header
+	act.wrappedClientCodec.On("WriteRequest", req, body).Return(nil).Once()
+	err := act.authClientCodec.WriteRequest(req, body)
+	c.Assert(err, IsNil)
+
+	// Token is now on the buffer
+	act.wrappedServerCodec.On("ReadRequestHeader", req).Return(nil).Once()
+	err = act.authServerCodec.ReadRequestHeader(req)
+	c.Assert(err, IsNil)
+	c.Assert(act.headerPassed, DeepEquals, header)
+
+	// Test for a non-authenticating call
+	act.Reset()
+	act.headerToReturn = header
+	req.ServiceMethod = "NonAuthenticatingCall"
+	act.wrappedClientCodec.On("WriteRequest", req, body).Return(nil).Once()
+	err = act.authClientCodec.WriteRequest(req, body)
+	c.Assert(err, IsNil)
+	// Token is now on the buffer
+	act.wrappedServerCodec.On("ReadRequestHeader", req).Return(nil).Once()
+	err = act.authServerCodec.ReadRequestHeader(req)
+	c.Assert(err, IsNil)
+	c.Assert(act.headerPassed, DeepEquals, []byte{})
+
 }

--- a/rpc/rpcutils/client.go
+++ b/rpc/rpcutils/client.go
@@ -42,7 +42,7 @@ func connectRPC(addr string) (*rpc.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return jsonrpc.NewClient(conn), nil
+	return NewAuthClient(jsonrpc.NewClientCodec(conn)), nil
 }
 
 func connectRPCTLS(addr string) (*rpc.Client, error) {
@@ -57,7 +57,7 @@ func connectRPCTLS(addr string) (*rpc.Client, error) {
 	cipher := conn.ConnectionState().CipherSuite
 	glog.V(2).Infof("RPC client connected with TLS cipher=%s (%d)\n", utils.GetCipherName(cipher), cipher)
 
-	return jsonrpc.NewClient(conn), nil
+	return NewAuthClient(jsonrpc.NewClientCodec(conn)), nil
 }
 
 // newClient that will create at most max active rpc connections at any given time. discardClientTimeout timeout for

--- a/rpc/rpcutils/client.go
+++ b/rpc/rpcutils/client.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net"
 	"net/rpc"
-	"net/rpc/jsonrpc"
 	"sync"
 	"time"
 
@@ -42,7 +41,7 @@ func connectRPC(addr string) (*rpc.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewAuthClient(jsonrpc.NewClientCodec(conn)), nil
+	return NewDefaultAuthClient(conn), nil
 }
 
 func connectRPCTLS(addr string) (*rpc.Client, error) {
@@ -57,7 +56,7 @@ func connectRPCTLS(addr string) (*rpc.Client, error) {
 	cipher := conn.ConnectionState().CipherSuite
 	glog.V(2).Infof("RPC client connected with TLS cipher=%s (%d)\n", utils.GetCipherName(cipher), cipher)
 
-	return NewAuthClient(jsonrpc.NewClientCodec(conn)), nil
+	return NewDefaultAuthClient(conn), nil
 }
 
 // newClient that will create at most max active rpc connections at any given time. discardClientTimeout timeout for

--- a/rpc/rpcutils/client_test.go
+++ b/rpc/rpcutils/client_test.go
@@ -54,7 +54,6 @@ func (rtt *RPCTestType) StructCall(arg TestArgs, reply *TestArgs) error {
 }
 
 func (s *MySuite) SetUpSuite(c *C) {
-	act.Reset()
 	NonAuthenticatingCalls = []string{
 		"NonAuthenticatingCall",
 		"RPCTestType.Sleep",

--- a/rpc/rpcutils/client_test.go
+++ b/rpc/rpcutils/client_test.go
@@ -5,7 +5,6 @@ package rpcutils
 import (
 	"net"
 	"net/rpc"
-	"net/rpc/jsonrpc"
 	"sync"
 	"testing"
 	"time"
@@ -55,6 +54,16 @@ func (rtt *RPCTestType) StructCall(arg TestArgs, reply *TestArgs) error {
 }
 
 func (s *MySuite) SetUpSuite(c *C) {
+	act.Reset()
+	NonAuthenticatingCalls = []string{
+		"NonAuthenticatingCall",
+		"RPCTestType.Sleep",
+		"RPCTestType.NilReply",
+		"RPCTestType.Echo",
+		"RPCTestType.StructCall",
+		"RPCTestType.blam",
+		"Blam.blam",
+	}
 	rtt = new(RPCTestType)
 	RegisterLocal("RPCTestType", rtt)
 	rpc.Register(rtt)
@@ -70,7 +79,7 @@ func (s *MySuite) SetUpSuite(c *C) {
 			if err != nil {
 				c.Errorf("Error accepting connections: %s", err)
 			}
-			go rpc.ServeCodec(jsonrpc.NewServerCodec(conn))
+			go rpc.ServeCodec(NewDefaultAuthServerCodec(conn))
 		}
 	}()
 
@@ -105,7 +114,7 @@ func (s *MySuite) TestTimeout(c *C) {
 
 	client, err := newClient("localhost:32111", 1, 10*time.Millisecond, connectRPC)
 
-	sleepTime := 100 * time.Millisecond
+	sleepTime := 1000 * time.Millisecond
 
 	var reply time.Duration
 
@@ -169,5 +178,5 @@ func (s *MySuite) TestInvalidAddress(c *C) {
 	}()
 	client, _ := newClient("1.2.3.4:1234", 1, 1, connectRPC)
 	// CC-1570: Client is lazy, so have to make a call to cause a panic
-	client.Call("whatever", nil, nil, 1)
+	client.Call("NonAuthenticatingCall", nil, nil, 1)
 }

--- a/rpc/rpcutils/client_test.go
+++ b/rpc/rpcutils/client_test.go
@@ -64,6 +64,9 @@ func (s *MySuite) SetUpSuite(c *C) {
 		"RPCTestType.blam",
 		"Blam.blam",
 	}
+	NonAdminRequiredCalls = []string{
+		"NonAdminRequiredCall",
+	}
 	rtt = new(RPCTestType)
 	RegisterLocal("RPCTestType", rtt)
 	rpc.Register(rtt)

--- a/rpc/rpcutils/mocks/ClientCodec.go
+++ b/rpc/rpcutils/mocks/ClientCodec.go
@@ -1,0 +1,58 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+import "net/rpc"
+
+type ClientCodec struct {
+	mock.Mock
+}
+
+func (_m *ClientCodec) WriteRequest(_a0 *rpc.Request, _a1 interface{}) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*rpc.Request, interface{}) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *ClientCodec) ReadResponseHeader(_a0 *rpc.Response) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*rpc.Response) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *ClientCodec) ReadResponseBody(_a0 interface{}) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(interface{}) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *ClientCodec) Close() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/rpc/rpcutils/mocks/ReadWriteCloser.go
+++ b/rpc/rpcutils/mocks/ReadWriteCloser.go
@@ -1,0 +1,58 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+type ReadWriteCloser struct {
+	mock.Mock
+}
+
+func (_m *ReadWriteCloser) Write(p []byte) (int, error) {
+	ret := _m.Called(p)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func([]byte) int); ok {
+		r0 = rf(p)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]byte) error); ok {
+		r1 = rf(p)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *ReadWriteCloser) Read(p []byte) (int, error) {
+	ret := _m.Called(p)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func([]byte) int); ok {
+		r0 = rf(p)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]byte) error); ok {
+		r1 = rf(p)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *ReadWriteCloser) Close() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/rpc/rpcutils/mocks/ServerCodec.go
+++ b/rpc/rpcutils/mocks/ServerCodec.go
@@ -1,0 +1,58 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+import "net/rpc"
+
+type ServerCodec struct {
+	mock.Mock
+}
+
+func (_m *ServerCodec) ReadRequestHeader(_a0 *rpc.Request) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*rpc.Request) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *ServerCodec) ReadRequestBody(_a0 interface{}) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(interface{}) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *ServerCodec) WriteResponse(_a0 *rpc.Response, _a1 interface{}) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*rpc.Response, interface{}) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *ServerCodec) Close() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/smoke.sh
+++ b/smoke.sh
@@ -94,6 +94,7 @@ cleanup() {
 
     echo "Removing up ${SMOKE_VAR_PATH} ..."
     sudo rm -rf ${SMOKE_VAR_PATH}
+    sudo rm -rf /tmp/serviced-root
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
DO NOT MERGE

For comments only

These changes require a delegate to be authenticated and have admin access to issue any RPC calls except for the "AuthenticateHost" call.  The master is an exception and can issue RPC calls even if it is not added as a host, as long as it has the master private key.

In the future, most delegates will not have admin access, so we will need to expand the list of "NonAdminRequiredCalls", which currently is an empty list.