### PR TITLE
Cache service path with tenantID

### DIFF
--- a/acceptance/dockerImage/build/Dockerfile.xenial
+++ b/acceptance/dockerImage/build/Dockerfile.xenial
@@ -1,0 +1,127 @@
+FROM ubuntu:xenial
+MAINTAINER Zenoss, Inc <dev@zenoss.com>
+
+# Get the basic set of dev tools
+RUN	apt-get update -qq && apt-get install -y -q build-essential wget curl unzip make
+
+#
+# Install native prerequisites for the ruby gems we need (e.g.nokogiri)
+#
+RUN apt-get update -qq && apt-get install -y -q zlib1g-dev=1:1.2.8.dfsg-2ubuntu4 libxml2-dev=2.9.3+dfsg1-1ubuntu0.1 libxml2 libxslt1-dev
+
+# Prerequesites for capybara-webkit
+RUN apt-get install -y -q qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
+
+#
+# Install Ruby via rvm
+#
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN curl -sSL https://get.rvm.io | bash -s stable --ruby
+RUN /bin/bash -lc "source /usr/local/rvm/scripts/rvm"
+
+#
+# Install Cucumber, Capybara and the other gems we need
+#
+RUN /bin/bash -lc "gem install cucumber -v 2.3.2"
+RUN /bin/bash -lc "gem install nokogiri -v 1.6.7.2"
+RUN /bin/bash -lc "gem install capybara -v 2.6.2"
+RUN /bin/bash -lc "gem install capybara-screenshot -v 1.0.11"
+RUN /bin/bash -lc "gem install poltergeist -v 1.9.0"
+RUN /bin/bash -lc "gem install rspec -v 3.4.0"
+RUN /bin/bash -lc "gem install selenium-webdriver -v 2.52.0"
+RUN /bin/bash -lc "gem install site_prism -v 2.8"
+RUN /bin/bash -lc "gem install headless -v 2.2.2"
+RUN /bin/bash -lc "gem install capybara-webkit -v 1.8.0"
+
+#
+# Install the xvfb for firefox and chrome so they can run on a headless system
+#
+RUN apt-get update -qq && apt-get install -y -q xvfb
+
+#
+# Install phantomjs (from https://gist.github.com/julionc/7476620)
+#
+RUN apt-get update -qq && apt-get install -y -q build-essential chrpath libssl-dev libxft-dev
+RUN apt-get update -qq && apt-get install -y -q libfreetype6 libfreetype6-dev
+RUN apt-get update -qq && apt-get install -y -q libfontconfig1 libfontconfig1-dev
+RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -P /usr/local/share --trust-server-names --content-disposition
+RUN cd /usr/local/share && tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2
+RUN ln -sf /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/share/phantomjs
+RUN ln -sf /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
+RUN ln -sf /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/bin/phantomjs
+RUN rm -rf /usr/local/share/phantomjs-2.1.1-linux-x86_64.tar.bz2
+RUN rm -rf /usr/local/share/phantomjs-2.1.1-linux-x86_64.tar.bz2
+
+#
+# Install firefox.
+# Note that the selenium driver doesn't work with all FF versions, so
+# if you use a different version of FF, you might have to upgrade selenium or vice-versa
+#
+RUN wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/44.0/linux-x86_64/en-US/firefox-44.0.tar.bz2 -P /usr/local/share
+RUN cd /usr/local/share && tar xvjf firefox-44.0.tar.bz2
+RUN ln -fs /usr/local/share/firefox/firefox /usr/bin/firefox
+RUN rm -rf /usr/local/share/firefox-44.0.tar.bz2
+
+#
+# Install chromedriver that selenium needs to work with chrome
+# (from https://devblog.supportbee.com/2014/10/27/setting-up-cucumber-to-run-with-Chrome-on-Linux/)
+#
+RUN wget -N http://chromedriver.storage.googleapis.com/2.21/chromedriver_linux64.zip -P /tmp
+RUN unzip /tmp/chromedriver_linux64.zip -d /tmp
+RUN mv /tmp/chromedriver /usr/bin
+RUN chmod +x /usr/bin/chromedriver
+RUN rm /tmp/chromedriver_linux64.zip
+
+#
+# Install chrome - blend of info from several sources
+# General process info: http://askubuntu.com/questions/79280/how-to-install-chrome-browser-properly-via-command-line
+# Public Key info for safe download: http://www.google.com/linuxrepositories/
+# Info about differnet Chrome versions: http://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
+#
+RUN apt-get update -qq && apt-get install -y -q libxss1 libappindicator1 libindicator7
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+#
+# Tried a specific version like 41.0.2272.76-1, but specifying on the command line doesn't always work :-(
+RUN apt-get update -qq && apt-get install -y -q --force-yes google-chrome-stable
+
+#
+# Add the Java app that generates a nice HTML report
+#
+# need software-properties-common for add-apt-repositry command
+RUN apt-get install software-properties-common -yq
+RUN add-apt-repository ppa:openjdk-r/ppa
+RUN apt-get update -qq && apt-get install -y -q openjdk-7-jre-headless
+RUN mkdir -p /usr/share/reporter
+ADD reporter.jar /usr/share/reporter/reporter.jar
+
+#
+# Setup Xvfb - FF and chrome will connect to this DISPLAY
+# (https://github.com/keyvanfatehi/docker-chrome-xvfb)
+#
+ENV DISPLAY :99
+ADD xvfb_init /etc/init.d/xvfb
+RUN chmod a+x /etc/init.d/xvfb
+
+#
+# Add the script used to run cucumber.
+#
+ADD runCucumber.sh /usr/sbin/runCucumber.sh
+RUN chmod a+x /usr/sbin/runCucumber.sh
+
+#
+# Setup a default timezone that matches CST since the default TZ in the ubuntu
+# image is a value unknown to the UI (which can cause other problems).
+#
+RUN echo "America/Chicago" >/etc/timezone
+RUN dpkg-reconfigure --frontend noninteractive tzdata
+
+#
+# Silence warnings from serviced about a missing config file
+#
+RUN touch /etc/default/serviced
+
+#
+# This is the directory that wlll be the mount point for the cucumber files
+#
+WORKDIR /capybara

--- a/acceptance/ui/features/api/cli_host.rb
+++ b/acceptance/ui/features/api/cli_host.rb
@@ -31,7 +31,8 @@ module CCApi
             poolValue =  getTableValue(pool)
             commitmentValue =  getTableValue(commitment)
 
-            result = CC.CLI.execute("%{serviced} host add '#{nameValue}:#{portValue}' '#{poolValue}' --memory '#{commitmentValue}'")
+            result = CC.CLI.execute("%{serviced} host add '#{nameValue}:#{portValue}' '#{poolValue}' --memory '#{commitmentValue}' -k /dev/null")
+            result = result.split("\n")[-1]
 
             hostIDValue =  getTableValue(hostID)
             expect(result.strip).to eq(hostIDValue.to_s)

--- a/acceptance/ui/features/hosts.feature
+++ b/acceptance/ui/features/hosts.feature
@@ -20,7 +20,6 @@ Feature: Host Management
       And I should see an empty Hosts page
 
   Scenario: View Add Host dialog
