### PR TITLE
Feature/fix zendev host add

### DIFF
--- a/auth/localkeys.go
+++ b/auth/localkeys.go
@@ -200,6 +200,13 @@ func CreateOrLoadMasterKeys(filename string) error {
 		return err
 	}
 
+	return LoadMasterKeyFile(filename)	
+}
+
+// LoadMasterKeyFile will load the master keys from disk if 
+//  the file exists.  If the file does not exist, it will
+//  return an error
+func LoadMasterKeyFile(filename string) error {
 	publicKey, privateKey, err := LoadKeyPairFromFile(filename)
 	if err != nil {
 		return err

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -210,13 +210,9 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 // This will authenticate the host once to get a valid token for any CLI commands
 //  that require it.
 func (c *ServicedCli) authenticateHost(options *config.Options) error {
-	// If we are the master, load the master keys
-	if options.Master {
-		masterKeyFile := filepath.Join(options.IsvcsPath, auth.MasterKeyFileName)
-		if err := auth.CreateOrLoadMasterKeys(masterKeyFile); err != nil {
-			return err
-		}
-	}
+	// Try to load the master keys, fail silently if they don't exist
+	masterKeyFile := filepath.Join(options.IsvcsPath, auth.MasterKeyFileName)
+	auth.LoadMasterKeyFile(masterKeyFile)
 
 	// Load the delegate keys
 	delegateKeyFile := filepath.Join(options.EtcPath, auth.DelegateKeyFileName)

--- a/smoke.sh
+++ b/smoke.sh
@@ -13,7 +13,7 @@ TEST_VAR_PATH=/tmp/serviced-smoke/var
 
 # Add a host
 add_host() {
-    HOST_ID=$(sudo SERVICED_MASTER=1 SERVICED_ISVCS_PATH=${SERVICED_ISVCS_PATH} SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} host add "${IP}:4979" default --register | tail -n 1)
+    HOST_ID=$(sudo SERVICED_ISVCS_PATH=${SERVICED_ISVCS_PATH} SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} host add "${IP}:4979" default --register | tail -n 1)
     sleep 1
     [ -z "$(SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} host list ${HOST_ID} 2>/dev/null)" ] && return 1
     return 0


### PR DESCRIPTION
Don't check for SERVICED_MASTER on CLI client startup, just try to load the master keys.  This will fix the current issue with zendev serviced -dx failing on host add.