### PR TITLE
Fix CC-2686: panic in serviced host register

### DIFF
--- a/cli/cmd/host.go
+++ b/cli/cmd/host.go
@@ -319,6 +319,7 @@ func (c *ServicedCli) cmdHostRegister(ctx *cli.Context) {
 	if len(args) != 1 {
 		fmt.Printf("Incorrect Usage.\n\n")
 		cli.ShowCommandHelp(ctx, "register")
+		return
 	}
 
 	var (

--- a/cli/cmd/host_test.go
+++ b/cli/cmd/host_test.go
@@ -377,3 +377,21 @@ func ExampleServicedCLI_CmdHostRemove_complete() {
 	// test-host-id-1
 	// test-host-id-3
 }
+
+func ExampleServicedCLI_CmdHostRegister_usage() {
+	InitHostAPITest("serviced", "host", "register")
+
+	// Output:
+	// Incorrect Usage.
+	//
+	// NAME:
+	//    register - Set the authentication keys to use for this host. When KEYSFILE is -, read from stdin.
+
+	// USAGE:
+	//    command register [command options] [arguments...]
+
+	// DESCRIPTION:
+	//    serviced host register KEYSFILE
+
+	// OPTIONS:
+}


### PR DESCRIPTION
A missing `return` in the code led to a correct printing of usage and then an incorrect panic when it went on to run the code anyway.

Demo:

```
[ian:~/metis/src/github.com/control-center/serviced] feature/CC-2686* 2m6s 2 ± ./serviced host register
Incorrect Usage.

NAME:
   register - Set the authentication keys to use for this host. When KEYSFILE is -, read from stdin.

USAGE:
   command register [command options] [arguments...]

DESCRIPTION:
   serviced host register KEYSFILE

OPTIONS:
   
```