### PR TITLE
Update unit tests to match new RPC and CLI interfaces

### DIFF
--- a/cli/api/apimocks/API.go
+++ b/cli/api/apimocks/API.go
@@ -117,7 +117,7 @@ func (_m *API) GetHostMap() (map[string]host.Host, error) {
 
 	return r0, r1
 }
-func (_m *API) AddHost(_a0 api.HostConfig) (*host.Host, error) {
+func (_m *API) AddHost(_a0 api.HostConfig) (*host.Host, []byte, error) {
 	ret := _m.Called(_a0)
 
 	var r0 *host.Host
@@ -136,7 +136,7 @@ func (_m *API) AddHost(_a0 api.HostConfig) (*host.Host, error) {
 		r1 = ret.Error(1)
 	}
 
-	return r0, r1
+	return r0, []byte("Fake host keys"), r1
 }
 func (_m *API) RemoveHost(_a0 string) error {
 	ret := _m.Called(_a0)
@@ -182,6 +182,15 @@ func (_m *API) SetHostMemory(_a0 api.HostUpdateConfig) error {
 	}
 
 	return r0
+}
+func (_m *API) GetHostPublicKey(string) ([]byte, error) {
+	return nil, nil
+}
+func (_m *API) RegisterHost([]byte) error {
+	return nil
+}
+func (_m *API) RegisterRemoteHost(*host.Host, []byte) error {
+	return nil
 }
 func (_m *API) GetResourcePools() ([]pool.ResourcePool, error) {
 	ret := _m.Called()

--- a/cli/api/apimocks/API.go
+++ b/cli/api/apimocks/API.go
@@ -1,4 +1,4 @@
-package apimocks
+package mocks
 
 import "github.com/control-center/serviced/cli/api"
 import "github.com/stretchr/testify/mock"
@@ -10,7 +10,6 @@ import "github.com/control-center/serviced/domain/host"
 import "github.com/control-center/serviced/domain/pool"
 import "github.com/control-center/serviced/domain/service"
 import "github.com/control-center/serviced/domain/servicedefinition"
-
 import template "github.com/control-center/serviced/domain/servicetemplate"
 import "github.com/control-center/serviced/isvcs"
 import "github.com/control-center/serviced/metrics"
@@ -129,14 +128,23 @@ func (_m *API) AddHost(_a0 api.HostConfig) (*host.Host, []byte, error) {
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(api.HostConfig) error); ok {
+	var r1 []byte
+	if rf, ok := ret.Get(1).(func(api.HostConfig) []byte); ok {
 		r1 = rf(_a0)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]byte)
+		}
 	}
 
