### PR TITLE
store images in a map when looking up service instances

### DIFF
--- a/facade/instance.go
+++ b/facade/instance.go
@@ -50,7 +50,18 @@ func (f *Facade) GetServiceInstances(ctx datastore.Context, since time.Time, ser
 		return nil, err
 	}
 
+	logger = logger.WithFields(log.Fields{
+		"servicename": svc.Name,
+		"poolid":      svc.PoolID,
+		"imageid":     svc.ImageID,
+	})
 	logger.Debug("Loaded service")
+
+	// get the hash of the service image
+	imageHash, err := f.getImageHash(ctx, svc.ImageID)
+	if err != nil {
+		return nil, err
+	}
 
 	states, err := f.zzk.GetServiceStates(svc.PoolID, svc.ID)
 	if err != nil {
@@ -79,7 +90,7 @@ func (f *Facade) GetServiceInstances(ctx datastore.Context, since time.Time, ser
 			hostMap[state.HostID] = hst
 		}
 
-		inst, err := f.getInstance(ctx, hst, *svc, state)
+		inst, err := f.getInstance(ctx, hst, *svc, imageHash, state)
 		if err != nil {
 			return nil, err
 		}
@@ -118,6 +129,9 @@ func (f *Facade) GetHostInstances(ctx datastore.Context, since time.Time, hostID
 	// keep track of the services previously looked up
 	svcMap := make(map[string]service.Service)
 
+	// keep track of the images previously looked up
+	imgMap := make(map[string]string)
+
 	var hst host.Host
 	err := f.hostStore.Get(ctx, host.HostKey(hostID), &hst)
 	if err != nil {
@@ -145,23 +159,32 @@ func (f *Facade) GetHostInstances(ctx datastore.Context, since time.Time, hostID
 	insts := make([]service.Instance, len(states))
 	for i, state := range states {
 
+		st8log := logger.WithFields(log.Fields{
+			"serviceid":  state.ServiceID,
+			"instanceid": state.InstanceID,
+		})
+
 		svc, ok := svcMap[state.ServiceID]
 		if !ok {
 			s, err := f.serviceStore.Get(ctx, state.ServiceID)
 			if err != nil {
-
-				logger.WithFields(log.Fields{
-					"serviceid":  state.ServiceID,
-					"instanceid": state.InstanceID,
-				}).WithError(err).Debug("Could not look up service for instance")
-
+				st8log.WithError(err).Debug("Could not look up service for instance")
 				return nil, err
 			}
 			svc = *s
 			svcMap[state.ServiceID] = svc
 		}
 
-		inst, err := f.getInstance(ctx, hst, svc, state)
+		imageHash, ok := imgMap[svc.ImageID]
+		if !ok {
+			imageHash, err = f.getImageHash(ctx, svc.ImageID)
+			if err != nil {
+				return nil, err
+			}
+			imgMap[svc.ImageID] = imageHash
+		}
+
+		inst, err := f.getInstance(ctx, hst, svc, imageHash, state)
 		if err != nil {
 			return nil, err
 		}
@@ -191,42 +214,12 @@ func (f *Facade) GetHostInstances(ctx datastore.Context, since time.Time, hostID
 }
 
 // getInstance calculates the fields of the service instance object.
-func (f *Facade) getInstance(ctx datastore.Context, hst host.Host, svc service.Service, state zkservice.State) (*service.Instance, error) {
+func (f *Facade) getInstance(ctx datastore.Context, hst host.Host, svc service.Service, imageHash string, state zkservice.State) (*service.Instance, error) {
 	logger := plog.WithFields(log.Fields{
 		"hostid":     state.HostID,
 		"serviceid":  state.ServiceID,
 		"instanceid": state.InstanceID,
 	})
-
-	// check the image
-	imageSynced, err := func(imageName, imageUUID string) (bool, error) {
-		imgLogger := logger.WithField("imagename", imageName)
-
-		imageID, err := commons.ParseImageID(imageName)
-		if err != nil {
-
-			imgLogger.WithError(err).Debug("Could not parse service image")
-			return false, err
-		}
-		imgLogger.Debug("Parsed service image")
-
-		imageID.Tag = docker.Latest
-		imageData, err := f.registryStore.Get(ctx, imageID.String())
-		if err != nil {
-
-			imgLogger.WithError(err).Debug("Could not look up service image in registry")
-
-			// TODO: expecting wrapped error here
-			return false, err
-		}
-		imgLogger.Debug("Loaded service image from registry")
-
-		return imageData.UUID == imageUUID, nil
-	}(svc.ImageID, state.ImageID)
-
-	if err != nil {
-		return nil, err
-	}
 
 	// get the current state
 	var curState service.CurrentState
@@ -265,7 +258,7 @@ func (f *Facade) getInstance(ctx datastore.Context, hst host.Host, svc service.S
 		ServiceID:     svc.ID,
 		ServiceName:   svc.Name,
 		ContainerID:   state.ContainerID,
-		ImageSynced:   imageSynced,
+		ImageSynced:   imageHash == state.ImageID,
 		DesiredState:  state.DesiredState,
 		CurrentState:  curState,
 		HealthStatus:  f.getInstanceHealth(&svc, state.InstanceID),
@@ -277,6 +270,29 @@ func (f *Facade) getInstance(ctx datastore.Context, hst host.Host, svc service.S
 	logger.Debug("Loaded service instance")
 
 	return inst, nil
+}
+
+// getImageHash returns the hash of the latest image given the name
+func (f *Facade) getImageHash(ctx datastore.Context, imageName string) (string, error) {
+	logger := plog.WithField("imagename", imageName)
+
+	imageID, err := commons.ParseImageID(imageName)
+	if err != nil {
+		logger.WithError(err).Debug("Could not parse service image")
+		return "", err
+	}
+
+	logger.Debug("Parsed service image")
+
+	imageID.Tag = docker.Latest
+	imageData, err := f.registryStore.Get(ctx, imageID.String())
+	if err != nil {
+		logger.WithError(err).Debug("Could not look up service image in image registry")
+		return "", err
+	}
+
+	logger.WithField("imagehash", imageData).Debug("Loaded image hash")
+	return imageData.UUID, nil
 }
 
 // GetAggregateServices returns the aggregated states of a bulk of services

--- a/facade/instance_test.go
+++ b/facade/instance_test.go
@@ -56,6 +56,13 @@ func (ft *FacadeUnitTest) TestGetServiceInstances_StatesError(c *C) {
 		DesiredState: int(service.SVCRun),
 	}
 
+	img := &registry.Image{
+		Library: "testtenant",
+		Repo:    "image",
+		Tag:     "latest",
+		UUID:    "someimageuuid",
+	}
+	ft.registryStore.On("Get", ft.ctx, "testtenant/image:latest").Return(img, nil)
 	ft.serviceStore.On("Get", ft.ctx, "testservice").Return(svc, nil)
 	ft.zzk.On("GetServiceStates", "default", "testservice").Return(nil, ErrTestZK)
 	inst, err := ft.Facade.GetServiceInstances(ft.ctx, testStartTime, "testservice")
@@ -92,6 +99,13 @@ func (ft *FacadeUnitTest) TestGetServiceInstances_HostNotFound(c *C) {
 	}
 	ft.zzk.On("GetServiceStates", "default", "testservice").Return(states, nil)
 
+	img := &registry.Image{
+		Library: "testtenant",
+		Repo:    "image",
+		Tag:     "latest",
+		UUID:    "someimageuuid",
+	}
+	ft.registryStore.On("Get", ft.ctx, "testtenant/image:latest").Return(img, nil)
 	ft.hostStore.On("Get", ft.ctx, host.HostKey("testhost"), mock.AnythingOfType("*host.Host")).Return(ErrTestHostStore)
 	inst, err := ft.Facade.GetServiceInstances(ft.ctx, testStartTime, "testservice")
 	c.Assert(err, Equals, ErrTestHostStore)


### PR DESCRIPTION
Added a facade method to get the image hash value and mapped the data to reduce the number of database calls.