### PR TITLE
Add function which resets host private key to facade

### DIFF
--- a/domain/hostkey/mocks/Store.go
+++ b/domain/hostkey/mocks/Store.go
@@ -1,0 +1,56 @@
+package mocks
+
+import "github.com/control-center/serviced/domain/hostkey"
+import "github.com/stretchr/testify/mock"
+
+import "github.com/control-center/serviced/datastore"
+
+type Store struct {
+	mock.Mock
+}
+
+func (_m *Store) Get(ctx datastore.Context, id string) (*hostkey.HostKey, error) {
+	ret := _m.Called(ctx, id)
+
+	var r0 *hostkey.HostKey
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) *hostkey.HostKey); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*hostkey.HostKey)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) Put(ctx datastore.Context, id string, val *hostkey.HostKey) error {
+	ret := _m.Called(ctx, id, val)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, *hostkey.HostKey) error); ok {
+		r0 = rf(ctx, id, val)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Store) Delete(ctx datastore.Context, id string) error {
+	ret := _m.Called(ctx, id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -79,6 +79,8 @@ func (f *Facade) SetDFS(dfs dfs.DFS) { f.dfs = dfs }
 
 func (f *Facade) SetHostStore(store host.Store) { f.hostStore = store }
 
+func (f *Facade) SetHostkeyStore(store hostkey.Store) { f.hostkeyStore = store }
+
 func (f *Facade) SetRegistryStore(store registry.ImageRegistryStore) { f.registryStore = store }
 
 func (f *Facade) SetPoolStore(store pool.Store) { f.poolStore = store }

--- a/facade/facade_unit_test.go
+++ b/facade/facade_unit_test.go
@@ -18,9 +18,11 @@ package facade_test
 import (
 	"time"
 
+	"github.com/control-center/serviced/auth"
 	datastoremocks "github.com/control-center/serviced/datastore/mocks"
 	dfsmocks "github.com/control-center/serviced/dfs/mocks"
 	hostmocks "github.com/control-center/serviced/domain/host/mocks"
+	keymocks "github.com/control-center/serviced/domain/hostkey/mocks"
 	poolmocks "github.com/control-center/serviced/domain/pool/mocks"
 	registrymocks "github.com/control-center/serviced/domain/registry/mocks"
 	servicemocks "github.com/control-center/serviced/domain/service/mocks"
@@ -41,6 +43,7 @@ type FacadeUnitTest struct {
 	dfs           *dfsmocks.DFS
 	hostStore     *hostmocks.Store
 	poolStore     *poolmocks.Store
+	hostkeyStore  *keymocks.Store
 	registryStore *registrymocks.ImageRegistryStore
 	serviceStore  *servicemocks.Store
 	configStore   *configmocks.Store
@@ -50,6 +53,10 @@ type FacadeUnitTest struct {
 
 func (ft *FacadeUnitTest) SetUpSuite(c *C) {
 	ft.Facade = facade.New()
+
+	// Create a master key pair
+	pub, priv, _ := auth.GenerateRSAKeyPairPEM(nil)
+	auth.LoadMasterKeysFromPEM(pub, priv)
 }
 
 func (ft *FacadeUnitTest) SetUpTest(c *C) {
@@ -60,6 +67,9 @@ func (ft *FacadeUnitTest) SetUpTest(c *C) {
 
 	ft.hostStore = &hostmocks.Store{}
 	ft.Facade.SetHostStore(ft.hostStore)
+
+	ft.hostkeyStore = &keymocks.Store{}
+	ft.Facade.SetHostkeyStore(ft.hostkeyStore)
 
 	ft.poolStore = &poolmocks.Store{}
 	ft.Facade.SetPoolStore(ft.poolStore)

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -79,6 +79,8 @@ type FacadeInterface interface {
 
 	GetHostKey(ctx datastore.Context, hostID string) ([]byte, error)
 
+	ResetHostKey(ctx datastore.Context, hostID string) ([]byte, error)
+
 	GetActiveHostIDs(ctx datastore.Context) ([]string, error)
 
 	UpdateHost(ctx datastore.Context, entity *host.Host) error

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -422,6 +422,27 @@ func (_m *FacadeInterface) GetHostKey(ctx datastore.Context, hostID string) ([]b
 
 	return r0, r1
 }
+func (_m *FacadeInterface) ResetHostKey(ctx datastore.Context, hostID string) ([]byte, error) {
+	ret := _m.Called(ctx, hostID)
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) []byte); ok {
+		r0 = rf(ctx, hostID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, hostID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
 func (_m *FacadeInterface) GetActiveHostIDs(ctx datastore.Context) ([]string, error) {
 	ret := _m.Called(ctx)
 


### PR DESCRIPTION
* Added ResetHostKey
* Refactored code for generating host keys from AddHost into routine shared with ResetHostKey
* Added relevant unit tests

Contributes to [CC-2623](https://jira.zenoss.com/browse/CC-2623)