-    Given PENDING
     When I am on the hosts page
       And I click the add Host button
     Then I should see the Add Host dialog
@@ -34,73 +33,73 @@ Feature: Host Management
       And I should see the RAM Limit field
 
   Scenario: Add an invalid host with an invalid port
-    Given PENDING there are no hosts added
+    Given there are no hosts added
     When I am on the hosts page
       And I click the add Host button
       And I fill in the Host field with "host"
       And I fill in the Port field with "bogusport"
       And I fill in the Resource Pool field with "table://hosts/defaultHost/pool"
       And I fill in the RAM Limit field with "table://hosts/defaultHost/commitment"
-      And I click "Add Host"
+      And I click "Next"
     Then I should see "Error"
       And I should see "Invalid port number"
       And the Port field should be flagged as invalid
       And I should see an empty Hosts page
 
   Scenario: Add an invalid host with an empty host
-    Given PENDING there are no hosts added
+    Given there are no hosts added
     When I am on the hosts page
       And I click the add Host button
       And I fill in the Port field with "4979"
       And I fill in the Resource Pool field with "table://hosts/defaultHost/pool"
       And I fill in the RAM Limit field with "table://hosts/defaultHost/commitment"
-      And I click "Add Host"
+      And I click "Next"
     Then I should see "Error"
       And I should see "Please enter a valid host name"
       And I should see an empty Hosts page
 
   Scenario: Add an invalid host with an invalid host name
-    Given PENDING there are no hosts added
+    Given there are no hosts added
     When I am on the hosts page
       And I click the add Host button
       And I fill in the Host field with "172.17.42.1"
       And I fill in the Port field with "9999"
       And I fill in the Resource Pool field with "table://hosts/defaultHost/pool"
       And I fill in the RAM Limit field with "table://hosts/defaultHost/commitment"
-      And I click "Add Host"
+      And I click "Next"
     Then I should see "Error"
       And I should see "Bad Request: dial tcp4 172.17.42.1:9999"
       And I should see an empty Hosts page
 
   Scenario: Add an invalid host with a port out of range
-    Given PENDING there are no hosts added
+    Given there are no hosts added
     When I am on the hosts page
       And I click the add Host button
       And I fill in the Host field with "172.17.42.1"
       And I fill in the Port field with "75000"
       And I fill in the Resource Pool field with "table://hosts/defaultHost/pool"
       And I fill in the RAM Limit field with "table://hosts/defaultHost/commitment"
-      And I click "Add Host"
+      And I click "Next"
     Then I should see "Error"
       And I should see "The port number must be between 1 and 65535"
       And I click "Cancel"
     And I should see an empty Hosts page
 
   Scenario: Add an invalid host with an invalid RAM Limit field
-    Given PENDING there are no hosts added
+    Given there are no hosts added
     When I am on the hosts page
       And I click the add Host button
       And I fill in the Host field with "table://hosts/defaultHost/hostName"
       And I fill in the Port field with "table://hosts/defaultHost/rpcPort"
       And I fill in the Resource Pool field with "table://hosts/defaultHost/pool"
       And I fill in the RAM Limit field with "invalidentry"
-      And I click "Add Host"
+      And I click "Next"
     Then I should see "Error"
       And I should see "Invalid RAM Limit value"
       And I should see an empty Hosts page
 
   Scenario: Fill in the hosts dialog and cancel
-    Given PENDING there are no hosts added
+    Given there are no hosts added
     When I am on the hosts page
       And I click the add Host button
       And I fill in the Host field with "table://hosts/defaultHost/hostName"
@@ -113,14 +112,14 @@ Feature: Host Management
 
   @clean_hosts
   Scenario: Add a valid host
-    Given PENDING there are no hosts added
+    Given there are no hosts added
     When I am on the hosts page
       And I click the add Host button
       And I fill in the Host field with "table://hosts/defaultHost/hostName"
       And I fill in the Port field with "table://hosts/defaultHost/rpcPort"
       And I fill in the Resource Pool field with "table://hosts/defaultHost/pool"
       And I fill in the RAM Limit field with "table://hosts/defaultHost/commitment"
-      And I click "Add Host"
+      And I click "Next"
     Then I should see "Success"
       And I should see "table://hosts/defaultHost/name" in the "Name" column
       And I should see "table://hosts/defaultHost/pool" in the "Resource Pool" column
@@ -131,14 +130,14 @@ Feature: Host Management
 
   @clean_hosts
   Scenario: Add another valid host
-    Given PENDING only the default host is added
+    Given only the default host is added
     When I am on the hosts page
       And I click the add Host button
       And I fill in the Host field with "table://hosts/host2/hostName"
       And I fill in the Port field with "table://hosts/host2/rpcPort"
       And I fill in the Resource Pool field with "table://hosts/host2/pool"
       And I fill in the RAM Limit field with "table://hosts/host2/commitment"
-      And I click "Add Host"
+      And I click "Next"
     Then I should see "Success"
       And I should see an entry for "table://hosts/host2/name" in the table
       And I should see "table://hosts/defaultHost/name" in the "Name" column
@@ -154,14 +153,14 @@ Feature: Host Management
 
   @clean_hosts @clean_pools
   Scenario: Add a valid host in a non-default Resource Pool
-    Given PENDING that the "table://hosts/host3/pool" pool is added
+    Given that the "table://hosts/host3/pool" pool is added
     When I am on the hosts page
       And I click the add Host button
       And I fill in the Host field with "table://hosts/host3/hostName"
       And I fill in the Port field with "table://hosts/host3/rpcPort"
       And I fill in the Resource Pool field with "table://hosts/host3/pool"
       And I fill in the RAM Limit field with "table://hosts/host3/commitment"
-      And I click "Add Host"
+      And I click "Next"
     Then I should see "Success"
       And I should see an entry for "table://hosts/host3/name" in the table
       And I should see "table://hosts/host3/name" in the "Name" column
@@ -174,14 +173,14 @@ Feature: Host Management
 
   @clean_hosts
   Scenario: Add a duplicate host
-    Given PENDING only the default host is added
+    Given only the default host is added
     When I am on the hosts page
       And I click the add Host button
       And I fill in the Host field with "table://hosts/defaultHost/hostName"
       And I fill in the Port field with "table://hosts/defaultHost/rpcPort"
       And I fill in the Resource Pool field with "table://hosts/defaultHost/pool"
       And I fill in the RAM Limit field with "table://hosts/defaultHost/commitment"
-      And I click "Add Host"
+      And I click "Next"
     Then I should see "Error"
       And I should see "Internal Server Error: host already exists"
     When I close the dialog

--- a/acceptance/ui/features/steps/hosts_steps.rb
+++ b/acceptance/ui/features/steps/hosts_steps.rb
@@ -132,6 +132,7 @@ def addHostUI(name, port, pool, commitment)
     fillInPort(port)
     fillInResourcePool(pool)
     fillInRAMLimit(commitment)
-    click_link_or_button("Add Host")
+    click_link_or_button("Next")
+    click_link_or_button("OK")
 end
 

--- a/auth/localkeys.go
+++ b/auth/localkeys.go
@@ -200,6 +200,13 @@ func CreateOrLoadMasterKeys(filename string) error {
 		return err
 	}
 
