### PR TITLE
CC-2685 : Fix wiring in gocheck for domain/service package

### DIFF
--- a/domain/service/all_test.go
+++ b/domain/service/all_test.go
@@ -11,14 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build unit
+// +build unit integration
 
-package service_test
+package service
 
 import (
 	. "gopkg.in/check.v1"
+	"testing"
 )
 
-var _ = Suite(&ServiceDomainUnitTestSuite{})
-
-type ServiceDomainUnitTestSuite struct{}
+// This plumbs gocheck into testing
+func Test(t *testing.T) {
+	TestingT(t)
+}

--- a/domain/service/servicestore_test.go
+++ b/domain/service/servicestore_test.go
@@ -20,16 +20,10 @@ import (
 	"github.com/control-center/serviced/datastore/elastic"
 	. "gopkg.in/check.v1"
 
-	"testing"
 	"time"
 
 	"github.com/control-center/serviced/domain/servicedefinition"
 )
-
-// This plumbs gocheck into testing
-func Test(t *testing.T) {
-	TestingT(t)
-}
 
 var _ = Suite(&S{
 	ElasticTest: elastic.ElasticTest{


### PR DESCRIPTION
Tests failed because the way gocheck was wired in was causing some to run twice.