### PR TITLE
Fixes CC-2679 clone of ZEN-24758 RM UI broken b/c of blocked requests for mixed content

### DIFF
--- a/web/vhost.go
+++ b/web/vhost.go
@@ -154,7 +154,7 @@ func (h *VHostHandler) Handle(useTLS bool, w http.ResponseWriter, r *http.Reques
 	// Set up the X-Forwarded-Proto header so that downstream servers know
 	// the request originated as HTTPS.
 	if _, found := r.Header["X-Forwarded-Proto"]; !found {
-		r.Header.Set("X-Forwarded-Proto", "tcp")
+		r.Header.Set("X-Forwarded-Proto", "https")
 	}
 
 	rp.ServeHTTP(w, r)


### PR DESCRIPTION
Sets X-Forwarded-Proto https Header in vhost.go, so that pagespeed appropriately serves secure requests.