+	return LoadMasterKeyFile(filename)	
+}
+
+// LoadMasterKeyFile will load the master keys from disk if 
+//  the file exists.  If the file does not exist, it will
+//  return an error
+func LoadMasterKeyFile(filename string) error {
 	publicKey, privateKey, err := LoadKeyPairFromFile(filename)
 	if err != nil {
 		return err

--- a/cli/api/apimocks/API.go
+++ b/cli/api/apimocks/API.go
@@ -278,6 +278,27 @@ func (_m *API) WriteDelegateKey(_a0 string, _a1 []byte) error {
 
 	return r0
 }
+func (_m *API) ResetHostKey(_a0 string) ([]byte, error) {
+	ret := _m.Called(_a0)
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(string) []byte); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
 func (_m *API) GetResourcePools() ([]pool.ResourcePool, error) {
 	ret := _m.Called()
 

--- a/cli/api/host.go
+++ b/cli/api/host.go
@@ -162,6 +162,15 @@ func (a *api) GetHostPublicKey(id string) ([]byte, error) {
 	return client.GetHostPublicKey(id)
 }
 
+// Reset a host's key
+func (a *api) ResetHostKey(id string) ([]byte, error) {
+	client, err := a.connectMaster()
+	if err != nil {
+		return nil, err
+	}
+	return client.ResetHostKey(id)
+}
+
 // Write delegate keys to disk
 func (a *api) RegisterHost(keydata []byte) error {
 	keyfile := filepath.Join(config.GetOptions().EtcPath, auth.DelegateKeyFileName)

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -49,6 +49,7 @@ type API interface {
 	RegisterRemoteHost(*host.Host, []byte) error
 	WriteDelegateKey(string, []byte) error
 	AuthenticateHost(string) (string, int64, error)
+	ResetHostKey(string) ([]byte, error)
 
 	// Pools
 	GetResourcePools() ([]pool.ResourcePool, error)

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -210,13 +210,9 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 // This will authenticate the host once to get a valid token for any CLI commands
 //  that require it.
 func (c *ServicedCli) authenticateHost(options *config.Options) error {
-	// If we are the master, load the master keys
-	if options.Master {
-		masterKeyFile := filepath.Join(options.IsvcsPath, auth.MasterKeyFileName)
-		if err := auth.CreateOrLoadMasterKeys(masterKeyFile); err != nil {
-			return err
-		}
-	}
+	// Try to load the master keys, fail silently if they don't exist
+	masterKeyFile := filepath.Join(options.IsvcsPath, auth.MasterKeyFileName)
+	auth.LoadMasterKeyFile(masterKeyFile)
 
 	// Load the delegate keys
 	delegateKeyFile := filepath.Join(options.EtcPath, auth.DelegateKeyFileName)

--- a/cli/cmd/host.go
+++ b/cli/cmd/host.go
@@ -19,7 +19,6 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/codegangsta/cli"
@@ -252,38 +251,9 @@ func (c *ServicedCli) cmdHostAdd(ctx *cli.Context) {
 		return
 	}
 
-	writeKeyFile := false
-	if ctx.Bool("register") {
-		if err := c.driver.RegisterRemoteHost(host, privateKey); err != nil {
-			fmt.Fprintf(os.Stderr, "Error registering host: %s\n", err.Error())
-			writeKeyFile = true
-		} else {
-			fmt.Println("Registered host at", host.IPAddr)
-		}
-	} else {
-		writeKeyFile = true
-	}
-
 	keyfileName := ctx.String("key-file")
-	if keyfileName != "" {
-		writeKeyFile = true
-	}
-
-	if writeKeyFile == true {
-		if keyfileName == "" {
-			keyfileName = fmt.Sprintf("IP-%s.delegate.key", strings.Replace(host.IPAddr, ".", "-", -1))
-		}
-		if keyfileName, err = filepath.Abs(keyfileName); err != nil {
-			fmt.Fprintf(os.Stderr, "Error writing delegate key file \"%s\": %s\n", keyfileName, err.Error())
-			return
-		}
-		if err := c.driver.WriteDelegateKey(keyfileName, privateKey); err != nil {
-			fmt.Fprintf(os.Stderr, "Error writing delegate key file \"%s\": %s\n", keyfileName, err.Error())
-			return
-		}
-		fmt.Fprintln(os.Stderr, "Wrote delegate key file to", keyfileName)
-	}
-	fmt.Println(host.ID)
+	registerHost := ctx.Bool("register")
+	c.outputDelegateKey(host, privateKey, keyfileName, registerHost)
 }
 
 // serviced host remove HOSTID ...

--- a/cli/cmd/host.go
+++ b/cli/cmd/host.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/codegangsta/cli"
@@ -272,11 +273,15 @@ func (c *ServicedCli) cmdHostAdd(ctx *cli.Context) {
 		if keyfileName == "" {
 			keyfileName = fmt.Sprintf("IP-%s.delegate.key", strings.Replace(host.IPAddr, ".", "-", -1))
 		}
+		if keyfileName, err = filepath.Abs(keyfileName); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing delegate key file \"%s\": %s\n", keyfileName, err.Error())
+			return
+		}
 		if err := c.driver.WriteDelegateKey(keyfileName, privateKey); err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing delegate key file \"%s\": %s\n", keyfileName, err.Error())
-		} else {
-			fmt.Println("Wrote delegate key file to", keyfileName)
+			return
 		}
+		fmt.Fprintln(os.Stderr, "Wrote delegate key file to", keyfileName)
 	}
 	fmt.Println(host.ID)
 }

--- a/cli/cmd/host_test.go
+++ b/cli/cmd/host_test.go
@@ -230,6 +230,8 @@ func ExampleServicedCLI_CmdHostList_complete() {
 	// test-host-id-3
 }
 
