### PR TITLE
Feature/CC-2378

### DIFF
--- a/volume/devicemapper/stats.go
+++ b/volume/devicemapper/stats.go
@@ -210,24 +210,24 @@ func getDeviceSize(dev string) (uint64, error) {
 
 // dfStats contains stats reported by df
 type dfStats struct {
-	BlockSize uint64
-	FilesystemPath string
-	BlocksTotal uint64
-	BlocksUsed uint64
+	BlockSize       uint64
+	FilesystemPath  string
+	BlocksTotal     uint64
+	BlocksUsed      uint64
 	BlocksAvailable uint64
-	MountPoint string
+	MountPoint      string
 }
 
-// filesystemNotMountedErr is the error raised when a filesystem is not mounted
-var filesystemNotMountedErr = errors.New("Filesystem not mounted.")
+// errFilesystemNotMounted is the error raised when a filesystem is not mounted
+var errFilesystemNotMounted = errors.New("Filesystem not mounted.")
 
 // getFilesystemStats calls df to see if the filesystem is mounted and
 // gets the parsed info for it if it is.
 // If it is not mounted, it calls getUnmountedFilesystemStats for the info.
 func getFilesystemStats(dev string) (uint64, uint64, error) {
 	totalBlocks, freeBlocks, err := getMountedFilesystemStats(dev)
-	// Catch the filesystemNotMountedErr and try getUnmountedFilesystemStats
-	if err == filesystemNotMountedErr {
+	// Catch the errFilesystemNotMounted and try getUnmountedFilesystemStats
+	if err == errFilesystemNotMounted {
 		totalBlocks, freeBlocks, err = getUnmountedFilesystemStats(dev)
 		if err != nil {
 			return 0, 0, err
@@ -267,7 +267,7 @@ func getMountedFilesystemStats(dev string) (uint64, uint64, error) {
 		}
 	}
 	if !mounted {
-		return 0, 0, filesystemNotMountedErr
+		return 0, 0, errFilesystemNotMounted
 	}
 
 	return totalBlocks, freeBlocks, err
@@ -300,7 +300,7 @@ func parseDfOutput(r io.Reader) ([]*dfStats, error) {
 			b, err = strconv.ParseUint(strings.TrimSuffix(blockStr, "T"), 10, 64)
 			bytes = b * base * base * base * base
 		} else {
-			bytes, err =  strconv.ParseUint(blockStr, 10, 64)
+			bytes, err = strconv.ParseUint(blockStr, 10, 64)
 		}
 
 		return bytes, err
@@ -335,12 +335,12 @@ func parseDfOutput(r io.Reader) ([]*dfStats, error) {
 			}
 			mountPoint := f[5]
 			statsSlice = append(statsSlice, &dfStats{
-				BlockSize: blockSize,
-				FilesystemPath: filesystemPath,
-				BlocksTotal: totalBlocks,
-				BlocksUsed: usedBlocks,
+				BlockSize:       blockSize,
+				FilesystemPath:  filesystemPath,
+				BlocksTotal:     totalBlocks,
+				BlocksUsed:      usedBlocks,
 				BlocksAvailable: availableBlocks,
-				MountPoint: mountPoint,
+				MountPoint:      mountPoint,
 			})
 		}
 	}
@@ -410,14 +410,14 @@ func parseDumpe2fsOutput(r io.Reader) (*filesystemStats, error) {
 		return 0, nil, nil
 	}
 
-	malformedRangeErr := errors.New("Malformed range.  Expected form: \"x-y\"")
+	errMalformedRange := errors.New("Malformed range.  Expected form: \"x-y\"")
 
 	// Gets the inclusive difference of a range
 	// e.g. rangeDiffIncl("1-15") == 15
 	rangeDiffIncl := func(rangeStr string) (uint64, error) {
 		splitRange := strings.Split(rangeStr, "-")
 		if len(splitRange) != 2 {
-			return 0, malformedRangeErr
+			return 0, errMalformedRange
 		}
 		uLeft, err := strconv.ParseUint(splitRange[0], 10, 64)
 		if err != nil {

--- a/volume/devicemapper/stats_test.go
+++ b/volume/devicemapper/stats_test.go
@@ -16,9 +16,9 @@
 package devicemapper
 
 import (
-  "os"
-  "testing"
 	. "gopkg.in/check.v1"
+	"os"
+	"testing"
 )
 
 func TestStats(t *testing.T) { TestingT(t) }
@@ -39,26 +39,26 @@ func (s *StatsSuite) TestParseDumpe2fsOutput(c *C) {
 		panic(err)
 	}
 
-  // Compare to hand picked values
+	// Compare to hand picked values
 	c.Check(fs, DeepEquals, &filesystemStats{
-		BlocksTotal: 26214400,
+		BlocksTotal:     26214400,
 		BlockSize:       4096,
 		FreeBlocks:      25755051,
-		UnusableBlocks: 444088,
-		Superblocks: 15,
-		GroupsTotal: 800,
-		JournalLength: 32768,
-		SuperblockSize: 1,
-		GroupDescSize: 7,
-		BitmapSize: 1,
+		UnusableBlocks:  444088,
+		Superblocks:     15,
+		GroupsTotal:     800,
+		JournalLength:   32768,
+		SuperblockSize:  1,
+		GroupDescSize:   7,
+		BitmapSize:      1,
 		InodeBitmapSize: 1,
-		InodeTableSize: 512,
+		InodeTableSize:  512,
 	})
 }
 
 // TestParseDfOutput tests that sample df output parses correctly
 func (s *StatsSuite) TestParseDfOutput(c *C) {
-  r, err := os.Open("testdata/df.out.data")
+	r, err := os.Open("testdata/df.out.data")
 	if err != nil {
 		panic(err)
 	}
@@ -68,15 +68,15 @@ func (s *StatsSuite) TestParseDfOutput(c *C) {
 		panic(err)
 	}
 
-  // Our test data only has 1 element, compare to hand picked values
+	// Our test data only has 1 element, compare to hand picked values
 	c.Check(dfSlice[0], DeepEquals, &dfStats{
-    BlockSize: 1024,
-    FilesystemPath: "/dev/mapper/docker-8:1-12852375-1VbuL3AP0QC0ETsvpys9su",
-    BlocksTotal: 103081248,
-    BlocksUsed: 537608,
-    BlocksAvailable: 97284376,
-    MountPoint: "/exports/serviced_volumes_v2/e0fqzrnmnwgiytbznlqi0fy08",
-  })
+		BlockSize:       1024,
+		FilesystemPath:  "/dev/mapper/docker-8:1-12852375-1VbuL3AP0QC0ETsvpys9su",
+		BlocksTotal:     103081248,
+		BlocksUsed:      537608,
+		BlocksAvailable: 97284376,
+		MountPoint:      "/exports/serviced_volumes_v2/e0fqzrnmnwgiytbznlqi0fy08",
+	})
 }
 
 // TestConsistantStats tests that parseDumpe2fsOutput and parseDfOutput

--- a/volume/devicemapper/stats_test.go
+++ b/volume/devicemapper/stats_test.go
@@ -1,0 +1,106 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package devicemapper
+
+import (
+  "os"
+  "testing"
+	. "gopkg.in/check.v1"
+)
+
+func TestStats(t *testing.T) { TestingT(t) }
+
+type StatsSuite struct{}
+
+var _ = Suite(&StatsSuite{})
+
+// TestParseDumpe2fsOutput tests that sample dumpe2fs output parses correctly
+func (s *StatsSuite) TestParseDumpe2fsOutput(c *C) {
+	r, err := os.Open("testdata/dumpe2fs.out.data")
+	if err != nil {
+		panic(err)
+	}
+	defer r.Close()
+	fs, err := parseDumpe2fsOutput(r)
+	if err != nil {
+		panic(err)
+	}
+
+  // Compare to hand picked values
+	c.Check(fs, DeepEquals, &filesystemStats{
+		BlocksTotal: 26214400,
+		BlockSize:       4096,
+		FreeBlocks:      25755051,
+		UnusableBlocks: 444088,
+		Superblocks: 15,
+		GroupsTotal: 800,
+		JournalLength: 32768,
+		SuperblockSize: 1,
+		GroupDescSize: 7,
+		BitmapSize: 1,
+		InodeBitmapSize: 1,
+		InodeTableSize: 512,
+	})
+}
+
+// TestParseDfOutput tests that sample df output parses correctly
+func (s *StatsSuite) TestParseDfOutput(c *C) {
+  r, err := os.Open("testdata/df.out.data")
+	if err != nil {
+		panic(err)
+	}
+	defer r.Close()
+	dfSlice, err := parseDfOutput(r)
+	if err != nil {
+		panic(err)
+	}
+
+  // Our test data only has 1 element, compare to hand picked values
+	c.Check(dfSlice[0], DeepEquals, &dfStats{
+    BlockSize: 1024,
+    FilesystemPath: "/dev/mapper/docker-8:1-12852375-1VbuL3AP0QC0ETsvpys9su",
+    BlocksTotal: 103081248,
+    BlocksUsed: 537608,
+    BlocksAvailable: 97284376,
+    MountPoint: "/exports/serviced_volumes_v2/e0fqzrnmnwgiytbznlqi0fy08",
+  })
+}
+
+// TestConsistantStats tests that parseDumpe2fsOutput and parseDfOutput
+// give us the same usable fs size
+func (s *StatsSuite) TestConsistantStats(c *C) {
+	rDe, err := os.Open("testdata/dumpe2fs.out.data")
+	if err != nil {
+		panic(err)
+	}
+	defer rDe.Close()
+	rDf, err := os.Open("testdata/df.out.data")
+	if err != nil {
+		panic(err)
+	}
+	defer rDf.Close()
+	fs, err := parseDumpe2fsOutput(rDe)
+	if err != nil {
+		panic(err)
+	}
+	dfSlice, err := parseDfOutput(rDf)
+	if err != nil {
+		panic(err)
+	}
+	sizeDe := (fs.BlocksTotal - fs.UnusableBlocks) * fs.BlockSize
+	sizeDf := dfSlice[0].BlocksTotal * dfSlice[0].BlockSize
+	c.Check(sizeDe, DeepEquals, sizeDf)
+}

--- a/volume/devicemapper/testdata/df.out.data
+++ b/volume/devicemapper/testdata/df.out.data
@@ -1,0 +1,2 @@
+Filesystem                                             1K-blocks   Used Available Use% Mounted on
+/dev/mapper/docker-8:1-12852375-1VbuL3AP0QC0ETsvpys9su 103081248 537608  97284376   1% /exports/serviced_volumes_v2/e0fqzrnmnwgiytbznlqi0fy08

--- a/volume/devicemapper/testdata/dumpe2fs.out.data
+++ b/volume/devicemapper/testdata/dumpe2fs.out.data
@@ -1,0 +1,5682 @@
+Filesystem volume name:   <none>
+Last mounted on:          /mnt/dfs
+Filesystem UUID:          a6df7be4-43e7-497f-87a0-38c87dfcafea
+Filesystem magic number:  0xEF53
+Filesystem revision #:    1 (dynamic)
+Filesystem features:      has_journal ext_attr resize_inode dir_index filetype needs_recovery extent flex_bg sparse_super large_file huge_file uninit_bg dir_nlink extra_isize
+Filesystem flags:         signed_directory_hash 
+Default mount options:    user_xattr acl
+Filesystem state:         clean
+Errors behavior:          Continue
+Filesystem OS type:       Linux
+Inode count:              6553600
+Block count:              26214400
+Reserved block count:     1310720
+Free blocks:              25755051
+Free inodes:              6553589
+First block:              0
+Block size:               4096
+Fragment size:            4096
+Reserved GDT blocks:      1017
+Blocks per group:         32768
+Fragments per group:      32768
+Inodes per group:         8192
+Inode blocks per group:   512
+RAID stride:              16
+RAID stripe width:        16
+Flex block group size:    16
+Filesystem created:       Fri Oct  7 12:03:15 2016
+Last mount time:          Fri Oct  7 12:04:22 2016
+Last write time:          Fri Oct  7 12:04:22 2016
+Mount count:              1
+Maximum mount count:      -1
+Last checked:             Fri Oct  7 12:03:15 2016
+Check interval:           0 (<none>)
+Lifetime writes:          1732 MB
+Reserved blocks uid:      0 (user root)
+Reserved blocks gid:      0 (group root)
+First inode:              11
+Inode size:	          256
+Required extra isize:     28
+Desired extra isize:      28
+Journal inode:            8
+Default directory hash:   half_md4
+Directory Hash Seed:      bb125a97-eefb-4b1b-8b07-fb7e5f758213
+Journal backup:           inode blocks
+Journal features:         journal_incompat_revoke
+Journal size:             128M
+Journal length:           32768
+Journal sequence:         0x00000cfe
+Journal start:            16414
+
+
+Group 0: (Blocks 0-32767) [ITABLE_ZEROED]
+  Checksum 0xf051, unused inodes 8168
+  Primary superblock at 0, Group descriptors at 1-7
+  Reserved GDT blocks at 8-1024
+  Block bitmap at 1025 (+1025), Inode bitmap at 1041 (+1041)
+  Inode table at 1057-1568 (+1057)
+  23513 free blocks, 8168 free inodes, 2 directories, 8168 unused inodes
+  Free blocks: 9255-32767
+  Free inodes: 25-8192
+Group 1: (Blocks 32768-65535) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x90ea, unused inodes 8192
+  Backup superblock at 32768, Group descriptors at 32769-32775
+  Reserved GDT blocks at 32776-33792
+  Block bitmap at 1026 (bg #0 + 1026), Inode bitmap at 1042 (bg #0 + 1042)
+  Inode table at 1569-2080 (bg #0 + 1569)
+  1023 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 33793-33807, 46096-47103
+  Free inodes: 8193-16384
+Group 2: (Blocks 65536-98303) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb20c, unused inodes 8192
+  Block bitmap at 1027 (bg #0 + 1027), Inode bitmap at 1043 (bg #0 + 1043)
+  Inode table at 2081-2592 (bg #0 + 2081)
+  0 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 
+  Free inodes: 16385-24576
+Group 3: (Blocks 98304-131071) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe634, unused inodes 8192
+  Backup superblock at 98304, Group descriptors at 98305-98311
+  Reserved GDT blocks at 98312-99328
+  Block bitmap at 1028 (bg #0 + 1028), Inode bitmap at 1044 (bg #0 + 1044)
+  Inode table at 2593-3104 (bg #0 + 2593)
+  1023 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 99329-100351
+  Free inodes: 24577-32768
+Group 4: (Blocks 131072-163839) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfe01, unused inodes 8192
+  Block bitmap at 1029 (bg #0 + 1029), Inode bitmap at 1045 (bg #0 + 1045)
+  Inode table at 3105-3616 (bg #0 + 3105)
+  12110 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 151564-151567, 151576-151583, 151592-151599, 151608-151615, 151624-151631, 151640-151647, 151656-151663, 151672-151679, 151700-151807, 151898-163839
+  Free inodes: 32769-40960
+Group 5: (Blocks 163840-196607) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4ddb, unused inodes 8192
+  Backup superblock at 163840, Group descriptors at 163841-163847
+  Reserved GDT blocks at 163848-164864
+  Block bitmap at 1030 (bg #0 + 1030), Inode bitmap at 1046 (bg #0 + 1046)
+  Inode table at 3617-4128 (bg #0 + 3617)
+  31743 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 164865-196607
+  Free inodes: 40961-49152
+Group 6: (Blocks 196608-229375) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0fec, unused inodes 8192
+  Block bitmap at 1031 (bg #0 + 1031), Inode bitmap at 1047 (bg #0 + 1047)
+  Inode table at 4129-4640 (bg #0 + 4129)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 196608-229375
+  Free inodes: 49153-57344
+Group 7: (Blocks 229376-262143) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd5d3, unused inodes 8192
+  Backup superblock at 229376, Group descriptors at 229377-229383
+  Reserved GDT blocks at 229384-230400
+  Block bitmap at 1032 (bg #0 + 1032), Inode bitmap at 1048 (bg #0 + 1048)
+  Inode table at 4641-5152 (bg #0 + 4641)
+  31743 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 230401-262143
+  Free inodes: 57345-65536
+Group 8: (Blocks 262144-294911) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd27c, unused inodes 8192
+  Block bitmap at 1033 (bg #0 + 1033), Inode bitmap at 1049 (bg #0 + 1049)
+  Inode table at 5153-5664 (bg #0 + 5153)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 262144-294911
+  Free inodes: 65537-73728
+Group 9: (Blocks 294912-327679) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4865, unused inodes 8192
+  Backup superblock at 294912, Group descriptors at 294913-294919
+  Reserved GDT blocks at 294920-295936
+  Block bitmap at 1034 (bg #0 + 1034), Inode bitmap at 1050 (bg #0 + 1050)
+  Inode table at 5665-6176 (bg #0 + 5665)
+  31743 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 295937-327679
+  Free inodes: 73729-81920
+Group 10: (Blocks 327680-360447) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9b40, unused inodes 8192
+  Block bitmap at 1035 (bg #0 + 1035), Inode bitmap at 1051 (bg #0 + 1051)
+  Inode table at 6177-6688 (bg #0 + 6177)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 327680-360447
+  Free inodes: 81921-90112
+Group 11: (Blocks 360448-393215) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1b88, unused inodes 8192
+  Block bitmap at 1036 (bg #0 + 1036), Inode bitmap at 1052 (bg #0 + 1052)
+  Inode table at 6689-7200 (bg #0 + 6689)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 360448-393215
+  Free inodes: 90113-98304
+Group 12: (Blocks 393216-425983) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd116, unused inodes 8192
+  Block bitmap at 1037 (bg #0 + 1037), Inode bitmap at 1053 (bg #0 + 1053)
+  Inode table at 7201-7712 (bg #0 + 7201)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 393216-425983
+  Free inodes: 98305-106496
+Group 13: (Blocks 425984-458751) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6e3c, unused inodes 8192
+  Block bitmap at 1038 (bg #0 + 1038), Inode bitmap at 1054 (bg #0 + 1054)
+  Inode table at 7713-8224 (bg #0 + 7713)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 425984-458751
+  Free inodes: 106497-114688
+Group 14: (Blocks 458752-491519) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6b1f, unused inodes 8192
+  Block bitmap at 1039 (bg #0 + 1039), Inode bitmap at 1055 (bg #0 + 1055)
+  Inode table at 8225-8736 (bg #0 + 8225)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 458752-491519
+  Free inodes: 114689-122880
+Group 15: (Blocks 491520-524287) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd4b0, unused inodes 8192
+  Block bitmap at 1040 (bg #0 + 1040), Inode bitmap at 1056 (bg #0 + 1056)
+  Inode table at 8737-9248 (bg #0 + 8737)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 491520-524287
+  Free inodes: 122881-131072
+Group 16: (Blocks 524288-557055) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5921, unused inodes 8192
+  Block bitmap at 524288 (+0), Inode bitmap at 524304 (+16)
+  Inode table at 524320-524831 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 532512-557055
+  Free inodes: 131073-139264
+Group 17: (Blocks 557056-589823) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc25c, unused inodes 8192
+  Block bitmap at 524289 (bg #16 + 1), Inode bitmap at 524305 (bg #16 + 17)
+  Inode table at 524832-525343 (bg #16 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 557056-589823
+  Free inodes: 139265-147456
+Group 18: (Blocks 589824-622591) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6332, unused inodes 8192
+  Block bitmap at 524290 (bg #16 + 2), Inode bitmap at 524306 (bg #16 + 18)
+  Inode table at 525344-525855 (bg #16 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 589824-622591
+  Free inodes: 147457-155648
+Group 19: (Blocks 622592-655359) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc3e9, unused inodes 8192
+  Block bitmap at 524291 (bg #16 + 3), Inode bitmap at 524307 (bg #16 + 19)
+  Inode table at 525856-526367 (bg #16 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 622592-655359
+  Free inodes: 155649-163840
+Group 20: (Blocks 655360-688127) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x61ed, unused inodes 8192
+  Block bitmap at 524292 (bg #16 + 4), Inode bitmap at 524308 (bg #16 + 20)
+  Inode table at 526368-526879 (bg #16 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 655360-688127
+  Free inodes: 163841-172032
+Group 21: (Blocks 688128-720895) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc136, unused inodes 8192
+  Block bitmap at 524293 (bg #16 + 5), Inode bitmap at 524309 (bg #16 + 21)
+  Inode table at 526880-527391 (bg #16 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 688128-720895
+  Free inodes: 172033-180224
+Group 22: (Blocks 720896-753663) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6058, unused inodes 8192
+  Block bitmap at 524294 (bg #16 + 6), Inode bitmap at 524310 (bg #16 + 22)
+  Inode table at 527392-527903 (bg #16 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 720896-753663
+  Free inodes: 180225-188416
+Group 23: (Blocks 753664-786431) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc083, unused inodes 8192
+  Block bitmap at 524295 (bg #16 + 7), Inode bitmap at 524311 (bg #16 + 23)
+  Inode table at 527904-528415 (bg #16 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 753664-786431
+  Free inodes: 188417-196608
+Group 24: (Blocks 786432-819199) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6453, unused inodes 8192
+  Block bitmap at 524296 (bg #16 + 8), Inode bitmap at 524312 (bg #16 + 24)
+  Inode table at 528416-528927 (bg #16 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 786432-819199
+  Free inodes: 196609-204800
+Group 25: (Blocks 819200-851967) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe1bb, unused inodes 8192
+  Backup superblock at 819200, Group descriptors at 819201-819207
+  Reserved GDT blocks at 819208-820224
+  Block bitmap at 524297 (bg #16 + 9), Inode bitmap at 524313 (bg #16 + 25)
+  Inode table at 528928-529439 (bg #16 + 4640)
+  31743 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 820225-851967
+  Free inodes: 204801-212992
+Group 26: (Blocks 851968-884735) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x65e6, unused inodes 8192
+  Block bitmap at 524298 (bg #16 + 10), Inode bitmap at 524314 (bg #16 + 26)
+  Inode table at 529440-529951 (bg #16 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 851968-884735
+  Free inodes: 212993-221184
+Group 27: (Blocks 884736-917503) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe00e, unused inodes 8192
+  Backup superblock at 884736, Group descriptors at 884737-884743
+  Reserved GDT blocks at 884744-885760
+  Block bitmap at 524299 (bg #16 + 11), Inode bitmap at 524315 (bg #16 + 27)
+  Inode table at 529952-530463 (bg #16 + 5664)
+  31743 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 885761-917503
+  Free inodes: 221185-229376
+Group 28: (Blocks 917504-950271) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6739, unused inodes 8192
+  Block bitmap at 524300 (bg #16 + 12), Inode bitmap at 524316 (bg #16 + 28)
+  Inode table at 530464-530975 (bg #16 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 917504-950271
+  Free inodes: 229377-237568
+Group 29: (Blocks 950272-983039) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc7e2, unused inodes 8192
+  Block bitmap at 524301 (bg #16 + 13), Inode bitmap at 524317 (bg #16 + 29)
+  Inode table at 530976-531487 (bg #16 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 950272-983039
+  Free inodes: 237569-245760
+Group 30: (Blocks 983040-1015807) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x668c, unused inodes 8192
+  Block bitmap at 524302 (bg #16 + 14), Inode bitmap at 524318 (bg #16 + 30)
+  Inode table at 531488-531999 (bg #16 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 983040-1015807
+  Free inodes: 245761-253952
+Group 31: (Blocks 1015808-1048575) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc657, unused inodes 8192
+  Block bitmap at 524303 (bg #16 + 15), Inode bitmap at 524319 (bg #16 + 31)
+  Inode table at 532000-532511 (bg #16 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1015808-1048575
+  Free inodes: 253953-262144
+Group 32: (Blocks 1048576-1081343) [ITABLE_ZEROED]
+  Checksum 0x96a5, unused inodes 8191
+  Block bitmap at 1048576 (+0), Inode bitmap at 1048592 (+16)
+  Inode table at 1048608-1049119 (+32)
+  24543 free blocks, 8191 free inodes, 1 directories, 8191 unused inodes
+  Free blocks: 1056801-1081343
+  Free inodes: 262146-270336
+Group 33: (Blocks 1081344-1114111) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5766, unused inodes 8192
+  Block bitmap at 1048577 (bg #32 + 1), Inode bitmap at 1048593 (bg #32 + 17)
+  Inode table at 1049120-1049631 (bg #32 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1081344-1114111
+  Free inodes: 270337-278528
+Group 34: (Blocks 1114112-1146879) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf608, unused inodes 8192
+  Block bitmap at 1048578 (bg #32 + 2), Inode bitmap at 1048594 (bg #32 + 18)
+  Inode table at 1049632-1050143 (bg #32 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1114112-1146879
+  Free inodes: 278529-286720
+Group 35: (Blocks 1146880-1179647) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x56d3, unused inodes 8192
+  Block bitmap at 1048579 (bg #32 + 3), Inode bitmap at 1048595 (bg #32 + 19)
+  Inode table at 1050144-1050655 (bg #32 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1146880-1179647
+  Free inodes: 286721-294912
+Group 36: (Blocks 1179648-1212415) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf4d7, unused inodes 8192
+  Block bitmap at 1048580 (bg #32 + 4), Inode bitmap at 1048596 (bg #32 + 20)
+  Inode table at 1050656-1051167 (bg #32 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1179648-1212415
+  Free inodes: 294913-303104
+Group 37: (Blocks 1212416-1245183) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x540c, unused inodes 8192
+  Block bitmap at 1048581 (bg #32 + 5), Inode bitmap at 1048597 (bg #32 + 21)
+  Inode table at 1051168-1051679 (bg #32 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1212416-1245183
+  Free inodes: 303105-311296
+Group 38: (Blocks 1245184-1277951) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf562, unused inodes 8192
+  Block bitmap at 1048582 (bg #32 + 6), Inode bitmap at 1048598 (bg #32 + 22)
+  Inode table at 1051680-1052191 (bg #32 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1245184-1277951
+  Free inodes: 311297-319488
+Group 39: (Blocks 1277952-1310719) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x55b9, unused inodes 8192
+  Block bitmap at 1048583 (bg #32 + 7), Inode bitmap at 1048599 (bg #32 + 23)
+  Inode table at 1052192-1052703 (bg #32 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1277952-1310719
+  Free inodes: 319489-327680
+Group 40: (Blocks 1310720-1343487) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf169, unused inodes 8192
+  Block bitmap at 1048584 (bg #32 + 8), Inode bitmap at 1048600 (bg #32 + 24)
+  Inode table at 1052704-1053215 (bg #32 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1310720-1343487
+  Free inodes: 327681-335872
+Group 41: (Blocks 1343488-1376255) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x51b2, unused inodes 8192
+  Block bitmap at 1048585 (bg #32 + 9), Inode bitmap at 1048601 (bg #32 + 25)
+  Inode table at 1053216-1053727 (bg #32 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1343488-1376255
+  Free inodes: 335873-344064
+Group 42: (Blocks 1376256-1409023) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf0dc, unused inodes 8192
+  Block bitmap at 1048586 (bg #32 + 10), Inode bitmap at 1048602 (bg #32 + 26)
+  Inode table at 1053728-1054239 (bg #32 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1376256-1409023
+  Free inodes: 344065-352256
+Group 43: (Blocks 1409024-1441791) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5007, unused inodes 8192
+  Block bitmap at 1048587 (bg #32 + 11), Inode bitmap at 1048603 (bg #32 + 27)
+  Inode table at 1054240-1054751 (bg #32 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1409024-1441791
+  Free inodes: 352257-360448
+Group 44: (Blocks 1441792-1474559) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf203, unused inodes 8192
+  Block bitmap at 1048588 (bg #32 + 12), Inode bitmap at 1048604 (bg #32 + 28)
+  Inode table at 1054752-1055263 (bg #32 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1441792-1474559
+  Free inodes: 360449-368640
+Group 45: (Blocks 1474560-1507327) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x52d8, unused inodes 8192
+  Block bitmap at 1048589 (bg #32 + 13), Inode bitmap at 1048605 (bg #32 + 29)
+  Inode table at 1055264-1055775 (bg #32 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1474560-1507327
+  Free inodes: 368641-376832
+Group 46: (Blocks 1507328-1540095) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf3b6, unused inodes 8192
+  Block bitmap at 1048590 (bg #32 + 14), Inode bitmap at 1048606 (bg #32 + 30)
+  Inode table at 1055776-1056287 (bg #32 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1507328-1540095
+  Free inodes: 376833-385024
+Group 47: (Blocks 1540096-1572863) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x536d, unused inodes 8192
+  Block bitmap at 1048591 (bg #32 + 15), Inode bitmap at 1048607 (bg #32 + 31)
+  Inode table at 1056288-1056799 (bg #32 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1540096-1572863
+  Free inodes: 385025-393216
+Group 48: (Blocks 1572864-1605631) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbf0d, unused inodes 8192
+  Block bitmap at 1572864 (+0), Inode bitmap at 1572880 (+16)
+  Inode table at 1572896-1573407 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1581088-1605631
+  Free inodes: 393217-401408
+Group 49: (Blocks 1605632-1638399) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0143, unused inodes 8192
+  Backup superblock at 1605632, Group descriptors at 1605633-1605639
+  Reserved GDT blocks at 1605640-1606656
+  Block bitmap at 1572865 (bg #48 + 1), Inode bitmap at 1572881 (bg #48 + 17)
+  Inode table at 1573408-1573919 (bg #48 + 544)
+  31743 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1606657-1638399
+  Free inodes: 401409-409600
+Group 50: (Blocks 1638400-1671167) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x851e, unused inodes 8192
+  Block bitmap at 1572866 (bg #48 + 2), Inode bitmap at 1572882 (bg #48 + 18)
+  Inode table at 1573920-1574431 (bg #48 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1638400-1671167
+  Free inodes: 409601-417792
+Group 51: (Blocks 1671168-1703935) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x25c5, unused inodes 8192
+  Block bitmap at 1572867 (bg #48 + 3), Inode bitmap at 1572883 (bg #48 + 19)
+  Inode table at 1574432-1574943 (bg #48 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1671168-1703935
+  Free inodes: 417793-425984
+Group 52: (Blocks 1703936-1736703) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x87c1, unused inodes 8192
+  Block bitmap at 1572868 (bg #48 + 4), Inode bitmap at 1572884 (bg #48 + 20)
+  Inode table at 1574944-1575455 (bg #48 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1703936-1736703
+  Free inodes: 425985-434176
+Group 53: (Blocks 1736704-1769471) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x271a, unused inodes 8192
+  Block bitmap at 1572869 (bg #48 + 5), Inode bitmap at 1572885 (bg #48 + 21)
+  Inode table at 1575456-1575967 (bg #48 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1736704-1769471
+  Free inodes: 434177-442368
+Group 54: (Blocks 1769472-1802239) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8674, unused inodes 8192
+  Block bitmap at 1572870 (bg #48 + 6), Inode bitmap at 1572886 (bg #48 + 22)
+  Inode table at 1575968-1576479 (bg #48 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1769472-1802239
+  Free inodes: 442369-450560
+Group 55: (Blocks 1802240-1835007) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x26af, unused inodes 8192
+  Block bitmap at 1572871 (bg #48 + 7), Inode bitmap at 1572887 (bg #48 + 23)
+  Inode table at 1576480-1576991 (bg #48 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1802240-1835007
+  Free inodes: 450561-458752
+Group 56: (Blocks 1835008-1867775) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x827f, unused inodes 8192
+  Block bitmap at 1572872 (bg #48 + 8), Inode bitmap at 1572888 (bg #48 + 24)
+  Inode table at 1576992-1577503 (bg #48 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1835008-1867775
+  Free inodes: 458753-466944
+Group 57: (Blocks 1867776-1900543) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x22a4, unused inodes 8192
+  Block bitmap at 1572873 (bg #48 + 9), Inode bitmap at 1572889 (bg #48 + 25)
+  Inode table at 1577504-1578015 (bg #48 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1867776-1900543
+  Free inodes: 466945-475136
+Group 58: (Blocks 1900544-1933311) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x83ca, unused inodes 8192
+  Block bitmap at 1572874 (bg #48 + 10), Inode bitmap at 1572890 (bg #48 + 26)
+  Inode table at 1578016-1578527 (bg #48 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1900544-1933311
+  Free inodes: 475137-483328
+Group 59: (Blocks 1933312-1966079) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2311, unused inodes 8192
+  Block bitmap at 1572875 (bg #48 + 11), Inode bitmap at 1572891 (bg #48 + 27)
+  Inode table at 1578528-1579039 (bg #48 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1933312-1966079
+  Free inodes: 483329-491520
+Group 60: (Blocks 1966080-1998847) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8115, unused inodes 8192
+  Block bitmap at 1572876 (bg #48 + 12), Inode bitmap at 1572892 (bg #48 + 28)
+  Inode table at 1579040-1579551 (bg #48 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1966080-1998847
+  Free inodes: 491521-499712
+Group 61: (Blocks 1998848-2031615) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x21ce, unused inodes 8192
+  Block bitmap at 1572877 (bg #48 + 13), Inode bitmap at 1572893 (bg #48 + 29)
+  Inode table at 1579552-1580063 (bg #48 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 1998848-2031615
+  Free inodes: 499713-507904
+Group 62: (Blocks 2031616-2064383) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x80a0, unused inodes 8192
+  Block bitmap at 1572878 (bg #48 + 14), Inode bitmap at 1572894 (bg #48 + 30)
+  Inode table at 1580064-1580575 (bg #48 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2031616-2064383
+  Free inodes: 507905-516096
+Group 63: (Blocks 2064384-2097151) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x207b, unused inodes 8192
+  Block bitmap at 1572879 (bg #48 + 15), Inode bitmap at 1572895 (bg #48 + 31)
+  Inode table at 1580576-1581087 (bg #48 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2064384-2097151
+  Free inodes: 516097-524288
+Group 64: (Blocks 2097152-2129919) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa66c, unused inodes 8192
+  Block bitmap at 2097152 (+0), Inode bitmap at 2097168 (+16)
+  Inode table at 2097184-2097695 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2105376-2129919
+  Free inodes: 524289-532480
+Group 65: (Blocks 2129920-2162687) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3d11, unused inodes 8192
+  Block bitmap at 2097153 (bg #64 + 1), Inode bitmap at 2097169 (bg #64 + 17)
+  Inode table at 2097696-2098207 (bg #64 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2129920-2162687
+  Free inodes: 532481-540672
+Group 66: (Blocks 2162688-2195455) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9c7f, unused inodes 8192
+  Block bitmap at 2097154 (bg #64 + 2), Inode bitmap at 2097170 (bg #64 + 18)
+  Inode table at 2098208-2098719 (bg #64 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2162688-2195455
+  Free inodes: 540673-548864
+Group 67: (Blocks 2195456-2228223) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3ca4, unused inodes 8192
+  Block bitmap at 2097155 (bg #64 + 3), Inode bitmap at 2097171 (bg #64 + 19)
+  Inode table at 2098720-2099231 (bg #64 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2195456-2228223
+  Free inodes: 548865-557056
+Group 68: (Blocks 2228224-2260991) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9ea0, unused inodes 8192
+  Block bitmap at 2097156 (bg #64 + 4), Inode bitmap at 2097172 (bg #64 + 20)
+  Inode table at 2099232-2099743 (bg #64 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2228224-2260991
+  Free inodes: 557057-565248
+Group 69: (Blocks 2260992-2293759) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3e7b, unused inodes 8192
+  Block bitmap at 2097157 (bg #64 + 5), Inode bitmap at 2097173 (bg #64 + 21)
+  Inode table at 2099744-2100255 (bg #64 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2260992-2293759
+  Free inodes: 565249-573440
+Group 70: (Blocks 2293760-2326527) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9f15, unused inodes 8192
+  Block bitmap at 2097158 (bg #64 + 6), Inode bitmap at 2097174 (bg #64 + 22)
+  Inode table at 2100256-2100767 (bg #64 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2293760-2326527
+  Free inodes: 573441-581632
+Group 71: (Blocks 2326528-2359295) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3fce, unused inodes 8192
+  Block bitmap at 2097159 (bg #64 + 7), Inode bitmap at 2097175 (bg #64 + 23)
+  Inode table at 2100768-2101279 (bg #64 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2326528-2359295
+  Free inodes: 581633-589824
+Group 72: (Blocks 2359296-2392063) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9b1e, unused inodes 8192
+  Block bitmap at 2097160 (bg #64 + 8), Inode bitmap at 2097176 (bg #64 + 24)
+  Inode table at 2101280-2101791 (bg #64 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2359296-2392063
+  Free inodes: 589825-598016
+Group 73: (Blocks 2392064-2424831) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3bc5, unused inodes 8192
+  Block bitmap at 2097161 (bg #64 + 9), Inode bitmap at 2097177 (bg #64 + 25)
+  Inode table at 2101792-2102303 (bg #64 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2392064-2424831
+  Free inodes: 598017-606208
+Group 74: (Blocks 2424832-2457599) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9aab, unused inodes 8192
+  Block bitmap at 2097162 (bg #64 + 10), Inode bitmap at 2097178 (bg #64 + 26)
+  Inode table at 2102304-2102815 (bg #64 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2424832-2457599
+  Free inodes: 606209-614400
+Group 75: (Blocks 2457600-2490367) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3a70, unused inodes 8192
+  Block bitmap at 2097163 (bg #64 + 11), Inode bitmap at 2097179 (bg #64 + 27)
+  Inode table at 2102816-2103327 (bg #64 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2457600-2490367
+  Free inodes: 614401-622592
+Group 76: (Blocks 2490368-2523135) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9874, unused inodes 8192
+  Block bitmap at 2097164 (bg #64 + 12), Inode bitmap at 2097180 (bg #64 + 28)
+  Inode table at 2103328-2103839 (bg #64 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2490368-2523135
+  Free inodes: 622593-630784
+Group 77: (Blocks 2523136-2555903) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x38af, unused inodes 8192
+  Block bitmap at 2097165 (bg #64 + 13), Inode bitmap at 2097181 (bg #64 + 29)
+  Inode table at 2103840-2104351 (bg #64 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2523136-2555903
+  Free inodes: 630785-638976
+Group 78: (Blocks 2555904-2588671) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x99c1, unused inodes 8192
+  Block bitmap at 2097166 (bg #64 + 14), Inode bitmap at 2097182 (bg #64 + 30)
+  Inode table at 2104352-2104863 (bg #64 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2555904-2588671
+  Free inodes: 638977-647168
+Group 79: (Blocks 2588672-2621439) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x391a, unused inodes 8192
+  Block bitmap at 2097167 (bg #64 + 15), Inode bitmap at 2097183 (bg #64 + 31)
+  Inode table at 2104864-2105375 (bg #64 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2588672-2621439
+  Free inodes: 647169-655360
+Group 80: (Blocks 2621440-2654207) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd57a, unused inodes 8192
+  Block bitmap at 2621440 (+0), Inode bitmap at 2621456 (+16)
+  Inode table at 2621472-2621983 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2629664-2654207
+  Free inodes: 655361-663552
+Group 81: (Blocks 2654208-2686975) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6b34, unused inodes 8192
+  Backup superblock at 2654208, Group descriptors at 2654209-2654215
+  Reserved GDT blocks at 2654216-2655232
+  Block bitmap at 2621441 (bg #80 + 1), Inode bitmap at 2621457 (bg #80 + 17)
+  Inode table at 2621984-2622495 (bg #80 + 544)
+  31743 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2655233-2686975
+  Free inodes: 663553-671744
+Group 82: (Blocks 2686976-2719743) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xef69, unused inodes 8192
+  Block bitmap at 2621442 (bg #80 + 2), Inode bitmap at 2621458 (bg #80 + 18)
+  Inode table at 2622496-2623007 (bg #80 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2686976-2719743
+  Free inodes: 671745-679936
+Group 83: (Blocks 2719744-2752511) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4fb2, unused inodes 8192
+  Block bitmap at 2621443 (bg #80 + 3), Inode bitmap at 2621459 (bg #80 + 19)
+  Inode table at 2623008-2623519 (bg #80 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2719744-2752511
+  Free inodes: 679937-688128
+Group 84: (Blocks 2752512-2785279) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xedb6, unused inodes 8192
+  Block bitmap at 2621444 (bg #80 + 4), Inode bitmap at 2621460 (bg #80 + 20)
+  Inode table at 2623520-2624031 (bg #80 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2752512-2785279
+  Free inodes: 688129-696320
+Group 85: (Blocks 2785280-2818047) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4d6d, unused inodes 8192
+  Block bitmap at 2621445 (bg #80 + 5), Inode bitmap at 2621461 (bg #80 + 21)
+  Inode table at 2624032-2624543 (bg #80 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2785280-2818047
+  Free inodes: 696321-704512
+Group 86: (Blocks 2818048-2850815) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xec03, unused inodes 8192
+  Block bitmap at 2621446 (bg #80 + 6), Inode bitmap at 2621462 (bg #80 + 22)
+  Inode table at 2624544-2625055 (bg #80 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2818048-2850815
+  Free inodes: 704513-712704
+Group 87: (Blocks 2850816-2883583) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4cd8, unused inodes 8192
+  Block bitmap at 2621447 (bg #80 + 7), Inode bitmap at 2621463 (bg #80 + 23)
+  Inode table at 2625056-2625567 (bg #80 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2850816-2883583
+  Free inodes: 712705-720896
+Group 88: (Blocks 2883584-2916351) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe808, unused inodes 8192
+  Block bitmap at 2621448 (bg #80 + 8), Inode bitmap at 2621464 (bg #80 + 24)
+  Inode table at 2625568-2626079 (bg #80 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2883584-2916351
+  Free inodes: 720897-729088
+Group 89: (Blocks 2916352-2949119) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x48d3, unused inodes 8192
+  Block bitmap at 2621449 (bg #80 + 9), Inode bitmap at 2621465 (bg #80 + 25)
+  Inode table at 2626080-2626591 (bg #80 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2916352-2949119
+  Free inodes: 729089-737280
+Group 90: (Blocks 2949120-2981887) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe9bd, unused inodes 8192
+  Block bitmap at 2621450 (bg #80 + 10), Inode bitmap at 2621466 (bg #80 + 26)
+  Inode table at 2626592-2627103 (bg #80 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2949120-2981887
+  Free inodes: 737281-745472
+Group 91: (Blocks 2981888-3014655) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4966, unused inodes 8192
+  Block bitmap at 2621451 (bg #80 + 11), Inode bitmap at 2621467 (bg #80 + 27)
+  Inode table at 2627104-2627615 (bg #80 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 2981888-3014655
+  Free inodes: 745473-753664
+Group 92: (Blocks 3014656-3047423) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xeb62, unused inodes 8192
+  Block bitmap at 2621452 (bg #80 + 12), Inode bitmap at 2621468 (bg #80 + 28)
+  Inode table at 2627616-2628127 (bg #80 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3014656-3047423
+  Free inodes: 753665-761856
+Group 93: (Blocks 3047424-3080191) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4bb9, unused inodes 8192
+  Block bitmap at 2621453 (bg #80 + 13), Inode bitmap at 2621469 (bg #80 + 29)
+  Inode table at 2628128-2628639 (bg #80 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3047424-3080191
+  Free inodes: 761857-770048
+Group 94: (Blocks 3080192-3112959) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xead7, unused inodes 8192
+  Block bitmap at 2621454 (bg #80 + 14), Inode bitmap at 2621470 (bg #80 + 30)
+  Inode table at 2628640-2629151 (bg #80 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3080192-3112959
+  Free inodes: 770049-778240
+Group 95: (Blocks 3112960-3145727) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4a0c, unused inodes 8192
+  Block bitmap at 2621455 (bg #80 + 15), Inode bitmap at 2621471 (bg #80 + 31)
+  Inode table at 2629152-2629663 (bg #80 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3112960-3145727
+  Free inodes: 778241-786432
+Group 96: (Blocks 3145728-3178495) [ITABLE_ZEROED]
+  Checksum 0x1afe, unused inodes 8191
+  Block bitmap at 3145728 (+0), Inode bitmap at 3145744 (+16)
+  Inode table at 3145760-3146271 (+32)
+  24543 free blocks, 8191 free inodes, 1 directories, 8191 unused inodes
+  Free blocks: 3153953-3178495
+  Free inodes: 786434-794624
+Group 97: (Blocks 3178496-3211263) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xdb3d, unused inodes 8192
+  Block bitmap at 3145729 (bg #96 + 1), Inode bitmap at 3145745 (bg #96 + 17)
+  Inode table at 3146272-3146783 (bg #96 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3178496-3211263
+  Free inodes: 794625-802816
+Group 98: (Blocks 3211264-3244031) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7a53, unused inodes 8192
+  Block bitmap at 3145730 (bg #96 + 2), Inode bitmap at 3145746 (bg #96 + 18)
+  Inode table at 3146784-3147295 (bg #96 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3211264-3244031
+  Free inodes: 802817-811008
+Group 99: (Blocks 3244032-3276799) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xda88, unused inodes 8192
+  Block bitmap at 3145731 (bg #96 + 3), Inode bitmap at 3145747 (bg #96 + 19)
+  Inode table at 3147296-3147807 (bg #96 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3244032-3276799
+  Free inodes: 811009-819200
+Group 100: (Blocks 3276800-3309567) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x788c, unused inodes 8192
+  Block bitmap at 3145732 (bg #96 + 4), Inode bitmap at 3145748 (bg #96 + 20)
+  Inode table at 3147808-3148319 (bg #96 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3276800-3309567
+  Free inodes: 819201-827392
+Group 101: (Blocks 3309568-3342335) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd857, unused inodes 8192
+  Block bitmap at 3145733 (bg #96 + 5), Inode bitmap at 3145749 (bg #96 + 21)
+  Inode table at 3148320-3148831 (bg #96 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3309568-3342335
+  Free inodes: 827393-835584
+Group 102: (Blocks 3342336-3375103) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7939, unused inodes 8192
+  Block bitmap at 3145734 (bg #96 + 6), Inode bitmap at 3145750 (bg #96 + 22)
+  Inode table at 3148832-3149343 (bg #96 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3342336-3375103
+  Free inodes: 835585-843776
+Group 103: (Blocks 3375104-3407871) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd9e2, unused inodes 8192
+  Block bitmap at 3145735 (bg #96 + 7), Inode bitmap at 3145751 (bg #96 + 23)
+  Inode table at 3149344-3149855 (bg #96 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3375104-3407871
+  Free inodes: 843777-851968
+Group 104: (Blocks 3407872-3440639) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7d32, unused inodes 8192
+  Block bitmap at 3145736 (bg #96 + 8), Inode bitmap at 3145752 (bg #96 + 24)
+  Inode table at 3149856-3150367 (bg #96 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3407872-3440639
+  Free inodes: 851969-860160
+Group 105: (Blocks 3440640-3473407) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xdde9, unused inodes 8192
+  Block bitmap at 3145737 (bg #96 + 9), Inode bitmap at 3145753 (bg #96 + 25)
+  Inode table at 3150368-3150879 (bg #96 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3440640-3473407
+  Free inodes: 860161-868352
+Group 106: (Blocks 3473408-3506175) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7c87, unused inodes 8192
+  Block bitmap at 3145738 (bg #96 + 10), Inode bitmap at 3145754 (bg #96 + 26)
+  Inode table at 3150880-3151391 (bg #96 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3473408-3506175
+  Free inodes: 868353-876544
+Group 107: (Blocks 3506176-3538943) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xdc5c, unused inodes 8192
+  Block bitmap at 3145739 (bg #96 + 11), Inode bitmap at 3145755 (bg #96 + 27)
+  Inode table at 3151392-3151903 (bg #96 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3506176-3538943
+  Free inodes: 876545-884736
+Group 108: (Blocks 3538944-3571711) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7e58, unused inodes 8192
+  Block bitmap at 3145740 (bg #96 + 12), Inode bitmap at 3145756 (bg #96 + 28)
+  Inode table at 3151904-3152415 (bg #96 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3538944-3571711
+  Free inodes: 884737-892928
+Group 109: (Blocks 3571712-3604479) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xde83, unused inodes 8192
+  Block bitmap at 3145741 (bg #96 + 13), Inode bitmap at 3145757 (bg #96 + 29)
+  Inode table at 3152416-3152927 (bg #96 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3571712-3604479
+  Free inodes: 892929-901120
+Group 110: (Blocks 3604480-3637247) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7fed, unused inodes 8192
+  Block bitmap at 3145742 (bg #96 + 14), Inode bitmap at 3145758 (bg #96 + 30)
+  Inode table at 3152928-3153439 (bg #96 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3604480-3637247
+  Free inodes: 901121-909312
+Group 111: (Blocks 3637248-3670015) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xdf36, unused inodes 8192
+  Block bitmap at 3145743 (bg #96 + 15), Inode bitmap at 3145759 (bg #96 + 31)
+  Inode table at 3153440-3153951 (bg #96 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3637248-3670015
+  Free inodes: 909313-917504
+Group 112: (Blocks 3670016-3702783) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3356, unused inodes 8192
+  Block bitmap at 3670016 (+0), Inode bitmap at 3670032 (+16)
+  Inode table at 3670048-3670559 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3678240-3702783
+  Free inodes: 917505-925696
+Group 113: (Blocks 3702784-3735551) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa82b, unused inodes 8192
+  Block bitmap at 3670017 (bg #112 + 1), Inode bitmap at 3670033 (bg #112 + 17)
+  Inode table at 3670560-3671071 (bg #112 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3702784-3735551
+  Free inodes: 925697-933888
+Group 114: (Blocks 3735552-3768319) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0945, unused inodes 8192
+  Block bitmap at 3670018 (bg #112 + 2), Inode bitmap at 3670034 (bg #112 + 18)
+  Inode table at 3671072-3671583 (bg #112 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3735552-3768319
+  Free inodes: 933889-942080
+Group 115: (Blocks 3768320-3801087) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa99e, unused inodes 8192
+  Block bitmap at 3670019 (bg #112 + 3), Inode bitmap at 3670035 (bg #112 + 19)
+  Inode table at 3671584-3672095 (bg #112 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3768320-3801087
+  Free inodes: 942081-950272
+Group 116: (Blocks 3801088-3833855) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0b9a, unused inodes 8192
+  Block bitmap at 3670020 (bg #112 + 4), Inode bitmap at 3670036 (bg #112 + 20)
+  Inode table at 3672096-3672607 (bg #112 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3801088-3833855
+  Free inodes: 950273-958464
+Group 117: (Blocks 3833856-3866623) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xab41, unused inodes 8192
+  Block bitmap at 3670021 (bg #112 + 5), Inode bitmap at 3670037 (bg #112 + 21)
+  Inode table at 3672608-3673119 (bg #112 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3833856-3866623
+  Free inodes: 958465-966656
+Group 118: (Blocks 3866624-3899391) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0a2f, unused inodes 8192
+  Block bitmap at 3670022 (bg #112 + 6), Inode bitmap at 3670038 (bg #112 + 22)
+  Inode table at 3673120-3673631 (bg #112 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3866624-3899391
+  Free inodes: 966657-974848
+Group 119: (Blocks 3899392-3932159) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xaaf4, unused inodes 8192
+  Block bitmap at 3670023 (bg #112 + 7), Inode bitmap at 3670039 (bg #112 + 23)
+  Inode table at 3673632-3674143 (bg #112 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3899392-3932159
+  Free inodes: 974849-983040
+Group 120: (Blocks 3932160-3964927) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0e24, unused inodes 8192
+  Block bitmap at 3670024 (bg #112 + 8), Inode bitmap at 3670040 (bg #112 + 24)
+  Inode table at 3674144-3674655 (bg #112 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3932160-3964927
+  Free inodes: 983041-991232
+Group 121: (Blocks 3964928-3997695) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xaeff, unused inodes 8192
+  Block bitmap at 3670025 (bg #112 + 9), Inode bitmap at 3670041 (bg #112 + 25)
+  Inode table at 3674656-3675167 (bg #112 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3964928-3997695
+  Free inodes: 991233-999424
+Group 122: (Blocks 3997696-4030463) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0f91, unused inodes 8192
+  Block bitmap at 3670026 (bg #112 + 10), Inode bitmap at 3670042 (bg #112 + 26)
+  Inode table at 3675168-3675679 (bg #112 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 3997696-4030463
+  Free inodes: 999425-1007616
+Group 123: (Blocks 4030464-4063231) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xaf4a, unused inodes 8192
+  Block bitmap at 3670027 (bg #112 + 11), Inode bitmap at 3670043 (bg #112 + 27)
+  Inode table at 3675680-3676191 (bg #112 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4030464-4063231
+  Free inodes: 1007617-1015808
+Group 124: (Blocks 4063232-4095999) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0d4e, unused inodes 8192
+  Block bitmap at 3670028 (bg #112 + 12), Inode bitmap at 3670044 (bg #112 + 28)
+  Inode table at 3676192-3676703 (bg #112 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4063232-4095999
+  Free inodes: 1015809-1024000
+Group 125: (Blocks 4096000-4128767) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x88a6, unused inodes 8192
+  Backup superblock at 4096000, Group descriptors at 4096001-4096007
+  Reserved GDT blocks at 4096008-4097024
+  Block bitmap at 3670029 (bg #112 + 13), Inode bitmap at 3670045 (bg #112 + 29)
+  Inode table at 3676704-3677215 (bg #112 + 6688)
+  31743 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4097025-4128767
+  Free inodes: 1024001-1032192
+Group 126: (Blocks 4128768-4161535) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0cfb, unused inodes 8192
+  Block bitmap at 3670030 (bg #112 + 14), Inode bitmap at 3670046 (bg #112 + 30)
+  Inode table at 3677216-3677727 (bg #112 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4128768-4161535
+  Free inodes: 1032193-1040384
+Group 127: (Blocks 4161536-4194303) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xac20, unused inodes 8192
+  Block bitmap at 3670031 (bg #112 + 15), Inode bitmap at 3670047 (bg #112 + 31)
+  Inode table at 3677728-3678239 (bg #112 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4161536-4194303
+  Free inodes: 1040385-1048576
+Group 128: (Blocks 4194304-4227071) [ITABLE_ZEROED]
+  Checksum 0x283c, unused inodes 8191
+  Block bitmap at 4194304 (+0), Inode bitmap at 4194320 (+16)
+  Inode table at 4194336-4194847 (+32)
+  24543 free blocks, 8191 free inodes, 1 directories, 8191 unused inodes
+  Free blocks: 4202529-4227071
+  Free inodes: 1048578-1056768
+Group 129: (Blocks 4227072-4259839) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe9ff, unused inodes 8192
+  Block bitmap at 4194305 (bg #128 + 1), Inode bitmap at 4194321 (bg #128 + 17)
+  Inode table at 4194848-4195359 (bg #128 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4227072-4259839
+  Free inodes: 1056769-1064960
+Group 130: (Blocks 4259840-4292607) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4891, unused inodes 8192
+  Block bitmap at 4194306 (bg #128 + 2), Inode bitmap at 4194322 (bg #128 + 18)
+  Inode table at 4195360-4195871 (bg #128 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4259840-4292607
+  Free inodes: 1064961-1073152
+Group 131: (Blocks 4292608-4325375) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe84a, unused inodes 8192
+  Block bitmap at 4194307 (bg #128 + 3), Inode bitmap at 4194323 (bg #128 + 19)
+  Inode table at 4195872-4196383 (bg #128 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4292608-4325375
+  Free inodes: 1073153-1081344
+Group 132: (Blocks 4325376-4358143) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4a4e, unused inodes 8192
+  Block bitmap at 4194308 (bg #128 + 4), Inode bitmap at 4194324 (bg #128 + 20)
+  Inode table at 4196384-4196895 (bg #128 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4325376-4358143
+  Free inodes: 1081345-1089536
+Group 133: (Blocks 4358144-4390911) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xea95, unused inodes 8192
+  Block bitmap at 4194309 (bg #128 + 5), Inode bitmap at 4194325 (bg #128 + 21)
+  Inode table at 4196896-4197407 (bg #128 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4358144-4390911
+  Free inodes: 1089537-1097728
+Group 134: (Blocks 4390912-4423679) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4bfb, unused inodes 8192
+  Block bitmap at 4194310 (bg #128 + 6), Inode bitmap at 4194326 (bg #128 + 22)
+  Inode table at 4197408-4197919 (bg #128 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4390912-4423679
+  Free inodes: 1097729-1105920
+Group 135: (Blocks 4423680-4456447) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xeb20, unused inodes 8192
+  Block bitmap at 4194311 (bg #128 + 7), Inode bitmap at 4194327 (bg #128 + 23)
+  Inode table at 4197920-4198431 (bg #128 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4423680-4456447
+  Free inodes: 1105921-1114112
+Group 136: (Blocks 4456448-4489215) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4ff0, unused inodes 8192
+  Block bitmap at 4194312 (bg #128 + 8), Inode bitmap at 4194328 (bg #128 + 24)
+  Inode table at 4198432-4198943 (bg #128 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4456448-4489215
+  Free inodes: 1114113-1122304
+Group 137: (Blocks 4489216-4521983) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xef2b, unused inodes 8192
+  Block bitmap at 4194313 (bg #128 + 9), Inode bitmap at 4194329 (bg #128 + 25)
+  Inode table at 4198944-4199455 (bg #128 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4489216-4521983
+  Free inodes: 1122305-1130496
+Group 138: (Blocks 4521984-4554751) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4e45, unused inodes 8192
+  Block bitmap at 4194314 (bg #128 + 10), Inode bitmap at 4194330 (bg #128 + 26)
+  Inode table at 4199456-4199967 (bg #128 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4521984-4554751
+  Free inodes: 1130497-1138688
+Group 139: (Blocks 4554752-4587519) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xee9e, unused inodes 8192
+  Block bitmap at 4194315 (bg #128 + 11), Inode bitmap at 4194331 (bg #128 + 27)
+  Inode table at 4199968-4200479 (bg #128 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4554752-4587519
+  Free inodes: 1138689-1146880
+Group 140: (Blocks 4587520-4620287) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4c9a, unused inodes 8192
+  Block bitmap at 4194316 (bg #128 + 12), Inode bitmap at 4194332 (bg #128 + 28)
+  Inode table at 4200480-4200991 (bg #128 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4587520-4620287
+  Free inodes: 1146881-1155072
+Group 141: (Blocks 4620288-4653055) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xec41, unused inodes 8192
+  Block bitmap at 4194317 (bg #128 + 13), Inode bitmap at 4194333 (bg #128 + 29)
+  Inode table at 4200992-4201503 (bg #128 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4620288-4653055
+  Free inodes: 1155073-1163264
+Group 142: (Blocks 4653056-4685823) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4d2f, unused inodes 8192
+  Block bitmap at 4194318 (bg #128 + 14), Inode bitmap at 4194334 (bg #128 + 30)
+  Inode table at 4201504-4202015 (bg #128 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4653056-4685823
+  Free inodes: 1163265-1171456
+Group 143: (Blocks 4685824-4718591) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xedf4, unused inodes 8192
+  Block bitmap at 4194319 (bg #128 + 15), Inode bitmap at 4194335 (bg #128 + 31)
+  Inode table at 4202016-4202527 (bg #128 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4685824-4718591
+  Free inodes: 1171457-1179648
+Group 144: (Blocks 4718592-4751359) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0194, unused inodes 8192
+  Block bitmap at 4718592 (+0), Inode bitmap at 4718608 (+16)
+  Inode table at 4718624-4719135 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4726816-4751359
+  Free inodes: 1179649-1187840
+Group 145: (Blocks 4751360-4784127) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9ae9, unused inodes 8192
+  Block bitmap at 4718593 (bg #144 + 1), Inode bitmap at 4718609 (bg #144 + 17)
+  Inode table at 4719136-4719647 (bg #144 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4751360-4784127
+  Free inodes: 1187841-1196032
+Group 146: (Blocks 4784128-4816895) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3b87, unused inodes 8192
+  Block bitmap at 4718594 (bg #144 + 2), Inode bitmap at 4718610 (bg #144 + 18)
+  Inode table at 4719648-4720159 (bg #144 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4784128-4816895
+  Free inodes: 1196033-1204224
+Group 147: (Blocks 4816896-4849663) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9b5c, unused inodes 8192
+  Block bitmap at 4718595 (bg #144 + 3), Inode bitmap at 4718611 (bg #144 + 19)
+  Inode table at 4720160-4720671 (bg #144 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4816896-4849663
+  Free inodes: 1204225-1212416
+Group 148: (Blocks 4849664-4882431) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3958, unused inodes 8192
+  Block bitmap at 4718596 (bg #144 + 4), Inode bitmap at 4718612 (bg #144 + 20)
+  Inode table at 4720672-4721183 (bg #144 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4849664-4882431
+  Free inodes: 1212417-1220608
+Group 149: (Blocks 4882432-4915199) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9983, unused inodes 8192
+  Block bitmap at 4718597 (bg #144 + 5), Inode bitmap at 4718613 (bg #144 + 21)
+  Inode table at 4721184-4721695 (bg #144 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4882432-4915199
+  Free inodes: 1220609-1228800
+Group 150: (Blocks 4915200-4947967) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x38ed, unused inodes 8192
+  Block bitmap at 4718598 (bg #144 + 6), Inode bitmap at 4718614 (bg #144 + 22)
+  Inode table at 4721696-4722207 (bg #144 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4915200-4947967
+  Free inodes: 1228801-1236992
+Group 151: (Blocks 4947968-4980735) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9836, unused inodes 8192
+  Block bitmap at 4718599 (bg #144 + 7), Inode bitmap at 4718615 (bg #144 + 23)
+  Inode table at 4722208-4722719 (bg #144 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4947968-4980735
+  Free inodes: 1236993-1245184
+Group 152: (Blocks 4980736-5013503) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3ce6, unused inodes 8192
+  Block bitmap at 4718600 (bg #144 + 8), Inode bitmap at 4718616 (bg #144 + 24)
+  Inode table at 4722720-4723231 (bg #144 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 4980736-5013503
+  Free inodes: 1245185-1253376
+Group 153: (Blocks 5013504-5046271) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9c3d, unused inodes 8192
+  Block bitmap at 4718601 (bg #144 + 9), Inode bitmap at 4718617 (bg #144 + 25)
+  Inode table at 4723232-4723743 (bg #144 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5013504-5046271
+  Free inodes: 1253377-1261568
+Group 154: (Blocks 5046272-5079039) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3d53, unused inodes 8192
+  Block bitmap at 4718602 (bg #144 + 10), Inode bitmap at 4718618 (bg #144 + 26)
+  Inode table at 4723744-4724255 (bg #144 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5046272-5079039
+  Free inodes: 1261569-1269760
+Group 155: (Blocks 5079040-5111807) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9d88, unused inodes 8192
+  Block bitmap at 4718603 (bg #144 + 11), Inode bitmap at 4718619 (bg #144 + 27)
+  Inode table at 4724256-4724767 (bg #144 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5079040-5111807
+  Free inodes: 1269761-1277952
+Group 156: (Blocks 5111808-5144575) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3f8c, unused inodes 8192
+  Block bitmap at 4718604 (bg #144 + 12), Inode bitmap at 4718620 (bg #144 + 28)
+  Inode table at 4724768-4725279 (bg #144 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5111808-5144575
+  Free inodes: 1277953-1286144
+Group 157: (Blocks 5144576-5177343) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9f57, unused inodes 8192
+  Block bitmap at 4718605 (bg #144 + 13), Inode bitmap at 4718621 (bg #144 + 29)
+  Inode table at 4725280-4725791 (bg #144 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5144576-5177343
+  Free inodes: 1286145-1294336
+Group 158: (Blocks 5177344-5210111) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3e39, unused inodes 8192
+  Block bitmap at 4718606 (bg #144 + 14), Inode bitmap at 4718622 (bg #144 + 30)
+  Inode table at 4725792-4726303 (bg #144 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5177344-5210111
+  Free inodes: 1294337-1302528
+Group 159: (Blocks 5210112-5242879) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9ee2, unused inodes 8192
+  Block bitmap at 4718607 (bg #144 + 15), Inode bitmap at 4718623 (bg #144 + 31)
+  Inode table at 4726304-4726815 (bg #144 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5210112-5242879
+  Free inodes: 1302529-1310720
+Group 160: (Blocks 5242880-5275647) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x94ae, unused inodes 8192
+  Block bitmap at 5242880 (+0), Inode bitmap at 5242896 (+16)
+  Inode table at 5242912-5243423 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5251104-5275647
+  Free inodes: 1310721-1318912
+Group 161: (Blocks 5275648-5308415) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0fd3, unused inodes 8192
+  Block bitmap at 5242881 (bg #160 + 1), Inode bitmap at 5242897 (bg #160 + 17)
+  Inode table at 5243424-5243935 (bg #160 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5275648-5308415
+  Free inodes: 1318913-1327104
+Group 162: (Blocks 5308416-5341183) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xaebd, unused inodes 8192
+  Block bitmap at 5242882 (bg #160 + 2), Inode bitmap at 5242898 (bg #160 + 18)
+  Inode table at 5243936-5244447 (bg #160 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5308416-5341183
+  Free inodes: 1327105-1335296
+Group 163: (Blocks 5341184-5373951) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0e66, unused inodes 8192
+  Block bitmap at 5242883 (bg #160 + 3), Inode bitmap at 5242899 (bg #160 + 19)
+  Inode table at 5244448-5244959 (bg #160 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5341184-5373951
+  Free inodes: 1335297-1343488
+Group 164: (Blocks 5373952-5406719) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xac62, unused inodes 8192
+  Block bitmap at 5242884 (bg #160 + 4), Inode bitmap at 5242900 (bg #160 + 20)
+  Inode table at 5244960-5245471 (bg #160 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5373952-5406719
+  Free inodes: 1343489-1351680
+Group 165: (Blocks 5406720-5439487) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0cb9, unused inodes 8192
+  Block bitmap at 5242885 (bg #160 + 5), Inode bitmap at 5242901 (bg #160 + 21)
+  Inode table at 5245472-5245983 (bg #160 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5406720-5439487
+  Free inodes: 1351681-1359872
+Group 166: (Blocks 5439488-5472255) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xadd7, unused inodes 8192
+  Block bitmap at 5242886 (bg #160 + 6), Inode bitmap at 5242902 (bg #160 + 22)
+  Inode table at 5245984-5246495 (bg #160 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5439488-5472255
+  Free inodes: 1359873-1368064
+Group 167: (Blocks 5472256-5505023) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0d0c, unused inodes 8192
+  Block bitmap at 5242887 (bg #160 + 7), Inode bitmap at 5242903 (bg #160 + 23)
+  Inode table at 5246496-5247007 (bg #160 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5472256-5505023
+  Free inodes: 1368065-1376256
+Group 168: (Blocks 5505024-5537791) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa9dc, unused inodes 8192
+  Block bitmap at 5242888 (bg #160 + 8), Inode bitmap at 5242904 (bg #160 + 24)
+  Inode table at 5247008-5247519 (bg #160 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5505024-5537791
+  Free inodes: 1376257-1384448
+Group 169: (Blocks 5537792-5570559) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0907, unused inodes 8192
+  Block bitmap at 5242889 (bg #160 + 9), Inode bitmap at 5242905 (bg #160 + 25)
+  Inode table at 5247520-5248031 (bg #160 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5537792-5570559
+  Free inodes: 1384449-1392640
+Group 170: (Blocks 5570560-5603327) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa869, unused inodes 8192
+  Block bitmap at 5242890 (bg #160 + 10), Inode bitmap at 5242906 (bg #160 + 26)
+  Inode table at 5248032-5248543 (bg #160 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5570560-5603327
+  Free inodes: 1392641-1400832
+Group 171: (Blocks 5603328-5636095) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x08b2, unused inodes 8192
+  Block bitmap at 5242891 (bg #160 + 11), Inode bitmap at 5242907 (bg #160 + 27)
+  Inode table at 5248544-5249055 (bg #160 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5603328-5636095
+  Free inodes: 1400833-1409024
+Group 172: (Blocks 5636096-5668863) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xaab6, unused inodes 8192
+  Block bitmap at 5242892 (bg #160 + 12), Inode bitmap at 5242908 (bg #160 + 28)
+  Inode table at 5249056-5249567 (bg #160 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5636096-5668863
+  Free inodes: 1409025-1417216
+Group 173: (Blocks 5668864-5701631) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0a6d, unused inodes 8192
+  Block bitmap at 5242893 (bg #160 + 13), Inode bitmap at 5242909 (bg #160 + 29)
+  Inode table at 5249568-5250079 (bg #160 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5668864-5701631
+  Free inodes: 1417217-1425408
+Group 174: (Blocks 5701632-5734399) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xab03, unused inodes 8192
+  Block bitmap at 5242894 (bg #160 + 14), Inode bitmap at 5242910 (bg #160 + 30)
+  Inode table at 5250080-5250591 (bg #160 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5701632-5734399
+  Free inodes: 1425409-1433600
+Group 175: (Blocks 5734400-5767167) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0bd8, unused inodes 8192
+  Block bitmap at 5242895 (bg #160 + 15), Inode bitmap at 5242911 (bg #160 + 31)
+  Inode table at 5250592-5251103 (bg #160 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5734400-5767167
+  Free inodes: 1433601-1441792
+Group 176: (Blocks 5767168-5799935) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe7b8, unused inodes 8192
+  Block bitmap at 5767168 (+0), Inode bitmap at 5767184 (+16)
+  Inode table at 5767200-5767711 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5775392-5799935
+  Free inodes: 1441793-1449984
+Group 177: (Blocks 5799936-5832703) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7cc5, unused inodes 8192
+  Block bitmap at 5767169 (bg #176 + 1), Inode bitmap at 5767185 (bg #176 + 17)
+  Inode table at 5767712-5768223 (bg #176 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5799936-5832703
+  Free inodes: 1449985-1458176
+Group 178: (Blocks 5832704-5865471) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xddab, unused inodes 8192
+  Block bitmap at 5767170 (bg #176 + 2), Inode bitmap at 5767186 (bg #176 + 18)
+  Inode table at 5768224-5768735 (bg #176 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5832704-5865471
+  Free inodes: 1458177-1466368
+Group 179: (Blocks 5865472-5898239) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7d70, unused inodes 8192
+  Block bitmap at 5767171 (bg #176 + 3), Inode bitmap at 5767187 (bg #176 + 19)
+  Inode table at 5768736-5769247 (bg #176 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5865472-5898239
+  Free inodes: 1466369-1474560
+Group 180: (Blocks 5898240-5931007) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xdf74, unused inodes 8192
+  Block bitmap at 5767172 (bg #176 + 4), Inode bitmap at 5767188 (bg #176 + 20)
+  Inode table at 5769248-5769759 (bg #176 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5898240-5931007
+  Free inodes: 1474561-1482752
+Group 181: (Blocks 5931008-5963775) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7faf, unused inodes 8192
+  Block bitmap at 5767173 (bg #176 + 5), Inode bitmap at 5767189 (bg #176 + 21)
+  Inode table at 5769760-5770271 (bg #176 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5931008-5963775
+  Free inodes: 1482753-1490944
+Group 182: (Blocks 5963776-5996543) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xdec1, unused inodes 8192
+  Block bitmap at 5767174 (bg #176 + 6), Inode bitmap at 5767190 (bg #176 + 22)
+  Inode table at 5770272-5770783 (bg #176 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5963776-5996543
+  Free inodes: 1490945-1499136
+Group 183: (Blocks 5996544-6029311) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7e1a, unused inodes 8192
+  Block bitmap at 5767175 (bg #176 + 7), Inode bitmap at 5767191 (bg #176 + 23)
+  Inode table at 5770784-5771295 (bg #176 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 5996544-6029311
+  Free inodes: 1499137-1507328
+Group 184: (Blocks 6029312-6062079) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xdaca, unused inodes 8192
+  Block bitmap at 5767176 (bg #176 + 8), Inode bitmap at 5767192 (bg #176 + 24)
+  Inode table at 5771296-5771807 (bg #176 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6029312-6062079
+  Free inodes: 1507329-1515520
+Group 185: (Blocks 6062080-6094847) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7a11, unused inodes 8192
+  Block bitmap at 5767177 (bg #176 + 9), Inode bitmap at 5767193 (bg #176 + 25)
+  Inode table at 5771808-5772319 (bg #176 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6062080-6094847
+  Free inodes: 1515521-1523712
+Group 186: (Blocks 6094848-6127615) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xdb7f, unused inodes 8192
+  Block bitmap at 5767178 (bg #176 + 10), Inode bitmap at 5767194 (bg #176 + 26)
+  Inode table at 5772320-5772831 (bg #176 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6094848-6127615
+  Free inodes: 1523713-1531904
+Group 187: (Blocks 6127616-6160383) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7ba4, unused inodes 8192
+  Block bitmap at 5767179 (bg #176 + 11), Inode bitmap at 5767195 (bg #176 + 27)
+  Inode table at 5772832-5773343 (bg #176 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6127616-6160383
+  Free inodes: 1531905-1540096
+Group 188: (Blocks 6160384-6193151) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd9a0, unused inodes 8192
+  Block bitmap at 5767180 (bg #176 + 12), Inode bitmap at 5767196 (bg #176 + 28)
+  Inode table at 5773344-5773855 (bg #176 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6160384-6193151
+  Free inodes: 1540097-1548288
+Group 189: (Blocks 6193152-6225919) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x797b, unused inodes 8192
+  Block bitmap at 5767181 (bg #176 + 13), Inode bitmap at 5767197 (bg #176 + 29)
+  Inode table at 5773856-5774367 (bg #176 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6193152-6225919
+  Free inodes: 1548289-1556480
+Group 190: (Blocks 6225920-6258687) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd815, unused inodes 8192
+  Block bitmap at 5767182 (bg #176 + 14), Inode bitmap at 5767198 (bg #176 + 30)
+  Inode table at 5774368-5774879 (bg #176 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6225920-6258687
+  Free inodes: 1556481-1564672
+Group 191: (Blocks 6258688-6291455) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x78ce, unused inodes 8192
+  Block bitmap at 5767183 (bg #176 + 15), Inode bitmap at 5767199 (bg #176 + 31)
+  Inode table at 5774880-5775391 (bg #176 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6258688-6291455
+  Free inodes: 1564673-1572864
+Group 192: (Blocks 6291456-6324223) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfed9, unused inodes 8192
+  Block bitmap at 6291456 (+0), Inode bitmap at 6291472 (+16)
+  Inode table at 6291488-6291999 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6299680-6324223
+  Free inodes: 1572865-1581056
+Group 193: (Blocks 6324224-6356991) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x65a4, unused inodes 8192
+  Block bitmap at 6291457 (bg #192 + 1), Inode bitmap at 6291473 (bg #192 + 17)
+  Inode table at 6292000-6292511 (bg #192 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6324224-6356991
+  Free inodes: 1581057-1589248
+Group 194: (Blocks 6356992-6389759) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc4ca, unused inodes 8192
+  Block bitmap at 6291458 (bg #192 + 2), Inode bitmap at 6291474 (bg #192 + 18)
+  Inode table at 6292512-6293023 (bg #192 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6356992-6389759
+  Free inodes: 1589249-1597440
+Group 195: (Blocks 6389760-6422527) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6411, unused inodes 8192
+  Block bitmap at 6291459 (bg #192 + 3), Inode bitmap at 6291475 (bg #192 + 19)
+  Inode table at 6293024-6293535 (bg #192 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6389760-6422527
+  Free inodes: 1597441-1605632
+Group 196: (Blocks 6422528-6455295) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc615, unused inodes 8192
+  Block bitmap at 6291460 (bg #192 + 4), Inode bitmap at 6291476 (bg #192 + 20)
+  Inode table at 6293536-6294047 (bg #192 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6422528-6455295
+  Free inodes: 1605633-1613824
+Group 197: (Blocks 6455296-6488063) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x66ce, unused inodes 8192
+  Block bitmap at 6291461 (bg #192 + 5), Inode bitmap at 6291477 (bg #192 + 21)
+  Inode table at 6294048-6294559 (bg #192 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6455296-6488063
+  Free inodes: 1613825-1622016
+Group 198: (Blocks 6488064-6520831) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc7a0, unused inodes 8192
+  Block bitmap at 6291462 (bg #192 + 6), Inode bitmap at 6291478 (bg #192 + 22)
+  Inode table at 6294560-6295071 (bg #192 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6488064-6520831
+  Free inodes: 1622017-1630208
+Group 199: (Blocks 6520832-6553599) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x677b, unused inodes 8192
+  Block bitmap at 6291463 (bg #192 + 7), Inode bitmap at 6291479 (bg #192 + 23)
+  Inode table at 6295072-6295583 (bg #192 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6520832-6553599
+  Free inodes: 1630209-1638400
+Group 200: (Blocks 6553600-6586367) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc3ab, unused inodes 8192
+  Block bitmap at 6291464 (bg #192 + 8), Inode bitmap at 6291480 (bg #192 + 24)
+  Inode table at 6295584-6296095 (bg #192 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6553600-6586367
+  Free inodes: 1638401-1646592
+Group 201: (Blocks 6586368-6619135) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6370, unused inodes 8192
+  Block bitmap at 6291465 (bg #192 + 9), Inode bitmap at 6291481 (bg #192 + 25)
+  Inode table at 6296096-6296607 (bg #192 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6586368-6619135
+  Free inodes: 1646593-1654784
+Group 202: (Blocks 6619136-6651903) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc21e, unused inodes 8192
+  Block bitmap at 6291466 (bg #192 + 10), Inode bitmap at 6291482 (bg #192 + 26)
+  Inode table at 6296608-6297119 (bg #192 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6619136-6651903
+  Free inodes: 1654785-1662976
+Group 203: (Blocks 6651904-6684671) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x62c5, unused inodes 8192
+  Block bitmap at 6291467 (bg #192 + 11), Inode bitmap at 6291483 (bg #192 + 27)
+  Inode table at 6297120-6297631 (bg #192 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6651904-6684671
+  Free inodes: 1662977-1671168
+Group 204: (Blocks 6684672-6717439) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc0c1, unused inodes 8192
+  Block bitmap at 6291468 (bg #192 + 12), Inode bitmap at 6291484 (bg #192 + 28)
+  Inode table at 6297632-6298143 (bg #192 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6684672-6717439
+  Free inodes: 1671169-1679360
+Group 205: (Blocks 6717440-6750207) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x601a, unused inodes 8192
+  Block bitmap at 6291469 (bg #192 + 13), Inode bitmap at 6291485 (bg #192 + 29)
+  Inode table at 6298144-6298655 (bg #192 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6717440-6750207
+  Free inodes: 1679361-1687552
+Group 206: (Blocks 6750208-6782975) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc174, unused inodes 8192
+  Block bitmap at 6291470 (bg #192 + 14), Inode bitmap at 6291486 (bg #192 + 30)
+  Inode table at 6298656-6299167 (bg #192 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6750208-6782975
+  Free inodes: 1687553-1695744
+Group 207: (Blocks 6782976-6815743) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x61af, unused inodes 8192
+  Block bitmap at 6291471 (bg #192 + 15), Inode bitmap at 6291487 (bg #192 + 31)
+  Inode table at 6299168-6299679 (bg #192 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6782976-6815743
+  Free inodes: 1695745-1703936
+Group 208: (Blocks 6815744-6848511) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8dcf, unused inodes 8192
+  Block bitmap at 6815744 (+0), Inode bitmap at 6815760 (+16)
+  Inode table at 6815776-6816287 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6823968-6848511
+  Free inodes: 1703937-1712128
+Group 209: (Blocks 6848512-6881279) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x16b2, unused inodes 8192
+  Block bitmap at 6815745 (bg #208 + 1), Inode bitmap at 6815761 (bg #208 + 17)
+  Inode table at 6816288-6816799 (bg #208 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6848512-6881279
+  Free inodes: 1712129-1720320
+Group 210: (Blocks 6881280-6914047) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb7dc, unused inodes 8192
+  Block bitmap at 6815746 (bg #208 + 2), Inode bitmap at 6815762 (bg #208 + 18)
+  Inode table at 6816800-6817311 (bg #208 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6881280-6914047
+  Free inodes: 1720321-1728512
+Group 211: (Blocks 6914048-6946815) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1707, unused inodes 8192
+  Block bitmap at 6815747 (bg #208 + 3), Inode bitmap at 6815763 (bg #208 + 19)
+  Inode table at 6817312-6817823 (bg #208 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6914048-6946815
+  Free inodes: 1728513-1736704
+Group 212: (Blocks 6946816-6979583) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb503, unused inodes 8192
+  Block bitmap at 6815748 (bg #208 + 4), Inode bitmap at 6815764 (bg #208 + 20)
+  Inode table at 6817824-6818335 (bg #208 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6946816-6979583
+  Free inodes: 1736705-1744896
+Group 213: (Blocks 6979584-7012351) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x15d8, unused inodes 8192
+  Block bitmap at 6815749 (bg #208 + 5), Inode bitmap at 6815765 (bg #208 + 21)
+  Inode table at 6818336-6818847 (bg #208 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 6979584-7012351
+  Free inodes: 1744897-1753088
+Group 214: (Blocks 7012352-7045119) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb4b6, unused inodes 8192
+  Block bitmap at 6815750 (bg #208 + 6), Inode bitmap at 6815766 (bg #208 + 22)
+  Inode table at 6818848-6819359 (bg #208 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7012352-7045119
+  Free inodes: 1753089-1761280
+Group 215: (Blocks 7045120-7077887) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x146d, unused inodes 8192
+  Block bitmap at 6815751 (bg #208 + 7), Inode bitmap at 6815767 (bg #208 + 23)
+  Inode table at 6819360-6819871 (bg #208 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7045120-7077887
+  Free inodes: 1761281-1769472
+Group 216: (Blocks 7077888-7110655) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb0bd, unused inodes 8192
+  Block bitmap at 6815752 (bg #208 + 8), Inode bitmap at 6815768 (bg #208 + 24)
+  Inode table at 6819872-6820383 (bg #208 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7077888-7110655
+  Free inodes: 1769473-1777664
+Group 217: (Blocks 7110656-7143423) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1066, unused inodes 8192
+  Block bitmap at 6815753 (bg #208 + 9), Inode bitmap at 6815769 (bg #208 + 25)
+  Inode table at 6820384-6820895 (bg #208 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7110656-7143423
+  Free inodes: 1777665-1785856
+Group 218: (Blocks 7143424-7176191) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb108, unused inodes 8192
+  Block bitmap at 6815754 (bg #208 + 10), Inode bitmap at 6815770 (bg #208 + 26)
+  Inode table at 6820896-6821407 (bg #208 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7143424-7176191
+  Free inodes: 1785857-1794048
+Group 219: (Blocks 7176192-7208959) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x11d3, unused inodes 8192
+  Block bitmap at 6815755 (bg #208 + 11), Inode bitmap at 6815771 (bg #208 + 27)
+  Inode table at 6821408-6821919 (bg #208 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7176192-7208959
+  Free inodes: 1794049-1802240
+Group 220: (Blocks 7208960-7241727) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb3d7, unused inodes 8192
+  Block bitmap at 6815756 (bg #208 + 12), Inode bitmap at 6815772 (bg #208 + 28)
+  Inode table at 6821920-6822431 (bg #208 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7208960-7241727
+  Free inodes: 1802241-1810432
+Group 221: (Blocks 7241728-7274495) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x130c, unused inodes 8192
+  Block bitmap at 6815757 (bg #208 + 13), Inode bitmap at 6815773 (bg #208 + 29)
+  Inode table at 6822432-6822943 (bg #208 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7241728-7274495
+  Free inodes: 1810433-1818624
+Group 222: (Blocks 7274496-7307263) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb262, unused inodes 8192
+  Block bitmap at 6815758 (bg #208 + 14), Inode bitmap at 6815774 (bg #208 + 30)
+  Inode table at 6822944-6823455 (bg #208 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7274496-7307263
+  Free inodes: 1818625-1826816
+Group 223: (Blocks 7307264-7340031) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x12b9, unused inodes 8192
+  Block bitmap at 6815759 (bg #208 + 15), Inode bitmap at 6815775 (bg #208 + 31)
+  Inode table at 6823456-6823967 (bg #208 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7307264-7340031
+  Free inodes: 1826817-1835008
+Group 224: (Blocks 7340032-7372799) [ITABLE_ZEROED]
+  Checksum 0xf57e, unused inodes 8181
+  Block bitmap at 7340032 (+0), Inode bitmap at 7340048 (+16)
+  Inode table at 7340064-7340575 (+32)
+  24540 free blocks, 8182 free inodes, 4 directories, 8181 unused inodes
+  Free blocks: 7348260-7372799
+  Free inodes: 1835019-1843200
+Group 225: (Blocks 7372800-7405567) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8388, unused inodes 8192
+  Block bitmap at 7340033 (bg #224 + 1), Inode bitmap at 7340049 (bg #224 + 17)
+  Inode table at 7340576-7341087 (bg #224 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7372800-7405567
+  Free inodes: 1843201-1851392
+Group 226: (Blocks 7405568-7438335) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x22e6, unused inodes 8192
+  Block bitmap at 7340034 (bg #224 + 2), Inode bitmap at 7340050 (bg #224 + 18)
+  Inode table at 7341088-7341599 (bg #224 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7405568-7438335
+  Free inodes: 1851393-1859584
+Group 227: (Blocks 7438336-7471103) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x823d, unused inodes 8192
+  Block bitmap at 7340035 (bg #224 + 3), Inode bitmap at 7340051 (bg #224 + 19)
+  Inode table at 7341600-7342111 (bg #224 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7438336-7471103
+  Free inodes: 1859585-1867776
+Group 228: (Blocks 7471104-7503871) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2039, unused inodes 8192
+  Block bitmap at 7340036 (bg #224 + 4), Inode bitmap at 7340052 (bg #224 + 20)
+  Inode table at 7342112-7342623 (bg #224 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7471104-7503871
+  Free inodes: 1867777-1875968
+Group 229: (Blocks 7503872-7536639) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x80e2, unused inodes 8192
+  Block bitmap at 7340037 (bg #224 + 5), Inode bitmap at 7340053 (bg #224 + 21)
+  Inode table at 7342624-7343135 (bg #224 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7503872-7536639
+  Free inodes: 1875969-1884160
+Group 230: (Blocks 7536640-7569407) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x218c, unused inodes 8192
+  Block bitmap at 7340038 (bg #224 + 6), Inode bitmap at 7340054 (bg #224 + 22)
+  Inode table at 7343136-7343647 (bg #224 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7536640-7569407
+  Free inodes: 1884161-1892352
+Group 231: (Blocks 7569408-7602175) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8157, unused inodes 8192
+  Block bitmap at 7340039 (bg #224 + 7), Inode bitmap at 7340055 (bg #224 + 23)
+  Inode table at 7343648-7344159 (bg #224 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7569408-7602175
+  Free inodes: 1892353-1900544
+Group 232: (Blocks 7602176-7634943) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2587, unused inodes 8192
+  Block bitmap at 7340040 (bg #224 + 8), Inode bitmap at 7340056 (bg #224 + 24)
+  Inode table at 7344160-7344671 (bg #224 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7602176-7634943
+  Free inodes: 1900545-1908736
+Group 233: (Blocks 7634944-7667711) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x855c, unused inodes 8192
+  Block bitmap at 7340041 (bg #224 + 9), Inode bitmap at 7340057 (bg #224 + 25)
+  Inode table at 7344672-7345183 (bg #224 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7634944-7667711
+  Free inodes: 1908737-1916928
+Group 234: (Blocks 7667712-7700479) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2432, unused inodes 8192
+  Block bitmap at 7340042 (bg #224 + 10), Inode bitmap at 7340058 (bg #224 + 26)
+  Inode table at 7345184-7345695 (bg #224 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7667712-7700479
+  Free inodes: 1916929-1925120
+Group 235: (Blocks 7700480-7733247) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x84e9, unused inodes 8192
+  Block bitmap at 7340043 (bg #224 + 11), Inode bitmap at 7340059 (bg #224 + 27)
+  Inode table at 7345696-7346207 (bg #224 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7700480-7733247
+  Free inodes: 1925121-1933312
+Group 236: (Blocks 7733248-7766015) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x26ed, unused inodes 8192
+  Block bitmap at 7340044 (bg #224 + 12), Inode bitmap at 7340060 (bg #224 + 28)
+  Inode table at 7346208-7346719 (bg #224 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7733248-7766015
+  Free inodes: 1933313-1941504
+Group 237: (Blocks 7766016-7798783) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8636, unused inodes 8192
+  Block bitmap at 7340045 (bg #224 + 13), Inode bitmap at 7340061 (bg #224 + 29)
+  Inode table at 7346720-7347231 (bg #224 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7766016-7798783
+  Free inodes: 1941505-1949696
+Group 238: (Blocks 7798784-7831551) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2758, unused inodes 8192
+  Block bitmap at 7340046 (bg #224 + 14), Inode bitmap at 7340062 (bg #224 + 30)
+  Inode table at 7347232-7347743 (bg #224 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7798784-7831551
+  Free inodes: 1949697-1957888
+Group 239: (Blocks 7831552-7864319) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8783, unused inodes 8192
+  Block bitmap at 7340047 (bg #224 + 15), Inode bitmap at 7340063 (bg #224 + 31)
+  Inode table at 7347744-7348255 (bg #224 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7831552-7864319
+  Free inodes: 1957889-1966080
+Group 240: (Blocks 7864320-7897087) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6be3, unused inodes 8192
+  Block bitmap at 7864320 (+0), Inode bitmap at 7864336 (+16)
+  Inode table at 7864352-7864863 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7872544-7897087
+  Free inodes: 1966081-1974272
+Group 241: (Blocks 7897088-7929855) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf09e, unused inodes 8192
+  Block bitmap at 7864321 (bg #240 + 1), Inode bitmap at 7864337 (bg #240 + 17)
+  Inode table at 7864864-7865375 (bg #240 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7897088-7929855
+  Free inodes: 1974273-1982464
+Group 242: (Blocks 7929856-7962623) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x51f0, unused inodes 8192
+  Block bitmap at 7864322 (bg #240 + 2), Inode bitmap at 7864338 (bg #240 + 18)
+  Inode table at 7865376-7865887 (bg #240 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7929856-7962623
+  Free inodes: 1982465-1990656
+Group 243: (Blocks 7962624-7995391) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd418, unused inodes 8192
+  Backup superblock at 7962624, Group descriptors at 7962625-7962631
+  Reserved GDT blocks at 7962632-7963648
+  Block bitmap at 7864323 (bg #240 + 3), Inode bitmap at 7864339 (bg #240 + 19)
+  Inode table at 7865888-7866399 (bg #240 + 1568)
+  31743 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7963649-7995391
+  Free inodes: 1990657-1998848
+Group 244: (Blocks 7995392-8028159) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x532f, unused inodes 8192
+  Block bitmap at 7864324 (bg #240 + 4), Inode bitmap at 7864340 (bg #240 + 20)
+  Inode table at 7866400-7866911 (bg #240 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 7995392-8028159
+  Free inodes: 1998849-2007040
+Group 245: (Blocks 8028160-8060927) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf3f4, unused inodes 8192
+  Block bitmap at 7864325 (bg #240 + 5), Inode bitmap at 7864341 (bg #240 + 21)
+  Inode table at 7866912-7867423 (bg #240 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8028160-8060927
+  Free inodes: 2007041-2015232
+Group 246: (Blocks 8060928-8093695) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x529a, unused inodes 8192
+  Block bitmap at 7864326 (bg #240 + 6), Inode bitmap at 7864342 (bg #240 + 22)
+  Inode table at 7867424-7867935 (bg #240 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8060928-8093695
+  Free inodes: 2015233-2023424
+Group 247: (Blocks 8093696-8126463) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf241, unused inodes 8192
+  Block bitmap at 7864327 (bg #240 + 7), Inode bitmap at 7864343 (bg #240 + 23)
+  Inode table at 7867936-7868447 (bg #240 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8093696-8126463
+  Free inodes: 2023425-2031616
+Group 248: (Blocks 8126464-8159231) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5691, unused inodes 8192
+  Block bitmap at 7864328 (bg #240 + 8), Inode bitmap at 7864344 (bg #240 + 24)
+  Inode table at 7868448-7868959 (bg #240 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8126464-8159231
+  Free inodes: 2031617-2039808
+Group 249: (Blocks 8159232-8191999) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf64a, unused inodes 8192
+  Block bitmap at 7864329 (bg #240 + 9), Inode bitmap at 7864345 (bg #240 + 25)
+  Inode table at 7868960-7869471 (bg #240 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8159232-8191999
+  Free inodes: 2039809-2048000
+Group 250: (Blocks 8192000-8224767) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5724, unused inodes 8192
+  Block bitmap at 7864330 (bg #240 + 10), Inode bitmap at 7864346 (bg #240 + 26)
+  Inode table at 7869472-7869983 (bg #240 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8192000-8224767
+  Free inodes: 2048001-2056192
+Group 251: (Blocks 8224768-8257535) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf7ff, unused inodes 8192
+  Block bitmap at 7864331 (bg #240 + 11), Inode bitmap at 7864347 (bg #240 + 27)
+  Inode table at 7869984-7870495 (bg #240 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8224768-8257535
+  Free inodes: 2056193-2064384
+Group 252: (Blocks 8257536-8290303) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x55fb, unused inodes 8192
+  Block bitmap at 7864332 (bg #240 + 12), Inode bitmap at 7864348 (bg #240 + 28)
+  Inode table at 7870496-7871007 (bg #240 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8257536-8290303
+  Free inodes: 2064385-2072576
+Group 253: (Blocks 8290304-8323071) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf520, unused inodes 8192
+  Block bitmap at 7864333 (bg #240 + 13), Inode bitmap at 7864349 (bg #240 + 29)
+  Inode table at 7871008-7871519 (bg #240 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8290304-8323071
+  Free inodes: 2072577-2080768
+Group 254: (Blocks 8323072-8355839) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x544e, unused inodes 8192
+  Block bitmap at 7864334 (bg #240 + 14), Inode bitmap at 7864350 (bg #240 + 30)
+  Inode table at 7871520-7872031 (bg #240 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8323072-8355839
+  Free inodes: 2080769-2088960
+Group 255: (Blocks 8355840-8388607) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf495, unused inodes 8192
+  Block bitmap at 7864335 (bg #240 + 15), Inode bitmap at 7864351 (bg #240 + 31)
+  Inode table at 7872032-7872543 (bg #240 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8355840-8388607
+  Free inodes: 2088961-2097152
+Group 256: (Blocks 8388608-8421375) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9b5d, unused inodes 8192
+  Block bitmap at 8388608 (+0), Inode bitmap at 8388624 (+16)
+  Inode table at 8388640-8389151 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8396832-8421375
+  Free inodes: 2097153-2105344
+Group 257: (Blocks 8421376-8454143) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0020, unused inodes 8192
+  Block bitmap at 8388609 (bg #256 + 1), Inode bitmap at 8388625 (bg #256 + 17)
+  Inode table at 8389152-8389663 (bg #256 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8421376-8454143
+  Free inodes: 2105345-2113536
+Group 258: (Blocks 8454144-8486911) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa14e, unused inodes 8192
+  Block bitmap at 8388610 (bg #256 + 2), Inode bitmap at 8388626 (bg #256 + 18)
+  Inode table at 8389664-8390175 (bg #256 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8454144-8486911
+  Free inodes: 2113537-2121728
+Group 259: (Blocks 8486912-8519679) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0195, unused inodes 8192
+  Block bitmap at 8388611 (bg #256 + 3), Inode bitmap at 8388627 (bg #256 + 19)
+  Inode table at 8390176-8390687 (bg #256 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8486912-8519679
+  Free inodes: 2121729-2129920
+Group 260: (Blocks 8519680-8552447) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa391, unused inodes 8192
+  Block bitmap at 8388612 (bg #256 + 4), Inode bitmap at 8388628 (bg #256 + 20)
+  Inode table at 8390688-8391199 (bg #256 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8519680-8552447
+  Free inodes: 2129921-2138112
+Group 261: (Blocks 8552448-8585215) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x034a, unused inodes 8192
+  Block bitmap at 8388613 (bg #256 + 5), Inode bitmap at 8388629 (bg #256 + 21)
+  Inode table at 8391200-8391711 (bg #256 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8552448-8585215
+  Free inodes: 2138113-2146304
+Group 262: (Blocks 8585216-8617983) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa224, unused inodes 8192
+  Block bitmap at 8388614 (bg #256 + 6), Inode bitmap at 8388630 (bg #256 + 22)
+  Inode table at 8391712-8392223 (bg #256 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8585216-8617983
+  Free inodes: 2146305-2154496
+Group 263: (Blocks 8617984-8650751) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x02ff, unused inodes 8192
+  Block bitmap at 8388615 (bg #256 + 7), Inode bitmap at 8388631 (bg #256 + 23)
+  Inode table at 8392224-8392735 (bg #256 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8617984-8650751
+  Free inodes: 2154497-2162688
+Group 264: (Blocks 8650752-8683519) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa62f, unused inodes 8192
+  Block bitmap at 8388616 (bg #256 + 8), Inode bitmap at 8388632 (bg #256 + 24)
+  Inode table at 8392736-8393247 (bg #256 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8650752-8683519
+  Free inodes: 2162689-2170880
+Group 265: (Blocks 8683520-8716287) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x06f4, unused inodes 8192
+  Block bitmap at 8388617 (bg #256 + 9), Inode bitmap at 8388633 (bg #256 + 25)
+  Inode table at 8393248-8393759 (bg #256 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8683520-8716287
+  Free inodes: 2170881-2179072
+Group 266: (Blocks 8716288-8749055) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa79a, unused inodes 8192
+  Block bitmap at 8388618 (bg #256 + 10), Inode bitmap at 8388634 (bg #256 + 26)
+  Inode table at 8393760-8394271 (bg #256 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8716288-8749055
+  Free inodes: 2179073-2187264
+Group 267: (Blocks 8749056-8781823) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0741, unused inodes 8192
+  Block bitmap at 8388619 (bg #256 + 11), Inode bitmap at 8388635 (bg #256 + 27)
+  Inode table at 8394272-8394783 (bg #256 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8749056-8781823
+  Free inodes: 2187265-2195456
+Group 268: (Blocks 8781824-8814591) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa545, unused inodes 8192
+  Block bitmap at 8388620 (bg #256 + 12), Inode bitmap at 8388636 (bg #256 + 28)
+  Inode table at 8394784-8395295 (bg #256 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8781824-8814591
+  Free inodes: 2195457-2203648
+Group 269: (Blocks 8814592-8847359) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x059e, unused inodes 8192
+  Block bitmap at 8388621 (bg #256 + 13), Inode bitmap at 8388637 (bg #256 + 29)
+  Inode table at 8395296-8395807 (bg #256 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8814592-8847359
+  Free inodes: 2203649-2211840
+Group 270: (Blocks 8847360-8880127) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa4f0, unused inodes 8192
+  Block bitmap at 8388622 (bg #256 + 14), Inode bitmap at 8388638 (bg #256 + 30)
+  Inode table at 8395808-8396319 (bg #256 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8847360-8880127
+  Free inodes: 2211841-2220032
+Group 271: (Blocks 8880128-8912895) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x042b, unused inodes 8192
+  Block bitmap at 8388623 (bg #256 + 15), Inode bitmap at 8388639 (bg #256 + 31)
+  Inode table at 8396320-8396831 (bg #256 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8880128-8912895
+  Free inodes: 2220033-2228224
+Group 272: (Blocks 8912896-8945663) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe84b, unused inodes 8192
+  Block bitmap at 8912896 (+0), Inode bitmap at 8912912 (+16)
+  Inode table at 8912928-8913439 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8921120-8945663
+  Free inodes: 2228225-2236416
+Group 273: (Blocks 8945664-8978431) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7336, unused inodes 8192
+  Block bitmap at 8912897 (bg #272 + 1), Inode bitmap at 8912913 (bg #272 + 17)
+  Inode table at 8913440-8913951 (bg #272 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8945664-8978431
+  Free inodes: 2236417-2244608
+Group 274: (Blocks 8978432-9011199) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd258, unused inodes 8192
+  Block bitmap at 8912898 (bg #272 + 2), Inode bitmap at 8912914 (bg #272 + 18)
+  Inode table at 8913952-8914463 (bg #272 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 8978432-9011199
+  Free inodes: 2244609-2252800
+Group 275: (Blocks 9011200-9043967) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7283, unused inodes 8192
+  Block bitmap at 8912899 (bg #272 + 3), Inode bitmap at 8912915 (bg #272 + 19)
+  Inode table at 8914464-8914975 (bg #272 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9011200-9043967
+  Free inodes: 2252801-2260992
+Group 276: (Blocks 9043968-9076735) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd087, unused inodes 8192
+  Block bitmap at 8912900 (bg #272 + 4), Inode bitmap at 8912916 (bg #272 + 20)
+  Inode table at 8914976-8915487 (bg #272 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9043968-9076735
+  Free inodes: 2260993-2269184
+Group 277: (Blocks 9076736-9109503) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x705c, unused inodes 8192
+  Block bitmap at 8912901 (bg #272 + 5), Inode bitmap at 8912917 (bg #272 + 21)
+  Inode table at 8915488-8915999 (bg #272 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9076736-9109503
+  Free inodes: 2269185-2277376
+Group 278: (Blocks 9109504-9142271) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd132, unused inodes 8192
+  Block bitmap at 8912902 (bg #272 + 6), Inode bitmap at 8912918 (bg #272 + 22)
+  Inode table at 8916000-8916511 (bg #272 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9109504-9142271
+  Free inodes: 2277377-2285568
+Group 279: (Blocks 9142272-9175039) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x71e9, unused inodes 8192
+  Block bitmap at 8912903 (bg #272 + 7), Inode bitmap at 8912919 (bg #272 + 23)
+  Inode table at 8916512-8917023 (bg #272 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9142272-9175039
+  Free inodes: 2285569-2293760
+Group 280: (Blocks 9175040-9207807) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd539, unused inodes 8192
+  Block bitmap at 8912904 (bg #272 + 8), Inode bitmap at 8912920 (bg #272 + 24)
+  Inode table at 8917024-8917535 (bg #272 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9175040-9207807
+  Free inodes: 2293761-2301952
+Group 281: (Blocks 9207808-9240575) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x75e2, unused inodes 8192
+  Block bitmap at 8912905 (bg #272 + 9), Inode bitmap at 8912921 (bg #272 + 25)
+  Inode table at 8917536-8918047 (bg #272 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9207808-9240575
+  Free inodes: 2301953-2310144
+Group 282: (Blocks 9240576-9273343) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd48c, unused inodes 8192
+  Block bitmap at 8912906 (bg #272 + 10), Inode bitmap at 8912922 (bg #272 + 26)
+  Inode table at 8918048-8918559 (bg #272 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9240576-9273343
+  Free inodes: 2310145-2318336
+Group 283: (Blocks 9273344-9306111) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7457, unused inodes 8192
+  Block bitmap at 8912907 (bg #272 + 11), Inode bitmap at 8912923 (bg #272 + 27)
+  Inode table at 8918560-8919071 (bg #272 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9273344-9306111
+  Free inodes: 2318337-2326528
+Group 284: (Blocks 9306112-9338879) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd653, unused inodes 8192
+  Block bitmap at 8912908 (bg #272 + 12), Inode bitmap at 8912924 (bg #272 + 28)
+  Inode table at 8919072-8919583 (bg #272 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9306112-9338879
+  Free inodes: 2326529-2334720
+Group 285: (Blocks 9338880-9371647) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7688, unused inodes 8192
+  Block bitmap at 8912909 (bg #272 + 13), Inode bitmap at 8912925 (bg #272 + 29)
+  Inode table at 8919584-8920095 (bg #272 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9338880-9371647
+  Free inodes: 2334721-2342912
+Group 286: (Blocks 9371648-9404415) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd7e6, unused inodes 8192
+  Block bitmap at 8912910 (bg #272 + 14), Inode bitmap at 8912926 (bg #272 + 30)
+  Inode table at 8920096-8920607 (bg #272 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9371648-9404415
+  Free inodes: 2342913-2351104
+Group 287: (Blocks 9404416-9437183) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x773d, unused inodes 8192
+  Block bitmap at 8912911 (bg #272 + 15), Inode bitmap at 8912927 (bg #272 + 31)
+  Inode table at 8920608-8921119 (bg #272 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9404416-9437183
+  Free inodes: 2351105-2359296
+Group 288: (Blocks 9437184-9469951) [ITABLE_ZEROED]
+  Checksum 0x27cf, unused inodes 8191
+  Block bitmap at 9437184 (+0), Inode bitmap at 9437200 (+16)
+  Inode table at 9437216-9437727 (+32)
+  24543 free blocks, 8191 free inodes, 1 directories, 8191 unused inodes
+  Free blocks: 9445409-9469951
+  Free inodes: 2359298-2367488
+Group 289: (Blocks 9469952-9502719) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe60c, unused inodes 8192
+  Block bitmap at 9437185 (bg #288 + 1), Inode bitmap at 9437201 (bg #288 + 17)
+  Inode table at 9437728-9438239 (bg #288 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9469952-9502719
+  Free inodes: 2367489-2375680
+Group 290: (Blocks 9502720-9535487) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4762, unused inodes 8192
+  Block bitmap at 9437186 (bg #288 + 2), Inode bitmap at 9437202 (bg #288 + 18)
+  Inode table at 9438240-9438751 (bg #288 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9502720-9535487
+  Free inodes: 2375681-2383872
+Group 291: (Blocks 9535488-9568255) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe7b9, unused inodes 8192
+  Block bitmap at 9437187 (bg #288 + 3), Inode bitmap at 9437203 (bg #288 + 19)
+  Inode table at 9438752-9439263 (bg #288 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9535488-9568255
+  Free inodes: 2383873-2392064
+Group 292: (Blocks 9568256-9601023) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x45bd, unused inodes 8192
+  Block bitmap at 9437188 (bg #288 + 4), Inode bitmap at 9437204 (bg #288 + 20)
+  Inode table at 9439264-9439775 (bg #288 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9568256-9601023
+  Free inodes: 2392065-2400256
+Group 293: (Blocks 9601024-9633791) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe566, unused inodes 8192
+  Block bitmap at 9437189 (bg #288 + 5), Inode bitmap at 9437205 (bg #288 + 21)
+  Inode table at 9439776-9440287 (bg #288 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9601024-9633791
+  Free inodes: 2400257-2408448
+Group 294: (Blocks 9633792-9666559) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4408, unused inodes 8192
+  Block bitmap at 9437190 (bg #288 + 6), Inode bitmap at 9437206 (bg #288 + 22)
+  Inode table at 9440288-9440799 (bg #288 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9633792-9666559
+  Free inodes: 2408449-2416640
+Group 295: (Blocks 9666560-9699327) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe4d3, unused inodes 8192
+  Block bitmap at 9437191 (bg #288 + 7), Inode bitmap at 9437207 (bg #288 + 23)
+  Inode table at 9440800-9441311 (bg #288 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9666560-9699327
+  Free inodes: 2416641-2424832
+Group 296: (Blocks 9699328-9732095) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4003, unused inodes 8192
+  Block bitmap at 9437192 (bg #288 + 8), Inode bitmap at 9437208 (bg #288 + 24)
+  Inode table at 9441312-9441823 (bg #288 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9699328-9732095
+  Free inodes: 2424833-2433024
+Group 297: (Blocks 9732096-9764863) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe0d8, unused inodes 8192
+  Block bitmap at 9437193 (bg #288 + 9), Inode bitmap at 9437209 (bg #288 + 25)
+  Inode table at 9441824-9442335 (bg #288 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9732096-9764863
+  Free inodes: 2433025-2441216
+Group 298: (Blocks 9764864-9797631) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x41b6, unused inodes 8192
+  Block bitmap at 9437194 (bg #288 + 10), Inode bitmap at 9437210 (bg #288 + 26)
+  Inode table at 9442336-9442847 (bg #288 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9764864-9797631
+  Free inodes: 2441217-2449408
+Group 299: (Blocks 9797632-9830399) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe16d, unused inodes 8192
+  Block bitmap at 9437195 (bg #288 + 11), Inode bitmap at 9437211 (bg #288 + 27)
+  Inode table at 9442848-9443359 (bg #288 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9797632-9830399
+  Free inodes: 2449409-2457600
+Group 300: (Blocks 9830400-9863167) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4369, unused inodes 8192
+  Block bitmap at 9437196 (bg #288 + 12), Inode bitmap at 9437212 (bg #288 + 28)
+  Inode table at 9443360-9443871 (bg #288 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9830400-9863167
+  Free inodes: 2457601-2465792
+Group 301: (Blocks 9863168-9895935) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe3b2, unused inodes 8192
+  Block bitmap at 9437197 (bg #288 + 13), Inode bitmap at 9437213 (bg #288 + 29)
+  Inode table at 9443872-9444383 (bg #288 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9863168-9895935
+  Free inodes: 2465793-2473984
+Group 302: (Blocks 9895936-9928703) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x42dc, unused inodes 8192
+  Block bitmap at 9437198 (bg #288 + 14), Inode bitmap at 9437214 (bg #288 + 30)
+  Inode table at 9444384-9444895 (bg #288 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9895936-9928703
+  Free inodes: 2473985-2482176
+Group 303: (Blocks 9928704-9961471) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe207, unused inodes 8192
+  Block bitmap at 9437199 (bg #288 + 15), Inode bitmap at 9437215 (bg #288 + 31)
+  Inode table at 9444896-9445407 (bg #288 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9928704-9961471
+  Free inodes: 2482177-2490368
+Group 304: (Blocks 9961472-9994239) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0e67, unused inodes 8192
+  Block bitmap at 9961472 (+0), Inode bitmap at 9961488 (+16)
+  Inode table at 9961504-9962015 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9969696-9994239
+  Free inodes: 2490369-2498560
+Group 305: (Blocks 9994240-10027007) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x951a, unused inodes 8192
+  Block bitmap at 9961473 (bg #304 + 1), Inode bitmap at 9961489 (bg #304 + 17)
+  Inode table at 9962016-9962527 (bg #304 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 9994240-10027007
+  Free inodes: 2498561-2506752
+Group 306: (Blocks 10027008-10059775) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3474, unused inodes 8192
+  Block bitmap at 9961474 (bg #304 + 2), Inode bitmap at 9961490 (bg #304 + 18)
+  Inode table at 9962528-9963039 (bg #304 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10027008-10059775
+  Free inodes: 2506753-2514944
+Group 307: (Blocks 10059776-10092543) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x94af, unused inodes 8192
+  Block bitmap at 9961475 (bg #304 + 3), Inode bitmap at 9961491 (bg #304 + 19)
+  Inode table at 9963040-9963551 (bg #304 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10059776-10092543
+  Free inodes: 2514945-2523136
+Group 308: (Blocks 10092544-10125311) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x36ab, unused inodes 8192
+  Block bitmap at 9961476 (bg #304 + 4), Inode bitmap at 9961492 (bg #304 + 20)
+  Inode table at 9963552-9964063 (bg #304 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10092544-10125311
+  Free inodes: 2523137-2531328
+Group 309: (Blocks 10125312-10158079) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9670, unused inodes 8192
+  Block bitmap at 9961477 (bg #304 + 5), Inode bitmap at 9961493 (bg #304 + 21)
+  Inode table at 9964064-9964575 (bg #304 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10125312-10158079
+  Free inodes: 2531329-2539520
+Group 310: (Blocks 10158080-10190847) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x371e, unused inodes 8192
+  Block bitmap at 9961478 (bg #304 + 6), Inode bitmap at 9961494 (bg #304 + 22)
+  Inode table at 9964576-9965087 (bg #304 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10158080-10190847
+  Free inodes: 2539521-2547712
+Group 311: (Blocks 10190848-10223615) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x97c5, unused inodes 8192
+  Block bitmap at 9961479 (bg #304 + 7), Inode bitmap at 9961495 (bg #304 + 23)
+  Inode table at 9965088-9965599 (bg #304 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10190848-10223615
+  Free inodes: 2547713-2555904
+Group 312: (Blocks 10223616-10256383) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3315, unused inodes 8192
+  Block bitmap at 9961480 (bg #304 + 8), Inode bitmap at 9961496 (bg #304 + 24)
+  Inode table at 9965600-9966111 (bg #304 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10223616-10256383
+  Free inodes: 2555905-2564096
+Group 313: (Blocks 10256384-10289151) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x93ce, unused inodes 8192
+  Block bitmap at 9961481 (bg #304 + 9), Inode bitmap at 9961497 (bg #304 + 25)
+  Inode table at 9966112-9966623 (bg #304 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10256384-10289151
+  Free inodes: 2564097-2572288
+Group 314: (Blocks 10289152-10321919) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x32a0, unused inodes 8192
+  Block bitmap at 9961482 (bg #304 + 10), Inode bitmap at 9961498 (bg #304 + 26)
+  Inode table at 9966624-9967135 (bg #304 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10289152-10321919
+  Free inodes: 2572289-2580480
+Group 315: (Blocks 10321920-10354687) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x927b, unused inodes 8192
+  Block bitmap at 9961483 (bg #304 + 11), Inode bitmap at 9961499 (bg #304 + 27)
+  Inode table at 9967136-9967647 (bg #304 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10321920-10354687
+  Free inodes: 2580481-2588672
+Group 316: (Blocks 10354688-10387455) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x307f, unused inodes 8192
+  Block bitmap at 9961484 (bg #304 + 12), Inode bitmap at 9961500 (bg #304 + 28)
+  Inode table at 9967648-9968159 (bg #304 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10354688-10387455
+  Free inodes: 2588673-2596864
+Group 317: (Blocks 10387456-10420223) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x90a4, unused inodes 8192
+  Block bitmap at 9961485 (bg #304 + 13), Inode bitmap at 9961501 (bg #304 + 29)
+  Inode table at 9968160-9968671 (bg #304 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10387456-10420223
+  Free inodes: 2596865-2605056
+Group 318: (Blocks 10420224-10452991) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x31ca, unused inodes 8192
+  Block bitmap at 9961486 (bg #304 + 14), Inode bitmap at 9961502 (bg #304 + 30)
+  Inode table at 9968672-9969183 (bg #304 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10420224-10452991
+  Free inodes: 2605057-2613248
+Group 319: (Blocks 10452992-10485759) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9111, unused inodes 8192
+  Block bitmap at 9961487 (bg #304 + 15), Inode bitmap at 9961503 (bg #304 + 31)
+  Inode table at 9969184-9969695 (bg #304 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10452992-10485759
+  Free inodes: 2613249-2621440
+Group 320: (Blocks 10485760-10518527) [ITABLE_ZEROED]
+  Checksum 0xbd78, unused inodes 8189
+  Block bitmap at 10485760 (+0), Inode bitmap at 10485776 (+16)
+  Inode table at 10485792-10486303 (+32)
+  24543 free blocks, 8190 free inodes, 1 directories, 8189 unused inodes
+  Free blocks: 10493985-10518527
+  Free inodes: 2621442, 2621444-2629632
+Group 321: (Blocks 10518528-10551295) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4b82, unused inodes 8192
+  Block bitmap at 10485761 (bg #320 + 1), Inode bitmap at 10485777 (bg #320 + 17)
+  Inode table at 10486304-10486815 (bg #320 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10518528-10551295
+  Free inodes: 2629633-2637824
+Group 322: (Blocks 10551296-10584063) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2d15, unused inodes 8192
+  Block bitmap at 10485762 (bg #320 + 2), Inode bitmap at 10485778 (bg #320 + 18)
+  Inode table at 10486816-10487327 (bg #320 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10551296-10584063
+  Free inodes: 2637825-2646016
+Group 323: (Blocks 10584064-10616831) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8dce, unused inodes 8192
+  Block bitmap at 10485763 (bg #320 + 3), Inode bitmap at 10485779 (bg #320 + 19)
+  Inode table at 10487328-10487839 (bg #320 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10584064-10616831
+  Free inodes: 2646017-2654208
+Group 324: (Blocks 10616832-10649599) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2fca, unused inodes 8192
+  Block bitmap at 10485764 (bg #320 + 4), Inode bitmap at 10485780 (bg #320 + 20)
+  Inode table at 10487840-10488351 (bg #320 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10616832-10649599
+  Free inodes: 2654209-2662400
+Group 325: (Blocks 10649600-10682367) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8f11, unused inodes 8192
+  Block bitmap at 10485765 (bg #320 + 5), Inode bitmap at 10485781 (bg #320 + 21)
+  Inode table at 10488352-10488863 (bg #320 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10649600-10682367
+  Free inodes: 2662401-2670592
+Group 326: (Blocks 10682368-10715135) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2e7f, unused inodes 8192
+  Block bitmap at 10485766 (bg #320 + 6), Inode bitmap at 10485782 (bg #320 + 22)
+  Inode table at 10488864-10489375 (bg #320 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10682368-10715135
+  Free inodes: 2670593-2678784
+Group 327: (Blocks 10715136-10747903) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8ea4, unused inodes 8192
+  Block bitmap at 10485767 (bg #320 + 7), Inode bitmap at 10485783 (bg #320 + 23)
+  Inode table at 10489376-10489887 (bg #320 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10715136-10747903
+  Free inodes: 2678785-2686976
+Group 328: (Blocks 10747904-10780671) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2a74, unused inodes 8192
+  Block bitmap at 10485768 (bg #320 + 8), Inode bitmap at 10485784 (bg #320 + 24)
+  Inode table at 10489888-10490399 (bg #320 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10747904-10780671
+  Free inodes: 2686977-2695168
+Group 329: (Blocks 10780672-10813439) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8aaf, unused inodes 8192
+  Block bitmap at 10485769 (bg #320 + 9), Inode bitmap at 10485785 (bg #320 + 25)
+  Inode table at 10490400-10490911 (bg #320 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10780672-10813439
+  Free inodes: 2695169-2703360
+Group 330: (Blocks 10813440-10846207) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2bc1, unused inodes 8192
+  Block bitmap at 10485770 (bg #320 + 10), Inode bitmap at 10485786 (bg #320 + 26)
+  Inode table at 10490912-10491423 (bg #320 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10813440-10846207
+  Free inodes: 2703361-2711552
+Group 331: (Blocks 10846208-10878975) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8b1a, unused inodes 8192
+  Block bitmap at 10485771 (bg #320 + 11), Inode bitmap at 10485787 (bg #320 + 27)
+  Inode table at 10491424-10491935 (bg #320 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10846208-10878975
+  Free inodes: 2711553-2719744
+Group 332: (Blocks 10878976-10911743) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x291e, unused inodes 8192
+  Block bitmap at 10485772 (bg #320 + 12), Inode bitmap at 10485788 (bg #320 + 28)
+  Inode table at 10491936-10492447 (bg #320 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10878976-10911743
+  Free inodes: 2719745-2727936
+Group 333: (Blocks 10911744-10944511) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x89c5, unused inodes 8192
+  Block bitmap at 10485773 (bg #320 + 13), Inode bitmap at 10485789 (bg #320 + 29)
+  Inode table at 10492448-10492959 (bg #320 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10911744-10944511
+  Free inodes: 2727937-2736128
+Group 334: (Blocks 10944512-10977279) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x28ab, unused inodes 8192
+  Block bitmap at 10485774 (bg #320 + 14), Inode bitmap at 10485790 (bg #320 + 30)
+  Inode table at 10492960-10493471 (bg #320 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10944512-10977279
+  Free inodes: 2736129-2744320
+Group 335: (Blocks 10977280-11010047) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8870, unused inodes 8192
+  Block bitmap at 10485775 (bg #320 + 15), Inode bitmap at 10485791 (bg #320 + 31)
+  Inode table at 10493472-10493983 (bg #320 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 10977280-11010047
+  Free inodes: 2744321-2752512
+Group 336: (Blocks 11010048-11042815) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6410, unused inodes 8192
+  Block bitmap at 11010048 (+0), Inode bitmap at 11010064 (+16)
+  Inode table at 11010080-11010591 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11018272-11042815
+  Free inodes: 2752513-2760704
+Group 337: (Blocks 11042816-11075583) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xff6d, unused inodes 8192
+  Block bitmap at 11010049 (bg #336 + 1), Inode bitmap at 11010065 (bg #336 + 17)
+  Inode table at 11010592-11011103 (bg #336 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11042816-11075583
+  Free inodes: 2760705-2768896
+Group 338: (Blocks 11075584-11108351) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5e03, unused inodes 8192
+  Block bitmap at 11010050 (bg #336 + 2), Inode bitmap at 11010066 (bg #336 + 18)
+  Inode table at 11011104-11011615 (bg #336 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11075584-11108351
+  Free inodes: 2768897-2777088
+Group 339: (Blocks 11108352-11141119) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfed8, unused inodes 8192
+  Block bitmap at 11010051 (bg #336 + 3), Inode bitmap at 11010067 (bg #336 + 19)
+  Inode table at 11011616-11012127 (bg #336 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11108352-11141119
+  Free inodes: 2777089-2785280
+Group 340: (Blocks 11141120-11173887) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5cdc, unused inodes 8192
+  Block bitmap at 11010052 (bg #336 + 4), Inode bitmap at 11010068 (bg #336 + 20)
+  Inode table at 11012128-11012639 (bg #336 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11141120-11173887
+  Free inodes: 2785281-2793472
+Group 341: (Blocks 11173888-11206655) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfc07, unused inodes 8192
+  Block bitmap at 11010053 (bg #336 + 5), Inode bitmap at 11010069 (bg #336 + 21)
+  Inode table at 11012640-11013151 (bg #336 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11173888-11206655
+  Free inodes: 2793473-2801664
+Group 342: (Blocks 11206656-11239423) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5d69, unused inodes 8192
+  Block bitmap at 11010054 (bg #336 + 6), Inode bitmap at 11010070 (bg #336 + 22)
+  Inode table at 11013152-11013663 (bg #336 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11206656-11239423
+  Free inodes: 2801665-2809856
+Group 343: (Blocks 11239424-11272191) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd881, unused inodes 8192
+  Backup superblock at 11239424, Group descriptors at 11239425-11239431
+  Reserved GDT blocks at 11239432-11240448
+  Block bitmap at 11010055 (bg #336 + 7), Inode bitmap at 11010071 (bg #336 + 23)
+  Inode table at 11013664-11014175 (bg #336 + 3616)
+  31743 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11240449-11272191
+  Free inodes: 2809857-2818048
+Group 344: (Blocks 11272192-11304959) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5962, unused inodes 8192
+  Block bitmap at 11010056 (bg #336 + 8), Inode bitmap at 11010072 (bg #336 + 24)
+  Inode table at 11014176-11014687 (bg #336 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11272192-11304959
+  Free inodes: 2818049-2826240
+Group 345: (Blocks 11304960-11337727) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf9b9, unused inodes 8192
+  Block bitmap at 11010057 (bg #336 + 9), Inode bitmap at 11010073 (bg #336 + 25)
+  Inode table at 11014688-11015199 (bg #336 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11304960-11337727
+  Free inodes: 2826241-2834432
+Group 346: (Blocks 11337728-11370495) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x58d7, unused inodes 8192
+  Block bitmap at 11010058 (bg #336 + 10), Inode bitmap at 11010074 (bg #336 + 26)
+  Inode table at 11015200-11015711 (bg #336 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11337728-11370495
+  Free inodes: 2834433-2842624
+Group 347: (Blocks 11370496-11403263) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf80c, unused inodes 8192
+  Block bitmap at 11010059 (bg #336 + 11), Inode bitmap at 11010075 (bg #336 + 27)
+  Inode table at 11015712-11016223 (bg #336 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11370496-11403263
+  Free inodes: 2842625-2850816
+Group 348: (Blocks 11403264-11436031) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5a08, unused inodes 8192
+  Block bitmap at 11010060 (bg #336 + 12), Inode bitmap at 11010076 (bg #336 + 28)
+  Inode table at 11016224-11016735 (bg #336 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11403264-11436031
+  Free inodes: 2850817-2859008
+Group 349: (Blocks 11436032-11468799) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfad3, unused inodes 8192
+  Block bitmap at 11010061 (bg #336 + 13), Inode bitmap at 11010077 (bg #336 + 29)
+  Inode table at 11016736-11017247 (bg #336 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11436032-11468799
+  Free inodes: 2859009-2867200
+Group 350: (Blocks 11468800-11501567) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5bbd, unused inodes 8192
+  Block bitmap at 11010062 (bg #336 + 14), Inode bitmap at 11010078 (bg #336 + 30)
+  Inode table at 11017248-11017759 (bg #336 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11468800-11501567
+  Free inodes: 2867201-2875392
+Group 351: (Blocks 11501568-11534335) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfb66, unused inodes 8192
+  Block bitmap at 11010063 (bg #336 + 15), Inode bitmap at 11010079 (bg #336 + 31)
+  Inode table at 11017760-11018271 (bg #336 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11501568-11534335
+  Free inodes: 2875393-2883584
+Group 352: (Blocks 11534336-11567103) [ITABLE_ZEROED]
+  Checksum 0x4119, unused inodes 7882
+  Block bitmap at 11534336 (+0), Inode bitmap at 11534352 (+16)
+  Inode table at 11534368-11534879 (+32)
+  24535 free blocks, 7895 free inodes, 7 directories, 7882 unused inodes
+  Free blocks: 11542569-11567103
+  Free inodes: 2883692, 2883737, 2883739-2883740, 2883746, 2883750, 2883753, 2883760, 2883769, 2883794, 2883880-2883881, 2883893, 2883895-2891776
+Group 353: (Blocks 11567104-11599871) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1cb0, unused inodes 8192
+  Block bitmap at 11534337 (bg #352 + 1), Inode bitmap at 11534353 (bg #352 + 17)
+  Inode table at 11534880-11535391 (bg #352 + 544)
+  29474 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11567414-11567437, 11567880-11567888, 11568038-11568059, 11568368-11568369, 11568692-11568715, 11568740-11568763, 11568884, 11568957-11568980, 11569177-11569200, 11569332-11569355, 11569839, 11570560-11570687, 11570704-11570706, 11570708-11599871
+  Free inodes: 2891777-2899968
+Group 354: (Blocks 11599872-11632639) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcb39, unused inodes 8192
+  Block bitmap at 11534338 (bg #352 + 2), Inode bitmap at 11534354 (bg #352 + 18)
+  Inode table at 11535392-11535903 (bg #352 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11599872-11632639
+  Free inodes: 2899969-2908160
+Group 355: (Blocks 11632640-11665407) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6be2, unused inodes 8192
+  Block bitmap at 11534339 (bg #352 + 3), Inode bitmap at 11534355 (bg #352 + 19)
+  Inode table at 11535904-11536415 (bg #352 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11632640-11665407
+  Free inodes: 2908161-2916352
+Group 356: (Blocks 11665408-11698175) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc9e6, unused inodes 8192
+  Block bitmap at 11534340 (bg #352 + 4), Inode bitmap at 11534356 (bg #352 + 20)
+  Inode table at 11536416-11536927 (bg #352 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11665408-11698175
+  Free inodes: 2916353-2924544
+Group 357: (Blocks 11698176-11730943) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x693d, unused inodes 8192
+  Block bitmap at 11534341 (bg #352 + 5), Inode bitmap at 11534357 (bg #352 + 21)
+  Inode table at 11536928-11537439 (bg #352 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11698176-11730943
+  Free inodes: 2924545-2932736
+Group 358: (Blocks 11730944-11763711) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc853, unused inodes 8192
+  Block bitmap at 11534342 (bg #352 + 6), Inode bitmap at 11534358 (bg #352 + 22)
+  Inode table at 11537440-11537951 (bg #352 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11730944-11763711
+  Free inodes: 2932737-2940928
+Group 359: (Blocks 11763712-11796479) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6888, unused inodes 8192
+  Block bitmap at 11534343 (bg #352 + 7), Inode bitmap at 11534359 (bg #352 + 23)
+  Inode table at 11537952-11538463 (bg #352 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11763712-11796479
+  Free inodes: 2940929-2949120
+Group 360: (Blocks 11796480-11829247) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcc58, unused inodes 8192
+  Block bitmap at 11534344 (bg #352 + 8), Inode bitmap at 11534360 (bg #352 + 24)
+  Inode table at 11538464-11538975 (bg #352 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11796480-11829247
+  Free inodes: 2949121-2957312
+Group 361: (Blocks 11829248-11862015) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6c83, unused inodes 8192
+  Block bitmap at 11534345 (bg #352 + 9), Inode bitmap at 11534361 (bg #352 + 25)
+  Inode table at 11538976-11539487 (bg #352 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11829248-11862015
+  Free inodes: 2957313-2965504
+Group 362: (Blocks 11862016-11894783) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcded, unused inodes 8192
+  Block bitmap at 11534346 (bg #352 + 10), Inode bitmap at 11534362 (bg #352 + 26)
+  Inode table at 11539488-11539999 (bg #352 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11862016-11894783
+  Free inodes: 2965505-2973696
+Group 363: (Blocks 11894784-11927551) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6d36, unused inodes 8192
+  Block bitmap at 11534347 (bg #352 + 11), Inode bitmap at 11534363 (bg #352 + 27)
+  Inode table at 11540000-11540511 (bg #352 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11894784-11927551
+  Free inodes: 2973697-2981888
+Group 364: (Blocks 11927552-11960319) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcf32, unused inodes 8192
+  Block bitmap at 11534348 (bg #352 + 12), Inode bitmap at 11534364 (bg #352 + 28)
+  Inode table at 11540512-11541023 (bg #352 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11927552-11960319
+  Free inodes: 2981889-2990080
+Group 365: (Blocks 11960320-11993087) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6fe9, unused inodes 8192
+  Block bitmap at 11534349 (bg #352 + 13), Inode bitmap at 11534365 (bg #352 + 29)
+  Inode table at 11541024-11541535 (bg #352 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11960320-11993087
+  Free inodes: 2990081-2998272
+Group 366: (Blocks 11993088-12025855) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xce87, unused inodes 8192
+  Block bitmap at 11534350 (bg #352 + 14), Inode bitmap at 11534366 (bg #352 + 30)
+  Inode table at 11541536-11542047 (bg #352 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 11993088-12025855
+  Free inodes: 2998273-3006464
+Group 367: (Blocks 12025856-12058623) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6e5c, unused inodes 8192
+  Block bitmap at 11534351 (bg #352 + 15), Inode bitmap at 11534367 (bg #352 + 31)
+  Inode table at 11542048-11542559 (bg #352 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12025856-12058623
+  Free inodes: 3006465-3014656
+Group 368: (Blocks 12058624-12091391) [ITABLE_ZEROED]
+  Checksum 0xd882, unused inodes 8191
+  Block bitmap at 12058624 (+0), Inode bitmap at 12058640 (+16)
+  Inode table at 12058656-12059167 (+32)
+  24543 free blocks, 8191 free inodes, 1 directories, 8191 unused inodes
+  Free blocks: 12066849-12091391
+  Free inodes: 3014658-3022848
+Group 369: (Blocks 12091392-12124159) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1941, unused inodes 8192
+  Block bitmap at 12058625 (bg #368 + 1), Inode bitmap at 12058641 (bg #368 + 17)
+  Inode table at 12059168-12059679 (bg #368 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12091392-12124159
+  Free inodes: 3022849-3031040
+Group 370: (Blocks 12124160-12156927) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb82f, unused inodes 8192
+  Block bitmap at 12058626 (bg #368 + 2), Inode bitmap at 12058642 (bg #368 + 18)
+  Inode table at 12059680-12060191 (bg #368 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12124160-12156927
+  Free inodes: 3031041-3039232
+Group 371: (Blocks 12156928-12189695) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x18f4, unused inodes 8192
+  Block bitmap at 12058627 (bg #368 + 3), Inode bitmap at 12058643 (bg #368 + 19)
+  Inode table at 12060192-12060703 (bg #368 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12156928-12189695
+  Free inodes: 3039233-3047424
+Group 372: (Blocks 12189696-12222463) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbaf0, unused inodes 8192
+  Block bitmap at 12058628 (bg #368 + 4), Inode bitmap at 12058644 (bg #368 + 20)
+  Inode table at 12060704-12061215 (bg #368 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12189696-12222463
+  Free inodes: 3047425-3055616
+Group 373: (Blocks 12222464-12255231) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1a2b, unused inodes 8192
+  Block bitmap at 12058629 (bg #368 + 5), Inode bitmap at 12058645 (bg #368 + 21)
+  Inode table at 12061216-12061727 (bg #368 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12222464-12255231
+  Free inodes: 3055617-3063808
+Group 374: (Blocks 12255232-12287999) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbb45, unused inodes 8192
+  Block bitmap at 12058630 (bg #368 + 6), Inode bitmap at 12058646 (bg #368 + 22)
+  Inode table at 12061728-12062239 (bg #368 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12255232-12287999
+  Free inodes: 3063809-3072000
+Group 375: (Blocks 12288000-12320767) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1b9e, unused inodes 8192
+  Block bitmap at 12058631 (bg #368 + 7), Inode bitmap at 12058647 (bg #368 + 23)
+  Inode table at 12062240-12062751 (bg #368 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12288000-12320767
+  Free inodes: 3072001-3080192
+Group 376: (Blocks 12320768-12353535) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbf4e, unused inodes 8192
+  Block bitmap at 12058632 (bg #368 + 8), Inode bitmap at 12058648 (bg #368 + 24)
+  Inode table at 12062752-12063263 (bg #368 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12320768-12353535
+  Free inodes: 3080193-3088384
+Group 377: (Blocks 12353536-12386303) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1f95, unused inodes 8192
+  Block bitmap at 12058633 (bg #368 + 9), Inode bitmap at 12058649 (bg #368 + 25)
+  Inode table at 12063264-12063775 (bg #368 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12353536-12386303
+  Free inodes: 3088385-3096576
+Group 378: (Blocks 12386304-12419071) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbefb, unused inodes 8192
+  Block bitmap at 12058634 (bg #368 + 10), Inode bitmap at 12058650 (bg #368 + 26)
+  Inode table at 12063776-12064287 (bg #368 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12386304-12419071
+  Free inodes: 3096577-3104768
+Group 379: (Blocks 12419072-12451839) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1e20, unused inodes 8192
+  Block bitmap at 12058635 (bg #368 + 11), Inode bitmap at 12058651 (bg #368 + 27)
+  Inode table at 12064288-12064799 (bg #368 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12419072-12451839
+  Free inodes: 3104769-3112960
+Group 380: (Blocks 12451840-12484607) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbc24, unused inodes 8192
+  Block bitmap at 12058636 (bg #368 + 12), Inode bitmap at 12058652 (bg #368 + 28)
+  Inode table at 12064800-12065311 (bg #368 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12451840-12484607
+  Free inodes: 3112961-3121152
+Group 381: (Blocks 12484608-12517375) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1cff, unused inodes 8192
+  Block bitmap at 12058637 (bg #368 + 13), Inode bitmap at 12058653 (bg #368 + 29)
+  Inode table at 12065312-12065823 (bg #368 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12484608-12517375
+  Free inodes: 3121153-3129344
+Group 382: (Blocks 12517376-12550143) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbd91, unused inodes 8192
+  Block bitmap at 12058638 (bg #368 + 14), Inode bitmap at 12058654 (bg #368 + 30)
+  Inode table at 12065824-12066335 (bg #368 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12517376-12550143
+  Free inodes: 3129345-3137536
+Group 383: (Blocks 12550144-12582911) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1d4a, unused inodes 8192
+  Block bitmap at 12058639 (bg #368 + 15), Inode bitmap at 12058655 (bg #368 + 31)
+  Inode table at 12066336-12066847 (bg #368 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12550144-12582911
+  Free inodes: 3137537-3145728
+Group 384: (Blocks 12582912-12615679) [ITABLE_ZEROED]
+  Checksum 0x9996, unused inodes 8190
+  Block bitmap at 12582912 (+0), Inode bitmap at 12582928 (+16)
+  Inode table at 12582944-12583455 (+32)
+  24543 free blocks, 8190 free inodes, 1 directories, 8190 unused inodes
+  Free blocks: 12591137-12615679
+  Free inodes: 3145731-3153920
+Group 385: (Blocks 12615680-12648447) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7b1d, unused inodes 8192
+  Block bitmap at 12582913 (bg #384 + 1), Inode bitmap at 12582929 (bg #384 + 17)
+  Inode table at 12583456-12583967 (bg #384 + 544)
+  32767 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12615681-12648447
+  Free inodes: 3153921-3162112
+Group 386: (Blocks 12648448-12681215) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf9fb, unused inodes 8192
+  Block bitmap at 12582914 (bg #384 + 2), Inode bitmap at 12582930 (bg #384 + 18)
+  Inode table at 12583968-12584479 (bg #384 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12648448-12681215
+  Free inodes: 3162113-3170304
+Group 387: (Blocks 12681216-12713983) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5920, unused inodes 8192
+  Block bitmap at 12582915 (bg #384 + 3), Inode bitmap at 12582931 (bg #384 + 19)
+  Inode table at 12584480-12584991 (bg #384 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12681216-12713983
+  Free inodes: 3170305-3178496
+Group 388: (Blocks 12713984-12746751) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfb24, unused inodes 8192
+  Block bitmap at 12582916 (bg #384 + 4), Inode bitmap at 12582932 (bg #384 + 20)
+  Inode table at 12584992-12585503 (bg #384 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12713984-12746751
+  Free inodes: 3178497-3186688
+Group 389: (Blocks 12746752-12779519) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5bff, unused inodes 8192
+  Block bitmap at 12582917 (bg #384 + 5), Inode bitmap at 12582933 (bg #384 + 21)
+  Inode table at 12585504-12586015 (bg #384 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12746752-12779519
+  Free inodes: 3186689-3194880
+Group 390: (Blocks 12779520-12812287) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfa91, unused inodes 8192
+  Block bitmap at 12582918 (bg #384 + 6), Inode bitmap at 12582934 (bg #384 + 22)
+  Inode table at 12586016-12586527 (bg #384 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12779520-12812287
+  Free inodes: 3194881-3203072
+Group 391: (Blocks 12812288-12845055) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5a4a, unused inodes 8192
+  Block bitmap at 12582919 (bg #384 + 7), Inode bitmap at 12582935 (bg #384 + 23)
+  Inode table at 12586528-12587039 (bg #384 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12812288-12845055
+  Free inodes: 3203073-3211264
+Group 392: (Blocks 12845056-12877823) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfe9a, unused inodes 8192
+  Block bitmap at 12582920 (bg #384 + 8), Inode bitmap at 12582936 (bg #384 + 24)
+  Inode table at 12587040-12587551 (bg #384 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12845056-12877823
+  Free inodes: 3211265-3219456
+Group 393: (Blocks 12877824-12910591) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5e41, unused inodes 8192
+  Block bitmap at 12582921 (bg #384 + 9), Inode bitmap at 12582937 (bg #384 + 25)
+  Inode table at 12587552-12588063 (bg #384 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12877824-12910591
+  Free inodes: 3219457-3227648
+Group 394: (Blocks 12910592-12943359) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xff2f, unused inodes 8192
+  Block bitmap at 12582922 (bg #384 + 10), Inode bitmap at 12582938 (bg #384 + 26)
+  Inode table at 12588064-12588575 (bg #384 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12910592-12943359
+  Free inodes: 3227649-3235840
+Group 395: (Blocks 12943360-12976127) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5ff4, unused inodes 8192
+  Block bitmap at 12582923 (bg #384 + 11), Inode bitmap at 12582939 (bg #384 + 27)
+  Inode table at 12588576-12589087 (bg #384 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12943360-12976127
+  Free inodes: 3235841-3244032
+Group 396: (Blocks 12976128-13008895) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfdf0, unused inodes 8192
+  Block bitmap at 12582924 (bg #384 + 12), Inode bitmap at 12582940 (bg #384 + 28)
+  Inode table at 12589088-12589599 (bg #384 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 12976128-13008895
+  Free inodes: 3244033-3252224
+Group 397: (Blocks 13008896-13041663) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5d2b, unused inodes 8192
+  Block bitmap at 12582925 (bg #384 + 13), Inode bitmap at 12582941 (bg #384 + 29)
+  Inode table at 12589600-12590111 (bg #384 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13008896-13041663
+  Free inodes: 3252225-3260416
+Group 398: (Blocks 13041664-13074431) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfc45, unused inodes 8192
+  Block bitmap at 12582926 (bg #384 + 14), Inode bitmap at 12582942 (bg #384 + 30)
+  Inode table at 12590112-12590623 (bg #384 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13041664-13074431
+  Free inodes: 3260417-3268608
+Group 399: (Blocks 13074432-13107199) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5c9e, unused inodes 8192
+  Block bitmap at 12582927 (bg #384 + 15), Inode bitmap at 12582943 (bg #384 + 31)
+  Inode table at 12590624-12591135 (bg #384 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13074432-13107199
+  Free inodes: 3268609-3276800
+Group 400: (Blocks 13107200-13139967) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb0fe, unused inodes 8192
+  Block bitmap at 13107200 (+0), Inode bitmap at 13107216 (+16)
+  Inode table at 13107232-13107743 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13115424-13139967
+  Free inodes: 3276801-3284992
+Group 401: (Blocks 13139968-13172735) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x041b, unused inodes 8192
+  Block bitmap at 13107201 (bg #400 + 1), Inode bitmap at 13107217 (bg #400 + 17)
+  Inode table at 13107744-13108255 (bg #400 + 544)
+  0 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 
+  Free inodes: 3284993-3293184
+Group 402: (Blocks 13172736-13205503) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8aed, unused inodes 8192
+  Block bitmap at 13107202 (bg #400 + 2), Inode bitmap at 13107218 (bg #400 + 18)
+  Inode table at 13108256-13108767 (bg #400 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13172736-13205503
+  Free inodes: 3293185-3301376
+Group 403: (Blocks 13205504-13238271) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2a36, unused inodes 8192
+  Block bitmap at 13107203 (bg #400 + 3), Inode bitmap at 13107219 (bg #400 + 19)
+  Inode table at 13108768-13109279 (bg #400 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13205504-13238271
+  Free inodes: 3301377-3309568
+Group 404: (Blocks 13238272-13271039) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8832, unused inodes 8192
+  Block bitmap at 13107204 (bg #400 + 4), Inode bitmap at 13107220 (bg #400 + 20)
+  Inode table at 13109280-13109791 (bg #400 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13238272-13271039
+  Free inodes: 3309569-3317760
+Group 405: (Blocks 13271040-13303807) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x28e9, unused inodes 8192
+  Block bitmap at 13107205 (bg #400 + 5), Inode bitmap at 13107221 (bg #400 + 21)
+  Inode table at 13109792-13110303 (bg #400 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13271040-13303807
+  Free inodes: 3317761-3325952
+Group 406: (Blocks 13303808-13336575) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8987, unused inodes 8192
+  Block bitmap at 13107206 (bg #400 + 6), Inode bitmap at 13107222 (bg #400 + 22)
+  Inode table at 13110304-13110815 (bg #400 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13303808-13336575
+  Free inodes: 3325953-3334144
+Group 407: (Blocks 13336576-13369343) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x295c, unused inodes 8192
+  Block bitmap at 13107207 (bg #400 + 7), Inode bitmap at 13107223 (bg #400 + 23)
+  Inode table at 13110816-13111327 (bg #400 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13336576-13369343
+  Free inodes: 3334145-3342336
+Group 408: (Blocks 13369344-13402111) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8d8c, unused inodes 8192
+  Block bitmap at 13107208 (bg #400 + 8), Inode bitmap at 13107224 (bg #400 + 24)
+  Inode table at 13111328-13111839 (bg #400 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13369344-13402111
+  Free inodes: 3342337-3350528
+Group 409: (Blocks 13402112-13434879) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2d57, unused inodes 8192
+  Block bitmap at 13107209 (bg #400 + 9), Inode bitmap at 13107225 (bg #400 + 25)
+  Inode table at 13111840-13112351 (bg #400 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13402112-13434879
+  Free inodes: 3350529-3358720
+Group 410: (Blocks 13434880-13467647) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8c39, unused inodes 8192
+  Block bitmap at 13107210 (bg #400 + 10), Inode bitmap at 13107226 (bg #400 + 26)
+  Inode table at 13112352-13112863 (bg #400 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13434880-13467647
+  Free inodes: 3358721-3366912
+Group 411: (Blocks 13467648-13500415) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2ce2, unused inodes 8192
+  Block bitmap at 13107211 (bg #400 + 11), Inode bitmap at 13107227 (bg #400 + 27)
+  Inode table at 13112864-13113375 (bg #400 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13467648-13500415
+  Free inodes: 3366913-3375104
+Group 412: (Blocks 13500416-13533183) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8ee6, unused inodes 8192
+  Block bitmap at 13107212 (bg #400 + 12), Inode bitmap at 13107228 (bg #400 + 28)
+  Inode table at 13113376-13113887 (bg #400 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13500416-13533183
+  Free inodes: 3375105-3383296
+Group 413: (Blocks 13533184-13565951) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2e3d, unused inodes 8192
+  Block bitmap at 13107213 (bg #400 + 13), Inode bitmap at 13107229 (bg #400 + 29)
+  Inode table at 13113888-13114399 (bg #400 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13533184-13565951
+  Free inodes: 3383297-3391488
+Group 414: (Blocks 13565952-13598719) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8f53, unused inodes 8192
+  Block bitmap at 13107214 (bg #400 + 14), Inode bitmap at 13107230 (bg #400 + 30)
+  Inode table at 13114400-13114911 (bg #400 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13565952-13598719
+  Free inodes: 3391489-3399680
+Group 415: (Blocks 13598720-13631487) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2f88, unused inodes 8192
+  Block bitmap at 13107215 (bg #400 + 15), Inode bitmap at 13107231 (bg #400 + 31)
+  Inode table at 13114912-13115423 (bg #400 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13598720-13631487
+  Free inodes: 3399681-3407872
+Group 416: (Blocks 13631488-13664255) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x25c4, unused inodes 8192
+  Block bitmap at 13631488 (+0), Inode bitmap at 13631504 (+16)
+  Inode table at 13631520-13632031 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13639712-13664255
+  Free inodes: 3407873-3416064
+Group 417: (Blocks 13664256-13697023) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbeb9, unused inodes 8192
+  Block bitmap at 13631489 (bg #416 + 1), Inode bitmap at 13631505 (bg #416 + 17)
+  Inode table at 13632032-13632543 (bg #416 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13664256-13697023
+  Free inodes: 3416065-3424256
+Group 418: (Blocks 13697024-13729791) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1fd7, unused inodes 8192
+  Block bitmap at 13631490 (bg #416 + 2), Inode bitmap at 13631506 (bg #416 + 18)
+  Inode table at 13632544-13633055 (bg #416 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13697024-13729791
+  Free inodes: 3424257-3432448
+Group 419: (Blocks 13729792-13762559) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbf0c, unused inodes 8192
+  Block bitmap at 13631491 (bg #416 + 3), Inode bitmap at 13631507 (bg #416 + 19)
+  Inode table at 13633056-13633567 (bg #416 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13729792-13762559
+  Free inodes: 3432449-3440640
+Group 420: (Blocks 13762560-13795327) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1d08, unused inodes 8192
+  Block bitmap at 13631492 (bg #416 + 4), Inode bitmap at 13631508 (bg #416 + 20)
+  Inode table at 13633568-13634079 (bg #416 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13762560-13795327
+  Free inodes: 3440641-3448832
+Group 421: (Blocks 13795328-13828095) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbdd3, unused inodes 8192
+  Block bitmap at 13631493 (bg #416 + 5), Inode bitmap at 13631509 (bg #416 + 21)
+  Inode table at 13634080-13634591 (bg #416 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13795328-13828095
+  Free inodes: 3448833-3457024
+Group 422: (Blocks 13828096-13860863) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1cbd, unused inodes 8192
+  Block bitmap at 13631494 (bg #416 + 6), Inode bitmap at 13631510 (bg #416 + 22)
+  Inode table at 13634592-13635103 (bg #416 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13828096-13860863
+  Free inodes: 3457025-3465216
+Group 423: (Blocks 13860864-13893631) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbc66, unused inodes 8192
+  Block bitmap at 13631495 (bg #416 + 7), Inode bitmap at 13631511 (bg #416 + 23)
+  Inode table at 13635104-13635615 (bg #416 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13860864-13893631
+  Free inodes: 3465217-3473408
+Group 424: (Blocks 13893632-13926399) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x18b6, unused inodes 8192
+  Block bitmap at 13631496 (bg #416 + 8), Inode bitmap at 13631512 (bg #416 + 24)
+  Inode table at 13635616-13636127 (bg #416 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13893632-13926399
+  Free inodes: 3473409-3481600
+Group 425: (Blocks 13926400-13959167) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb86d, unused inodes 8192
+  Block bitmap at 13631497 (bg #416 + 9), Inode bitmap at 13631513 (bg #416 + 25)
+  Inode table at 13636128-13636639 (bg #416 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13926400-13959167
+  Free inodes: 3481601-3489792
+Group 426: (Blocks 13959168-13991935) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1903, unused inodes 8192
+  Block bitmap at 13631498 (bg #416 + 10), Inode bitmap at 13631514 (bg #416 + 26)
+  Inode table at 13636640-13637151 (bg #416 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13959168-13991935
+  Free inodes: 3489793-3497984
+Group 427: (Blocks 13991936-14024703) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb9d8, unused inodes 8192
+  Block bitmap at 13631499 (bg #416 + 11), Inode bitmap at 13631515 (bg #416 + 27)
+  Inode table at 13637152-13637663 (bg #416 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 13991936-14024703
+  Free inodes: 3497985-3506176
+Group 428: (Blocks 14024704-14057471) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1bdc, unused inodes 8192
+  Block bitmap at 13631500 (bg #416 + 12), Inode bitmap at 13631516 (bg #416 + 28)
+  Inode table at 13637664-13638175 (bg #416 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14024704-14057471
+  Free inodes: 3506177-3514368
+Group 429: (Blocks 14057472-14090239) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbb07, unused inodes 8192
+  Block bitmap at 13631501 (bg #416 + 13), Inode bitmap at 13631517 (bg #416 + 29)
+  Inode table at 13638176-13638687 (bg #416 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14057472-14090239
+  Free inodes: 3514369-3522560
+Group 430: (Blocks 14090240-14123007) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1a69, unused inodes 8192
+  Block bitmap at 13631502 (bg #416 + 14), Inode bitmap at 13631518 (bg #416 + 30)
+  Inode table at 13638688-13639199 (bg #416 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14090240-14123007
+  Free inodes: 3522561-3530752
+Group 431: (Blocks 14123008-14155775) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbab2, unused inodes 8192
+  Block bitmap at 13631503 (bg #416 + 15), Inode bitmap at 13631519 (bg #416 + 31)
+  Inode table at 13639200-13639711 (bg #416 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14123008-14155775
+  Free inodes: 3530753-3538944
+Group 432: (Blocks 14155776-14188543) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x56d2, unused inodes 8192
+  Block bitmap at 14155776 (+0), Inode bitmap at 14155792 (+16)
+  Inode table at 14155808-14156319 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14164000-14188543
+  Free inodes: 3538945-3547136
+Group 433: (Blocks 14188544-14221311) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcdaf, unused inodes 8192
+  Block bitmap at 14155777 (bg #432 + 1), Inode bitmap at 14155793 (bg #432 + 17)
+  Inode table at 14156320-14156831 (bg #432 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14188544-14221311
+  Free inodes: 3547137-3555328
+Group 434: (Blocks 14221312-14254079) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6cc1, unused inodes 8192
+  Block bitmap at 14155778 (bg #432 + 2), Inode bitmap at 14155794 (bg #432 + 18)
+  Inode table at 14156832-14157343 (bg #432 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14221312-14254079
+  Free inodes: 3555329-3563520
+Group 435: (Blocks 14254080-14286847) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcc1a, unused inodes 8192
+  Block bitmap at 14155779 (bg #432 + 3), Inode bitmap at 14155795 (bg #432 + 19)
+  Inode table at 14157344-14157855 (bg #432 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14254080-14286847
+  Free inodes: 3563521-3571712
+Group 436: (Blocks 14286848-14319615) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6e1e, unused inodes 8192
+  Block bitmap at 14155780 (bg #432 + 4), Inode bitmap at 14155796 (bg #432 + 20)
+  Inode table at 14157856-14158367 (bg #432 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14286848-14319615
+  Free inodes: 3571713-3579904
+Group 437: (Blocks 14319616-14352383) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcec5, unused inodes 8192
+  Block bitmap at 14155781 (bg #432 + 5), Inode bitmap at 14155797 (bg #432 + 21)
+  Inode table at 14158368-14158879 (bg #432 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14319616-14352383
+  Free inodes: 3579905-3588096
+Group 438: (Blocks 14352384-14385151) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6fab, unused inodes 8192
+  Block bitmap at 14155782 (bg #432 + 6), Inode bitmap at 14155798 (bg #432 + 22)
+  Inode table at 14158880-14159391 (bg #432 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14352384-14385151
+  Free inodes: 3588097-3596288
+Group 439: (Blocks 14385152-14417919) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcf70, unused inodes 8192
+  Block bitmap at 14155783 (bg #432 + 7), Inode bitmap at 14155799 (bg #432 + 23)
+  Inode table at 14159392-14159903 (bg #432 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14385152-14417919
+  Free inodes: 3596289-3604480
+Group 440: (Blocks 14417920-14450687) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6ba0, unused inodes 8192
+  Block bitmap at 14155784 (bg #432 + 8), Inode bitmap at 14155800 (bg #432 + 24)
+  Inode table at 14159904-14160415 (bg #432 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14417920-14450687
+  Free inodes: 3604481-3612672
+Group 441: (Blocks 14450688-14483455) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcb7b, unused inodes 8192
+  Block bitmap at 14155785 (bg #432 + 9), Inode bitmap at 14155801 (bg #432 + 25)
+  Inode table at 14160416-14160927 (bg #432 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14450688-14483455
+  Free inodes: 3612673-3620864
+Group 442: (Blocks 14483456-14516223) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6a15, unused inodes 8192
+  Block bitmap at 14155786 (bg #432 + 10), Inode bitmap at 14155802 (bg #432 + 26)
+  Inode table at 14160928-14161439 (bg #432 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14483456-14516223
+  Free inodes: 3620865-3629056
+Group 443: (Blocks 14516224-14548991) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcace, unused inodes 8192
+  Block bitmap at 14155787 (bg #432 + 11), Inode bitmap at 14155803 (bg #432 + 27)
+  Inode table at 14161440-14161951 (bg #432 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14516224-14548991
+  Free inodes: 3629057-3637248
+Group 444: (Blocks 14548992-14581759) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x68ca, unused inodes 8192
+  Block bitmap at 14155788 (bg #432 + 12), Inode bitmap at 14155804 (bg #432 + 28)
+  Inode table at 14161952-14162463 (bg #432 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14548992-14581759
+  Free inodes: 3637249-3645440
+Group 445: (Blocks 14581760-14614527) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc811, unused inodes 8192
+  Block bitmap at 14155789 (bg #432 + 13), Inode bitmap at 14155805 (bg #432 + 29)
+  Inode table at 14162464-14162975 (bg #432 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14581760-14614527
+  Free inodes: 3645441-3653632
+Group 446: (Blocks 14614528-14647295) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x697f, unused inodes 8192
+  Block bitmap at 14155790 (bg #432 + 14), Inode bitmap at 14155806 (bg #432 + 30)
+  Inode table at 14162976-14163487 (bg #432 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14614528-14647295
+  Free inodes: 3653633-3661824
+Group 447: (Blocks 14647296-14680063) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc9a4, unused inodes 8192
+  Block bitmap at 14155791 (bg #432 + 15), Inode bitmap at 14155807 (bg #432 + 31)
+  Inode table at 14163488-14163999 (bg #432 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14647296-14680063
+  Free inodes: 3661825-3670016
+Group 448: (Blocks 14680064-14712831) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4fb3, unused inodes 8192
+  Block bitmap at 14680064 (+0), Inode bitmap at 14680080 (+16)
+  Inode table at 14680096-14680607 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14688288-14712831
+  Free inodes: 3670017-3678208
+Group 449: (Blocks 14712832-14745599) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd4ce, unused inodes 8192
+  Block bitmap at 14680065 (bg #448 + 1), Inode bitmap at 14680081 (bg #448 + 17)
+  Inode table at 14680608-14681119 (bg #448 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14712832-14745599
+  Free inodes: 3678209-3686400
+Group 450: (Blocks 14745600-14778367) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x75a0, unused inodes 8192
+  Block bitmap at 14680066 (bg #448 + 2), Inode bitmap at 14680082 (bg #448 + 18)
+  Inode table at 14681120-14681631 (bg #448 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14745600-14778367
+  Free inodes: 3686401-3694592
+Group 451: (Blocks 14778368-14811135) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd57b, unused inodes 8192
+  Block bitmap at 14680067 (bg #448 + 3), Inode bitmap at 14680083 (bg #448 + 19)
+  Inode table at 14681632-14682143 (bg #448 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14778368-14811135
+  Free inodes: 3694593-3702784
+Group 452: (Blocks 14811136-14843903) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x777f, unused inodes 8192
+  Block bitmap at 14680068 (bg #448 + 4), Inode bitmap at 14680084 (bg #448 + 20)
+  Inode table at 14682144-14682655 (bg #448 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14811136-14843903
+  Free inodes: 3702785-3710976
+Group 453: (Blocks 14843904-14876671) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd7a4, unused inodes 8192
+  Block bitmap at 14680069 (bg #448 + 5), Inode bitmap at 14680085 (bg #448 + 21)
+  Inode table at 14682656-14683167 (bg #448 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14843904-14876671
+  Free inodes: 3710977-3719168
+Group 454: (Blocks 14876672-14909439) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x76ca, unused inodes 8192
+  Block bitmap at 14680070 (bg #448 + 6), Inode bitmap at 14680086 (bg #448 + 22)
+  Inode table at 14683168-14683679 (bg #448 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14876672-14909439
+  Free inodes: 3719169-3727360
+Group 455: (Blocks 14909440-14942207) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd611, unused inodes 8192
+  Block bitmap at 14680071 (bg #448 + 7), Inode bitmap at 14680087 (bg #448 + 23)
+  Inode table at 14683680-14684191 (bg #448 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14909440-14942207
+  Free inodes: 3727361-3735552
+Group 456: (Blocks 14942208-14974975) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x72c1, unused inodes 8192
+  Block bitmap at 14680072 (bg #448 + 8), Inode bitmap at 14680088 (bg #448 + 24)
+  Inode table at 14684192-14684703 (bg #448 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14942208-14974975
+  Free inodes: 3735553-3743744
+Group 457: (Blocks 14974976-15007743) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd21a, unused inodes 8192
+  Block bitmap at 14680073 (bg #448 + 9), Inode bitmap at 14680089 (bg #448 + 25)
+  Inode table at 14684704-14685215 (bg #448 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 14974976-15007743
+  Free inodes: 3743745-3751936
+Group 458: (Blocks 15007744-15040511) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7374, unused inodes 8192
+  Block bitmap at 14680074 (bg #448 + 10), Inode bitmap at 14680090 (bg #448 + 26)
+  Inode table at 14685216-14685727 (bg #448 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15007744-15040511
+  Free inodes: 3751937-3760128
+Group 459: (Blocks 15040512-15073279) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd3af, unused inodes 8192
+  Block bitmap at 14680075 (bg #448 + 11), Inode bitmap at 14680091 (bg #448 + 27)
+  Inode table at 14685728-14686239 (bg #448 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15040512-15073279
+  Free inodes: 3760129-3768320
+Group 460: (Blocks 15073280-15106047) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x71ab, unused inodes 8192
+  Block bitmap at 14680076 (bg #448 + 12), Inode bitmap at 14680092 (bg #448 + 28)
+  Inode table at 14686240-14686751 (bg #448 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15073280-15106047
+  Free inodes: 3768321-3776512
+Group 461: (Blocks 15106048-15138815) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd170, unused inodes 8192
+  Block bitmap at 14680077 (bg #448 + 13), Inode bitmap at 14680093 (bg #448 + 29)
+  Inode table at 14686752-14687263 (bg #448 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15106048-15138815
+  Free inodes: 3776513-3784704
+Group 462: (Blocks 15138816-15171583) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x701e, unused inodes 8192
+  Block bitmap at 14680078 (bg #448 + 14), Inode bitmap at 14680094 (bg #448 + 30)
+  Inode table at 14687264-14687775 (bg #448 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15138816-15171583
+  Free inodes: 3784705-3792896
+Group 463: (Blocks 15171584-15204351) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd0c5, unused inodes 8192
+  Block bitmap at 14680079 (bg #448 + 15), Inode bitmap at 14680095 (bg #448 + 31)
+  Inode table at 14687776-14688287 (bg #448 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15171584-15204351
+  Free inodes: 3792897-3801088
+Group 464: (Blocks 15204352-15237119) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3ca5, unused inodes 8192
+  Block bitmap at 15204352 (+0), Inode bitmap at 15204368 (+16)
+  Inode table at 15204384-15204895 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15212576-15237119
+  Free inodes: 3801089-3809280
+Group 465: (Blocks 15237120-15269887) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa7d8, unused inodes 8192
+  Block bitmap at 15204353 (bg #464 + 1), Inode bitmap at 15204369 (bg #464 + 17)
+  Inode table at 15204896-15205407 (bg #464 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15237120-15269887
+  Free inodes: 3809281-3817472
+Group 466: (Blocks 15269888-15302655) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x06b6, unused inodes 8192
+  Block bitmap at 15204354 (bg #464 + 2), Inode bitmap at 15204370 (bg #464 + 18)
+  Inode table at 15205408-15205919 (bg #464 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15269888-15302655
+  Free inodes: 3817473-3825664
+Group 467: (Blocks 15302656-15335423) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa66d, unused inodes 8192
+  Block bitmap at 15204355 (bg #464 + 3), Inode bitmap at 15204371 (bg #464 + 19)
+  Inode table at 15205920-15206431 (bg #464 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15302656-15335423
+  Free inodes: 3825665-3833856
+Group 468: (Blocks 15335424-15368191) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0469, unused inodes 8192
+  Block bitmap at 15204356 (bg #464 + 4), Inode bitmap at 15204372 (bg #464 + 20)
+  Inode table at 15206432-15206943 (bg #464 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15335424-15368191
+  Free inodes: 3833857-3842048
+Group 469: (Blocks 15368192-15400959) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa4b2, unused inodes 8192
+  Block bitmap at 15204357 (bg #464 + 5), Inode bitmap at 15204373 (bg #464 + 21)
+  Inode table at 15206944-15207455 (bg #464 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15368192-15400959
+  Free inodes: 3842049-3850240
+Group 470: (Blocks 15400960-15433727) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x05dc, unused inodes 8192
+  Block bitmap at 15204358 (bg #464 + 6), Inode bitmap at 15204374 (bg #464 + 22)
+  Inode table at 15207456-15207967 (bg #464 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15400960-15433727
+  Free inodes: 3850241-3858432
+Group 471: (Blocks 15433728-15466495) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa507, unused inodes 8192
+  Block bitmap at 15204359 (bg #464 + 7), Inode bitmap at 15204375 (bg #464 + 23)
+  Inode table at 15207968-15208479 (bg #464 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15433728-15466495
+  Free inodes: 3858433-3866624
+Group 472: (Blocks 15466496-15499263) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x01d7, unused inodes 8192
+  Block bitmap at 15204360 (bg #464 + 8), Inode bitmap at 15204376 (bg #464 + 24)
+  Inode table at 15208480-15208991 (bg #464 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15466496-15499263
+  Free inodes: 3866625-3874816
+Group 473: (Blocks 15499264-15532031) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa10c, unused inodes 8192
+  Block bitmap at 15204361 (bg #464 + 9), Inode bitmap at 15204377 (bg #464 + 25)
+  Inode table at 15208992-15209503 (bg #464 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15499264-15532031
+  Free inodes: 3874817-3883008
+Group 474: (Blocks 15532032-15564799) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0062, unused inodes 8192
+  Block bitmap at 15204362 (bg #464 + 10), Inode bitmap at 15204378 (bg #464 + 26)
+  Inode table at 15209504-15210015 (bg #464 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15532032-15564799
+  Free inodes: 3883009-3891200
+Group 475: (Blocks 15564800-15597567) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa0b9, unused inodes 8192
+  Block bitmap at 15204363 (bg #464 + 11), Inode bitmap at 15204379 (bg #464 + 27)
+  Inode table at 15210016-15210527 (bg #464 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15564800-15597567
+  Free inodes: 3891201-3899392
+Group 476: (Blocks 15597568-15630335) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x02bd, unused inodes 8192
+  Block bitmap at 15204364 (bg #464 + 12), Inode bitmap at 15204380 (bg #464 + 28)
+  Inode table at 15210528-15211039 (bg #464 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15597568-15630335
+  Free inodes: 3899393-3907584
+Group 477: (Blocks 15630336-15663103) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa266, unused inodes 8192
+  Block bitmap at 15204365 (bg #464 + 13), Inode bitmap at 15204381 (bg #464 + 29)
+  Inode table at 15211040-15211551 (bg #464 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15630336-15663103
+  Free inodes: 3907585-3915776
+Group 478: (Blocks 15663104-15695871) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0308, unused inodes 8192
+  Block bitmap at 15204366 (bg #464 + 14), Inode bitmap at 15204382 (bg #464 + 30)
+  Inode table at 15211552-15212063 (bg #464 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15663104-15695871
+  Free inodes: 3915777-3923968
+Group 479: (Blocks 15695872-15728639) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa3d3, unused inodes 8192
+  Block bitmap at 15204367 (bg #464 + 15), Inode bitmap at 15204383 (bg #464 + 31)
+  Inode table at 15212064-15212575 (bg #464 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15695872-15728639
+  Free inodes: 3923969-3932160
+Group 480: (Blocks 15728640-15761407) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa99f, unused inodes 8192
+  Block bitmap at 15728640 (+0), Inode bitmap at 15728656 (+16)
+  Inode table at 15728672-15729183 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15736864-15761407
+  Free inodes: 3932161-3940352
+Group 481: (Blocks 15761408-15794175) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x32e2, unused inodes 8192
+  Block bitmap at 15728641 (bg #480 + 1), Inode bitmap at 15728657 (bg #480 + 17)
+  Inode table at 15729184-15729695 (bg #480 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15761408-15794175
+  Free inodes: 3940353-3948544
+Group 482: (Blocks 15794176-15826943) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x938c, unused inodes 8192
+  Block bitmap at 15728642 (bg #480 + 2), Inode bitmap at 15728658 (bg #480 + 18)
+  Inode table at 15729696-15730207 (bg #480 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15794176-15826943
+  Free inodes: 3948545-3956736
+Group 483: (Blocks 15826944-15859711) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3357, unused inodes 8192
+  Block bitmap at 15728643 (bg #480 + 3), Inode bitmap at 15728659 (bg #480 + 19)
+  Inode table at 15730208-15730719 (bg #480 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15826944-15859711
+  Free inodes: 3956737-3964928
+Group 484: (Blocks 15859712-15892479) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9153, unused inodes 8192
+  Block bitmap at 15728644 (bg #480 + 4), Inode bitmap at 15728660 (bg #480 + 20)
+  Inode table at 15730720-15731231 (bg #480 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15859712-15892479
+  Free inodes: 3964929-3973120
+Group 485: (Blocks 15892480-15925247) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3188, unused inodes 8192
+  Block bitmap at 15728645 (bg #480 + 5), Inode bitmap at 15728661 (bg #480 + 21)
+  Inode table at 15731232-15731743 (bg #480 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15892480-15925247
+  Free inodes: 3973121-3981312
+Group 486: (Blocks 15925248-15958015) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x90e6, unused inodes 8192
+  Block bitmap at 15728646 (bg #480 + 6), Inode bitmap at 15728662 (bg #480 + 22)
+  Inode table at 15731744-15732255 (bg #480 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15925248-15958015
+  Free inodes: 3981313-3989504
+Group 487: (Blocks 15958016-15990783) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x303d, unused inodes 8192
+  Block bitmap at 15728647 (bg #480 + 7), Inode bitmap at 15728663 (bg #480 + 23)
+  Inode table at 15732256-15732767 (bg #480 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15958016-15990783
+  Free inodes: 3989505-3997696
+Group 488: (Blocks 15990784-16023551) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x94ed, unused inodes 8192
+  Block bitmap at 15728648 (bg #480 + 8), Inode bitmap at 15728664 (bg #480 + 24)
+  Inode table at 15732768-15733279 (bg #480 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 15990784-16023551
+  Free inodes: 3997697-4005888
+Group 489: (Blocks 16023552-16056319) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3436, unused inodes 8192
+  Block bitmap at 15728649 (bg #480 + 9), Inode bitmap at 15728665 (bg #480 + 25)
+  Inode table at 15733280-15733791 (bg #480 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16023552-16056319
+  Free inodes: 4005889-4014080
+Group 490: (Blocks 16056320-16089087) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9558, unused inodes 8192
+  Block bitmap at 15728650 (bg #480 + 10), Inode bitmap at 15728666 (bg #480 + 26)
+  Inode table at 15733792-15734303 (bg #480 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16056320-16089087
+  Free inodes: 4014081-4022272
+Group 491: (Blocks 16089088-16121855) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3583, unused inodes 8192
+  Block bitmap at 15728651 (bg #480 + 11), Inode bitmap at 15728667 (bg #480 + 27)
+  Inode table at 15734304-15734815 (bg #480 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16089088-16121855
+  Free inodes: 4022273-4030464
+Group 492: (Blocks 16121856-16154623) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9787, unused inodes 8192
+  Block bitmap at 15728652 (bg #480 + 12), Inode bitmap at 15728668 (bg #480 + 28)
+  Inode table at 15734816-15735327 (bg #480 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16121856-16154623
+  Free inodes: 4030465-4038656
+Group 493: (Blocks 16154624-16187391) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x375c, unused inodes 8192
+  Block bitmap at 15728653 (bg #480 + 13), Inode bitmap at 15728669 (bg #480 + 29)
+  Inode table at 15735328-15735839 (bg #480 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16154624-16187391
+  Free inodes: 4038657-4046848
+Group 494: (Blocks 16187392-16220159) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9632, unused inodes 8192
+  Block bitmap at 15728654 (bg #480 + 14), Inode bitmap at 15728670 (bg #480 + 30)
+  Inode table at 15735840-15736351 (bg #480 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16187392-16220159
+  Free inodes: 4046849-4055040
+Group 495: (Blocks 16220160-16252927) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x36e9, unused inodes 8192
+  Block bitmap at 15728655 (bg #480 + 15), Inode bitmap at 15728671 (bg #480 + 31)
+  Inode table at 15736352-15736863 (bg #480 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16220160-16252927
+  Free inodes: 4055041-4063232
+Group 496: (Blocks 16252928-16285695) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xda89, unused inodes 8192
+  Block bitmap at 16252928 (+0), Inode bitmap at 16252944 (+16)
+  Inode table at 16252960-16253471 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16261152-16285695
+  Free inodes: 4063233-4071424
+Group 497: (Blocks 16285696-16318463) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x41f4, unused inodes 8192
+  Block bitmap at 16252929 (bg #496 + 1), Inode bitmap at 16252945 (bg #496 + 17)
+  Inode table at 16253472-16253983 (bg #496 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16285696-16318463
+  Free inodes: 4071425-4079616
+Group 498: (Blocks 16318464-16351231) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe09a, unused inodes 8192
+  Block bitmap at 16252930 (bg #496 + 2), Inode bitmap at 16252946 (bg #496 + 18)
+  Inode table at 16253984-16254495 (bg #496 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16318464-16351231
+  Free inodes: 4079617-4087808
+Group 499: (Blocks 16351232-16383999) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4041, unused inodes 8192
+  Block bitmap at 16252931 (bg #496 + 3), Inode bitmap at 16252947 (bg #496 + 19)
+  Inode table at 16254496-16255007 (bg #496 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16351232-16383999
+  Free inodes: 4087809-4096000
+Group 500: (Blocks 16384000-16416767) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe245, unused inodes 8192
+  Block bitmap at 16252932 (bg #496 + 4), Inode bitmap at 16252948 (bg #496 + 20)
+  Inode table at 16255008-16255519 (bg #496 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16384000-16416767
+  Free inodes: 4096001-4104192
+Group 501: (Blocks 16416768-16449535) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x429e, unused inodes 8192
+  Block bitmap at 16252933 (bg #496 + 5), Inode bitmap at 16252949 (bg #496 + 21)
+  Inode table at 16255520-16256031 (bg #496 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16416768-16449535
+  Free inodes: 4104193-4112384
+Group 502: (Blocks 16449536-16482303) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe3f0, unused inodes 8192
+  Block bitmap at 16252934 (bg #496 + 6), Inode bitmap at 16252950 (bg #496 + 22)
+  Inode table at 16256032-16256543 (bg #496 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16449536-16482303
+  Free inodes: 4112385-4120576
+Group 503: (Blocks 16482304-16515071) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x432b, unused inodes 8192
+  Block bitmap at 16252935 (bg #496 + 7), Inode bitmap at 16252951 (bg #496 + 23)
+  Inode table at 16256544-16257055 (bg #496 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16482304-16515071
+  Free inodes: 4120577-4128768
+Group 504: (Blocks 16515072-16547839) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe7fb, unused inodes 8192
+  Block bitmap at 16252936 (bg #496 + 8), Inode bitmap at 16252952 (bg #496 + 24)
+  Inode table at 16257056-16257567 (bg #496 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16515072-16547839
+  Free inodes: 4128769-4136960
+Group 505: (Blocks 16547840-16580607) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4720, unused inodes 8192
+  Block bitmap at 16252937 (bg #496 + 9), Inode bitmap at 16252953 (bg #496 + 25)
+  Inode table at 16257568-16258079 (bg #496 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16547840-16580607
+  Free inodes: 4136961-4145152
+Group 506: (Blocks 16580608-16613375) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe64e, unused inodes 8192
+  Block bitmap at 16252938 (bg #496 + 10), Inode bitmap at 16252954 (bg #496 + 26)
+  Inode table at 16258080-16258591 (bg #496 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16580608-16613375
+  Free inodes: 4145153-4153344
+Group 507: (Blocks 16613376-16646143) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4695, unused inodes 8192
+  Block bitmap at 16252939 (bg #496 + 11), Inode bitmap at 16252955 (bg #496 + 27)
+  Inode table at 16258592-16259103 (bg #496 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16613376-16646143
+  Free inodes: 4153345-4161536
+Group 508: (Blocks 16646144-16678911) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe491, unused inodes 8192
+  Block bitmap at 16252940 (bg #496 + 12), Inode bitmap at 16252956 (bg #496 + 28)
+  Inode table at 16259104-16259615 (bg #496 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16646144-16678911
+  Free inodes: 4161537-4169728
+Group 509: (Blocks 16678912-16711679) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x444a, unused inodes 8192
+  Block bitmap at 16252941 (bg #496 + 13), Inode bitmap at 16252957 (bg #496 + 29)
+  Inode table at 16259616-16260127 (bg #496 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16678912-16711679
+  Free inodes: 4169729-4177920
+Group 510: (Blocks 16711680-16744447) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe524, unused inodes 8192
+  Block bitmap at 16252942 (bg #496 + 14), Inode bitmap at 16252958 (bg #496 + 30)
+  Inode table at 16260128-16260639 (bg #496 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16711680-16744447
+  Free inodes: 4177921-4186112
+Group 511: (Blocks 16744448-16777215) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x45ff, unused inodes 8192
+  Block bitmap at 16252943 (bg #496 + 15), Inode bitmap at 16252959 (bg #496 + 31)
+  Inode table at 16260640-16261151 (bg #496 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16744448-16777215
+  Free inodes: 4186113-4194304
+Group 512: (Blocks 16777216-16809983) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x08e0, unused inodes 8192
+  Block bitmap at 16777216 (+0), Inode bitmap at 16777232 (+16)
+  Inode table at 16777248-16777759 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16785440-16809983
+  Free inodes: 4194305-4202496
+Group 513: (Blocks 16809984-16842751) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x939d, unused inodes 8192
+  Block bitmap at 16777217 (bg #512 + 1), Inode bitmap at 16777233 (bg #512 + 17)
+  Inode table at 16777760-16778271 (bg #512 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16809984-16842751
+  Free inodes: 4202497-4210688
+Group 514: (Blocks 16842752-16875519) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x32f3, unused inodes 8192
+  Block bitmap at 16777218 (bg #512 + 2), Inode bitmap at 16777234 (bg #512 + 18)
+  Inode table at 16778272-16778783 (bg #512 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16842752-16875519
+  Free inodes: 4210689-4218880
+Group 515: (Blocks 16875520-16908287) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9228, unused inodes 8192
+  Block bitmap at 16777219 (bg #512 + 3), Inode bitmap at 16777235 (bg #512 + 19)
+  Inode table at 16778784-16779295 (bg #512 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16875520-16908287
+  Free inodes: 4218881-4227072
+Group 516: (Blocks 16908288-16941055) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x302c, unused inodes 8192
+  Block bitmap at 16777220 (bg #512 + 4), Inode bitmap at 16777236 (bg #512 + 20)
+  Inode table at 16779296-16779807 (bg #512 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16908288-16941055
+  Free inodes: 4227073-4235264
+Group 517: (Blocks 16941056-16973823) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x90f7, unused inodes 8192
+  Block bitmap at 16777221 (bg #512 + 5), Inode bitmap at 16777237 (bg #512 + 21)
+  Inode table at 16779808-16780319 (bg #512 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16941056-16973823
+  Free inodes: 4235265-4243456
+Group 518: (Blocks 16973824-17006591) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3199, unused inodes 8192
+  Block bitmap at 16777222 (bg #512 + 6), Inode bitmap at 16777238 (bg #512 + 22)
+  Inode table at 16780320-16780831 (bg #512 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 16973824-17006591
+  Free inodes: 4243457-4251648
+Group 519: (Blocks 17006592-17039359) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9142, unused inodes 8192
+  Block bitmap at 16777223 (bg #512 + 7), Inode bitmap at 16777239 (bg #512 + 23)
+  Inode table at 16780832-16781343 (bg #512 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17006592-17039359
+  Free inodes: 4251649-4259840
+Group 520: (Blocks 17039360-17072127) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3592, unused inodes 8192
+  Block bitmap at 16777224 (bg #512 + 8), Inode bitmap at 16777240 (bg #512 + 24)
+  Inode table at 16781344-16781855 (bg #512 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17039360-17072127
+  Free inodes: 4259841-4268032
+Group 521: (Blocks 17072128-17104895) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9549, unused inodes 8192
+  Block bitmap at 16777225 (bg #512 + 9), Inode bitmap at 16777241 (bg #512 + 25)
+  Inode table at 16781856-16782367 (bg #512 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17072128-17104895
+  Free inodes: 4268033-4276224
+Group 522: (Blocks 17104896-17137663) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3427, unused inodes 8192
+  Block bitmap at 16777226 (bg #512 + 10), Inode bitmap at 16777242 (bg #512 + 26)
+  Inode table at 16782368-16782879 (bg #512 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17104896-17137663
+  Free inodes: 4276225-4284416
+Group 523: (Blocks 17137664-17170431) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x94fc, unused inodes 8192
+  Block bitmap at 16777227 (bg #512 + 11), Inode bitmap at 16777243 (bg #512 + 27)
+  Inode table at 16782880-16783391 (bg #512 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17137664-17170431
+  Free inodes: 4284417-4292608
+Group 524: (Blocks 17170432-17203199) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x36f8, unused inodes 8192
+  Block bitmap at 16777228 (bg #512 + 12), Inode bitmap at 16777244 (bg #512 + 28)
+  Inode table at 16783392-16783903 (bg #512 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17170432-17203199
+  Free inodes: 4292609-4300800
+Group 525: (Blocks 17203200-17235967) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9623, unused inodes 8192
+  Block bitmap at 16777229 (bg #512 + 13), Inode bitmap at 16777245 (bg #512 + 29)
+  Inode table at 16783904-16784415 (bg #512 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17203200-17235967
+  Free inodes: 4300801-4308992
+Group 526: (Blocks 17235968-17268735) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x374d, unused inodes 8192
+  Block bitmap at 16777230 (bg #512 + 14), Inode bitmap at 16777246 (bg #512 + 30)
+  Inode table at 16784416-16784927 (bg #512 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17235968-17268735
+  Free inodes: 4308993-4317184
+Group 527: (Blocks 17268736-17301503) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9796, unused inodes 8192
+  Block bitmap at 16777231 (bg #512 + 15), Inode bitmap at 16777247 (bg #512 + 31)
+  Inode table at 16784928-16785439 (bg #512 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17268736-17301503
+  Free inodes: 4317185-4325376
+Group 528: (Blocks 17301504-17334271) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7bf6, unused inodes 8192
+  Block bitmap at 17301504 (+0), Inode bitmap at 17301520 (+16)
+  Inode table at 17301536-17302047 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17309728-17334271
+  Free inodes: 4325377-4333568
+Group 529: (Blocks 17334272-17367039) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe08b, unused inodes 8192
+  Block bitmap at 17301505 (bg #528 + 1), Inode bitmap at 17301521 (bg #528 + 17)
+  Inode table at 17302048-17302559 (bg #528 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17334272-17367039
+  Free inodes: 4333569-4341760
+Group 530: (Blocks 17367040-17399807) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x41e5, unused inodes 8192
+  Block bitmap at 17301506 (bg #528 + 2), Inode bitmap at 17301522 (bg #528 + 18)
+  Inode table at 17302560-17303071 (bg #528 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17367040-17399807
+  Free inodes: 4341761-4349952
+Group 531: (Blocks 17399808-17432575) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe13e, unused inodes 8192
+  Block bitmap at 17301507 (bg #528 + 3), Inode bitmap at 17301523 (bg #528 + 19)
+  Inode table at 17303072-17303583 (bg #528 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17399808-17432575
+  Free inodes: 4349953-4358144
+Group 532: (Blocks 17432576-17465343) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x433a, unused inodes 8192
+  Block bitmap at 17301508 (bg #528 + 4), Inode bitmap at 17301524 (bg #528 + 20)
+  Inode table at 17303584-17304095 (bg #528 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17432576-17465343
+  Free inodes: 4358145-4366336
+Group 533: (Blocks 17465344-17498111) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe3e1, unused inodes 8192
+  Block bitmap at 17301509 (bg #528 + 5), Inode bitmap at 17301525 (bg #528 + 21)
+  Inode table at 17304096-17304607 (bg #528 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17465344-17498111
+  Free inodes: 4366337-4374528
+Group 534: (Blocks 17498112-17530879) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x428f, unused inodes 8192
+  Block bitmap at 17301510 (bg #528 + 6), Inode bitmap at 17301526 (bg #528 + 22)
+  Inode table at 17304608-17305119 (bg #528 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17498112-17530879
+  Free inodes: 4374529-4382720
+Group 535: (Blocks 17530880-17563647) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe254, unused inodes 8192
+  Block bitmap at 17301511 (bg #528 + 7), Inode bitmap at 17301527 (bg #528 + 23)
+  Inode table at 17305120-17305631 (bg #528 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17530880-17563647
+  Free inodes: 4382721-4390912
+Group 536: (Blocks 17563648-17596415) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4684, unused inodes 8192
+  Block bitmap at 17301512 (bg #528 + 8), Inode bitmap at 17301528 (bg #528 + 24)
+  Inode table at 17305632-17306143 (bg #528 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17563648-17596415
+  Free inodes: 4390913-4399104
+Group 537: (Blocks 17596416-17629183) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe65f, unused inodes 8192
+  Block bitmap at 17301513 (bg #528 + 9), Inode bitmap at 17301529 (bg #528 + 25)
+  Inode table at 17306144-17306655 (bg #528 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17596416-17629183
+  Free inodes: 4399105-4407296
+Group 538: (Blocks 17629184-17661951) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4731, unused inodes 8192
+  Block bitmap at 17301514 (bg #528 + 10), Inode bitmap at 17301530 (bg #528 + 26)
+  Inode table at 17306656-17307167 (bg #528 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17629184-17661951
+  Free inodes: 4407297-4415488
+Group 539: (Blocks 17661952-17694719) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe7ea, unused inodes 8192
+  Block bitmap at 17301515 (bg #528 + 11), Inode bitmap at 17301531 (bg #528 + 27)
+  Inode table at 17307168-17307679 (bg #528 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17661952-17694719
+  Free inodes: 4415489-4423680
+Group 540: (Blocks 17694720-17727487) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x45ee, unused inodes 8192
+  Block bitmap at 17301516 (bg #528 + 12), Inode bitmap at 17301532 (bg #528 + 28)
+  Inode table at 17307680-17308191 (bg #528 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17694720-17727487
+  Free inodes: 4423681-4431872
+Group 541: (Blocks 17727488-17760255) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe535, unused inodes 8192
+  Block bitmap at 17301517 (bg #528 + 13), Inode bitmap at 17301533 (bg #528 + 29)
+  Inode table at 17308192-17308703 (bg #528 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17727488-17760255
+  Free inodes: 4431873-4440064
+Group 542: (Blocks 17760256-17793023) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x445b, unused inodes 8192
+  Block bitmap at 17301518 (bg #528 + 14), Inode bitmap at 17301534 (bg #528 + 30)
+  Inode table at 17308704-17309215 (bg #528 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17760256-17793023
+  Free inodes: 4440065-4448256
+Group 543: (Blocks 17793024-17825791) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe480, unused inodes 8192
+  Block bitmap at 17301519 (bg #528 + 15), Inode bitmap at 17301535 (bg #528 + 31)
+  Inode table at 17309216-17309727 (bg #528 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17793024-17825791
+  Free inodes: 4448257-4456448
+Group 544: (Blocks 17825792-17858559) [ITABLE_ZEROED]
+  Checksum 0xb472, unused inodes 8191
+  Block bitmap at 17825792 (+0), Inode bitmap at 17825808 (+16)
+  Inode table at 17825824-17826335 (+32)
+  24543 free blocks, 8191 free inodes, 1 directories, 8191 unused inodes
+  Free blocks: 17834017-17858559
+  Free inodes: 4456450-4464640
+Group 545: (Blocks 17858560-17891327) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x75b1, unused inodes 8192
+  Block bitmap at 17825793 (bg #544 + 1), Inode bitmap at 17825809 (bg #544 + 17)
+  Inode table at 17826336-17826847 (bg #544 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17858560-17891327
+  Free inodes: 4464641-4472832
+Group 546: (Blocks 17891328-17924095) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd4df, unused inodes 8192
+  Block bitmap at 17825794 (bg #544 + 2), Inode bitmap at 17825810 (bg #544 + 18)
+  Inode table at 17826848-17827359 (bg #544 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17891328-17924095
+  Free inodes: 4472833-4481024
+Group 547: (Blocks 17924096-17956863) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7404, unused inodes 8192
+  Block bitmap at 17825795 (bg #544 + 3), Inode bitmap at 17825811 (bg #544 + 19)
+  Inode table at 17827360-17827871 (bg #544 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17924096-17956863
+  Free inodes: 4481025-4489216
+Group 548: (Blocks 17956864-17989631) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd600, unused inodes 8192
+  Block bitmap at 17825796 (bg #544 + 4), Inode bitmap at 17825812 (bg #544 + 20)
+  Inode table at 17827872-17828383 (bg #544 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17956864-17989631
+  Free inodes: 4489217-4497408
+Group 549: (Blocks 17989632-18022399) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x76db, unused inodes 8192
+  Block bitmap at 17825797 (bg #544 + 5), Inode bitmap at 17825813 (bg #544 + 21)
+  Inode table at 17828384-17828895 (bg #544 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 17989632-18022399
+  Free inodes: 4497409-4505600
+Group 550: (Blocks 18022400-18055167) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd7b5, unused inodes 8192
+  Block bitmap at 17825798 (bg #544 + 6), Inode bitmap at 17825814 (bg #544 + 22)
+  Inode table at 17828896-17829407 (bg #544 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18022400-18055167
+  Free inodes: 4505601-4513792
+Group 551: (Blocks 18055168-18087935) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x776e, unused inodes 8192
+  Block bitmap at 17825799 (bg #544 + 7), Inode bitmap at 17825815 (bg #544 + 23)
+  Inode table at 17829408-17829919 (bg #544 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18055168-18087935
+  Free inodes: 4513793-4521984
+Group 552: (Blocks 18087936-18120703) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd3be, unused inodes 8192
+  Block bitmap at 17825800 (bg #544 + 8), Inode bitmap at 17825816 (bg #544 + 24)
+  Inode table at 17829920-17830431 (bg #544 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18087936-18120703
+  Free inodes: 4521985-4530176
+Group 553: (Blocks 18120704-18153471) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7365, unused inodes 8192
+  Block bitmap at 17825801 (bg #544 + 9), Inode bitmap at 17825817 (bg #544 + 25)
+  Inode table at 17830432-17830943 (bg #544 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18120704-18153471
+  Free inodes: 4530177-4538368
+Group 554: (Blocks 18153472-18186239) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd20b, unused inodes 8192
+  Block bitmap at 17825802 (bg #544 + 10), Inode bitmap at 17825818 (bg #544 + 26)
+  Inode table at 17830944-17831455 (bg #544 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18153472-18186239
+  Free inodes: 4538369-4546560
+Group 555: (Blocks 18186240-18219007) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x72d0, unused inodes 8192
+  Block bitmap at 17825803 (bg #544 + 11), Inode bitmap at 17825819 (bg #544 + 27)
+  Inode table at 17831456-17831967 (bg #544 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18186240-18219007
+  Free inodes: 4546561-4554752
+Group 556: (Blocks 18219008-18251775) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd0d4, unused inodes 8192
+  Block bitmap at 17825804 (bg #544 + 12), Inode bitmap at 17825820 (bg #544 + 28)
+  Inode table at 17831968-17832479 (bg #544 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18219008-18251775
+  Free inodes: 4554753-4562944
+Group 557: (Blocks 18251776-18284543) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x700f, unused inodes 8192
+  Block bitmap at 17825805 (bg #544 + 13), Inode bitmap at 17825821 (bg #544 + 29)
+  Inode table at 17832480-17832991 (bg #544 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18251776-18284543
+  Free inodes: 4562945-4571136
+Group 558: (Blocks 18284544-18317311) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd161, unused inodes 8192
+  Block bitmap at 17825806 (bg #544 + 14), Inode bitmap at 17825822 (bg #544 + 30)
+  Inode table at 17832992-17833503 (bg #544 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18284544-18317311
+  Free inodes: 4571137-4579328
+Group 559: (Blocks 18317312-18350079) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x71ba, unused inodes 8192
+  Block bitmap at 17825807 (bg #544 + 15), Inode bitmap at 17825823 (bg #544 + 31)
+  Inode table at 17833504-17834015 (bg #544 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18317312-18350079
+  Free inodes: 4579329-4587520
+Group 560: (Blocks 18350080-18382847) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9dda, unused inodes 8192
+  Block bitmap at 18350080 (+0), Inode bitmap at 18350096 (+16)
+  Inode table at 18350112-18350623 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18358304-18382847
+  Free inodes: 4587521-4595712
+Group 561: (Blocks 18382848-18415615) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x06a7, unused inodes 8192
+  Block bitmap at 18350081 (bg #560 + 1), Inode bitmap at 18350097 (bg #560 + 17)
+  Inode table at 18350624-18351135 (bg #560 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18382848-18415615
+  Free inodes: 4595713-4603904
+Group 562: (Blocks 18415616-18448383) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa7c9, unused inodes 8192
+  Block bitmap at 18350082 (bg #560 + 2), Inode bitmap at 18350098 (bg #560 + 18)
+  Inode table at 18351136-18351647 (bg #560 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18415616-18448383
+  Free inodes: 4603905-4612096
+Group 563: (Blocks 18448384-18481151) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0712, unused inodes 8192
+  Block bitmap at 18350083 (bg #560 + 3), Inode bitmap at 18350099 (bg #560 + 19)
+  Inode table at 18351648-18352159 (bg #560 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18448384-18481151
+  Free inodes: 4612097-4620288
+Group 564: (Blocks 18481152-18513919) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa516, unused inodes 8192
+  Block bitmap at 18350084 (bg #560 + 4), Inode bitmap at 18350100 (bg #560 + 20)
+  Inode table at 18352160-18352671 (bg #560 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18481152-18513919
+  Free inodes: 4620289-4628480
+Group 565: (Blocks 18513920-18546687) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x05cd, unused inodes 8192
+  Block bitmap at 18350085 (bg #560 + 5), Inode bitmap at 18350101 (bg #560 + 21)
+  Inode table at 18352672-18353183 (bg #560 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18513920-18546687
+  Free inodes: 4628481-4636672
+Group 566: (Blocks 18546688-18579455) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa4a3, unused inodes 8192
+  Block bitmap at 18350086 (bg #560 + 6), Inode bitmap at 18350102 (bg #560 + 22)
+  Inode table at 18353184-18353695 (bg #560 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18546688-18579455
+  Free inodes: 4636673-4644864
+Group 567: (Blocks 18579456-18612223) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0478, unused inodes 8192
+  Block bitmap at 18350087 (bg #560 + 7), Inode bitmap at 18350103 (bg #560 + 23)
+  Inode table at 18353696-18354207 (bg #560 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18579456-18612223
+  Free inodes: 4644865-4653056
+Group 568: (Blocks 18612224-18644991) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa0a8, unused inodes 8192
+  Block bitmap at 18350088 (bg #560 + 8), Inode bitmap at 18350104 (bg #560 + 24)
+  Inode table at 18354208-18354719 (bg #560 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18612224-18644991
+  Free inodes: 4653057-4661248
+Group 569: (Blocks 18644992-18677759) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0073, unused inodes 8192
+  Block bitmap at 18350089 (bg #560 + 9), Inode bitmap at 18350105 (bg #560 + 25)
+  Inode table at 18354720-18355231 (bg #560 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18644992-18677759
+  Free inodes: 4661249-4669440
+Group 570: (Blocks 18677760-18710527) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa11d, unused inodes 8192
+  Block bitmap at 18350090 (bg #560 + 10), Inode bitmap at 18350106 (bg #560 + 26)
+  Inode table at 18355232-18355743 (bg #560 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18677760-18710527
+  Free inodes: 4669441-4677632
+Group 571: (Blocks 18710528-18743295) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x01c6, unused inodes 8192
+  Block bitmap at 18350091 (bg #560 + 11), Inode bitmap at 18350107 (bg #560 + 27)
+  Inode table at 18355744-18356255 (bg #560 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18710528-18743295
+  Free inodes: 4677633-4685824
+Group 572: (Blocks 18743296-18776063) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa3c2, unused inodes 8192
+  Block bitmap at 18350092 (bg #560 + 12), Inode bitmap at 18350108 (bg #560 + 28)
+  Inode table at 18356256-18356767 (bg #560 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18743296-18776063
+  Free inodes: 4685825-4694016
+Group 573: (Blocks 18776064-18808831) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0319, unused inodes 8192
+  Block bitmap at 18350093 (bg #560 + 13), Inode bitmap at 18350109 (bg #560 + 29)
+  Inode table at 18356768-18357279 (bg #560 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18776064-18808831
+  Free inodes: 4694017-4702208
+Group 574: (Blocks 18808832-18841599) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa277, unused inodes 8192
+  Block bitmap at 18350094 (bg #560 + 14), Inode bitmap at 18350110 (bg #560 + 30)
+  Inode table at 18357280-18357791 (bg #560 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18808832-18841599
+  Free inodes: 4702209-4710400
+Group 575: (Blocks 18841600-18874367) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x02ac, unused inodes 8192
+  Block bitmap at 18350095 (bg #560 + 15), Inode bitmap at 18350111 (bg #560 + 31)
+  Inode table at 18357792-18358303 (bg #560 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18841600-18874367
+  Free inodes: 4710401-4718592
+Group 576: (Blocks 18874368-18907135) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x84bb, unused inodes 8192
+  Block bitmap at 18874368 (+0), Inode bitmap at 18874384 (+16)
+  Inode table at 18874400-18874911 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18882592-18907135
+  Free inodes: 4718593-4726784
+Group 577: (Blocks 18907136-18939903) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1fc6, unused inodes 8192
+  Block bitmap at 18874369 (bg #576 + 1), Inode bitmap at 18874385 (bg #576 + 17)
+  Inode table at 18874912-18875423 (bg #576 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18907136-18939903
+  Free inodes: 4726785-4734976
+Group 578: (Blocks 18939904-18972671) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbea8, unused inodes 8192
+  Block bitmap at 18874370 (bg #576 + 2), Inode bitmap at 18874386 (bg #576 + 18)
+  Inode table at 18875424-18875935 (bg #576 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18939904-18972671
+  Free inodes: 4734977-4743168
+Group 579: (Blocks 18972672-19005439) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1e73, unused inodes 8192
+  Block bitmap at 18874371 (bg #576 + 3), Inode bitmap at 18874387 (bg #576 + 19)
+  Inode table at 18875936-18876447 (bg #576 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 18972672-19005439
+  Free inodes: 4743169-4751360
+Group 580: (Blocks 19005440-19038207) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbc77, unused inodes 8192
+  Block bitmap at 18874372 (bg #576 + 4), Inode bitmap at 18874388 (bg #576 + 20)
+  Inode table at 18876448-18876959 (bg #576 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19005440-19038207
+  Free inodes: 4751361-4759552
+Group 581: (Blocks 19038208-19070975) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1cac, unused inodes 8192
+  Block bitmap at 18874373 (bg #576 + 5), Inode bitmap at 18874389 (bg #576 + 21)
+  Inode table at 18876960-18877471 (bg #576 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19038208-19070975
+  Free inodes: 4759553-4767744
+Group 582: (Blocks 19070976-19103743) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbdc2, unused inodes 8192
+  Block bitmap at 18874374 (bg #576 + 6), Inode bitmap at 18874390 (bg #576 + 22)
+  Inode table at 18877472-18877983 (bg #576 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19070976-19103743
+  Free inodes: 4767745-4775936
+Group 583: (Blocks 19103744-19136511) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1d19, unused inodes 8192
+  Block bitmap at 18874375 (bg #576 + 7), Inode bitmap at 18874391 (bg #576 + 23)
+  Inode table at 18877984-18878495 (bg #576 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19103744-19136511
+  Free inodes: 4775937-4784128
+Group 584: (Blocks 19136512-19169279) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb9c9, unused inodes 8192
+  Block bitmap at 18874376 (bg #576 + 8), Inode bitmap at 18874392 (bg #576 + 24)
+  Inode table at 18878496-18879007 (bg #576 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19136512-19169279
+  Free inodes: 4784129-4792320
+Group 585: (Blocks 19169280-19202047) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1912, unused inodes 8192
+  Block bitmap at 18874377 (bg #576 + 9), Inode bitmap at 18874393 (bg #576 + 25)
+  Inode table at 18879008-18879519 (bg #576 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19169280-19202047
+  Free inodes: 4792321-4800512
+Group 586: (Blocks 19202048-19234815) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb87c, unused inodes 8192
+  Block bitmap at 18874378 (bg #576 + 10), Inode bitmap at 18874394 (bg #576 + 26)
+  Inode table at 18879520-18880031 (bg #576 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19202048-19234815
+  Free inodes: 4800513-4808704
+Group 587: (Blocks 19234816-19267583) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x18a7, unused inodes 8192
+  Block bitmap at 18874379 (bg #576 + 11), Inode bitmap at 18874395 (bg #576 + 27)
+  Inode table at 18880032-18880543 (bg #576 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19234816-19267583
+  Free inodes: 4808705-4816896
+Group 588: (Blocks 19267584-19300351) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbaa3, unused inodes 8192
+  Block bitmap at 18874380 (bg #576 + 12), Inode bitmap at 18874396 (bg #576 + 28)
+  Inode table at 18880544-18881055 (bg #576 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19267584-19300351
+  Free inodes: 4816897-4825088
+Group 589: (Blocks 19300352-19333119) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1a78, unused inodes 8192
+  Block bitmap at 18874381 (bg #576 + 13), Inode bitmap at 18874397 (bg #576 + 29)
+  Inode table at 18881056-18881567 (bg #576 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19300352-19333119
+  Free inodes: 4825089-4833280
+Group 590: (Blocks 19333120-19365887) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbb16, unused inodes 8192
+  Block bitmap at 18874382 (bg #576 + 14), Inode bitmap at 18874398 (bg #576 + 30)
+  Inode table at 18881568-18882079 (bg #576 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19333120-19365887
+  Free inodes: 4833281-4841472
+Group 591: (Blocks 19365888-19398655) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1bcd, unused inodes 8192
+  Block bitmap at 18874383 (bg #576 + 15), Inode bitmap at 18874399 (bg #576 + 31)
+  Inode table at 18882080-18882591 (bg #576 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19365888-19398655
+  Free inodes: 4841473-4849664
+Group 592: (Blocks 19398656-19431423) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf7ad, unused inodes 8192
+  Block bitmap at 19398656 (+0), Inode bitmap at 19398672 (+16)
+  Inode table at 19398688-19399199 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19406880-19431423
+  Free inodes: 4849665-4857856
+Group 593: (Blocks 19431424-19464191) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6cd0, unused inodes 8192
+  Block bitmap at 19398657 (bg #592 + 1), Inode bitmap at 19398673 (bg #592 + 17)
+  Inode table at 19399200-19399711 (bg #592 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19431424-19464191
+  Free inodes: 4857857-4866048
+Group 594: (Blocks 19464192-19496959) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcdbe, unused inodes 8192
+  Block bitmap at 19398658 (bg #592 + 2), Inode bitmap at 19398674 (bg #592 + 18)
+  Inode table at 19399712-19400223 (bg #592 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19464192-19496959
+  Free inodes: 4866049-4874240
+Group 595: (Blocks 19496960-19529727) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6d65, unused inodes 8192
+  Block bitmap at 19398659 (bg #592 + 3), Inode bitmap at 19398675 (bg #592 + 19)
+  Inode table at 19400224-19400735 (bg #592 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19496960-19529727
+  Free inodes: 4874241-4882432
+Group 596: (Blocks 19529728-19562495) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcf61, unused inodes 8192
+  Block bitmap at 19398660 (bg #592 + 4), Inode bitmap at 19398676 (bg #592 + 20)
+  Inode table at 19400736-19401247 (bg #592 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19529728-19562495
+  Free inodes: 4882433-4890624
+Group 597: (Blocks 19562496-19595263) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6fba, unused inodes 8192
+  Block bitmap at 19398661 (bg #592 + 5), Inode bitmap at 19398677 (bg #592 + 21)
+  Inode table at 19401248-19401759 (bg #592 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19562496-19595263
+  Free inodes: 4890625-4898816
+Group 598: (Blocks 19595264-19628031) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xced4, unused inodes 8192
+  Block bitmap at 19398662 (bg #592 + 6), Inode bitmap at 19398678 (bg #592 + 22)
+  Inode table at 19401760-19402271 (bg #592 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19595264-19628031
+  Free inodes: 4898817-4907008
+Group 599: (Blocks 19628032-19660799) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6e0f, unused inodes 8192
+  Block bitmap at 19398663 (bg #592 + 7), Inode bitmap at 19398679 (bg #592 + 23)
+  Inode table at 19402272-19402783 (bg #592 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19628032-19660799
+  Free inodes: 4907009-4915200
+Group 600: (Blocks 19660800-19693567) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcadf, unused inodes 8192
+  Block bitmap at 19398664 (bg #592 + 8), Inode bitmap at 19398680 (bg #592 + 24)
+  Inode table at 19402784-19403295 (bg #592 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19660800-19693567
+  Free inodes: 4915201-4923392
+Group 601: (Blocks 19693568-19726335) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6a04, unused inodes 8192
+  Block bitmap at 19398665 (bg #592 + 9), Inode bitmap at 19398681 (bg #592 + 25)
+  Inode table at 19403296-19403807 (bg #592 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19693568-19726335
+  Free inodes: 4923393-4931584
+Group 602: (Blocks 19726336-19759103) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcb6a, unused inodes 8192
+  Block bitmap at 19398666 (bg #592 + 10), Inode bitmap at 19398682 (bg #592 + 26)
+  Inode table at 19403808-19404319 (bg #592 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19726336-19759103
+  Free inodes: 4931585-4939776
+Group 603: (Blocks 19759104-19791871) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6bb1, unused inodes 8192
+  Block bitmap at 19398667 (bg #592 + 11), Inode bitmap at 19398683 (bg #592 + 27)
+  Inode table at 19404320-19404831 (bg #592 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19759104-19791871
+  Free inodes: 4939777-4947968
+Group 604: (Blocks 19791872-19824639) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc9b5, unused inodes 8192
+  Block bitmap at 19398668 (bg #592 + 12), Inode bitmap at 19398684 (bg #592 + 28)
+  Inode table at 19404832-19405343 (bg #592 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19791872-19824639
+  Free inodes: 4947969-4956160
+Group 605: (Blocks 19824640-19857407) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x696e, unused inodes 8192
+  Block bitmap at 19398669 (bg #592 + 13), Inode bitmap at 19398685 (bg #592 + 29)
+  Inode table at 19405344-19405855 (bg #592 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19824640-19857407
+  Free inodes: 4956161-4964352
+Group 606: (Blocks 19857408-19890175) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc800, unused inodes 8192
+  Block bitmap at 19398670 (bg #592 + 14), Inode bitmap at 19398686 (bg #592 + 30)
+  Inode table at 19405856-19406367 (bg #592 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19857408-19890175
+  Free inodes: 4964353-4972544
+Group 607: (Blocks 19890176-19922943) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x68db, unused inodes 8192
+  Block bitmap at 19398671 (bg #592 + 15), Inode bitmap at 19398687 (bg #592 + 31)
+  Inode table at 19406368-19406879 (bg #592 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19890176-19922943
+  Free inodes: 4972545-4980736
+Group 608: (Blocks 19922944-19955711) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6297, unused inodes 8192
+  Block bitmap at 19922944 (+0), Inode bitmap at 19922960 (+16)
+  Inode table at 19922976-19923487 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19931168-19955711
+  Free inodes: 4980737-4988928
+Group 609: (Blocks 19955712-19988479) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf9ea, unused inodes 8192
+  Block bitmap at 19922945 (bg #608 + 1), Inode bitmap at 19922961 (bg #608 + 17)
+  Inode table at 19923488-19923999 (bg #608 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19955712-19988479
+  Free inodes: 4988929-4997120
+Group 610: (Blocks 19988480-20021247) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5884, unused inodes 8192
+  Block bitmap at 19922946 (bg #608 + 2), Inode bitmap at 19922962 (bg #608 + 18)
+  Inode table at 19924000-19924511 (bg #608 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 19988480-20021247
+  Free inodes: 4997121-5005312
+Group 611: (Blocks 20021248-20054015) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf85f, unused inodes 8192
+  Block bitmap at 19922947 (bg #608 + 3), Inode bitmap at 19922963 (bg #608 + 19)
+  Inode table at 19924512-19925023 (bg #608 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20021248-20054015
+  Free inodes: 5005313-5013504
+Group 612: (Blocks 20054016-20086783) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5a5b, unused inodes 8192
+  Block bitmap at 19922948 (bg #608 + 4), Inode bitmap at 19922964 (bg #608 + 20)
+  Inode table at 19925024-19925535 (bg #608 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20054016-20086783
+  Free inodes: 5013505-5021696
+Group 613: (Blocks 20086784-20119551) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfa80, unused inodes 8192
+  Block bitmap at 19922949 (bg #608 + 5), Inode bitmap at 19922965 (bg #608 + 21)
+  Inode table at 19925536-19926047 (bg #608 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20086784-20119551
+  Free inodes: 5021697-5029888
+Group 614: (Blocks 20119552-20152319) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5bee, unused inodes 8192
+  Block bitmap at 19922950 (bg #608 + 6), Inode bitmap at 19922966 (bg #608 + 22)
+  Inode table at 19926048-19926559 (bg #608 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20119552-20152319
+  Free inodes: 5029889-5038080
+Group 615: (Blocks 20152320-20185087) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfb35, unused inodes 8192
+  Block bitmap at 19922951 (bg #608 + 7), Inode bitmap at 19922967 (bg #608 + 23)
+  Inode table at 19926560-19927071 (bg #608 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20152320-20185087
+  Free inodes: 5038081-5046272
+Group 616: (Blocks 20185088-20217855) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5fe5, unused inodes 8192
+  Block bitmap at 19922952 (bg #608 + 8), Inode bitmap at 19922968 (bg #608 + 24)
+  Inode table at 19927072-19927583 (bg #608 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20185088-20217855
+  Free inodes: 5046273-5054464
+Group 617: (Blocks 20217856-20250623) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xff3e, unused inodes 8192
+  Block bitmap at 19922953 (bg #608 + 9), Inode bitmap at 19922969 (bg #608 + 25)
+  Inode table at 19927584-19928095 (bg #608 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20217856-20250623
+  Free inodes: 5054465-5062656
+Group 618: (Blocks 20250624-20283391) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5e50, unused inodes 8192
+  Block bitmap at 19922954 (bg #608 + 10), Inode bitmap at 19922970 (bg #608 + 26)
+  Inode table at 19928096-19928607 (bg #608 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20250624-20283391
+  Free inodes: 5062657-5070848
+Group 619: (Blocks 20283392-20316159) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfe8b, unused inodes 8192
+  Block bitmap at 19922955 (bg #608 + 11), Inode bitmap at 19922971 (bg #608 + 27)
+  Inode table at 19928608-19929119 (bg #608 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20283392-20316159
+  Free inodes: 5070849-5079040
+Group 620: (Blocks 20316160-20348927) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5c8f, unused inodes 8192
+  Block bitmap at 19922956 (bg #608 + 12), Inode bitmap at 19922972 (bg #608 + 28)
+  Inode table at 19929120-19929631 (bg #608 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20316160-20348927
+  Free inodes: 5079041-5087232
+Group 621: (Blocks 20348928-20381695) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfc54, unused inodes 8192
+  Block bitmap at 19922957 (bg #608 + 13), Inode bitmap at 19922973 (bg #608 + 29)
+  Inode table at 19929632-19930143 (bg #608 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20348928-20381695
+  Free inodes: 5087233-5095424
+Group 622: (Blocks 20381696-20414463) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5d3a, unused inodes 8192
+  Block bitmap at 19922958 (bg #608 + 14), Inode bitmap at 19922974 (bg #608 + 30)
+  Inode table at 19930144-19930655 (bg #608 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20381696-20414463
+  Free inodes: 5095425-5103616
+Group 623: (Blocks 20414464-20447231) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfde1, unused inodes 8192
+  Block bitmap at 19922959 (bg #608 + 15), Inode bitmap at 19922975 (bg #608 + 31)
+  Inode table at 19930656-19931167 (bg #608 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20414464-20447231
+  Free inodes: 5103617-5111808
+Group 624: (Blocks 20447232-20479999) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1181, unused inodes 8192
+  Block bitmap at 20447232 (+0), Inode bitmap at 20447248 (+16)
+  Inode table at 20447264-20447775 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20455456-20479999
+  Free inodes: 5111809-5120000
+Group 625: (Blocks 20480000-20512767) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xafcf, unused inodes 8192
+  Backup superblock at 20480000, Group descriptors at 20480001-20480007
+  Reserved GDT blocks at 20480008-20481024
+  Block bitmap at 20447233 (bg #624 + 1), Inode bitmap at 20447249 (bg #624 + 17)
+  Inode table at 20447776-20448287 (bg #624 + 544)
+  31743 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20481025-20512767
+  Free inodes: 5120001-5128192
+Group 626: (Blocks 20512768-20545535) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2b92, unused inodes 8192
+  Block bitmap at 20447234 (bg #624 + 2), Inode bitmap at 20447250 (bg #624 + 18)
+  Inode table at 20448288-20448799 (bg #624 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20512768-20545535
+  Free inodes: 5128193-5136384
+Group 627: (Blocks 20545536-20578303) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8b49, unused inodes 8192
+  Block bitmap at 20447235 (bg #624 + 3), Inode bitmap at 20447251 (bg #624 + 19)
+  Inode table at 20448800-20449311 (bg #624 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20545536-20578303
+  Free inodes: 5136385-5144576
+Group 628: (Blocks 20578304-20611071) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x294d, unused inodes 8192
+  Block bitmap at 20447236 (bg #624 + 4), Inode bitmap at 20447252 (bg #624 + 20)
+  Inode table at 20449312-20449823 (bg #624 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20578304-20611071
+  Free inodes: 5144577-5152768
+Group 629: (Blocks 20611072-20643839) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8996, unused inodes 8192
+  Block bitmap at 20447237 (bg #624 + 5), Inode bitmap at 20447253 (bg #624 + 21)
+  Inode table at 20449824-20450335 (bg #624 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20611072-20643839
+  Free inodes: 5152769-5160960
+Group 630: (Blocks 20643840-20676607) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x28f8, unused inodes 8192
+  Block bitmap at 20447238 (bg #624 + 6), Inode bitmap at 20447254 (bg #624 + 22)
+  Inode table at 20450336-20450847 (bg #624 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20643840-20676607
+  Free inodes: 5160961-5169152
+Group 631: (Blocks 20676608-20709375) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8823, unused inodes 8192
+  Block bitmap at 20447239 (bg #624 + 7), Inode bitmap at 20447255 (bg #624 + 23)
+  Inode table at 20450848-20451359 (bg #624 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20676608-20709375
+  Free inodes: 5169153-5177344
+Group 632: (Blocks 20709376-20742143) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2cf3, unused inodes 8192
+  Block bitmap at 20447240 (bg #624 + 8), Inode bitmap at 20447256 (bg #624 + 24)
+  Inode table at 20451360-20451871 (bg #624 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20709376-20742143
+  Free inodes: 5177345-5185536
+Group 633: (Blocks 20742144-20774911) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8c28, unused inodes 8192
+  Block bitmap at 20447241 (bg #624 + 9), Inode bitmap at 20447257 (bg #624 + 25)
+  Inode table at 20451872-20452383 (bg #624 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20742144-20774911
+  Free inodes: 5185537-5193728
+Group 634: (Blocks 20774912-20807679) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2d46, unused inodes 8192
+  Block bitmap at 20447242 (bg #624 + 10), Inode bitmap at 20447258 (bg #624 + 26)
+  Inode table at 20452384-20452895 (bg #624 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20774912-20807679
+  Free inodes: 5193729-5201920
+Group 635: (Blocks 20807680-20840447) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8d9d, unused inodes 8192
+  Block bitmap at 20447243 (bg #624 + 11), Inode bitmap at 20447259 (bg #624 + 27)
+  Inode table at 20452896-20453407 (bg #624 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20807680-20840447
+  Free inodes: 5201921-5210112
+Group 636: (Blocks 20840448-20873215) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2f99, unused inodes 8192
+  Block bitmap at 20447244 (bg #624 + 12), Inode bitmap at 20447260 (bg #624 + 28)
+  Inode table at 20453408-20453919 (bg #624 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20840448-20873215
+  Free inodes: 5210113-5218304
+Group 637: (Blocks 20873216-20905983) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8f42, unused inodes 8192
+  Block bitmap at 20447245 (bg #624 + 13), Inode bitmap at 20447261 (bg #624 + 29)
+  Inode table at 20453920-20454431 (bg #624 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20873216-20905983
+  Free inodes: 5218305-5226496
+Group 638: (Blocks 20905984-20938751) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2e2c, unused inodes 8192
+  Block bitmap at 20447246 (bg #624 + 14), Inode bitmap at 20447262 (bg #624 + 30)
+  Inode table at 20454432-20454943 (bg #624 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20905984-20938751
+  Free inodes: 5226497-5234688
+Group 639: (Blocks 20938752-20971519) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8ef7, unused inodes 8192
+  Block bitmap at 20447247 (bg #624 + 15), Inode bitmap at 20447263 (bg #624 + 31)
+  Inode table at 20454944-20455455 (bg #624 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 20938752-20971519
+  Free inodes: 5234689-5242880
+Group 640: (Blocks 20971520-21004287) [ITABLE_ZEROED]
+  Checksum 0x0aeb, unused inodes 8191
+  Block bitmap at 20971520 (+0), Inode bitmap at 20971536 (+16)
+  Inode table at 20971552-20972063 (+32)
+  24543 free blocks, 8191 free inodes, 1 directories, 8191 unused inodes
+  Free blocks: 20979745-21004287
+  Free inodes: 5242882-5251072
+Group 641: (Blocks 21004288-21037055) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcb28, unused inodes 8192
+  Block bitmap at 20971521 (bg #640 + 1), Inode bitmap at 20971537 (bg #640 + 17)
+  Inode table at 20972064-20972575 (bg #640 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21004288-21037055
+  Free inodes: 5251073-5259264
+Group 642: (Blocks 21037056-21069823) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6a46, unused inodes 8192
+  Block bitmap at 20971522 (bg #640 + 2), Inode bitmap at 20971538 (bg #640 + 18)
+  Inode table at 20972576-20973087 (bg #640 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21037056-21069823
+  Free inodes: 5259265-5267456
+Group 643: (Blocks 21069824-21102591) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xca9d, unused inodes 8192
+  Block bitmap at 20971523 (bg #640 + 3), Inode bitmap at 20971539 (bg #640 + 19)
+  Inode table at 20973088-20973599 (bg #640 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21069824-21102591
+  Free inodes: 5267457-5275648
+Group 644: (Blocks 21102592-21135359) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6899, unused inodes 8192
+  Block bitmap at 20971524 (bg #640 + 4), Inode bitmap at 20971540 (bg #640 + 20)
+  Inode table at 20973600-20974111 (bg #640 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21102592-21135359
+  Free inodes: 5275649-5283840
+Group 645: (Blocks 21135360-21168127) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc842, unused inodes 8192
+  Block bitmap at 20971525 (bg #640 + 5), Inode bitmap at 20971541 (bg #640 + 21)
+  Inode table at 20974112-20974623 (bg #640 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21135360-21168127
+  Free inodes: 5283841-5292032
+Group 646: (Blocks 21168128-21200895) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x692c, unused inodes 8192
+  Block bitmap at 20971526 (bg #640 + 6), Inode bitmap at 20971542 (bg #640 + 22)
+  Inode table at 20974624-20975135 (bg #640 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21168128-21200895
+  Free inodes: 5292033-5300224
+Group 647: (Blocks 21200896-21233663) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc9f7, unused inodes 8192
+  Block bitmap at 20971527 (bg #640 + 7), Inode bitmap at 20971543 (bg #640 + 23)
+  Inode table at 20975136-20975647 (bg #640 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21200896-21233663
+  Free inodes: 5300225-5308416
+Group 648: (Blocks 21233664-21266431) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6d27, unused inodes 8192
+  Block bitmap at 20971528 (bg #640 + 8), Inode bitmap at 20971544 (bg #640 + 24)
+  Inode table at 20975648-20976159 (bg #640 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21233664-21266431
+  Free inodes: 5308417-5316608
+Group 649: (Blocks 21266432-21299199) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcdfc, unused inodes 8192
+  Block bitmap at 20971529 (bg #640 + 9), Inode bitmap at 20971545 (bg #640 + 25)
+  Inode table at 20976160-20976671 (bg #640 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21266432-21299199
+  Free inodes: 5316609-5324800
+Group 650: (Blocks 21299200-21331967) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6c92, unused inodes 8192
+  Block bitmap at 20971530 (bg #640 + 10), Inode bitmap at 20971546 (bg #640 + 26)
+  Inode table at 20976672-20977183 (bg #640 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21299200-21331967
+  Free inodes: 5324801-5332992
+Group 651: (Blocks 21331968-21364735) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcc49, unused inodes 8192
+  Block bitmap at 20971531 (bg #640 + 11), Inode bitmap at 20971547 (bg #640 + 27)
+  Inode table at 20977184-20977695 (bg #640 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21331968-21364735
+  Free inodes: 5332993-5341184
+Group 652: (Blocks 21364736-21397503) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6e4d, unused inodes 8192
+  Block bitmap at 20971532 (bg #640 + 12), Inode bitmap at 20971548 (bg #640 + 28)
+  Inode table at 20977696-20978207 (bg #640 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21364736-21397503
+  Free inodes: 5341185-5349376
+Group 653: (Blocks 21397504-21430271) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xce96, unused inodes 8192
+  Block bitmap at 20971533 (bg #640 + 13), Inode bitmap at 20971549 (bg #640 + 29)
+  Inode table at 20978208-20978719 (bg #640 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21397504-21430271
+  Free inodes: 5349377-5357568
+Group 654: (Blocks 21430272-21463039) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x6ff8, unused inodes 8192
+  Block bitmap at 20971534 (bg #640 + 14), Inode bitmap at 20971550 (bg #640 + 30)
+  Inode table at 20978720-20979231 (bg #640 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21430272-21463039
+  Free inodes: 5357569-5365760
+Group 655: (Blocks 21463040-21495807) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xcf23, unused inodes 8192
+  Block bitmap at 20971535 (bg #640 + 15), Inode bitmap at 20971551 (bg #640 + 31)
+  Inode table at 20979232-20979743 (bg #640 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21463040-21495807
+  Free inodes: 5365761-5373952
+Group 656: (Blocks 21495808-21528575) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2343, unused inodes 8192
+  Block bitmap at 21495808 (+0), Inode bitmap at 21495824 (+16)
+  Inode table at 21495840-21496351 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21504032-21528575
+  Free inodes: 5373953-5382144
+Group 657: (Blocks 21528576-21561343) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb83e, unused inodes 8192
+  Block bitmap at 21495809 (bg #656 + 1), Inode bitmap at 21495825 (bg #656 + 17)
+  Inode table at 21496352-21496863 (bg #656 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21528576-21561343
+  Free inodes: 5382145-5390336
+Group 658: (Blocks 21561344-21594111) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1950, unused inodes 8192
+  Block bitmap at 21495810 (bg #656 + 2), Inode bitmap at 21495826 (bg #656 + 18)
+  Inode table at 21496864-21497375 (bg #656 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21561344-21594111
+  Free inodes: 5390337-5398528
+Group 659: (Blocks 21594112-21626879) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb98b, unused inodes 8192
+  Block bitmap at 21495811 (bg #656 + 3), Inode bitmap at 21495827 (bg #656 + 19)
+  Inode table at 21497376-21497887 (bg #656 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21594112-21626879
+  Free inodes: 5398529-5406720
+Group 660: (Blocks 21626880-21659647) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1b8f, unused inodes 8192
+  Block bitmap at 21495812 (bg #656 + 4), Inode bitmap at 21495828 (bg #656 + 20)
+  Inode table at 21497888-21498399 (bg #656 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21626880-21659647
+  Free inodes: 5406721-5414912
+Group 661: (Blocks 21659648-21692415) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbb54, unused inodes 8192
+  Block bitmap at 21495813 (bg #656 + 5), Inode bitmap at 21495829 (bg #656 + 21)
+  Inode table at 21498400-21498911 (bg #656 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21659648-21692415
+  Free inodes: 5414913-5423104
+Group 662: (Blocks 21692416-21725183) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1a3a, unused inodes 8192
+  Block bitmap at 21495814 (bg #656 + 6), Inode bitmap at 21495830 (bg #656 + 22)
+  Inode table at 21498912-21499423 (bg #656 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21692416-21725183
+  Free inodes: 5423105-5431296
+Group 663: (Blocks 21725184-21757951) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbae1, unused inodes 8192
+  Block bitmap at 21495815 (bg #656 + 7), Inode bitmap at 21495831 (bg #656 + 23)
+  Inode table at 21499424-21499935 (bg #656 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21725184-21757951
+  Free inodes: 5431297-5439488
+Group 664: (Blocks 21757952-21790719) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1e31, unused inodes 8192
+  Block bitmap at 21495816 (bg #656 + 8), Inode bitmap at 21495832 (bg #656 + 24)
+  Inode table at 21499936-21500447 (bg #656 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21757952-21790719
+  Free inodes: 5439489-5447680
+Group 665: (Blocks 21790720-21823487) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbeea, unused inodes 8192
+  Block bitmap at 21495817 (bg #656 + 9), Inode bitmap at 21495833 (bg #656 + 25)
+  Inode table at 21500448-21500959 (bg #656 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21790720-21823487
+  Free inodes: 5447681-5455872
+Group 666: (Blocks 21823488-21856255) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1f84, unused inodes 8192
+  Block bitmap at 21495818 (bg #656 + 10), Inode bitmap at 21495834 (bg #656 + 26)
+  Inode table at 21500960-21501471 (bg #656 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21823488-21856255
+  Free inodes: 5455873-5464064
+Group 667: (Blocks 21856256-21889023) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbf5f, unused inodes 8192
+  Block bitmap at 21495819 (bg #656 + 11), Inode bitmap at 21495835 (bg #656 + 27)
+  Inode table at 21501472-21501983 (bg #656 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21856256-21889023
+  Free inodes: 5464065-5472256
+Group 668: (Blocks 21889024-21921791) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1d5b, unused inodes 8192
+  Block bitmap at 21495820 (bg #656 + 12), Inode bitmap at 21495836 (bg #656 + 28)
+  Inode table at 21501984-21502495 (bg #656 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21889024-21921791
+  Free inodes: 5472257-5480448
+Group 669: (Blocks 21921792-21954559) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbd80, unused inodes 8192
+  Block bitmap at 21495821 (bg #656 + 13), Inode bitmap at 21495837 (bg #656 + 29)
+  Inode table at 21502496-21503007 (bg #656 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21921792-21954559
+  Free inodes: 5480449-5488640
+Group 670: (Blocks 21954560-21987327) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1cee, unused inodes 8192
+  Block bitmap at 21495822 (bg #656 + 14), Inode bitmap at 21495838 (bg #656 + 30)
+  Inode table at 21503008-21503519 (bg #656 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21954560-21987327
+  Free inodes: 5488641-5496832
+Group 671: (Blocks 21987328-22020095) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xbc35, unused inodes 8192
+  Block bitmap at 21495823 (bg #656 + 15), Inode bitmap at 21495839 (bg #656 + 31)
+  Inode table at 21503520-21504031 (bg #656 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 21987328-22020095
+  Free inodes: 5496833-5505024
+Group 672: (Blocks 22020096-22052863) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb679, unused inodes 8192
+  Block bitmap at 22020096 (+0), Inode bitmap at 22020112 (+16)
+  Inode table at 22020128-22020639 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22028320-22052863
+  Free inodes: 5505025-5513216
+Group 673: (Blocks 22052864-22085631) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2d04, unused inodes 8192
+  Block bitmap at 22020097 (bg #672 + 1), Inode bitmap at 22020113 (bg #672 + 17)
+  Inode table at 22020640-22021151 (bg #672 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22052864-22085631
+  Free inodes: 5513217-5521408
+Group 674: (Blocks 22085632-22118399) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8c6a, unused inodes 8192
+  Block bitmap at 22020098 (bg #672 + 2), Inode bitmap at 22020114 (bg #672 + 18)
+  Inode table at 22021152-22021663 (bg #672 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22085632-22118399
+  Free inodes: 5521409-5529600
+Group 675: (Blocks 22118400-22151167) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2cb1, unused inodes 8192
+  Block bitmap at 22020099 (bg #672 + 3), Inode bitmap at 22020115 (bg #672 + 19)
+  Inode table at 22021664-22022175 (bg #672 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22118400-22151167
+  Free inodes: 5529601-5537792
+Group 676: (Blocks 22151168-22183935) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8eb5, unused inodes 8192
+  Block bitmap at 22020100 (bg #672 + 4), Inode bitmap at 22020116 (bg #672 + 20)
+  Inode table at 22022176-22022687 (bg #672 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22151168-22183935
+  Free inodes: 5537793-5545984
+Group 677: (Blocks 22183936-22216703) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2e6e, unused inodes 8192
+  Block bitmap at 22020101 (bg #672 + 5), Inode bitmap at 22020117 (bg #672 + 21)
+  Inode table at 22022688-22023199 (bg #672 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22183936-22216703
+  Free inodes: 5545985-5554176
+Group 678: (Blocks 22216704-22249471) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8f00, unused inodes 8192
+  Block bitmap at 22020102 (bg #672 + 6), Inode bitmap at 22020118 (bg #672 + 22)
+  Inode table at 22023200-22023711 (bg #672 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22216704-22249471
+  Free inodes: 5554177-5562368
+Group 679: (Blocks 22249472-22282239) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2fdb, unused inodes 8192
+  Block bitmap at 22020103 (bg #672 + 7), Inode bitmap at 22020119 (bg #672 + 23)
+  Inode table at 22023712-22024223 (bg #672 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22249472-22282239
+  Free inodes: 5562369-5570560
+Group 680: (Blocks 22282240-22315007) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8b0b, unused inodes 8192
+  Block bitmap at 22020104 (bg #672 + 8), Inode bitmap at 22020120 (bg #672 + 24)
+  Inode table at 22024224-22024735 (bg #672 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22282240-22315007
+  Free inodes: 5570561-5578752
+Group 681: (Blocks 22315008-22347775) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2bd0, unused inodes 8192
+  Block bitmap at 22020105 (bg #672 + 9), Inode bitmap at 22020121 (bg #672 + 25)
+  Inode table at 22024736-22025247 (bg #672 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22315008-22347775
+  Free inodes: 5578753-5586944
+Group 682: (Blocks 22347776-22380543) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8abe, unused inodes 8192
+  Block bitmap at 22020106 (bg #672 + 10), Inode bitmap at 22020122 (bg #672 + 26)
+  Inode table at 22025248-22025759 (bg #672 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22347776-22380543
+  Free inodes: 5586945-5595136
+Group 683: (Blocks 22380544-22413311) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2a65, unused inodes 8192
+  Block bitmap at 22020107 (bg #672 + 11), Inode bitmap at 22020123 (bg #672 + 27)
+  Inode table at 22025760-22026271 (bg #672 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22380544-22413311
+  Free inodes: 5595137-5603328
+Group 684: (Blocks 22413312-22446079) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8861, unused inodes 8192
+  Block bitmap at 22020108 (bg #672 + 12), Inode bitmap at 22020124 (bg #672 + 28)
+  Inode table at 22026272-22026783 (bg #672 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22413312-22446079
+  Free inodes: 5603329-5611520
+Group 685: (Blocks 22446080-22478847) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x28ba, unused inodes 8192
+  Block bitmap at 22020109 (bg #672 + 13), Inode bitmap at 22020125 (bg #672 + 29)
+  Inode table at 22026784-22027295 (bg #672 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22446080-22478847
+  Free inodes: 5611521-5619712
+Group 686: (Blocks 22478848-22511615) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x89d4, unused inodes 8192
+  Block bitmap at 22020110 (bg #672 + 14), Inode bitmap at 22020126 (bg #672 + 30)
+  Inode table at 22027296-22027807 (bg #672 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22478848-22511615
+  Free inodes: 5619713-5627904
+Group 687: (Blocks 22511616-22544383) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x290f, unused inodes 8192
+  Block bitmap at 22020111 (bg #672 + 15), Inode bitmap at 22020127 (bg #672 + 31)
+  Inode table at 22027808-22028319 (bg #672 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22511616-22544383
+  Free inodes: 5627905-5636096
+Group 688: (Blocks 22544384-22577151) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xc56f, unused inodes 8192
+  Block bitmap at 22544384 (+0), Inode bitmap at 22544400 (+16)
+  Inode table at 22544416-22544927 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22552608-22577151
+  Free inodes: 5636097-5644288
+Group 689: (Blocks 22577152-22609919) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5e12, unused inodes 8192
+  Block bitmap at 22544385 (bg #688 + 1), Inode bitmap at 22544401 (bg #688 + 17)
+  Inode table at 22544928-22545439 (bg #688 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22577152-22609919
+  Free inodes: 5644289-5652480
+Group 690: (Blocks 22609920-22642687) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xff7c, unused inodes 8192
+  Block bitmap at 22544386 (bg #688 + 2), Inode bitmap at 22544402 (bg #688 + 18)
+  Inode table at 22545440-22545951 (bg #688 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22609920-22642687
+  Free inodes: 5652481-5660672
+Group 691: (Blocks 22642688-22675455) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5fa7, unused inodes 8192
+  Block bitmap at 22544387 (bg #688 + 3), Inode bitmap at 22544403 (bg #688 + 19)
+  Inode table at 22545952-22546463 (bg #688 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22642688-22675455
+  Free inodes: 5660673-5668864
+Group 692: (Blocks 22675456-22708223) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfda3, unused inodes 8192
+  Block bitmap at 22544388 (bg #688 + 4), Inode bitmap at 22544404 (bg #688 + 20)
+  Inode table at 22546464-22546975 (bg #688 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22675456-22708223
+  Free inodes: 5668865-5677056
+Group 693: (Blocks 22708224-22740991) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5d78, unused inodes 8192
+  Block bitmap at 22544389 (bg #688 + 5), Inode bitmap at 22544405 (bg #688 + 21)
+  Inode table at 22546976-22547487 (bg #688 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22708224-22740991
+  Free inodes: 5677057-5685248
+Group 694: (Blocks 22740992-22773759) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfc16, unused inodes 8192
+  Block bitmap at 22544390 (bg #688 + 6), Inode bitmap at 22544406 (bg #688 + 22)
+  Inode table at 22547488-22547999 (bg #688 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22740992-22773759
+  Free inodes: 5685249-5693440
+Group 695: (Blocks 22773760-22806527) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5ccd, unused inodes 8192
+  Block bitmap at 22544391 (bg #688 + 7), Inode bitmap at 22544407 (bg #688 + 23)
+  Inode table at 22548000-22548511 (bg #688 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22773760-22806527
+  Free inodes: 5693441-5701632
+Group 696: (Blocks 22806528-22839295) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf81d, unused inodes 8192
+  Block bitmap at 22544392 (bg #688 + 8), Inode bitmap at 22544408 (bg #688 + 24)
+  Inode table at 22548512-22549023 (bg #688 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22806528-22839295
+  Free inodes: 5701633-5709824
+Group 697: (Blocks 22839296-22872063) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x58c6, unused inodes 8192
+  Block bitmap at 22544393 (bg #688 + 9), Inode bitmap at 22544409 (bg #688 + 25)
+  Inode table at 22549024-22549535 (bg #688 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22839296-22872063
+  Free inodes: 5709825-5718016
+Group 698: (Blocks 22872064-22904831) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf9a8, unused inodes 8192
+  Block bitmap at 22544394 (bg #688 + 10), Inode bitmap at 22544410 (bg #688 + 26)
+  Inode table at 22549536-22550047 (bg #688 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22872064-22904831
+  Free inodes: 5718017-5726208
+Group 699: (Blocks 22904832-22937599) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5973, unused inodes 8192
+  Block bitmap at 22544395 (bg #688 + 11), Inode bitmap at 22544411 (bg #688 + 27)
+  Inode table at 22550048-22550559 (bg #688 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22904832-22937599
+  Free inodes: 5726209-5734400
+Group 700: (Blocks 22937600-22970367) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfb77, unused inodes 8192
+  Block bitmap at 22544396 (bg #688 + 12), Inode bitmap at 22544412 (bg #688 + 28)
+  Inode table at 22550560-22551071 (bg #688 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22937600-22970367
+  Free inodes: 5734401-5742592
+Group 701: (Blocks 22970368-23003135) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5bac, unused inodes 8192
+  Block bitmap at 22544397 (bg #688 + 13), Inode bitmap at 22544413 (bg #688 + 29)
+  Inode table at 22551072-22551583 (bg #688 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 22970368-23003135
+  Free inodes: 5742593-5750784
+Group 702: (Blocks 23003136-23035903) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xfac2, unused inodes 8192
+  Block bitmap at 22544398 (bg #688 + 14), Inode bitmap at 22544414 (bg #688 + 30)
+  Inode table at 22551584-22552095 (bg #688 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23003136-23035903
+  Free inodes: 5750785-5758976
+Group 703: (Blocks 23035904-23068671) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5a19, unused inodes 8192
+  Block bitmap at 22544399 (bg #688 + 15), Inode bitmap at 22544415 (bg #688 + 31)
+  Inode table at 22552096-22552607 (bg #688 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23035904-23068671
+  Free inodes: 5758977-5767168
+Group 704: (Blocks 23068672-23101439) [ITABLE_ZEROED]
+  Checksum 0x8689, unused inodes 7904
+  Block bitmap at 23068672 (+0), Inode bitmap at 23068688 (+16)
+  Inode table at 23068704-23069215 (+32)
+  24507 free blocks, 7908 free inodes, 37 directories, 7904 unused inodes
+  Free blocks: 23076904-23076919, 23076921-23076923, 23076952-23101439
+  Free inodes: 5767425, 5767441, 5767455-5775360
+Group 705: (Blocks 23101440-23134207) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xef8c, unused inodes 8192
+  Block bitmap at 23068673 (bg #704 + 1), Inode bitmap at 23068689 (bg #704 + 17)
+  Inode table at 23069216-23069727 (bg #704 + 544)
+  31922 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23101696-23101951, 23102370-23102463, 23102490-23102975, 23102980-23102988, 23102990, 23102992-23103019, 23103021-23103487, 23103489, 23103491-23103501, 23103504, 23103506, 23103508, 23103510-23103999, 23104003-23104004, 23104021, 23104024-23104511, 23104516, 23104534-23104542, 23104559-23104560, 23104564-23105023, 23105027-23105029, 23105034-23105042, 23105059-23105061, 23105065, 23105067-23105535, 23105537-23105556, 23105566-23106047, 23106052, 23106054-23106082, 23106086-23106563, 23106568-23107072, 23107089-23107594, 23107598-23107601, 23107603-23107604, 23107606-23107630, 23107632-23134207
+  Free inodes: 5775361-5783552
+Group 706: (Blocks 23134208-23166975) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe61d, unused inodes 8192
+  Block bitmap at 23068674 (bg #704 + 2), Inode bitmap at 23068690 (bg #704 + 18)
+  Inode table at 23069728-23070239 (bg #704 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23134208-23166975
+  Free inodes: 5783553-5791744
+Group 707: (Blocks 23166976-23199743) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x46c6, unused inodes 8192
+  Block bitmap at 23068675 (bg #704 + 3), Inode bitmap at 23068691 (bg #704 + 19)
+  Inode table at 23070240-23070751 (bg #704 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23166976-23199743
+  Free inodes: 5791745-5799936
+Group 708: (Blocks 23199744-23232511) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe4c2, unused inodes 8192
+  Block bitmap at 23068676 (bg #704 + 4), Inode bitmap at 23068692 (bg #704 + 20)
+  Inode table at 23070752-23071263 (bg #704 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23199744-23232511
+  Free inodes: 5799937-5808128
+Group 709: (Blocks 23232512-23265279) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4419, unused inodes 8192
+  Block bitmap at 23068677 (bg #704 + 5), Inode bitmap at 23068693 (bg #704 + 21)
+  Inode table at 23071264-23071775 (bg #704 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23232512-23265279
+  Free inodes: 5808129-5816320
+Group 710: (Blocks 23265280-23298047) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe577, unused inodes 8192
+  Block bitmap at 23068678 (bg #704 + 6), Inode bitmap at 23068694 (bg #704 + 22)
+  Inode table at 23071776-23072287 (bg #704 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23265280-23298047
+  Free inodes: 5816321-5824512
+Group 711: (Blocks 23298048-23330815) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x45ac, unused inodes 8192
+  Block bitmap at 23068679 (bg #704 + 7), Inode bitmap at 23068695 (bg #704 + 23)
+  Inode table at 23072288-23072799 (bg #704 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23298048-23330815
+  Free inodes: 5824513-5832704
+Group 712: (Blocks 23330816-23363583) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe17c, unused inodes 8192
+  Block bitmap at 23068680 (bg #704 + 8), Inode bitmap at 23068696 (bg #704 + 24)
+  Inode table at 23072800-23073311 (bg #704 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23330816-23363583
+  Free inodes: 5832705-5840896
+Group 713: (Blocks 23363584-23396351) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x41a7, unused inodes 8192
+  Block bitmap at 23068681 (bg #704 + 9), Inode bitmap at 23068697 (bg #704 + 25)
+  Inode table at 23073312-23073823 (bg #704 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23363584-23396351
+  Free inodes: 5840897-5849088
+Group 714: (Blocks 23396352-23429119) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe0c9, unused inodes 8192
+  Block bitmap at 23068682 (bg #704 + 10), Inode bitmap at 23068698 (bg #704 + 26)
+  Inode table at 23073824-23074335 (bg #704 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23396352-23429119
+  Free inodes: 5849089-5857280
+Group 715: (Blocks 23429120-23461887) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4012, unused inodes 8192
+  Block bitmap at 23068683 (bg #704 + 11), Inode bitmap at 23068699 (bg #704 + 27)
+  Inode table at 23074336-23074847 (bg #704 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23429120-23461887
+  Free inodes: 5857281-5865472
+Group 716: (Blocks 23461888-23494655) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe216, unused inodes 8192
+  Block bitmap at 23068684 (bg #704 + 12), Inode bitmap at 23068700 (bg #704 + 28)
+  Inode table at 23074848-23075359 (bg #704 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23461888-23494655
+  Free inodes: 5865473-5873664
+Group 717: (Blocks 23494656-23527423) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x42cd, unused inodes 8192
+  Block bitmap at 23068685 (bg #704 + 13), Inode bitmap at 23068701 (bg #704 + 29)
+  Inode table at 23075360-23075871 (bg #704 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23494656-23527423
+  Free inodes: 5873665-5881856
+Group 718: (Blocks 23527424-23560191) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xe3a3, unused inodes 8192
+  Block bitmap at 23068686 (bg #704 + 14), Inode bitmap at 23068702 (bg #704 + 30)
+  Inode table at 23075872-23076383 (bg #704 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23527424-23560191
+  Free inodes: 5881857-5890048
+Group 719: (Blocks 23560192-23592959) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x4378, unused inodes 8192
+  Block bitmap at 23068687 (bg #704 + 15), Inode bitmap at 23068703 (bg #704 + 31)
+  Inode table at 23076384-23076895 (bg #704 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23560192-23592959
+  Free inodes: 5890049-5898240
+Group 720: (Blocks 23592960-23625727) [ITABLE_ZEROED]
+  Checksum 0xf5a6, unused inodes 8191
+  Block bitmap at 23592960 (+0), Inode bitmap at 23592976 (+16)
+  Inode table at 23592992-23593503 (+32)
+  24543 free blocks, 8191 free inodes, 1 directories, 8191 unused inodes
+  Free blocks: 23601185-23625727
+  Free inodes: 5898242-5906432
+Group 721: (Blocks 23625728-23658495) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3465, unused inodes 8192
+  Block bitmap at 23592961 (bg #720 + 1), Inode bitmap at 23592977 (bg #720 + 17)
+  Inode table at 23593504-23594015 (bg #720 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23625728-23658495
+  Free inodes: 5906433-5914624
+Group 722: (Blocks 23658496-23691263) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x950b, unused inodes 8192
+  Block bitmap at 23592962 (bg #720 + 2), Inode bitmap at 23592978 (bg #720 + 18)
+  Inode table at 23594016-23594527 (bg #720 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23658496-23691263
+  Free inodes: 5914625-5922816
+Group 723: (Blocks 23691264-23724031) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x35d0, unused inodes 8192
+  Block bitmap at 23592963 (bg #720 + 3), Inode bitmap at 23592979 (bg #720 + 19)
+  Inode table at 23594528-23595039 (bg #720 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23691264-23724031
+  Free inodes: 5922817-5931008
+Group 724: (Blocks 23724032-23756799) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x97d4, unused inodes 8192
+  Block bitmap at 23592964 (bg #720 + 4), Inode bitmap at 23592980 (bg #720 + 20)
+  Inode table at 23595040-23595551 (bg #720 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23724032-23756799
+  Free inodes: 5931009-5939200
+Group 725: (Blocks 23756800-23789567) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x370f, unused inodes 8192
+  Block bitmap at 23592965 (bg #720 + 5), Inode bitmap at 23592981 (bg #720 + 21)
+  Inode table at 23595552-23596063 (bg #720 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23756800-23789567
+  Free inodes: 5939201-5947392
+Group 726: (Blocks 23789568-23822335) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9661, unused inodes 8192
+  Block bitmap at 23592966 (bg #720 + 6), Inode bitmap at 23592982 (bg #720 + 22)
+  Inode table at 23596064-23596575 (bg #720 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23789568-23822335
+  Free inodes: 5947393-5955584
+Group 727: (Blocks 23822336-23855103) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x36ba, unused inodes 8192
+  Block bitmap at 23592967 (bg #720 + 7), Inode bitmap at 23592983 (bg #720 + 23)
+  Inode table at 23596576-23597087 (bg #720 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23822336-23855103
+  Free inodes: 5955585-5963776
+Group 728: (Blocks 23855104-23887871) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x926a, unused inodes 8192
+  Block bitmap at 23592968 (bg #720 + 8), Inode bitmap at 23592984 (bg #720 + 24)
+  Inode table at 23597088-23597599 (bg #720 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23855104-23887871
+  Free inodes: 5963777-5971968
+Group 729: (Blocks 23887872-23920639) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x1782, unused inodes 8192
+  Backup superblock at 23887872, Group descriptors at 23887873-23887879
+  Reserved GDT blocks at 23887880-23888896
+  Block bitmap at 23592969 (bg #720 + 9), Inode bitmap at 23592985 (bg #720 + 25)
+  Inode table at 23597600-23598111 (bg #720 + 4640)
+  31743 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23888897-23920639
+  Free inodes: 5971969-5980160
+Group 730: (Blocks 23920640-23953407) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x93df, unused inodes 8192
+  Block bitmap at 23592970 (bg #720 + 10), Inode bitmap at 23592986 (bg #720 + 26)
+  Inode table at 23598112-23598623 (bg #720 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23920640-23953407
+  Free inodes: 5980161-5988352
+Group 731: (Blocks 23953408-23986175) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x3304, unused inodes 8192
+  Block bitmap at 23592971 (bg #720 + 11), Inode bitmap at 23592987 (bg #720 + 27)
+  Inode table at 23598624-23599135 (bg #720 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23953408-23986175
+  Free inodes: 5988353-5996544
+Group 732: (Blocks 23986176-24018943) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9100, unused inodes 8192
+  Block bitmap at 23592972 (bg #720 + 12), Inode bitmap at 23592988 (bg #720 + 28)
+  Inode table at 23599136-23599647 (bg #720 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 23986176-24018943
+  Free inodes: 5996545-6004736
+Group 733: (Blocks 24018944-24051711) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x31db, unused inodes 8192
+  Block bitmap at 23592973 (bg #720 + 13), Inode bitmap at 23592989 (bg #720 + 29)
+  Inode table at 23599648-23600159 (bg #720 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24018944-24051711
+  Free inodes: 6004737-6012928
+Group 734: (Blocks 24051712-24084479) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x90b5, unused inodes 8192
+  Block bitmap at 23592974 (bg #720 + 14), Inode bitmap at 23592990 (bg #720 + 30)
+  Inode table at 23600160-23600671 (bg #720 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24051712-24084479
+  Free inodes: 6012929-6021120
+Group 735: (Blocks 24084480-24117247) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x306e, unused inodes 8192
+  Block bitmap at 23592975 (bg #720 + 15), Inode bitmap at 23592991 (bg #720 + 31)
+  Inode table at 23600672-23601183 (bg #720 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24084480-24117247
+  Free inodes: 6021121-6029312
+Group 736: (Blocks 24117248-24150015) [ITABLE_ZEROED]
+  Checksum 0x605c, unused inodes 8190
+  Block bitmap at 24117248 (+0), Inode bitmap at 24117264 (+16)
+  Inode table at 24117280-24117791 (+32)
+  24543 free blocks, 8190 free inodes, 1 directories, 8190 unused inodes
+  Free blocks: 24125473-24150015
+  Free inodes: 6029315-6037504
+Group 737: (Blocks 24150016-24182783) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa15f, unused inodes 8192
+  Block bitmap at 24117249 (bg #736 + 1), Inode bitmap at 24117265 (bg #736 + 17)
+  Inode table at 24117792-24118303 (bg #736 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24150016-24182783
+  Free inodes: 6037505-6045696
+Group 738: (Blocks 24182784-24215551) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0031, unused inodes 8192
+  Block bitmap at 24117250 (bg #736 + 2), Inode bitmap at 24117266 (bg #736 + 18)
+  Inode table at 24118304-24118815 (bg #736 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24182784-24215551
+  Free inodes: 6045697-6053888
+Group 739: (Blocks 24215552-24248319) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa0ea, unused inodes 8192
+  Block bitmap at 24117251 (bg #736 + 3), Inode bitmap at 24117267 (bg #736 + 19)
+  Inode table at 24118816-24119327 (bg #736 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24215552-24248319
+  Free inodes: 6053889-6062080
+Group 740: (Blocks 24248320-24281087) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x02ee, unused inodes 8192
+  Block bitmap at 24117252 (bg #736 + 4), Inode bitmap at 24117268 (bg #736 + 20)
+  Inode table at 24119328-24119839 (bg #736 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24248320-24281087
+  Free inodes: 6062081-6070272
+Group 741: (Blocks 24281088-24313855) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa235, unused inodes 8192
+  Block bitmap at 24117253 (bg #736 + 5), Inode bitmap at 24117269 (bg #736 + 21)
+  Inode table at 24119840-24120351 (bg #736 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24281088-24313855
+  Free inodes: 6070273-6078464
+Group 742: (Blocks 24313856-24346623) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x035b, unused inodes 8192
+  Block bitmap at 24117254 (bg #736 + 6), Inode bitmap at 24117270 (bg #736 + 22)
+  Inode table at 24120352-24120863 (bg #736 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24313856-24346623
+  Free inodes: 6078465-6086656
+Group 743: (Blocks 24346624-24379391) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa380, unused inodes 8192
+  Block bitmap at 24117255 (bg #736 + 7), Inode bitmap at 24117271 (bg #736 + 23)
+  Inode table at 24120864-24121375 (bg #736 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24346624-24379391
+  Free inodes: 6086657-6094848
+Group 744: (Blocks 24379392-24412159) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x0750, unused inodes 8192
+  Block bitmap at 24117256 (bg #736 + 8), Inode bitmap at 24117272 (bg #736 + 24)
+  Inode table at 24121376-24121887 (bg #736 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24379392-24412159
+  Free inodes: 6094849-6103040
+Group 745: (Blocks 24412160-24444927) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa78b, unused inodes 8192
+  Block bitmap at 24117257 (bg #736 + 9), Inode bitmap at 24117273 (bg #736 + 25)
+  Inode table at 24121888-24122399 (bg #736 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24412160-24444927
+  Free inodes: 6103041-6111232
+Group 746: (Blocks 24444928-24477695) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x06e5, unused inodes 8192
+  Block bitmap at 24117258 (bg #736 + 10), Inode bitmap at 24117274 (bg #736 + 26)
+  Inode table at 24122400-24122911 (bg #736 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24444928-24477695
+  Free inodes: 6111233-6119424
+Group 747: (Blocks 24477696-24510463) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa63e, unused inodes 8192
+  Block bitmap at 24117259 (bg #736 + 11), Inode bitmap at 24117275 (bg #736 + 27)
+  Inode table at 24122912-24123423 (bg #736 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24477696-24510463
+  Free inodes: 6119425-6127616
+Group 748: (Blocks 24510464-24543231) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x043a, unused inodes 8192
+  Block bitmap at 24117260 (bg #736 + 12), Inode bitmap at 24117276 (bg #736 + 28)
+  Inode table at 24123424-24123935 (bg #736 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24510464-24543231
+  Free inodes: 6127617-6135808
+Group 749: (Blocks 24543232-24575999) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa4e1, unused inodes 8192
+  Block bitmap at 24117261 (bg #736 + 13), Inode bitmap at 24117277 (bg #736 + 29)
+  Inode table at 24123936-24124447 (bg #736 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24543232-24575999
+  Free inodes: 6135809-6144000
+Group 750: (Blocks 24576000-24608767) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x058f, unused inodes 8192
+  Block bitmap at 24117262 (bg #736 + 14), Inode bitmap at 24117278 (bg #736 + 30)
+  Inode table at 24124448-24124959 (bg #736 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24576000-24608767
+  Free inodes: 6144001-6152192
+Group 751: (Blocks 24608768-24641535) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xa554, unused inodes 8192
+  Block bitmap at 24117263 (bg #736 + 15), Inode bitmap at 24117279 (bg #736 + 31)
+  Inode table at 24124960-24125471 (bg #736 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24608768-24641535
+  Free inodes: 6152193-6160384
+Group 752: (Blocks 24641536-24674303) [ITABLE_ZEROED]
+  Checksum 0xdd9a, unused inodes 8187
+  Block bitmap at 24641536 (+0), Inode bitmap at 24641552 (+16)
+  Inode table at 24641568-24642079 (+32)
+  24542 free blocks, 8188 free inodes, 2 directories, 8187 unused inodes
+  Free blocks: 24649762-24674303
+  Free inodes: 6160387, 6160390-6168576
+Group 753: (Blocks 24674304-24707071) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x15b0, unused inodes 8192
+  Block bitmap at 24641537 (bg #752 + 1), Inode bitmap at 24641553 (bg #752 + 17)
+  Inode table at 24642080-24642591 (bg #752 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24674304-24707071
+  Free inodes: 6168577-6176768
+Group 754: (Blocks 24707072-24739839) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7327, unused inodes 8192
+  Block bitmap at 24641538 (bg #752 + 2), Inode bitmap at 24641554 (bg #752 + 18)
+  Inode table at 24642592-24643103 (bg #752 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24707072-24739839
+  Free inodes: 6176769-6184960
+Group 755: (Blocks 24739840-24772607) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd3fc, unused inodes 8192
+  Block bitmap at 24641539 (bg #752 + 3), Inode bitmap at 24641555 (bg #752 + 19)
+  Inode table at 24643104-24643615 (bg #752 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24739840-24772607
+  Free inodes: 6184961-6193152
+Group 756: (Blocks 24772608-24805375) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x71f8, unused inodes 8192
+  Block bitmap at 24641540 (bg #752 + 4), Inode bitmap at 24641556 (bg #752 + 20)
+  Inode table at 24643616-24644127 (bg #752 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24772608-24805375
+  Free inodes: 6193153-6201344
+Group 757: (Blocks 24805376-24838143) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd123, unused inodes 8192
+  Block bitmap at 24641541 (bg #752 + 5), Inode bitmap at 24641557 (bg #752 + 21)
+  Inode table at 24644128-24644639 (bg #752 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24805376-24838143
+  Free inodes: 6201345-6209536
+Group 758: (Blocks 24838144-24870911) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x704d, unused inodes 8192
+  Block bitmap at 24641542 (bg #752 + 6), Inode bitmap at 24641558 (bg #752 + 22)
+  Inode table at 24644640-24645151 (bg #752 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24838144-24870911
+  Free inodes: 6209537-6217728
+Group 759: (Blocks 24870912-24903679) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd096, unused inodes 8192
+  Block bitmap at 24641543 (bg #752 + 7), Inode bitmap at 24641559 (bg #752 + 23)
+  Inode table at 24645152-24645663 (bg #752 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24870912-24903679
+  Free inodes: 6217729-6225920
+Group 760: (Blocks 24903680-24936447) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7446, unused inodes 8192
+  Block bitmap at 24641544 (bg #752 + 8), Inode bitmap at 24641560 (bg #752 + 24)
+  Inode table at 24645664-24646175 (bg #752 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24903680-24936447
+  Free inodes: 6225921-6234112
+Group 761: (Blocks 24936448-24969215) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd49d, unused inodes 8192
+  Block bitmap at 24641545 (bg #752 + 9), Inode bitmap at 24641561 (bg #752 + 25)
+  Inode table at 24646176-24646687 (bg #752 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24936448-24969215
+  Free inodes: 6234113-6242304
+Group 762: (Blocks 24969216-25001983) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x75f3, unused inodes 8192
+  Block bitmap at 24641546 (bg #752 + 10), Inode bitmap at 24641562 (bg #752 + 26)
+  Inode table at 24646688-24647199 (bg #752 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 24969216-25001983
+  Free inodes: 6242305-6250496
+Group 763: (Blocks 25001984-25034751) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd528, unused inodes 8192
+  Block bitmap at 24641547 (bg #752 + 11), Inode bitmap at 24641563 (bg #752 + 27)
+  Inode table at 24647200-24647711 (bg #752 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25001984-25034751
+  Free inodes: 6250497-6258688
+Group 764: (Blocks 25034752-25067519) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x772c, unused inodes 8192
+  Block bitmap at 24641548 (bg #752 + 12), Inode bitmap at 24641564 (bg #752 + 28)
+  Inode table at 24647712-24648223 (bg #752 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25034752-25067519
+  Free inodes: 6258689-6266880
+Group 765: (Blocks 25067520-25100287) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd7f7, unused inodes 8192
+  Block bitmap at 24641549 (bg #752 + 13), Inode bitmap at 24641565 (bg #752 + 29)
+  Inode table at 24648224-24648735 (bg #752 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25067520-25100287
+  Free inodes: 6266881-6275072
+Group 766: (Blocks 25100288-25133055) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x7699, unused inodes 8192
+  Block bitmap at 24641550 (bg #752 + 14), Inode bitmap at 24641566 (bg #752 + 30)
+  Inode table at 24648736-24649247 (bg #752 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25100288-25133055
+  Free inodes: 6275073-6283264
+Group 767: (Blocks 25133056-25165823) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xd642, unused inodes 8192
+  Block bitmap at 24641551 (bg #752 + 15), Inode bitmap at 24641567 (bg #752 + 31)
+  Inode table at 24649248-24649759 (bg #752 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25133056-25165823
+  Free inodes: 6283265-6291456
+Group 768: (Blocks 25165824-25198591) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xb98a, unused inodes 8192
+  Block bitmap at 25165824 (+0), Inode bitmap at 25165840 (+16)
+  Inode table at 25165856-25166367 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25174048-25198591
+  Free inodes: 6291457-6299648
+Group 769: (Blocks 25198592-25231359) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x22f7, unused inodes 8192
+  Block bitmap at 25165825 (bg #768 + 1), Inode bitmap at 25165841 (bg #768 + 17)
+  Inode table at 25166368-25166879 (bg #768 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25198592-25231359
+  Free inodes: 6299649-6307840
+Group 770: (Blocks 25231360-25264127) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8399, unused inodes 8192
+  Block bitmap at 25165826 (bg #768 + 2), Inode bitmap at 25165842 (bg #768 + 18)
+  Inode table at 25166880-25167391 (bg #768 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25231360-25264127
+  Free inodes: 6307841-6316032
+Group 771: (Blocks 25264128-25296895) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2342, unused inodes 8192
+  Block bitmap at 25165827 (bg #768 + 3), Inode bitmap at 25165843 (bg #768 + 19)
+  Inode table at 25167392-25167903 (bg #768 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25264128-25296895
+  Free inodes: 6316033-6324224
+Group 772: (Blocks 25296896-25329663) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8146, unused inodes 8192
+  Block bitmap at 25165828 (bg #768 + 4), Inode bitmap at 25165844 (bg #768 + 20)
+  Inode table at 25167904-25168415 (bg #768 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25296896-25329663
+  Free inodes: 6324225-6332416
+Group 773: (Blocks 25329664-25362431) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x219d, unused inodes 8192
+  Block bitmap at 25165829 (bg #768 + 5), Inode bitmap at 25165845 (bg #768 + 21)
+  Inode table at 25168416-25168927 (bg #768 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25329664-25362431
+  Free inodes: 6332417-6340608
+Group 774: (Blocks 25362432-25395199) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x80f3, unused inodes 8192
+  Block bitmap at 25165830 (bg #768 + 6), Inode bitmap at 25165846 (bg #768 + 22)
+  Inode table at 25168928-25169439 (bg #768 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25362432-25395199
+  Free inodes: 6340609-6348800
+Group 775: (Blocks 25395200-25427967) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2028, unused inodes 8192
+  Block bitmap at 25165831 (bg #768 + 7), Inode bitmap at 25165847 (bg #768 + 23)
+  Inode table at 25169440-25169951 (bg #768 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25395200-25427967
+  Free inodes: 6348801-6356992
+Group 776: (Blocks 25427968-25460735) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x84f8, unused inodes 8192
+  Block bitmap at 25165832 (bg #768 + 8), Inode bitmap at 25165848 (bg #768 + 24)
+  Inode table at 25169952-25170463 (bg #768 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25427968-25460735
+  Free inodes: 6356993-6365184
+Group 777: (Blocks 25460736-25493503) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2423, unused inodes 8192
+  Block bitmap at 25165833 (bg #768 + 9), Inode bitmap at 25165849 (bg #768 + 25)
+  Inode table at 25170464-25170975 (bg #768 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25460736-25493503
+  Free inodes: 6365185-6373376
+Group 778: (Blocks 25493504-25526271) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x854d, unused inodes 8192
+  Block bitmap at 25165834 (bg #768 + 10), Inode bitmap at 25165850 (bg #768 + 26)
+  Inode table at 25170976-25171487 (bg #768 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25493504-25526271
+  Free inodes: 6373377-6381568
+Group 779: (Blocks 25526272-25559039) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2596, unused inodes 8192
+  Block bitmap at 25165835 (bg #768 + 11), Inode bitmap at 25165851 (bg #768 + 27)
+  Inode table at 25171488-25171999 (bg #768 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25526272-25559039
+  Free inodes: 6381569-6389760
+Group 780: (Blocks 25559040-25591807) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8792, unused inodes 8192
+  Block bitmap at 25165836 (bg #768 + 12), Inode bitmap at 25165852 (bg #768 + 28)
+  Inode table at 25172000-25172511 (bg #768 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25559040-25591807
+  Free inodes: 6389761-6397952
+Group 781: (Blocks 25591808-25624575) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x2749, unused inodes 8192
+  Block bitmap at 25165837 (bg #768 + 13), Inode bitmap at 25165853 (bg #768 + 29)
+  Inode table at 25172512-25173023 (bg #768 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25591808-25624575
+  Free inodes: 6397953-6406144
+Group 782: (Blocks 25624576-25657343) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x8627, unused inodes 8192
+  Block bitmap at 25165838 (bg #768 + 14), Inode bitmap at 25165854 (bg #768 + 30)
+  Inode table at 25173024-25173535 (bg #768 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25624576-25657343
+  Free inodes: 6406145-6414336
+Group 783: (Blocks 25657344-25690111) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x26fc, unused inodes 8192
+  Block bitmap at 25165839 (bg #768 + 15), Inode bitmap at 25165855 (bg #768 + 31)
+  Inode table at 25173536-25174047 (bg #768 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25657344-25690111
+  Free inodes: 6414337-6422528
+Group 784: (Blocks 25690112-25722879) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0xca9c, unused inodes 8192
+  Block bitmap at 25690112 (+0), Inode bitmap at 25690128 (+16)
+  Inode table at 25690144-25690655 (+32)
+  24544 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25698336-25722879
+  Free inodes: 6422529-6430720
+Group 785: (Blocks 25722880-25755647) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x51e1, unused inodes 8192
+  Block bitmap at 25690113 (bg #784 + 1), Inode bitmap at 25690129 (bg #784 + 17)
+  Inode table at 25690656-25691167 (bg #784 + 544)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25722880-25755647
+  Free inodes: 6430721-6438912
+Group 786: (Blocks 25755648-25788415) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf08f, unused inodes 8192
+  Block bitmap at 25690114 (bg #784 + 2), Inode bitmap at 25690130 (bg #784 + 18)
+  Inode table at 25691168-25691679 (bg #784 + 1056)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25755648-25788415
+  Free inodes: 6438913-6447104
+Group 787: (Blocks 25788416-25821183) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5054, unused inodes 8192
+  Block bitmap at 25690115 (bg #784 + 3), Inode bitmap at 25690131 (bg #784 + 19)
+  Inode table at 25691680-25692191 (bg #784 + 1568)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25788416-25821183
+  Free inodes: 6447105-6455296
+Group 788: (Blocks 25821184-25853951) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf250, unused inodes 8192
+  Block bitmap at 25690116 (bg #784 + 4), Inode bitmap at 25690132 (bg #784 + 20)
+  Inode table at 25692192-25692703 (bg #784 + 2080)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25821184-25853951
+  Free inodes: 6455297-6463488
+Group 789: (Blocks 25853952-25886719) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x528b, unused inodes 8192
+  Block bitmap at 25690117 (bg #784 + 5), Inode bitmap at 25690133 (bg #784 + 21)
+  Inode table at 25692704-25693215 (bg #784 + 2592)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25853952-25886719
+  Free inodes: 6463489-6471680
+Group 790: (Blocks 25886720-25919487) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf3e5, unused inodes 8192
+  Block bitmap at 25690118 (bg #784 + 6), Inode bitmap at 25690134 (bg #784 + 22)
+  Inode table at 25693216-25693727 (bg #784 + 3104)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25886720-25919487
+  Free inodes: 6471681-6479872
+Group 791: (Blocks 25919488-25952255) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x533e, unused inodes 8192
+  Block bitmap at 25690119 (bg #784 + 7), Inode bitmap at 25690135 (bg #784 + 23)
+  Inode table at 25693728-25694239 (bg #784 + 3616)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25919488-25952255
+  Free inodes: 6479873-6488064
+Group 792: (Blocks 25952256-25985023) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf7ee, unused inodes 8192
+  Block bitmap at 25690120 (bg #784 + 8), Inode bitmap at 25690136 (bg #784 + 24)
+  Inode table at 25694240-25694751 (bg #784 + 4128)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25952256-25985023
+  Free inodes: 6488065-6496256
+Group 793: (Blocks 25985024-26017791) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5735, unused inodes 8192
+  Block bitmap at 25690121 (bg #784 + 9), Inode bitmap at 25690137 (bg #784 + 25)
+  Inode table at 25694752-25695263 (bg #784 + 4640)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 25985024-26017791
+  Free inodes: 6496257-6504448
+Group 794: (Blocks 26017792-26050559) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf65b, unused inodes 8192
+  Block bitmap at 25690122 (bg #784 + 10), Inode bitmap at 25690138 (bg #784 + 26)
+  Inode table at 25695264-25695775 (bg #784 + 5152)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 26017792-26050559
+  Free inodes: 6504449-6512640
+Group 795: (Blocks 26050560-26083327) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x5680, unused inodes 8192
+  Block bitmap at 25690123 (bg #784 + 11), Inode bitmap at 25690139 (bg #784 + 27)
+  Inode table at 25695776-25696287 (bg #784 + 5664)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 26050560-26083327
+  Free inodes: 6512641-6520832
+Group 796: (Blocks 26083328-26116095) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf484, unused inodes 8192
+  Block bitmap at 25690124 (bg #784 + 12), Inode bitmap at 25690140 (bg #784 + 28)
+  Inode table at 25696288-25696799 (bg #784 + 6176)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 26083328-26116095
+  Free inodes: 6520833-6529024
+Group 797: (Blocks 26116096-26148863) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0x545f, unused inodes 8192
+  Block bitmap at 25690125 (bg #784 + 13), Inode bitmap at 25690141 (bg #784 + 29)
+  Inode table at 25696800-25697311 (bg #784 + 6688)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 26116096-26148863
+  Free inodes: 6529025-6537216
+Group 798: (Blocks 26148864-26181631) [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
+  Checksum 0xf531, unused inodes 8192
+  Block bitmap at 25690126 (bg #784 + 14), Inode bitmap at 25690142 (bg #784 + 30)
+  Inode table at 25697312-25697823 (bg #784 + 7200)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 26148864-26181631
+  Free inodes: 6537217-6545408
+Group 799: (Blocks 26181632-26214399) [INODE_UNINIT, ITABLE_ZEROED]
+  Checksum 0x9213, unused inodes 8192
+  Block bitmap at 25690127 (bg #784 + 15), Inode bitmap at 25690143 (bg #784 + 31)
+  Inode table at 25697824-25698335 (bg #784 + 7712)
+  32768 free blocks, 8192 free inodes, 0 directories, 8192 unused inodes
+  Free blocks: 26181632-26214399
+  Free inodes: 6545409-6553600


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-2378
Original issue reported out of date volume graph for CC ZenPack, root cause is;
The Control Center ZenPack reports stale volume information because dumpe2fs doesn't consistantly update for a mounted filesystem.

This PR fixes this by using df when the filesystem is mounted and dumpe2fs when it isn't.
A bit of extra work was required to get the "usable" blocks from dumpe2fs so the volume size stays consistent between dumpe2fs and df.