### PR TITLE
Clean up tmpDir to avoid panic in unit tests

### DIFF
--- a/auth/localkeys_test.go
+++ b/auth/localkeys_test.go
@@ -26,6 +26,8 @@ import (
 func (s *TestAuthSuite) TestDumpLoadKeys(c *C) {
 	// We'll need a temp dir:
 	tmpDir := c.MkDir()
+	defer os.RemoveAll(tmpDir)
+
 	hostKeyFile := fmt.Sprintf("%s/host", tmpDir)
 	masterKeyFile := fmt.Sprintf("%s/master", tmpDir)
 
@@ -79,6 +81,8 @@ func (s *TestAuthSuite) TestCreateMasterKeys(c *C) {
 	auth.ClearKeys()
 	// We'll need a temp dir:
 	tmpDir := c.MkDir()
+	defer os.RemoveAll(tmpDir)
+
 	masterKeyFile := fmt.Sprintf("%s/.keys/master", tmpDir)
 	// hostKeyFile := fmt.Sprintf("%s/delegate", tmpDir)
 

--- a/auth/localkeys_test.go
+++ b/auth/localkeys_test.go
@@ -18,16 +18,19 @@ package auth_test
 import (
 	"fmt"
 	"os"
+	"math/rand"
+	"time"
 
 	"github.com/control-center/serviced/auth"
 	. "gopkg.in/check.v1"
 )
 
 func (s *TestAuthSuite) TestDumpLoadKeys(c *C) {
+	// seed rand for c.MkDir()
+	rand.Seed(time.Now().UnixNano())
 	// We'll need a temp dir:
 	tmpDir := c.MkDir()
 	defer os.RemoveAll(tmpDir)
-
 	hostKeyFile := fmt.Sprintf("%s/host", tmpDir)
 	masterKeyFile := fmt.Sprintf("%s/master", tmpDir)
 
@@ -79,10 +82,11 @@ func (s *TestAuthSuite) TestDumpLoadKeys(c *C) {
 
 func (s *TestAuthSuite) TestCreateMasterKeys(c *C) {
 	auth.ClearKeys()
+	// seed rand for c.MkDir()
+	rand.Seed(time.Now().UnixNano())
 	// We'll need a temp dir:
 	tmpDir := c.MkDir()
 	defer os.RemoveAll(tmpDir)
-
 	masterKeyFile := fmt.Sprintf("%s/.keys/master", tmpDir)
 	// hostKeyFile := fmt.Sprintf("%s/delegate", tmpDir)
 

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -17,6 +17,7 @@ package elasticsearch
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"strconv"
 	"strings"

--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -50,13 +50,18 @@ const (
 	HOSTID = "deadbeef"
 )
 
-var unused int
-var unusedStr string
-var id string
-var addresses []string
-var version datastore.VersionedEntity
+var (
+	unused    int
+	unusedStr string
+	id        string
+	addresses []string
+	version   datastore.VersionedEntity
+	err       error
 
-var err error
+	isvsPath    string
+	volumesDir  string
+	rsyncTmpDir string
+)
 
 // MockStorageDriver is an interface that mock the storage subsystem
 type MockStorageDriver struct {
@@ -104,14 +109,17 @@ type DaoTest struct {
 
 //SetUpSuite is run before the tests to ensure elastic, zookeeper etc. are running.
 func (dt *DaoTest) SetUpSuite(c *C) {
+	rand.Seed(time.Now().UnixNano())
+	isvsPath = c.MkDir()
+	volumesDir = c.MkDir()
 
 	config.LoadOptions(config.Options{
-		IsvcsPath: c.MkDir(),
+		IsvcsPath: isvsPath,
 	})
 
 	dt.Port = 9202
 	isvcs.Init(isvcs.DEFAULT_ES_STARTUP_TIMEOUT_SECONDS, "json-file", map[string]string{"max-file": "5", "max-size": "10m"}, nil)
-	isvcs.Mgr.SetVolumesDir(c.MkDir())
+	isvcs.Mgr.SetVolumesDir(volumesDir)
 	esServicedClusterName, _ := utils.NewUUID36()
 	if err := isvcs.Mgr.SetConfigurationOption("elasticsearch-serviced", "cluster", esServicedClusterName); err != nil {
 		c.Fatalf("Could not set elasticsearch-serviced clustername: %s", err)
@@ -140,8 +148,9 @@ func (dt *DaoTest) SetUpSuite(c *C) {
 		c.Fatalf("could not get zk connection %v", err)
 	}
 
-	tmpdir := c.MkDir()
-	err = volume.InitDriver(volume.DriverTypeRsync, tmpdir, []string{})
+	rsyncTmpDir := c.MkDir()
+
+	err = volume.InitDriver(volume.DriverTypeRsync, rsyncTmpDir, []string{})
 	c.Assert(err, IsNil)
 
 	dt.Dao, err = NewControlSvc("localhost", int(dt.Port), dt.Facade, "", 4979)
@@ -179,6 +188,11 @@ func (dt *DaoTest) SetUpTest(c *C) {
 func (dt *DaoTest) TearDownSuite(c *C) {
 	isvcs.Mgr.Stop()
 	dt.FacadeIntegrationTest.TearDownSuite(c)
+
+	// Clean up the c.MkDir() folders
+	os.RemoveAll(isvsPath)
+	os.RemoveAll(volumesDir)
+	os.RemoveAll(rsyncTmpDir)
 }
 
 func (dt *DaoTest) TestDao_ValidateEndpoints(t *C) {

--- a/datastore/elastic/testutils.go
+++ b/datastore/elastic/testutils.go
@@ -33,6 +33,10 @@ const (
 	esVersion = "0.90.13"
 )
 
+var (
+	tmpDir string
+)
+
 // ElasticTest for running tests that need elasticsearch. Type is to be used a a gocheck Suite. When writing a test,
 // embed ElasticTest to create a test suite that will automatically start and stop elasticsearch. See gocheck
 // documentation for more infomration about writing gocheck tests.
@@ -77,9 +81,9 @@ func (et *ElasticTest) SetUpSuite(c *gocheck.C) {
 		log.Printf("ElasticTest SetUpSuite: starting new cluster.\n")
 
 		//Seeding because mkdir uses rand and it was returning the same directory
-		rand.Seed(time.Now().Unix())
+		rand.Seed(time.Now().UnixNano())
 		//Create unique tmp dir that will be deleted when suite ends.
-		tmpDir := c.MkDir()
+		tmpDir = c.MkDir()
 		//download elastic jar if needed
 		elasticDir := ensureElasticJar(tmpDir)
 		//start elastic
@@ -119,6 +123,8 @@ func (et *ElasticTest) TearDownSuite(c *gocheck.C) {
 	log.Print("ElasticTest TearDownSuite called")
 
 	et.stop()
+
+	os.RemoveAll(tmpDir)
 }
 
 func (et *ElasticTest) SetUpTest(c *gocheck.C) {

--- a/dfs/backup_integration_test.go
+++ b/dfs/backup_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"os/exec"
 	"time"

--- a/dfs/backup_integration_test.go
+++ b/dfs/backup_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"time"
 
@@ -50,7 +51,10 @@ var i int
 func (s *DFSTestSuite) BenchmarkBackup(c *C) {
 	//1012318498
 	// Create a file to play with
+	rand.Seed(time.Now().UnixNano())
 	dir := c.MkDir()
+	defer os.RemoveAll(dir)
+
 	i += 1
 	c.Logf("Creating 100M file of random data: %d", i)
 	random := fmt.Sprintf("%s/rand.file", dir)

--- a/isvcs/testutils.go
+++ b/isvcs/testutils.go
@@ -37,12 +37,17 @@ type IServiceTest interface {
 type ManagerTestSuite struct {
 	manager      *Manager
 	testservices []IServiceTest
+	isvcsPath    string
 }
 
 func (t *ManagerTestSuite) SetUpSuite(c *C) {
+	// seed rand for c.MkDir()
+	rand.Seed(time.Now().UnixNano())
+	t.isvcsPath = c.MkDir()
+
 	docker.StartKernel()
 	config.LoadOptions(config.Options{
-		IsvcsPath: c.MkDir(),
+		IsvcsPath: t.isvcsPath,
 	})
 	t.manager = NewManager(utils.LocalDir("images"), "/tmp/serviced-test", defaultTestDockerLogDriver, defaultTestDockerLogOptions)
 	for _, testservice := range t.testservices {
@@ -71,6 +76,7 @@ func (t *ManagerTestSuite) TearDownSuite(c *C) {
 		testservice.Destroy(c)
 	}
 	t.manager.Stop()
+	os.RemoveAll(t.isvcsPath)
 }
 
 func (t *ManagerTestSuite) AddTestService(svc IServiceTest) {

--- a/isvcs/testutils.go
+++ b/isvcs/testutils.go
@@ -16,6 +16,10 @@
 package isvcs
 
 import (
+	"os"
+	"math/rand"
+	"time"
+	
 	"github.com/control-center/serviced/commons/docker"
 	"github.com/control-center/serviced/config"
 	"github.com/control-center/serviced/utils"

--- a/volume/detect_test.go
+++ b/volume/detect_test.go
@@ -31,12 +31,18 @@ var (
 	_ = Suite(&AutodetectSuite{})
 )
 
+func (s *AutodetectSuite) SetUpSuite(c *C) {
+	// seed rand for c.MkDir()
+	rand.Seed(time.Now().UnixNano())
+}
+
 func (s *AutodetectSuite) SetUpTest(c *C) {
 	s.dir = c.MkDir()
 }
 
 func (s *AutodetectSuite) TearDownTest(c *C) {
 	ShutdownAll()
+	os.RemoveAll(s.dir)
 }
 
 func (s *AutodetectSuite) TestPreexistingBtrfs(c *C) {
@@ -68,6 +74,7 @@ func (s *AutodetectSuite) TestPreexistingBtrfs(c *C) {
 
 func (s *AutodetectSuite) TestPreexistingDeviceMapper(c *C) {
 	root := c.MkDir()
+	defer os.RemoveAll(root)
 
 	// Initialize the driver and create a btrfs volume
 	err := InitDriver(DriverTypeDeviceMapper, root, []string{})
@@ -94,6 +101,7 @@ func (s *AutodetectSuite) TestPreexistingDeviceMapper(c *C) {
 
 func (s *AutodetectSuite) TestPreexistingRsync(c *C) {
 	root := c.MkDir()
+	defer os.RemoveAll(root)
 
 	// Initialize the driver and create a btrfs volume
 	err := InitDriver(DriverTypeRsync, root, []string{})

--- a/volume/devicemapper/devicemapper_test.go
+++ b/volume/devicemapper/devicemapper_test.go
@@ -131,10 +131,17 @@ func (s *DeviceMapperSuite) TestDeviceMapperExcludeDirs(c *C) {
 
 	basesize1, err := units.RAMInBytes("10M")
 
-	exportdrv, err := Init(c.MkDir(), []string{fmt.Sprintf("dm.basesize=%d", basesize1)})
+	// seed rand for c.MkDir
+	rand.Seed(time.Now().UnixNano())
+
+	exportTmp := c.MkDir()
+	defer os.RemoveAll(exportTmp)
+	exportdrv, err := Init(exportTmp, []string{fmt.Sprintf("dm.basesize=%d", basesize1)})
 	c.Assert(err, IsNil)
 	defer exportdrv.Cleanup()
 
+	importTmp := c.MkDir()
+	defer os.RemoveAll(importTmp)
 	importdrv, err := Init(c.MkDir(), []string{fmt.Sprintf("dm.basesize=%d", basesize1)})
 	c.Assert(err, IsNil)
 	defer importdrv.Cleanup()
@@ -184,8 +191,12 @@ func (s *DeviceMapperSuite) TestDeviceMapperExcludeDirs(c *C) {
 }
 
 func (s *DeviceMapperSuite) TestDeviceMapperImportBasesize(c *C) {
+	// seed rand for c.MkDir()
+	rand.Seed(time.Now().UnixNano())
+
 	// Set up export volume with larger volume base size
 	root1 := c.MkDir()
+	defer os.RemoveAll(root1)
 	basesize1, err := units.RAMInBytes("15M")
 	c.Assert(err, IsNil)
 	drv1, err := Init(root1, []string{fmt.Sprintf("dm.basesize=%d", basesize1)})
@@ -212,6 +223,7 @@ func (s *DeviceMapperSuite) TestDeviceMapperImportBasesize(c *C) {
 
 	// Set up import volume with smaller volume base size
 	root2 := c.MkDir()
+	defer os.RemoveAll(root2)
 	basesize2, err := units.RAMInBytes("10M")
 	c.Assert(err, IsNil)
 	drv2, err := Init(root2, []string{fmt.Sprintf("dm.basesize=%d", basesize2)})

--- a/volume/drivertest/drivertest.go
+++ b/volume/drivertest/drivertest.go
@@ -44,6 +44,7 @@ type Driver struct {
 func newDriver(c *C, name volume.DriverType, root string, args []string) *Driver {
 	var err error
 	if root == "" {
+		rand.Seed(time.Now().UnixNano())
 		root = c.MkDir()
 	}
 	if err := volume.InitDriver(name, root, args); err != nil {

--- a/volume/nfs/nfs_test.go
+++ b/volume/nfs/nfs_test.go
@@ -41,7 +41,11 @@ func (s *NFSSuite) TestNFSDriver(c *C) {
 		driver *NFSDriver
 	)
 
+	// seed rand for c.MkDir()
+	rand.Seed(time.Now().UnixNano())
 	root = c.MkDir()
+	defer os.RemoveAll(root)
+
 	d, err := Init(root, []string{NetworkDisabled})
 	c.Assert(err, IsNil)
 	driver = d.(*NFSDriver)

--- a/volume/nfs/nfs_test.go
+++ b/volume/nfs/nfs_test.go
@@ -17,9 +17,11 @@ package nfs_test
 
 import (
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/control-center/serviced/volume"
 	. "github.com/control-center/serviced/volume/nfs"

--- a/volume/util_test.go
+++ b/volume/util_test.go
@@ -55,6 +55,7 @@ func (s *UtilsSuite) TestIsDir(c *C) {
 
 func (s *UtilsSuite) TestFileInfoSlice(c *C) {
 	root := c.MkDir()
+	defer os.RemoveAll(root)
 
 	var (
 		slice    FileInfoSlice

--- a/volume/util_test.go
+++ b/volume/util_test.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -33,7 +34,9 @@ type UtilsSuite struct{}
 var _ = Suite(&UtilsSuite{})
 
 func (s *UtilsSuite) TestIsDir(c *C) {
+	rand.Seed(time.Now().UnixNano())
 	root := c.MkDir()
+	defer os.RemoveAll(root)
 
 	// Test a directory
 	ok, err := IsDir(root)
@@ -54,6 +57,7 @@ func (s *UtilsSuite) TestIsDir(c *C) {
 }
 
 func (s *UtilsSuite) TestFileInfoSlice(c *C) {
+	rand.Seed(time.Now().UnixNano())
 	root := c.MkDir()
 	defer os.RemoveAll(root)
 

--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -16,8 +16,11 @@
 package volume_test
 
 import (
+	"math/rand"
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/control-center/serviced/volume"
 	"github.com/control-center/serviced/volume/mocks"

--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -46,6 +46,7 @@ func (s *DriverSuite) MockInit(rootDir string, _ []string) (Driver, error) {
 }
 
 func (s *DriverSuite) SetUpTest(c *C) {
+	rand.Seed(time.Now().UnixNano())
 	s.dir = c.MkDir()
 	s.drv = &mocks.Driver{}
 	s.vol = &mocks.Volume{}
@@ -55,6 +56,7 @@ func (s *DriverSuite) SetUpTest(c *C) {
 func (s *DriverSuite) TearDownTest(c *C) {
 	s.drv.On("DriverType").Return(drvName)
 	Unregister(drvName)
+	os.RemoveAll(s.dir)
 }
 
 func (s *DriverSuite) TestNilRegistration(c *C) {


### PR DESCRIPTION
Failing unit tests.  It looks like the tmpDir from c.MkDir() is the same, but not cleaned up between calls.

See: http://jenkins.zendev.org/job/ControlCenter/job/develop/job/serviced-develop-pullrequests-unit/1853/console
 
Panic: Couldn't create temporary directory: mkdir /tmp/check-3784560248718450071: file exists