+/* The output of this command is dynamic, so disabling until we figure out how to do this
+
 func ExampleServicedCLI_CmdHostAdd() {
 	// Success
 	InitHostAPITest("serviced", "host", "add", "127.0.0.111:8080", "default")
@@ -238,6 +240,7 @@ func ExampleServicedCLI_CmdHostAdd() {
 	// Wrote delegate key file to IP-127-0-0-111.delegate.key
 	// 127.0.0.111-default
 }
+*/
 
 func ExampleServicedCLI_CmdHostAdd_register() {
 	// Register host.  Do not write key file
@@ -247,6 +250,8 @@ func ExampleServicedCLI_CmdHostAdd_register() {
 	// Registered host at 127.0.0.33
 	// 127.0.0.33-default
 }
+
+/* The output of this command is dynamic, so disabling until we figure out how to do this
 
 func ExampleServicedCLI_CmdHostAdd_registerfail() {
 	// Register host failed.  Write key file
@@ -259,6 +264,9 @@ func ExampleServicedCLI_CmdHostAdd_registerfail() {
 	// 127.0.0.1-default
 	// Error registering host: Forcing RemoteRegisterHost to fail for testing
 }
+*/
+
+/* The output of this command is dynamic, so disabling until we figure out how to do this
 
 func ExampleServicedCLI_CmdHostAdd_keyfile() {
 	// Specify location of key file.
@@ -268,6 +276,9 @@ func ExampleServicedCLI_CmdHostAdd_keyfile() {
 	// Wrote delegate key file to foobar
 	// 127.0.0.1-default
 }
+*/
+
+/* The output of this command is dynamic, so disabling until we figure out how to do this
 
 func ExampleServicedCLI_CmdHostAdd_keyfilefail() {
 	// Failure writing keyfile
@@ -279,6 +290,9 @@ func ExampleServicedCLI_CmdHostAdd_keyfilefail() {
 	// 127.0.0.1-default
 	// Error writing delegate key file "IP-127-0-0-1.delegate.key": Forcing WriteDelegateKey to fail for testing
 }
+*/
+
+/* The output of this command is dynamic, so disabling until we figure out how to do this
 
 func ExampleServicedCLI_CmdHostAdd_keyfileRegister() {
 	// Specify location of key file and register host.
@@ -290,6 +304,7 @@ func ExampleServicedCLI_CmdHostAdd_keyfileRegister() {
 	// Wrote delegate key file to foobar
 	// 127.0.0.3-default
 }
+*/
 
 func ExampleServicedCLI_CmdHostAdd_badurl() {
 	// Bad URL

--- a/cli/cmd/key.go
+++ b/cli/cmd/key.go
@@ -16,8 +16,11 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/codegangsta/cli"
+	"github.com/control-center/serviced/domain/host"
 )
 
 func (c *ServicedCli) initKey() {
@@ -32,6 +35,23 @@ func (c *ServicedCli) initKey() {
 				Description:  "serviced key list HostID",
 				BashComplete: c.printHostsFirst,
 				Action:       c.cmdHostKey,
+			}, {
+				Name:         "reset",
+				Usage:        "Regenerate host key",
+				Description:  "serviced key reset HostID",
+				BashComplete: c.printHostsFirst,
+				Action:       c.cmdKeyReset,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "key-file, k",
+						Value: "",
+						Usage: "Name of the output host key file",
+					},
+					cli.BoolFlag{
+						Name:  "register, r",
+						Usage: "Register delegate keys on the host via ssh",
+					},
+				},
 			},
 		},
 	}
@@ -52,4 +72,64 @@ func (c *ServicedCli) cmdHostKey(ctx *cli.Context) {
 		return
 	}
 	fmt.Printf(string(key))
+}
+
+func (c *ServicedCli) cmdKeyReset(ctx *cli.Context) {
+	args := ctx.Args()
+	if len(args) < 1 {
+		fmt.Printf("Incorrect Usage.\n\n")
+		cli.ShowCommandHelp(ctx, "list")
+		return
+	}
+
+	hostID := args[0]
+
+	host, err := c.driver.GetHost(hostID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not get host %s: %s", hostID, err.Error())
+		return
+	}
+
+	key, err := c.driver.ResetHostKey(hostID)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Could not reset host's public key. ", err.Error())
+		return
+	}
+
+	keyfileName := ctx.String("key-file")
+	registerHost := ctx.Bool("register")
+	c.outputDelegateKey(host, key, keyfileName, registerHost)
+}
+
+func (c *ServicedCli) outputDelegateKey(host *host.Host, keyData []byte, keyfileName string, register bool) {
+	writeKeyFile := false
+	if register {
+		if err := c.driver.RegisterRemoteHost(host, keyData); err != nil {
+			fmt.Fprintf(os.Stderr, "Error registering host: %s\n", err.Error())
+			writeKeyFile = true
+		} else {
+			fmt.Println("Registered host at", host.IPAddr)
+		}
+	} else {
+		writeKeyFile = true
+	}
+
+	if keyfileName != "" {
+		writeKeyFile = true
+	}
+
+	if writeKeyFile == true {
+		if keyfileName == "" {
+			keyfileName = fmt.Sprintf("IP-%s.delegate.key", strings.Replace(host.IPAddr, ".", "-", -1))
+		}
+		if keyfileName, err := filepath.Abs(keyfileName); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing delegate key file \"%s\": %s\n", keyfileName, err.Error())
+			return
+		}
+		if err := c.driver.WriteDelegateKey(keyfileName, keyData); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing delegate key file \"%s\": %s\n", keyfileName, err.Error())
+		}
+		fmt.Println("Wrote delegate key file to", keyfileName)
+	}
+	fmt.Println(host.ID)
 }

--- a/cli/cmd/key_test.go
+++ b/cli/cmd/key_test.go
@@ -1,0 +1,119 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/control-center/serviced/cli/api/apimocks"
+	"github.com/control-center/serviced/domain/host"
+	"github.com/control-center/serviced/utils"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type mySuite struct {
+	api mocks.API
+	cli *ServicedCli
+}
+
+var testHost = host.Host{
+	ID:             "test-host-id-2",
+	PoolID:         "default",
+	Name:           "beta",
+	IPAddr:         "192.168.0.1",
+	Cores:          2,
+	Memory:         512 * 1024 * 1024,
+	PrivateNetwork: "10.0.0.1/66",
+}
+var testHostFilename = "IP-192-168-0-1.delegate.key"
+var testKeyData = []byte("Fake Key Data")
+
+var _ = Suite(&mySuite{})
+
+func (s *mySuite) SetUpTest(c *C) {
+	s.api = mocks.API{}
+	s.cli = New(&s.api, utils.TestConfigReader(make(map[string]string)))
+}
+
+func (s *mySuite) Test_cmdKeyReset(c *C) {
+	s.api.On("GetHost", testHost.ID).Return(&testHost, nil)
+	s.api.On("ResetHostKey", testHost.ID).Return(testKeyData, nil)
+	s.api.On("WriteDelegateKey", testHostFilename, testKeyData).Return(nil)
+	s.cli.Run(strings.Split("serviced key reset "+testHost.ID, " "))
+	s.api.AssertExpectations(c)
+}
+
+func (s *mySuite) Test_cmdKeyReset_hostNotFound(c *C) {
+	s.api.On("GetHost", testHost.ID).Return(nil, errors.New("?"))
+	s.cli.Run(strings.Split("serviced key reset "+testHost.ID, " "))
+	s.api.AssertExpectations(c)
+}
+
+func (s *mySuite) Test_cmdKeyReset_resetError(c *C) {
+	s.api.On("GetHost", testHost.ID).Return(&testHost, nil)
+	s.api.On("ResetHostKey", testHost.ID).Return(nil, errors.New("?"))
+	s.cli.Run(strings.Split("serviced key reset "+testHost.ID, " "))
+	s.api.AssertExpectations(c)
+}
+
+func (s *mySuite) Test_outputDelegateKey(c *C) {
+	s.api.On("WriteDelegateKey", testHostFilename, testKeyData).Return(nil)
+	s.cli.outputDelegateKey(&testHost, testKeyData, "", false)
+	s.api.AssertExpectations(c)
+}
+
+func (s *mySuite) Test_outputDelegateKey_keyfile(c *C) {
+	keyfileName := "foo.bar"
+	s.api.On("WriteDelegateKey", keyfileName, testKeyData).Return(nil)
+	s.cli.outputDelegateKey(&testHost, testKeyData, keyfileName, false)
+	s.api.AssertExpectations(c)
+}
+
+func (s *mySuite) Test_outputDelegateKey_register(c *C) {
+	s.api.On("RegisterRemoteHost", &testHost, testKeyData).Return(nil)
+	s.cli.outputDelegateKey(&testHost, testKeyData, "", true)
+	s.api.AssertExpectations(c)
+}
+
+func (s *mySuite) Test_outputDelegateKey_registerfail(c *C) {
+	s.api.On("RegisterRemoteHost", &testHost, testKeyData).Return(errors.New("woot"))
+	s.api.On("WriteDelegateKey", testHostFilename, testKeyData).Return(nil)
+	s.cli.outputDelegateKey(&testHost, testKeyData, "", true)
+	s.api.AssertExpectations(c)
+}
+
+func (s *mySuite) Test_outputDelegateKey_register_keyfile(c *C) {
+	keyfileName := "foo-bar"
+	s.api.On("RegisterRemoteHost", &testHost, testKeyData).Return(nil)
+	s.api.On("WriteDelegateKey", keyfileName, testKeyData).Return(nil)
+	s.cli.outputDelegateKey(&testHost, testKeyData, keyfileName, true)
+	s.api.AssertExpectations(c)
+}
+
+func (s *mySuite) Test_outputDelegateKey_registerfail_keyfile(c *C) {
+	keyfileName := "foo-bar"
+	s.api.On("RegisterRemoteHost", &testHost, testKeyData).Return(errors.New("woot"))
+	s.api.On("WriteDelegateKey", keyfileName, testKeyData).Return(nil)
+	s.cli.outputDelegateKey(&testHost, testKeyData, keyfileName, true)
+	s.api.AssertExpectations(c)
+}

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -51,6 +51,7 @@ func New() *Facade {
 		configStore:   serviceconfigfile.NewStore(),
 		templateStore: servicetemplate.NewStore(),
 		userStore:     user.NewStore(),
+		serviceCache:  NewServiceCache(),
 	}
 }
 