-	return r0, []byte("Fake host keys"), r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(api.HostConfig) error); ok {
+		r2 = rf(_a0)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 func (_m *API) RemoveHost(_a0 string) error {
 	ret := _m.Called(_a0)
@@ -183,14 +191,38 @@ func (_m *API) SetHostMemory(_a0 api.HostUpdateConfig) error {
 
 	return r0
 }
-func (_m *API) GetHostPublicKey(string) ([]byte, error) {
-	return nil, nil
+func (_m *API) GetHostPublicKey(_a0 string) ([]byte, error) {
+	ret := _m.Called(_a0)
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(string) []byte); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
-func (_m *API) RegisterHost([]byte) error {
-	return nil
-}
-func (_m *API) RegisterRemoteHost(*host.Host, []byte) error {
-	return nil
+func (_m *API) RegisterHost(_a0 []byte) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]byte) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 func (_m *API) GetResourcePools() ([]pool.ResourcePool, error) {
 	ret := _m.Called()
@@ -990,6 +1022,7 @@ func (_m *API) ScriptRun(a0 string, a1 *script.Config, stopChan chan struct{}) e
 
 	return r0
 }
+
 func (_m *API) GetVolumeStatus() (*volume.Statuses, error) {
 	ret := _m.Called()
 
@@ -1101,12 +1134,12 @@ func (_m *API) EnablePublicEndpointVHost(serviceid string, endpointName string, 
 
 	return r0
 }
-func (_m *API) GetServiceInstances(_a0 string) ([]service.Instance, error) {
-	ret := _m.Called(_a0)
+func (_m *API) GetServiceInstances(serviceID string) ([]service.Instance, error) {
+	ret := _m.Called(serviceID)
 
 	var r0 []service.Instance
 	if rf, ok := ret.Get(0).(func(string) []service.Instance); ok {
-		r0 = rf(_a0)
+		r0 = rf(serviceID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]service.Instance)
@@ -1115,7 +1148,7 @@ func (_m *API) GetServiceInstances(_a0 string) ([]service.Instance, error) {
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(_a0)
+		r1 = rf(serviceID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/cli/cmd/host_test.go
+++ b/cli/cmd/host_test.go
@@ -104,16 +104,17 @@ func (t HostAPITest) GetHost(id string) (*host.Host, error) {
 	return nil, nil
 }
 
-func (t HostAPITest) AddHost(config api.HostConfig) (*host.Host, error) {
+func (t HostAPITest) AddHost(config api.HostConfig) (*host.Host, []byte, error) {
 	if t.fail {
-		return nil, ErrInvalidHost
+		return nil, nil, ErrInvalidHost
 	} else if config.PoolID == NilPool {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	h := host.New()
 	h.ID = fmt.Sprintf("%s-%s", config.Address.Host, config.PoolID)
-	return h, nil
+	h.IPAddr = "127.0.0.1"
+	return h, []byte("Fake HostKeys"), nil
 }
 
 func (t HostAPITest) RemoveHost(id string) error {
@@ -221,25 +222,6 @@ func ExampleServicedCLI_CmdHostAdd() {
 	// Output:
 	// bad format: badurl; must be formatted as HOST:PORT
 	// 127.0.0.1-default
-}
-
-func ExampleServicedCLI_CmdHostAdd_usage() {
-	InitHostAPITest("serviced", "host", "add")
-
-	// Output:
-	// Incorrect Usage.
-	//
-	// NAME:
-	//    add - Adds a new host
-	//
-	// USAGE:
-	//    command add [command options] [arguments...]
-	//
-	// DESCRIPTION:
-	//    serviced host add HOST:PORT RESOURCE_POOL
-	//
-	// OPTIONS:
-	//    --memory 	Memory to allocate on this host, e.g. 20G, 50%
 }
 
 func ExampleServicedCLI_CmdHostAdd_fail() {

--- a/rpc/master/mocks/ClientInterface.go
+++ b/rpc/master/mocks/ClientInterface.go
@@ -4,13 +4,13 @@ import "github.com/stretchr/testify/mock"
 
 import "time"
 import "github.com/control-center/serviced/domain/applicationendpoint"
-import "github.com/control-center/serviced/health"
 import "github.com/control-center/serviced/domain/host"
 import "github.com/control-center/serviced/domain/pool"
 import "github.com/control-center/serviced/domain/service"
 import "github.com/control-center/serviced/domain/servicedefinition"
 import "github.com/control-center/serviced/domain/servicetemplate"
 import "github.com/control-center/serviced/domain/user"
+import "github.com/control-center/serviced/health"
 import "github.com/control-center/serviced/isvcs"
 import "github.com/control-center/serviced/volume"
 
@@ -18,7 +18,6 @@ type ClientInterface struct {
 	mock.Mock
 }
 
-// Close provides a mock function with given fields:
 func (_m *ClientInterface) Close() error {
 	ret := _m.Called()
 
@@ -31,8 +30,6 @@ func (_m *ClientInterface) Close() error {
 
 	return r0
 }
-
-// GetHost provides a mock function with given fields: hostID
 func (_m *ClientInterface) GetHost(hostID string) (*host.Host, error) {
 	ret := _m.Called(hostID)
 
@@ -54,8 +51,6 @@ func (_m *ClientInterface) GetHost(hostID string) (*host.Host, error) {
 
 	return r0, r1
 }
-
-// GetHosts provides a mock function with given fields:
 func (_m *ClientInterface) GetHosts() ([]host.Host, error) {
 	ret := _m.Called()
 
@@ -77,8 +72,6 @@ func (_m *ClientInterface) GetHosts() ([]host.Host, error) {
 
 	return r0, r1
 }
-
-// GetActiveHostIDs provides a mock function with given fields:
 func (_m *ClientInterface) GetActiveHostIDs() ([]string, error) {
 	ret := _m.Called()
 
@@ -100,22 +93,27 @@ func (_m *ClientInterface) GetActiveHostIDs() ([]string, error) {
 
 	return r0, r1
 }
-
-// AddHost provides a mock function with given fields: h
-func (_m *ClientInterface) AddHost(h host.Host) error {
+func (_m *ClientInterface) AddHost(h host.Host) ([]byte, error) {
 	ret := _m.Called(h)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(host.Host) error); ok {
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(host.Host) []byte); ok {
 		r0 = rf(h)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
 	}
 
-	return r0
-}
+	var r1 error
+	if rf, ok := ret.Get(1).(func(host.Host) error); ok {
+		r1 = rf(h)
+	} else {
+		r1 = ret.Error(1)
+	}
 
-// UpdateHost provides a mock function with given fields: h
+	return r0, r1
+}
 func (_m *ClientInterface) UpdateHost(h host.Host) error {
 	ret := _m.Called(h)
 
@@ -128,8 +126,6 @@ func (_m *ClientInterface) UpdateHost(h host.Host) error {
 
 	return r0
 }
-
-// RemoveHost provides a mock function with given fields: hostID
 func (_m *ClientInterface) RemoveHost(hostID string) error {
 	ret := _m.Called(hostID)
 
@@ -142,8 +138,6 @@ func (_m *ClientInterface) RemoveHost(hostID string) error {
 
 	return r0
 }
-
-// FindHostsInPool provides a mock function with given fields: poolID
 func (_m *ClientInterface) FindHostsInPool(poolID string) ([]host.Host, error) {
 	ret := _m.Called(poolID)
 
@@ -165,8 +159,53 @@ func (_m *ClientInterface) FindHostsInPool(poolID string) ([]host.Host, error) {
 
 	return r0, r1
 }
+func (_m *ClientInterface) AuthenticateHost(hostID string) (string, int64, error) {
+	ret := _m.Called(hostID)
 
-// GetResourcePool provides a mock function with given fields: poolID
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(hostID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 int64
+	if rf, ok := ret.Get(1).(func(string) int64); ok {
+		r1 = rf(hostID)
+	} else {
+		r1 = ret.Get(1).(int64)
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(string) error); ok {
+		r2 = rf(hostID)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+func (_m *ClientInterface) GetHostPublicKey(hostID string) ([]byte, error) {
+	ret := _m.Called(hostID)
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(string) []byte); ok {
+		r0 = rf(hostID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(hostID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
 func (_m *ClientInterface) GetResourcePool(poolID string) (*pool.ResourcePool, error) {
 	ret := _m.Called(poolID)
 
@@ -188,8 +227,6 @@ func (_m *ClientInterface) GetResourcePool(poolID string) (*pool.ResourcePool, e
 
 	return r0, r1
 }
-
-// GetResourcePools provides a mock function with given fields:
 func (_m *ClientInterface) GetResourcePools() ([]pool.ResourcePool, error) {
 	ret := _m.Called()
 
@@ -211,8 +248,6 @@ func (_m *ClientInterface) GetResourcePools() ([]pool.ResourcePool, error) {
 
 	return r0, r1
 }
-
-// AddResourcePool provides a mock function with given fields: p
 func (_m *ClientInterface) AddResourcePool(p pool.ResourcePool) error {
 	ret := _m.Called(p)
 
@@ -225,8 +260,6 @@ func (_m *ClientInterface) AddResourcePool(p pool.ResourcePool) error {
 
 	return r0
 }
-
-// UpdateResourcePool provides a mock function with given fields: p
 func (_m *ClientInterface) UpdateResourcePool(p pool.ResourcePool) error {
 	ret := _m.Called(p)
 
@@ -239,8 +272,6 @@ func (_m *ClientInterface) UpdateResourcePool(p pool.ResourcePool) error {
 
 	return r0
 }
-
-// RemoveResourcePool provides a mock function with given fields: poolID
 func (_m *ClientInterface) RemoveResourcePool(poolID string) error {
 	ret := _m.Called(poolID)
 
@@ -253,8 +284,6 @@ func (_m *ClientInterface) RemoveResourcePool(poolID string) error {
 
 	return r0
 }
-
-// GetPoolIPs provides a mock function with given fields: poolID
 func (_m *ClientInterface) GetPoolIPs(poolID string) (*pool.PoolIPs, error) {
 	ret := _m.Called(poolID)
 
@@ -276,8 +305,6 @@ func (_m *ClientInterface) GetPoolIPs(poolID string) (*pool.PoolIPs, error) {
 
 	return r0, r1
 }
-
-// AddVirtualIP provides a mock function with given fields: requestVirtualIP
 func (_m *ClientInterface) AddVirtualIP(requestVirtualIP pool.VirtualIP) error {
 	ret := _m.Called(requestVirtualIP)
 
@@ -290,8 +317,6 @@ func (_m *ClientInterface) AddVirtualIP(requestVirtualIP pool.VirtualIP) error {
 
 	return r0
 }
-
-// RemoveVirtualIP provides a mock function with given fields: requestVirtualIP
 func (_m *ClientInterface) RemoveVirtualIP(requestVirtualIP pool.VirtualIP) error {
 	ret := _m.Called(requestVirtualIP)
 
@@ -304,8 +329,6 @@ func (_m *ClientInterface) RemoveVirtualIP(requestVirtualIP pool.VirtualIP) erro
 
 	return r0
 }
-
-// ServiceUse provides a mock function with given fields: serviceID, imageID, registry, replaceImgs, noOp
 func (_m *ClientInterface) ServiceUse(serviceID string, imageID string, registry string, replaceImgs []string, noOp bool) (string, error) {
 	ret := _m.Called(serviceID, imageID, registry, replaceImgs, noOp)
 
@@ -325,8 +348,6 @@ func (_m *ClientInterface) ServiceUse(serviceID string, imageID string, registry
 
 	return r0, r1
 }
-
-// WaitService provides a mock function with given fields: serviceIDs, state, timeout, recursive
 func (_m *ClientInterface) WaitService(serviceIDs []string, state service.DesiredState, timeout time.Duration, recursive bool) error {
 	ret := _m.Called(serviceIDs, state, timeout, recursive)
 
@@ -339,8 +360,6 @@ func (_m *ClientInterface) WaitService(serviceIDs []string, state service.Desire
 
 	return r0
 }
-
-// GetServiceInstances provides a mock function with given fields: serviceID
 func (_m *ClientInterface) GetServiceInstances(serviceID string) ([]service.Instance, error) {
 	ret := _m.Called(serviceID)
 
@@ -362,8 +381,6 @@ func (_m *ClientInterface) GetServiceInstances(serviceID string) ([]service.Inst
 
 	return r0, r1
 }
-
-// GetEvaluatedService provides a mock function with given fields: serviceID, instanceID
 func (_m *ClientInterface) GetEvaluatedService(serviceID string, instanceID int) (*service.Service, error) {
 	ret := _m.Called(serviceID, instanceID)
 
@@ -385,8 +402,6 @@ func (_m *ClientInterface) GetEvaluatedService(serviceID string, instanceID int)
 
 	return r0, r1
 }
-
-// GetTenantID provides a mock function with given fields: serviceID
 func (_m *ClientInterface) GetTenantID(serviceID string) (string, error) {
 	ret := _m.Called(serviceID)
 
@@ -406,8 +421,6 @@ func (_m *ClientInterface) GetTenantID(serviceID string) (string, error) {
 
 	return r0, r1
 }
-
-// StopServiceInstance provides a mock function with given fields: serviceID, instanceID
 func (_m *ClientInterface) StopServiceInstance(serviceID string, instanceID int) error {
 	ret := _m.Called(serviceID, instanceID)
 
@@ -420,8 +433,6 @@ func (_m *ClientInterface) StopServiceInstance(serviceID string, instanceID int)
 
 	return r0
 }
-
-// LocateServiceInstance provides a mock function with given fields: serviceID, instanceID
 func (_m *ClientInterface) LocateServiceInstance(serviceID string, instanceID int) (*service.LocationInstance, error) {
 	ret := _m.Called(serviceID, instanceID)
 
@@ -443,8 +454,6 @@ func (_m *ClientInterface) LocateServiceInstance(serviceID string, instanceID in
 
 	return r0, r1
 }
-
-// SendDockerAction provides a mock function with given fields: serviceID, instanceID, action, args
 func (_m *ClientInterface) SendDockerAction(serviceID string, instanceID int, action string, args []string) error {
 	ret := _m.Called(serviceID, instanceID, action, args)
 
@@ -457,8 +466,6 @@ func (_m *ClientInterface) SendDockerAction(serviceID string, instanceID int, ac
 
 	return r0
 }
-
-// AddServiceTemplate provides a mock function with given fields: serviceTemplate
 func (_m *ClientInterface) AddServiceTemplate(serviceTemplate servicetemplate.ServiceTemplate) (string, error) {
 	ret := _m.Called(serviceTemplate)
 
@@ -478,8 +485,6 @@ func (_m *ClientInterface) AddServiceTemplate(serviceTemplate servicetemplate.Se
 
 	return r0, r1
 }
-
-// GetServiceTemplates provides a mock function with given fields:
 func (_m *ClientInterface) GetServiceTemplates() (map[string]servicetemplate.ServiceTemplate, error) {
 	ret := _m.Called()
 
@@ -501,8 +506,6 @@ func (_m *ClientInterface) GetServiceTemplates() (map[string]servicetemplate.Ser
 
 	return r0, r1
 }
-
-// RemoveServiceTemplate provides a mock function with given fields: serviceTemplateID
 func (_m *ClientInterface) RemoveServiceTemplate(serviceTemplateID string) error {
 	ret := _m.Called(serviceTemplateID)
 
@@ -515,8 +518,6 @@ func (_m *ClientInterface) RemoveServiceTemplate(serviceTemplateID string) error
 
 	return r0
 }
-
-// DeployTemplate provides a mock function with given fields: request
 func (_m *ClientInterface) DeployTemplate(request servicetemplate.ServiceTemplateDeploymentRequest) ([]string, error) {
 	ret := _m.Called(request)
 
@@ -538,8 +539,6 @@ func (_m *ClientInterface) DeployTemplate(request servicetemplate.ServiceTemplat
 
 	return r0, r1
 }
-
-// GetVolumeStatus provides a mock function with given fields:
 func (_m *ClientInterface) GetVolumeStatus() (*volume.Statuses, error) {
 	ret := _m.Called()
 
@@ -561,8 +560,6 @@ func (_m *ClientInterface) GetVolumeStatus() (*volume.Statuses, error) {
 
 	return r0, r1
 }
-
-// GetServiceEndpoints provides a mock function with given fields: serviceIDs, reportImports, reportExports, validate
 func (_m *ClientInterface) GetServiceEndpoints(serviceIDs []string, reportImports bool, reportExports bool, validate bool) ([]applicationendpoint.EndpointReport, error) {
 	ret := _m.Called(serviceIDs, reportImports, reportExports, validate)
 
@@ -584,8 +581,6 @@ func (_m *ClientInterface) GetServiceEndpoints(serviceIDs []string, reportImport
 
 	return r0, r1
 }
-
-// ResetRegistry provides a mock function with given fields:
 func (_m *ClientInterface) ResetRegistry() error {
 	ret := _m.Called()
 
@@ -598,8 +593,6 @@ func (_m *ClientInterface) ResetRegistry() error {
 
 	return r0
 }
-
-// SyncRegistry provides a mock function with given fields:
 func (_m *ClientInterface) SyncRegistry() error {
 	ret := _m.Called()
 
@@ -612,8 +605,6 @@ func (_m *ClientInterface) SyncRegistry() error {
 
 	return r0
 }
-
-// UpgradeRegistry provides a mock function with given fields: endpoint, override
 func (_m *ClientInterface) UpgradeRegistry(endpoint string, override bool) error {
 	ret := _m.Called(endpoint, override)
 
@@ -626,8 +617,6 @@ func (_m *ClientInterface) UpgradeRegistry(endpoint string, override bool) error
 
 	return r0
 }
-
-// DockerOverride provides a mock function with given fields: newImage, oldImage
 func (_m *ClientInterface) DockerOverride(newImage string, oldImage string) error {
 	ret := _m.Called(newImage, oldImage)
 
@@ -640,8 +629,6 @@ func (_m *ClientInterface) DockerOverride(newImage string, oldImage string) erro
 
 	return r0
 }
-
-// AddPublicEndpointPort provides a mock function with given fields: serviceid, endpointName, portAddr, usetls, protocol, isEnabled, restart
 func (_m *ClientInterface) AddPublicEndpointPort(serviceid string, endpointName string, portAddr string, usetls bool, protocol string, isEnabled bool, restart bool) (*servicedefinition.Port, error) {
 	ret := _m.Called(serviceid, endpointName, portAddr, usetls, protocol, isEnabled, restart)
 
@@ -663,8 +650,6 @@ func (_m *ClientInterface) AddPublicEndpointPort(serviceid string, endpointName 
 
 	return r0, r1
 }
-
-// RemovePublicEndpointPort provides a mock function with given fields: serviceid, endpointName, portAddr
 func (_m *ClientInterface) RemovePublicEndpointPort(serviceid string, endpointName string, portAddr string) error {
 	ret := _m.Called(serviceid, endpointName, portAddr)
 
@@ -677,8 +662,6 @@ func (_m *ClientInterface) RemovePublicEndpointPort(serviceid string, endpointNa
 
 	return r0
 }
-
-// EnablePublicEndpointPort provides a mock function with given fields: serviceid, endpointName, portAddr, isEnabled
 func (_m *ClientInterface) EnablePublicEndpointPort(serviceid string, endpointName string, portAddr string, isEnabled bool) error {
 	ret := _m.Called(serviceid, endpointName, portAddr, isEnabled)
 
@@ -691,8 +674,6 @@ func (_m *ClientInterface) EnablePublicEndpointPort(serviceid string, endpointNa
 
 	return r0
 }
-
-// AddPublicEndpointVHost provides a mock function with given fields: serviceid, endpointName, vhost, isEnabled, restart
 func (_m *ClientInterface) AddPublicEndpointVHost(serviceid string, endpointName string, vhost string, isEnabled bool, restart bool) (*servicedefinition.VHost, error) {
 	ret := _m.Called(serviceid, endpointName, vhost, isEnabled, restart)
 
@@ -714,8 +695,6 @@ func (_m *ClientInterface) AddPublicEndpointVHost(serviceid string, endpointName
 
 	return r0, r1
 }
-
-// RemovePublicEndpointVHost provides a mock function with given fields: serviceid, endpointName, vhost
 func (_m *ClientInterface) RemovePublicEndpointVHost(serviceid string, endpointName string, vhost string) error {
 	ret := _m.Called(serviceid, endpointName, vhost)
 
@@ -728,8 +707,6 @@ func (_m *ClientInterface) RemovePublicEndpointVHost(serviceid string, endpointN
 
 	return r0
 }
-
-// EnablePublicEndpointVHost provides a mock function with given fields: serviceid, endpointName, vhost, isEnabled
 func (_m *ClientInterface) EnablePublicEndpointVHost(serviceid string, endpointName string, vhost string, isEnabled bool) error {
 	ret := _m.Called(serviceid, endpointName, vhost, isEnabled)
 
@@ -742,8 +719,6 @@ func (_m *ClientInterface) EnablePublicEndpointVHost(serviceid string, endpointN
 
 	return r0
 }
-
-// GetSystemUser provides a mock function with given fields:
 func (_m *ClientInterface) GetSystemUser() (user.User, error) {
 	ret := _m.Called()
 
@@ -763,29 +738,25 @@ func (_m *ClientInterface) GetSystemUser() (user.User, error) {
 
 	return r0, r1
 }
-
-// ValidateCredentials provides a mock function with given fields: user
-func (_m *ClientInterface) ValidateCredentials(someUser user.User) (bool, error) {
-	ret := _m.Called(someUser)
+func (_m *ClientInterface) ValidateCredentials(u user.User) (bool, error) {
+	ret := _m.Called(u)
 
 	var r0 bool
 	if rf, ok := ret.Get(0).(func(user.User) bool); ok {
-		r0 = rf(someUser)
+		r0 = rf(u)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(user.User) error); ok {
-		r1 = rf(someUser)
+		r1 = rf(u)
 	} else {
 		r1 = ret.Error(1)
 	}
 
 	return r0, r1
 }
-
-// GetISvcsHealth provides a mock function with given fields: IServiceNames
 func (_m *ClientInterface) GetISvcsHealth(IServiceNames []string) ([]isvcs.IServiceHealthResult, error) {
 	ret := _m.Called(IServiceNames)
 
@@ -807,8 +778,6 @@ func (_m *ClientInterface) GetISvcsHealth(IServiceNames []string) ([]isvcs.IServ
 
 	return r0, r1
 }
-
-// GetServicesHealth provides a mock function with given fields:
 func (_m *ClientInterface) GetServicesHealth() (map[string]map[int]map[string]health.HealthStatus, error) {
 	ret := _m.Called()
 
@@ -830,8 +799,6 @@ func (_m *ClientInterface) GetServicesHealth() (map[string]map[int]map[string]he
 
 	return r0, r1
 }
-
-// ReportHealthStatus provides a mock function with given fields: key, value, expires
 func (_m *ClientInterface) ReportHealthStatus(key health.HealthStatusKey, value health.HealthStatus, expires time.Duration) error {
 	ret := _m.Called(key, value, expires)
 
@@ -844,8 +811,6 @@ func (_m *ClientInterface) ReportHealthStatus(key health.HealthStatusKey, value 
 
 	return r0
 }
-
-// ReportInstanceDead provides a mock function with given fields: serviceID, instanceID
 func (_m *ClientInterface) ReportInstanceDead(serviceID string, instanceID int) error {
 	ret := _m.Called(serviceID, instanceID)
 


### PR DESCRIPTION
* Rerun 'mockery' tool to create updated mock ClientInterface
* Update AddHost to include delegate key return value
* Add GetHostPublicKey, RegisterHost, RegisterRemoteHost to mock
* Remove ExampleServicedCLI_CmdHostAdd_usage()
