### PR TITLE
Add --register arg to "add host" command

### DIFF
--- a/cli/api/apimocks/API.go
+++ b/cli/api/apimocks/API.go
@@ -224,6 +224,30 @@ func (_m *API) RegisterHost(_a0 []byte) error {
 
 	return r0
 }
+func (_m *API) RegisterRemoteHost(_a0 *host.Host, _a1 []byte) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*host.Host, []byte) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *API) WriteDelegateKey(_a0 string, _a1 []byte) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, []byte) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
 func (_m *API) GetResourcePools() ([]pool.ResourcePool, error) {
 	ret := _m.Called()
 

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -46,6 +46,8 @@ type API interface {
 	SetHostMemory(HostUpdateConfig) error
 	GetHostPublicKey(string) ([]byte, error)
 	RegisterHost([]byte) error
+	RegisterRemoteHost(*host.Host, []byte) error
+	WriteDelegateKey(string, []byte) error
 
 	// Pools
 	GetResourcePools() ([]pool.ResourcePool, error)

--- a/cli/cmd/host.go
+++ b/cli/cmd/host.go
@@ -68,6 +68,10 @@ func (c *ServicedCli) initHost() {
 						Value: "",
 						Usage: "Name of the output host key file",
 					},
+					cli.BoolFlag{
+						Name:  "register, r",
+						Usage: "Register delegate keys on the host via ssh",
+					},
 				},
 			}, {
 				Name:         "remove",
@@ -238,20 +242,43 @@ func (c *ServicedCli) cmdHostAdd(ctx *cli.Context) {
 		Memory:  ctx.String("memory"),
 	}
 
-	if host, privateKey, err := c.driver.AddHost(cfg); err != nil {
+	host, privateKey, err := c.driver.AddHost(cfg)
+	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		return
 	} else if host == nil {
 		fmt.Fprintln(os.Stderr, "received nil host")
+		return
+	}
+
+	writeKeyFile := false
+	if ctx.Bool("register") {
+		if err := c.driver.RegisterRemoteHost(host, privateKey); err != nil {
+			fmt.Fprintf(os.Stderr, "Error registering host: %s\n", err.Error())
+			writeKeyFile = true
+		} else {
+			fmt.Println("Registered host at", host.IPAddr)
+		}
 	} else {
-		keyfileName := ctx.String("key-file")
+		writeKeyFile = true
+	}
+
+	keyfileName := ctx.String("key-file")
+	if keyfileName != "" {
+		writeKeyFile = true
+	}
+
+	if writeKeyFile == true {
 		if keyfileName == "" {
 			keyfileName = fmt.Sprintf("IP-%s.delegate.key", strings.Replace(host.IPAddr, ".", "-", -1))
 		}
-		if err := ioutil.WriteFile(keyfileName, privateKey, 0440); err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if err := c.driver.WriteDelegateKey(keyfileName, privateKey); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing delegate key file \"%s\": %s\n", keyfileName, err.Error())
+		} else {
+			fmt.Println("Wrote delegate key file to", keyfileName)
 		}
-		fmt.Println(host.ID)
 	}
+	fmt.Println(host.ID)
 }
 
 // serviced host remove HOSTID ...

--- a/cli/cmd/host_test.go
+++ b/cli/cmd/host_test.go
@@ -126,6 +126,14 @@ func (t HostAPITest) RemoveHost(id string) error {
 	return nil
 }
 
+func (t HostAPITest) RegisterRemoteHost(h *host.Host, data []byte) error {
+	return nil
+}
+
+func (t HostAPITest) WriteDelegateKey(filename string, data []byte) error {
+	return nil
+}
+
 func TestServicedCLI_CmdHostList_one(t *testing.T) {
 	hostID := "test-host-id-1"
 
@@ -214,14 +222,20 @@ func ExampleServicedCLI_CmdHostList_complete() {
 }
 
 func ExampleServicedCLI_CmdHostAdd() {
-	// Bad URL
-	InitHostAPITest("serviced", "host", "add", "badurl", "default")
 	// Success
 	InitHostAPITest("serviced", "host", "add", "127.0.0.1:8080", "default")
 
 	// Output:
-	// bad format: badurl; must be formatted as HOST:PORT
+	// Wrote delegate key file to IP-127-0-0-1.delegate.key
 	// 127.0.0.1-default
+}
+
+func ExampleServicedCLI_CmdHostAdd_badurl() {
+	// Bad URL
+	InitHostAPITest("serviced", "host", "add", "badurl", "default")
+
+	// Output:
+	// bad format: badurl; must be formatted as HOST:PORT
 }
 
 func ExampleServicedCLI_CmdHostAdd_fail() {


### PR DESCRIPTION
Setting this boolean command line arg will cause the key to
automatically be installed on the added host.  If the added host is the
local host, the key will simply be written into the proper location; if
it is a remote host a ssh will be opened to run 'serviced host register'
with the key written to stdin.