@@ -69,6 +70,7 @@ type Facade struct {
 	dfs           dfs.DFS
 	hcache        *health.HealthStatusCache
 	metricsClient MetricsClient
+	serviceCache  *serviceCache
 
 	isvcsPath string
 }

--- a/facade/service.go
+++ b/facade/service.go
@@ -1073,9 +1073,6 @@ func (f *Facade) scheduleService(ctx datastore.Context, tenantID, serviceID stri
 		default:
 			svc.DesiredState = int(desiredState)
 		}
-		if err := f.fillServiceConfigs(ctx, svc); err != nil {
-			return err
-		}
 		if err := f.updateService(ctx, tenantID, *svc, false, false); err != nil {
 			glog.Errorf("Facade.ScheduleService update service %s (%s): %s", svc.Name, svc.ID, err)
 			return err

--- a/facade/service.go
+++ b/facade/service.go
@@ -858,8 +858,13 @@ func (f *Facade) GetServicesByPool(ctx datastore.Context, poolID string) ([]serv
 		glog.Error("Facade.GetServicesByPool: err=", err)
 		return results, err
 	}
-	if err = f.fillOutServices(ctx, results); err != nil {
-		return results, err
+
+	// For performance optimizations, do not retrieve config files, but we do need to fill out
+	//    the address assignments.
+	for i, _ := range results {
+		if err = f.fillServiceAddr(ctx, &results[i]); err != nil {
+			return results, err
+		}
 	}
 	return results, nil
 }

--- a/facade/service.go
+++ b/facade/service.go
@@ -237,9 +237,6 @@ func (f *Facade) updateService(ctx datastore.Context, tenantID string, svc servi
 	}
 	glog.Infof("Updated service %s (%s)", svc.Name, svc.ID)
 
-	// If the service has been reparented, we need to clear it from the cache
-	f.serviceCache.RemoveIfParentChanged(svc.ID, svc.ParentServiceID)
-
 	// FIXME - Do we really need to updateServiceConfigs everytime? can we skip this when called from schedulService?
 	// add the service configurations to the database
 	if err := f.updateServiceConfigs(ctx, svc.ID, configFiles, true); err != nil {
@@ -290,6 +287,9 @@ func (f *Facade) validateServiceUpdate(ctx datastore.Context, svc *service.Servi
 			glog.Errorf("Could not validate service name for updated service %s: %s", svc.ID, err)
 			return nil, err
 		}
+
+		// If the service has been reparented, we need to clear it from the cache
+		f.serviceCache.RemoveIfParentChanged(svc.ID, svc.ParentServiceID)
 	}
 
 	// disallow enabling ports and vhosts that are already enabled by a different

--- a/facade/service_unit_test.go
+++ b/facade/service_unit_test.go
@@ -40,13 +40,14 @@ func (ft *FacadeUnitTest) Test_GetTenantIDForRootApp(c *C) {
 
 func (ft *FacadeUnitTest) Test_GetTenantIDForRootAppFailsForNoSuchEntity(c *C) {
 	serviceID := getRandomServiceID(c)
-	ft.serviceStore.On("Get", ft.ctx, serviceID).Return(nil, datastore.ErrNoSuchEntity{})
+	expectedError := fmt.Errorf("mock DB error")
+	ft.serviceStore.On("Get", ft.ctx, serviceID).Return(nil, expectedError)
 
 	result, err := ft.Facade.GetTenantID(ft.ctx, serviceID)
 
 	c.Assert(len(result), Equals, 0)
 	c.Assert(err, Not(IsNil))
-	c.Assert(err, Equals, datastore.ErrNoSuchEntity{})
+	c.Assert(err.Error(), Equals, expectedError.Error())
 }
 
 func (ft *FacadeUnitTest) Test_GetTenantIDForRootAppFailsForOtherDBError(c *C) {

--- a/facade/serviceconfig.go
+++ b/facade/serviceconfig.go
@@ -15,7 +15,6 @@ package facade
 
 import (
 	"errors"
-	"path"
 	"reflect"
 
 	log "github.com/Sirupsen/logrus"
@@ -161,20 +160,10 @@ func (f *Facade) DeleteServiceConfig(ctx datastore.Context, fileID string) error
 // getServicePath returns the tenantID and the full path of the service
 // TODO: update function to include deploymentID in the service path
 func (f *Facade) getServicePath(ctx datastore.Context, serviceID string) (tenantID string, servicePath string, err error) {
-	store := f.serviceStore
-	svc, err := store.Get(ctx, serviceID)
-	if err != nil {
-		glog.Errorf("Could not look up service %s: %s", serviceID, err)
-		return "", "", err
+	gs := func(id string) (service.Service, error) {
+		return f.getService(ctx, id)
 	}
-	if svc.ParentServiceID == "" {
-		return serviceID, "/" + serviceID, nil
-	}
-	tenantID, servicePath, err = f.getServicePath(ctx, svc.ParentServiceID)
-	if err != nil {
-		return "", "", err
-	}
-	return tenantID, path.Join(servicePath, serviceID), nil
+	return f.serviceCache.GetServicePath(serviceID, gs)
 }
 
 // updateServiceConfigs adds or updates configuration files.  If forceDelete is

--- a/facade/servicepath_cache.go
+++ b/facade/servicepath_cache.go
@@ -1,0 +1,153 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package facade
+
+import (
+	"path"
+	"strings"
+	"sync"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/control-center/serviced/domain/service"
+)
+
+type serviceCache struct {
+	mutex sync.RWMutex
+	paths map[string]servicePath
+}
+
+type servicePath struct {
+	serviceID   string
+	tenantID    string
+	parentID    string
+	servicePath string
+}
+
+func NewServiceCache() *serviceCache {
+	return &serviceCache{
+		mutex: sync.RWMutex{},
+		paths: make(map[string]servicePath),
+	}
+}
+
+// GetTenantID returns the tenant ID for the specified service from its cache. If the specified service
+// is not in the cache, it uses getServiceFunc to populate the cache (assuming serviceID really exists in the DB).
+func (sc *serviceCache) GetTenantID(serviceID string, getServiceFunc service.GetService) (string, error) {
+	if cachedSvc, found := sc.lookUpService(serviceID); found {
+		return cachedSvc.tenantID, nil
+	}
+
+	cachedSvc, err := sc.updateCache(serviceID, getServiceFunc)
+	if err != nil {
+		return "", err
+	}
+	return cachedSvc.tenantID, nil
+}
+
+// GetServicePath returns the tenant ID and service path for the specified service from the. It assumes that
+// the cache has already been populated by a previous call to serviceCache.GetTenantID.
+func (sc *serviceCache) GetServicePath(serviceID string, getServiceFunc service.GetService) (string, string, error) {
+	if cachedSvc, found := sc.lookUpService(serviceID); found {
+		return cachedSvc.tenantID, cachedSvc.servicePath, nil
+	}
+
+	cachedSvc, err := sc.updateCache(serviceID, getServiceFunc)
+	if err != nil {
+		return "", "", err
+	}
+	return cachedSvc.tenantID, cachedSvc.servicePath, nil
+}
+
+// RemoveIfParentChanged will remove all entries from the cache for this service and its children if the
+// specified service's parentID is different from the cached value.
+// Returns true if one or more entries was removed from the cache; false otherwise.
+func (sc *serviceCache) RemoveIfParentChanged(serviceID string, parentID string) bool {
+	cachedSvc, ok := sc.lookUpService(serviceID)
+	if !ok || cachedSvc.parentID == parentID {
+		return false
+	}
+
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+	for key, value := range sc.paths {
+		if strings.HasPrefix(value.servicePath, cachedSvc.servicePath) {
+			delete(sc.paths, key)
+		}
+	}
+	return true
+}
+
+// Reset clears the cache.
+func (sc *serviceCache) Reset() {
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+	sc.paths = make(map[string]servicePath)
+}
+
+func (sc *serviceCache) lookUpService(svcID string) (servicePath, bool) {
+	sc.mutex.RLock()
+	defer sc.mutex.RUnlock()
+	cachedSvc, found := sc.paths[svcID]
+	return cachedSvc, found
+}
+
+func (sc *serviceCache) updateCache(serviceID string, getServiceFunc service.GetService) (servicePath, error) {
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+
+	svcPaths := make([]servicePath, 0)
+	cachedSvc, err := sc.buildServicePath(serviceID, &svcPaths, getServiceFunc)
+	if err != nil {
+		return servicePath{}, err
+	}
+
+	for _, path := range svcPaths {
+		sc.paths[path.serviceID] = path
+	}
+	return cachedSvc, nil
+}
+
+func (sc *serviceCache) buildServicePath(serviceID string, svcPaths *[]servicePath, getServiceFunc service.GetService) (svcPath servicePath, err error) {
+	logger := plog.WithFields(log.Fields{
+		"serviceid": serviceID,
+	})
+
+	svc, err := getServiceFunc(serviceID)
+	if err != nil {
+		logger.WithError(err).Error("Could not find service")
+		return servicePath{}, err
+	}
+	if svc.ParentServiceID == "" {
+		svcPath = servicePath{
+			serviceID:   serviceID,
+			tenantID:    serviceID,
+			servicePath: "/" + serviceID,
+		}
+		*svcPaths = append(*svcPaths, svcPath)
+		return svcPath, nil
+	}
+
+	parent, err := sc.buildServicePath(svc.ParentServiceID, svcPaths, getServiceFunc)
+	if err != nil {
+		return servicePath{}, err
+	}
+
+	svcPath = servicePath{
+		serviceID:   svc.ID,
+		tenantID:    parent.tenantID,
+		parentID:    svc.ParentServiceID,
+		servicePath: path.Join(parent.servicePath, svc.ID),
+	}
+	*svcPaths = append(*svcPaths, svcPath)
+	return svcPath, nil
+}

--- a/facade/servicepath_cache_test.go
+++ b/facade/servicepath_cache_test.go
@@ -1,0 +1,448 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package facade
+
+import (
+	"fmt"
+
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain/service"
+	servicemocks "github.com/control-center/serviced/domain/service/mocks"
+	. "gopkg.in/check.v1"
+)
+
+var _ = Suite(&ServicePathCacheTest{})
+
+type ServicePathCacheTest struct {
+	cache        *serviceCache
+	serviceStore *servicemocks.Store
+	unusedCTX    datastore.Context
+}
+
+func (t *ServicePathCacheTest) SetUpTest(c *C) {
+	t.cache = NewServiceCache()
+	t.serviceStore = &servicemocks.Store{}
+}
+
+func (t *ServicePathCacheTest) TearDownTest(c *C) {
+	t.cache = nil
+	t.serviceStore = nil
+}
+
+func (t *ServicePathCacheTest) Test_GetTenantID_SeedsCacheForTenantService(c *C) {
+	tenantID := "mockTenantId"
+	expectedService := service.Service{ID: tenantID}
+	t.serviceStore.On("Get", t.unusedCTX, tenantID).Return(&expectedService, nil)
+
+	result, err := t.cache.GetTenantID(tenantID, t.getService)
+
+	c.Assert(result, Equals, tenantID)
+	c.Assert(err, IsNil)
+
+	// Verify the cache contents
+	expectedCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+	}
+	t.assertExpectedCacheEntries(c, expectedCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_GetTenantID_SeedsCacheForNestedServices(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	grandchildID := "mockGrandChildId"
+
+	tenant := service.Service{ID: tenantID}
+	t.serviceStore.On("Get", t.unusedCTX, tenantID).Return(&tenant, nil)
+
+	child := service.Service{ID: childID, ParentServiceID: tenantID}
+	t.serviceStore.On("Get", t.unusedCTX, childID).Return(&child, nil)
+
+	grandchild := service.Service{ID: grandchildID, ParentServiceID: childID}
+	t.serviceStore.On("Get", t.unusedCTX, grandchildID).Return(&grandchild, nil)
+
+	result, err := t.cache.GetTenantID(grandchildID, t.getService)
+
+	c.Assert(result, Equals, tenantID)
+	c.Assert(err, IsNil)
+
+	// Verify the cache contents
+	expectedCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID,
+		},
+		servicePath{
+			serviceID:   grandchildID,
+			parentID:    childID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID + "/" + grandchildID,
+		},
+	}
+	t.assertExpectedCacheEntries(c, expectedCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_GetTenantID_UsesCachedValues(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	grandchildID := "mockGrandChildId"
+
+	// Load the cache manually
+	initialCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID,
+		},
+		servicePath{
+			serviceID:   grandchildID,
+			parentID:    childID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID + "/" + grandchildID,
+		},
+	}
+	for _, expected := range initialCacheEntries {
+		t.cache.paths[expected.serviceID] = expected
+	}
+
+	// NOTE: Since no mock expectations are set, the test will fail if any calls to t.getService occur
+	result, err := t.cache.GetTenantID(grandchildID, t.getService)
+
+	c.Assert(result, Equals, tenantID)
+	c.Assert(err, IsNil)
+	t.assertExpectedCacheEntries(c, initialCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_GetTenantID_ReturnsDBError(c *C) {
+	tenantID := "mockTenantId"
+	expectedError := fmt.Errorf("fake DB error")
+	t.serviceStore.On("Get", t.unusedCTX, tenantID).Return(nil, expectedError)
+
+	result, err := t.cache.GetTenantID(tenantID, t.getService)
+
+	c.Assert(result, Equals, "")
+	c.Assert(err.Error(), Equals, expectedError.Error())
+}
+
+func (t *ServicePathCacheTest) Test_GetServicePath_SeedsCacheForTenantService(c *C) {
+	tenantID := "mockTenantId"
+	expectedPath := "/" + tenantID
+
+	expectedService := service.Service{ID: tenantID}
+	t.serviceStore.On("Get", t.unusedCTX, tenantID).Return(&expectedService, nil)
+
+	tenantResult, pathResult, err := t.cache.GetServicePath(tenantID, t.getService)
+
+	c.Assert(tenantResult, Equals, tenantID)
+	c.Assert(pathResult, Equals, expectedPath)
+	c.Assert(err, IsNil)
+
+	// Verify the cache contents
+	expectedCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+	}
+	t.assertExpectedCacheEntries(c, expectedCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_GetServicePath_SeedsCacheForNestedServices(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	grandchildID := "mockGrandChildId"
+	expectedPath := "/" + tenantID + "/" + childID + "/" + grandchildID
+
+	tenant := service.Service{ID: tenantID}
+	t.serviceStore.On("Get", t.unusedCTX, tenantID).Return(&tenant, nil)
+
+	child := service.Service{ID: childID, ParentServiceID: tenantID}
+	t.serviceStore.On("Get", t.unusedCTX, childID).Return(&child, nil)
+
+	grandchild := service.Service{ID: grandchildID, ParentServiceID: childID}
+	t.serviceStore.On("Get", t.unusedCTX, grandchildID).Return(&grandchild, nil)
+
+	tenantResult, pathResult, err := t.cache.GetServicePath(grandchildID, t.getService)
+
+	c.Assert(tenantResult, Equals, tenantID)
+	c.Assert(pathResult, Equals, expectedPath)
+	c.Assert(err, IsNil)
+
+	// Verify the cache contents
+	expectedCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID,
+		},
+		servicePath{
+			serviceID:   grandchildID,
+			parentID:    childID,
+			tenantID:    tenantID,
+			servicePath: expectedPath,
+		},
+	}
+	t.assertExpectedCacheEntries(c, expectedCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_GetServicePath_UsesCachedValues(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	grandchildID := "mockGrandChildId"
+	expectedPath := "/" + tenantID + "/" + childID + "/" + grandchildID
+
+	// Load the cache manually
+	initialCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID,
+		},
+		servicePath{
+			serviceID:   grandchildID,
+			parentID:    childID,
+			tenantID:    tenantID,
+			servicePath: expectedPath,
+		},
+	}
+	for _, expected := range initialCacheEntries {
+		t.cache.paths[expected.serviceID] = expected
+	}
+
+	// NOTE: Since no mock expectations are set, the test will fail if any calls to t.getService occur
+	tenantResult, pathResult, err := t.cache.GetServicePath(grandchildID, t.getService)
+
+	c.Assert(tenantResult, Equals, tenantID)
+	c.Assert(pathResult, Equals, expectedPath)
+	c.Assert(err, IsNil)
+	t.assertExpectedCacheEntries(c, initialCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_GetServicePath_ReturnsDBError(c *C) {
+	tenantID := "mockTenantId"
+	expectedError := fmt.Errorf("fake DB error")
+	t.serviceStore.On("Get", t.unusedCTX, tenantID).Return(nil, expectedError)
+
+	tenantResult, pathResult, err := t.cache.GetServicePath(tenantID, t.getService)
+
+	c.Assert(tenantResult, Equals, "")
+	c.Assert(pathResult, Equals, "")
+	c.Assert(err.Error(), Equals, expectedError.Error())
+}
+
+func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_OnEmptyCache(c *C) {
+	tenantID := "mockTenantId"
+	removed := t.cache.RemoveIfParentChanged(tenantID, "")
+
+	// Nothing should be removed, so the cache should be unchanged
+	c.Assert(removed, Equals, false)
+	t.assertExpectedCacheEntries(c, []servicePath{})
+}
+
+func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_OnCacheMiss(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	expectedPath := "/" + tenantID + "/" + childID
+	initialCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: expectedPath,
+		},
+	}
+	for _, expected := range initialCacheEntries {
+		t.cache.paths[expected.serviceID] = expected
+	}
+
+	uncachedServiceID := "something compleletly differennt"
+	removed := t.cache.RemoveIfParentChanged(uncachedServiceID, tenantID)
+
+	// Nothing should be removed, so the cache should be unchanged
+	c.Assert(removed, Equals, false)
+	t.assertExpectedCacheEntries(c, initialCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_CachedParentMatches(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	expectedPath := "/" + tenantID + "/" + childID
+	initialCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: expectedPath,
+		},
+	}
+	for _, expected := range initialCacheEntries {
+		t.cache.paths[expected.serviceID] = expected
+	}
+
+	removed := t.cache.RemoveIfParentChanged(childID, tenantID)
+
+	// Nothing should be removed, so the cache should be unchanged
+	c.Assert(removed, Equals, false)
+	t.assertExpectedCacheEntries(c, initialCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_CachedParentDifferent(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	initialCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID,
+		},
+	}
+	for _, expected := range initialCacheEntries {
+		t.cache.paths[expected.serviceID] = expected
+	}
+
+	removed := t.cache.RemoveIfParentChanged(childID, "newParentId")
+
+	// The child should be removed
+	c.Assert(removed, Equals, true)
+	t.assertExpectedCacheEntries(c, []servicePath{initialCacheEntries[0]})
+}
+
+func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_RemoveMultipleEntries(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	grandchildID1 := "mockGrandChildId1"
+	grandchildID2 := "mockGrandChildId2"
+
+	// Load the cache manually
+	initialCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID,
+		},
+		servicePath{
+			serviceID:   grandchildID1,
+			parentID:    childID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID + "/" + grandchildID1,
+		},
+		servicePath{
+			serviceID:   grandchildID2,
+			parentID:    childID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID + "/" + grandchildID2,
+		},
+	}
+	for _, expected := range initialCacheEntries {
+		t.cache.paths[expected.serviceID] = expected
+	}
+
+	removed := t.cache.RemoveIfParentChanged(childID, "newParentId")
+
+	// The item and its descendants should be removed
+	c.Assert(removed, Equals, true)
+	t.assertExpectedCacheEntries(c, []servicePath{initialCacheEntries[0]})
+}
+
+func (t *ServicePathCacheTest) Test_Reset_EmptyCache(c *C) {
+	// should start empty
+	c.Assert(len(t.cache.paths), Equals, 0)
+
+	t.cache.Reset()
+
+	// should start still be empty
+	c.Assert(len(t.cache.paths), Equals, 0)
+}
+
+func (t *ServicePathCacheTest) getService(serviceID string) (service.Service, error) {
+	svc, err := t.serviceStore.Get(t.unusedCTX, serviceID)
+	if err != nil {
+		return service.Service{}, err
+	}
+	return *svc, nil
+}
+
+func (t *ServicePathCacheTest) assertExpectedCacheEntries(c *C, expectedCacheEntries []servicePath) {
+	c.Assert(len(t.cache.paths), Equals, len(expectedCacheEntries))
+	for _, expected := range expectedCacheEntries {
+		actual, ok := t.cache.paths[expected.serviceID]
+		c.Assert(ok, Equals, true)
+		c.Assert(actual.tenantID, Equals, expected.tenantID)
+		c.Assert(actual.parentID, Equals, expected.parentID)
+		c.Assert(actual.servicePath, Equals, expected.servicePath)
+	}
+}

--- a/node/agent_proxy.go
+++ b/node/agent_proxy.go
@@ -54,7 +54,7 @@ func (a *HostAgent) Ping(waitFor time.Duration, timestamp *time.Time) error {
 	return nil
 }
 
-func (a *HostAgent) GetServiceEndpoints(serviceId string, response *map[string][]applicationendpoint.ApplicationEndpoint) (err error) {
+func (a *HostAgent) GetISvcEndpoints(serviceId string, response *map[string][]applicationendpoint.ApplicationEndpoint) (err error) {
 	myList := make(map[string][]applicationendpoint.ApplicationEndpoint)
 
 	a.addControlPlaneEndpoint(myList)

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -112,7 +112,7 @@ type LoadBalancer interface {
 	// SendLogMessage allows the proxy to send messages/logs to the master (to be displayed on the serviced master)
 	SendLogMessage(serviceLogInfo ServiceLogInfo, _ *struct{}) error
 
-	GetServiceEndpoints(serviceId string, endpoints *map[string][]applicationendpoint.ApplicationEndpoint) error
+	GetISvcEndpoints(serviceId string, endpoints *map[string][]applicationendpoint.ApplicationEndpoint) error
 
 	// GetProxySnapshotQuiece blocks until there is a snapshot request
 	GetProxySnapshotQuiece(serviceId string, snapshotId *string) error

--- a/node/lbClient.go
+++ b/node/lbClient.go
@@ -59,10 +59,10 @@ func (a *LBClient) SendLogMessage(serviceLogInfo ServiceLogInfo, _ *struct{}) er
 	return a.rpcClient.Call("ControlCenterAgent.SendLogMessage", serviceLogInfo, nil, 0)
 }
 
-// GetServiceEndpoints returns a list of endpoints for the given service endpoint request.
-func (a *LBClient) GetServiceEndpoints(serviceId string, endpoints *map[string][]applicationendpoint.ApplicationEndpoint) error {
-	glog.V(4).Infof("ControlCenterAgent.GetServiceEndpoints()")
-	return a.rpcClient.Call("ControlCenterAgent.GetServiceEndpoints", serviceId, endpoints, 0)
+// GetISvcEndpoints returns a list of controlplane endpoints for the given service endpoint request.
+func (a *LBClient) GetISvcEndpoints(serviceId string, endpoints *map[string][]applicationendpoint.ApplicationEndpoint) error {
+	glog.V(4).Infof("ControlCenterAgent.GetISvcEndpoints()")
+	return a.rpcClient.Call("ControlCenterAgent.GetISvcEndpoints", serviceId, endpoints, 0)
 }
 
 // GetEvaluatedService returns a service where an evaluation has been executed against all templated properties.

--- a/rpc/master/hosts_client.go
+++ b/rpc/master/hosts_client.go
@@ -98,3 +98,9 @@ func (c *Client) GetHostPublicKey(hostID string) ([]byte, error) {
 	err := c.call("GetHostPublicKey", hostID, &response)
 	return response, err
 }
+
+func (c *Client) ResetHostKey(hostID string) ([]byte, error) {
+	response := []byte{}
+	err := c.call("ResetHostKey", hostID, &response)
+	return response, err
+}

--- a/rpc/master/hosts_server.go
+++ b/rpc/master/hosts_server.go
@@ -148,3 +148,10 @@ func (s *Server) GetHostPublicKey(hostID string, key *[]byte) error {
 	*key = publicKey
 	return err
 }
+
+// Reset and return host's private key
+func (s *Server) ResetHostKey(hostID string, key *[]byte) error {
+	publicKey, err := s.f.ResetHostKey(s.context(), hostID)
+	*key = publicKey
+	return err
+}

--- a/rpc/master/interface.go
+++ b/rpc/master/interface.go
@@ -65,6 +65,9 @@ type ClientInterface interface {
 	// Get hostID's public key
 	GetHostPublicKey(hostID string) ([]byte, error)
 
+	// Reset hostID's private key
+	ResetHostKey(hostID string) ([]byte, error)
+
 	//--------------------------------------------------------------------------
 	// Pool Management Functions
 

--- a/rpc/master/mocks/ClientInterface.go
+++ b/rpc/master/mocks/ClientInterface.go
@@ -206,6 +206,27 @@ func (_m *ClientInterface) GetHostPublicKey(hostID string) ([]byte, error) {
 
 	return r0, r1
 }
+func (_m *ClientInterface) ResetHostKey(hostID string) ([]byte, error) {
+	ret := _m.Called(hostID)
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(string) []byte); ok {
+		r0 = rf(hostID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(hostID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
 func (_m *ClientInterface) GetResourcePool(poolID string) (*pool.ResourcePool, error) {
 	ret := _m.Called(poolID)
 

--- a/smoke.sh
+++ b/smoke.sh
@@ -13,7 +13,7 @@ TEST_VAR_PATH=/tmp/serviced-smoke/var
 
 # Add a host
 add_host() {
-    HOST_ID=$(sudo SERVICED_MASTER=1 SERVICED_ISVCS_PATH=${SERVICED_ISVCS_PATH} SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} host add "${IP}:4979" default --register | tail -n 1)
+    HOST_ID=$(sudo SERVICED_ISVCS_PATH=${SERVICED_ISVCS_PATH} SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} host add "${IP}:4979" default --register | tail -n 1)
     sleep 1
     [ -z "$(SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} host list ${HOST_ID} 2>/dev/null)" ] && return 1
     return 0


### PR DESCRIPTION
The Facade tier already had code to cache tenantIDs for a given serviceID, but each time a service was scheduled, it was computing the service path for every config file on every service.  This proved to be very timing consuming with 100s of services.

This code replaces the tenantID cache with a cache of structs that contain tenantID and servicePath.  This change also required an additional call to remove cache entries when a service is removed or it's parent has changed.

Also, since we don't put the entire Service object in ZK any longer, I removed the call to fillServiceConfigs for any scheduleService operation.