### PR TITLE
Cache service path with TenantID (#2)

### DIFF
--- a/facade/facade.go
+++ b/facade/facade.go
@@ -51,6 +51,7 @@ func New() *Facade {
 		configStore:   serviceconfigfile.NewStore(),
 		templateStore: servicetemplate.NewStore(),
 		userStore:     user.NewStore(),
+		serviceCache:  NewServiceCache(),
 	}
 }
 
@@ -69,6 +70,7 @@ type Facade struct {
 	dfs           dfs.DFS
 	hcache        *health.HealthStatusCache
 	metricsClient MetricsClient
+	serviceCache  *serviceCache
 
 	isvcsPath string
 }

--- a/facade/service.go
+++ b/facade/service.go
@@ -1061,7 +1061,7 @@ func (f *Facade) scheduleService(ctx datastore.Context, tenantID, serviceID stri
 			return 0, fmt.Errorf("desired state unknown")
 		}
 		if err := f.validateServiceSchedule(ctx, serviceID, autoLaunch); err != nil {
-			glog.Errorf("Facade.scheduleService: Could not validate service schedule for service %s: %s", serviceID, err)
+			glog.Errorf("Could not validate service schedule for service %s: %s", serviceID, err)
 			return 0, err
 		}
 	}

--- a/facade/service.go
+++ b/facade/service.go
@@ -1073,9 +1073,6 @@ func (f *Facade) scheduleService(ctx datastore.Context, tenantID, serviceID stri
 		default:
 			svc.DesiredState = int(desiredState)
 		}
-		if err := f.fillServiceConfigs(ctx, svc); err != nil {
-			return err
-		}
 		if err := f.updateService(ctx, tenantID, *svc, false, false); err != nil {
 			glog.Errorf("Facade.ScheduleService update service %s (%s): %s", svc.Name, svc.ID, err)
 			return err

--- a/facade/service.go
+++ b/facade/service.go
@@ -858,8 +858,13 @@ func (f *Facade) GetServicesByPool(ctx datastore.Context, poolID string) ([]serv
 		glog.Error("Facade.GetServicesByPool: err=", err)
 		return results, err
 	}
-	if err = f.fillOutServices(ctx, results); err != nil {
-		return results, err
+
+	// For performance optimizations, do not retrieve config files, but we do need to fill out
+	//    the address assignments.
+	for i, _ := range results {
+		if err = f.fillServiceAddr(ctx, &results[i]); err != nil {
+			return results, err
+		}
 	}
 	return results, nil
 }

--- a/facade/service.go
+++ b/facade/service.go
@@ -237,9 +237,6 @@ func (f *Facade) updateService(ctx datastore.Context, tenantID string, svc servi
 	}
 	glog.Infof("Updated service %s (%s)", svc.Name, svc.ID)
 
-	// If the service has been reparented, we need to clear it from the cache
-	f.serviceCache.RemoveIfParentChanged(svc.ID, svc.ParentServiceID)
-
 	// FIXME - Do we really need to updateServiceConfigs everytime? can we skip this when called from schedulService?
 	// add the service configurations to the database
 	if err := f.updateServiceConfigs(ctx, svc.ID, configFiles, true); err != nil {
@@ -290,6 +287,9 @@ func (f *Facade) validateServiceUpdate(ctx datastore.Context, svc *service.Servi
 			glog.Errorf("Could not validate service name for updated service %s: %s", svc.ID, err)
 			return nil, err
 		}
+
+		// If the service has been reparented, we need to clear it from the cache
+		f.serviceCache.RemoveIfParentChanged(svc.ID, svc.ParentServiceID)
 	}
 
 	// disallow enabling ports and vhosts that are already enabled by a different

--- a/facade/service_unit_test.go
+++ b/facade/service_unit_test.go
@@ -40,13 +40,14 @@ func (ft *FacadeUnitTest) Test_GetTenantIDForRootApp(c *C) {
 
 func (ft *FacadeUnitTest) Test_GetTenantIDForRootAppFailsForNoSuchEntity(c *C) {
 	serviceID := getRandomServiceID(c)
-	ft.serviceStore.On("Get", ft.ctx, serviceID).Return(nil, datastore.ErrNoSuchEntity{})
+	expectedError := fmt.Errorf("mock DB error")
+	ft.serviceStore.On("Get", ft.ctx, serviceID).Return(nil, expectedError)
 
 	result, err := ft.Facade.GetTenantID(ft.ctx, serviceID)
 
 	c.Assert(len(result), Equals, 0)
 	c.Assert(err, Not(IsNil))
-	c.Assert(err, Equals, datastore.ErrNoSuchEntity{})
+	c.Assert(err.Error(), Equals, expectedError.Error())
 }
 
 func (ft *FacadeUnitTest) Test_GetTenantIDForRootAppFailsForOtherDBError(c *C) {

--- a/facade/serviceconfig.go
+++ b/facade/serviceconfig.go
@@ -15,7 +15,6 @@ package facade
 
 import (
 	"errors"
-	"path"
 	"reflect"
 
 	log "github.com/Sirupsen/logrus"
@@ -161,20 +160,10 @@ func (f *Facade) DeleteServiceConfig(ctx datastore.Context, fileID string) error
 // getServicePath returns the tenantID and the full path of the service
 // TODO: update function to include deploymentID in the service path
 func (f *Facade) getServicePath(ctx datastore.Context, serviceID string) (tenantID string, servicePath string, err error) {
-	store := f.serviceStore
-	svc, err := store.Get(ctx, serviceID)
-	if err != nil {
-		glog.Errorf("Could not look up service %s: %s", serviceID, err)
-		return "", "", err
+	gs := func(id string) (service.Service, error) {
+		return f.getService(ctx, id)
 	}
-	if svc.ParentServiceID == "" {
-		return serviceID, "/" + serviceID, nil
-	}
-	tenantID, servicePath, err = f.getServicePath(ctx, svc.ParentServiceID)
-	if err != nil {
-		return "", "", err
-	}
-	return tenantID, path.Join(servicePath, serviceID), nil
+	return f.serviceCache.GetServicePath(serviceID, gs)
 }
 
 // updateServiceConfigs adds or updates configuration files.  If forceDelete is

--- a/facade/servicepath_cache.go
+++ b/facade/servicepath_cache.go
@@ -1,0 +1,153 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package facade
+
+import (
+	"path"
+	"strings"
+	"sync"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/control-center/serviced/domain/service"
+)
+
+type serviceCache struct {
+	mutex sync.RWMutex
+	paths map[string]servicePath
+}
+
+type servicePath struct {
+	serviceID   string
+	tenantID    string
+	parentID    string
+	servicePath string
+}
+
+func NewServiceCache() *serviceCache {
+	return &serviceCache{
+		mutex: sync.RWMutex{},
+		paths: make(map[string]servicePath),
+	}
+}
+
+// GetTenantID returns the tenant ID for the specified service from its cache. If the specified service
+// is not in the cache, it uses getServiceFunc to populate the cache (assuming serviceID really exists in the DB).
+func (sc *serviceCache) GetTenantID(serviceID string, getServiceFunc service.GetService) (string, error) {
+	if cachedSvc, found := sc.lookUpService(serviceID); found {
+		return cachedSvc.tenantID, nil
+	}
+
+	cachedSvc, err := sc.updateCache(serviceID, getServiceFunc)
+	if err != nil {
+		return "", err
+	}
+	return cachedSvc.tenantID, nil
+}
+
+// GetServicePath returns the tenant ID and service path for the specified service from the. It assumes that
+// the cache has already been populated by a previous call to serviceCache.GetTenantID.
+func (sc *serviceCache) GetServicePath(serviceID string, getServiceFunc service.GetService) (string, string, error) {
+	if cachedSvc, found := sc.lookUpService(serviceID); found {
+		return cachedSvc.tenantID, cachedSvc.servicePath, nil
+	}
+
+	cachedSvc, err := sc.updateCache(serviceID, getServiceFunc)
+	if err != nil {
+		return "", "", err
+	}
+	return cachedSvc.tenantID, cachedSvc.servicePath, nil
+}
+
+// RemoveIfParentChanged will remove all entries from the cache for this service and its children if the
+// specified service's parentID is different from the cached value.
+// Returns true if one or more entries was removed from the cache; false otherwise.
+func (sc *serviceCache) RemoveIfParentChanged(serviceID string, parentID string) bool {
+	cachedSvc, ok := sc.lookUpService(serviceID)
+	if !ok || cachedSvc.parentID == parentID {
+		return false
+	}
+
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+	for key, value := range sc.paths {
+		if strings.HasPrefix(value.servicePath, cachedSvc.servicePath) {
+			delete(sc.paths, key)
+		}
+	}
+	return true
+}
+
+// Reset clears the cache.
+func (sc *serviceCache) Reset() {
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+	sc.paths = make(map[string]servicePath)
+}
+
+func (sc *serviceCache) lookUpService(svcID string) (servicePath, bool) {
+	sc.mutex.RLock()
+	defer sc.mutex.RUnlock()
+	cachedSvc, found := sc.paths[svcID]
+	return cachedSvc, found
+}
+
+func (sc *serviceCache) updateCache(serviceID string, getServiceFunc service.GetService) (servicePath, error) {
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+
+	svcPaths := make([]servicePath, 0)
+	cachedSvc, err := sc.buildServicePath(serviceID, &svcPaths, getServiceFunc)
+	if err != nil {
+		return servicePath{}, err
+	}
+
+	for _, path := range svcPaths {
+		sc.paths[path.serviceID] = path
+	}
+	return cachedSvc, nil
+}
+
+func (sc *serviceCache) buildServicePath(serviceID string, svcPaths *[]servicePath, getServiceFunc service.GetService) (svcPath servicePath, err error) {
+	logger := plog.WithFields(log.Fields{
+		"serviceid": serviceID,
+	})
+
+	svc, err := getServiceFunc(serviceID)
+	if err != nil {
+		logger.WithError(err).Error("Could not find service")
+		return servicePath{}, err
+	}
+	if svc.ParentServiceID == "" {
+		svcPath = servicePath{
+			serviceID:   serviceID,
+			tenantID:    serviceID,
+			servicePath: "/" + serviceID,
+		}
+		*svcPaths = append(*svcPaths, svcPath)
+		return svcPath, nil
+	}
+
+	parent, err := sc.buildServicePath(svc.ParentServiceID, svcPaths, getServiceFunc)
+	if err != nil {
+		return servicePath{}, err
+	}
+
+	svcPath = servicePath{
+		serviceID:   svc.ID,
+		tenantID:    parent.tenantID,
+		parentID:    svc.ParentServiceID,
+		servicePath: path.Join(parent.servicePath, svc.ID),
+	}
+	*svcPaths = append(*svcPaths, svcPath)
+	return svcPath, nil
+}

--- a/facade/servicepath_cache_test.go
+++ b/facade/servicepath_cache_test.go
@@ -1,0 +1,448 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package facade
+
+import (
+	"fmt"
+
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain/service"
+	servicemocks "github.com/control-center/serviced/domain/service/mocks"
+	. "gopkg.in/check.v1"
+)
+
+var _ = Suite(&ServicePathCacheTest{})
+
+type ServicePathCacheTest struct {
+	cache        *serviceCache
+	serviceStore *servicemocks.Store
+	unusedCTX    datastore.Context
+}
+
+func (t *ServicePathCacheTest) SetUpTest(c *C) {
+	t.cache = NewServiceCache()
+	t.serviceStore = &servicemocks.Store{}
+}
+
+func (t *ServicePathCacheTest) TearDownTest(c *C) {
+	t.cache = nil
+	t.serviceStore = nil
+}
+
+func (t *ServicePathCacheTest) Test_GetTenantID_SeedsCacheForTenantService(c *C) {
+	tenantID := "mockTenantId"
+	expectedService := service.Service{ID: tenantID}
+	t.serviceStore.On("Get", t.unusedCTX, tenantID).Return(&expectedService, nil)
+
+	result, err := t.cache.GetTenantID(tenantID, t.getService)
+
+	c.Assert(result, Equals, tenantID)
+	c.Assert(err, IsNil)
+
+	// Verify the cache contents
+	expectedCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+	}
+	t.assertExpectedCacheEntries(c, expectedCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_GetTenantID_SeedsCacheForNestedServices(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	grandchildID := "mockGrandChildId"
+
+	tenant := service.Service{ID: tenantID}
+	t.serviceStore.On("Get", t.unusedCTX, tenantID).Return(&tenant, nil)
+
+	child := service.Service{ID: childID, ParentServiceID: tenantID}
+	t.serviceStore.On("Get", t.unusedCTX, childID).Return(&child, nil)
+
+	grandchild := service.Service{ID: grandchildID, ParentServiceID: childID}
+	t.serviceStore.On("Get", t.unusedCTX, grandchildID).Return(&grandchild, nil)
+
+	result, err := t.cache.GetTenantID(grandchildID, t.getService)
+
+	c.Assert(result, Equals, tenantID)
+	c.Assert(err, IsNil)
+
+	// Verify the cache contents
+	expectedCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID,
+		},
+		servicePath{
+			serviceID:   grandchildID,
+			parentID:    childID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID + "/" + grandchildID,
+		},
+	}
+	t.assertExpectedCacheEntries(c, expectedCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_GetTenantID_UsesCachedValues(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	grandchildID := "mockGrandChildId"
+
+	// Load the cache manually
+	initialCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID,
+		},
+		servicePath{
+			serviceID:   grandchildID,
+			parentID:    childID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID + "/" + grandchildID,
+		},
+	}
+	for _, expected := range initialCacheEntries {
+		t.cache.paths[expected.serviceID] = expected
+	}
+
+	// NOTE: Since no mock expectations are set, the test will fail if any calls to t.getService occur
+	result, err := t.cache.GetTenantID(grandchildID, t.getService)
+
+	c.Assert(result, Equals, tenantID)
+	c.Assert(err, IsNil)
+	t.assertExpectedCacheEntries(c, initialCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_GetTenantID_ReturnsDBError(c *C) {
+	tenantID := "mockTenantId"
+	expectedError := fmt.Errorf("fake DB error")
+	t.serviceStore.On("Get", t.unusedCTX, tenantID).Return(nil, expectedError)
+
+	result, err := t.cache.GetTenantID(tenantID, t.getService)
+
+	c.Assert(result, Equals, "")
+	c.Assert(err.Error(), Equals, expectedError.Error())
+}
+
+func (t *ServicePathCacheTest) Test_GetServicePath_SeedsCacheForTenantService(c *C) {
+	tenantID := "mockTenantId"
+	expectedPath := "/" + tenantID
+
+	expectedService := service.Service{ID: tenantID}
+	t.serviceStore.On("Get", t.unusedCTX, tenantID).Return(&expectedService, nil)
+
+	tenantResult, pathResult, err := t.cache.GetServicePath(tenantID, t.getService)
+
+	c.Assert(tenantResult, Equals, tenantID)
+	c.Assert(pathResult, Equals, expectedPath)
+	c.Assert(err, IsNil)
+
+	// Verify the cache contents
+	expectedCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+	}
+	t.assertExpectedCacheEntries(c, expectedCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_GetServicePath_SeedsCacheForNestedServices(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	grandchildID := "mockGrandChildId"
+	expectedPath := "/" + tenantID + "/" + childID + "/" + grandchildID
+
+	tenant := service.Service{ID: tenantID}
+	t.serviceStore.On("Get", t.unusedCTX, tenantID).Return(&tenant, nil)
+
+	child := service.Service{ID: childID, ParentServiceID: tenantID}
+	t.serviceStore.On("Get", t.unusedCTX, childID).Return(&child, nil)
+
+	grandchild := service.Service{ID: grandchildID, ParentServiceID: childID}
+	t.serviceStore.On("Get", t.unusedCTX, grandchildID).Return(&grandchild, nil)
+
+	tenantResult, pathResult, err := t.cache.GetServicePath(grandchildID, t.getService)
+
+	c.Assert(tenantResult, Equals, tenantID)
+	c.Assert(pathResult, Equals, expectedPath)
+	c.Assert(err, IsNil)
+
+	// Verify the cache contents
+	expectedCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID,
+		},
+		servicePath{
+			serviceID:   grandchildID,
+			parentID:    childID,
+			tenantID:    tenantID,
+			servicePath: expectedPath,
+		},
+	}
+	t.assertExpectedCacheEntries(c, expectedCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_GetServicePath_UsesCachedValues(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	grandchildID := "mockGrandChildId"
+	expectedPath := "/" + tenantID + "/" + childID + "/" + grandchildID
+
+	// Load the cache manually
+	initialCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID,
+		},
+		servicePath{
+			serviceID:   grandchildID,
+			parentID:    childID,
+			tenantID:    tenantID,
+			servicePath: expectedPath,
+		},
+	}
+	for _, expected := range initialCacheEntries {
+		t.cache.paths[expected.serviceID] = expected
+	}
+
+	// NOTE: Since no mock expectations are set, the test will fail if any calls to t.getService occur
+	tenantResult, pathResult, err := t.cache.GetServicePath(grandchildID, t.getService)
+
+	c.Assert(tenantResult, Equals, tenantID)
+	c.Assert(pathResult, Equals, expectedPath)
+	c.Assert(err, IsNil)
+	t.assertExpectedCacheEntries(c, initialCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_GetServicePath_ReturnsDBError(c *C) {
+	tenantID := "mockTenantId"
+	expectedError := fmt.Errorf("fake DB error")
+	t.serviceStore.On("Get", t.unusedCTX, tenantID).Return(nil, expectedError)
+
+	tenantResult, pathResult, err := t.cache.GetServicePath(tenantID, t.getService)
+
+	c.Assert(tenantResult, Equals, "")
+	c.Assert(pathResult, Equals, "")
+	c.Assert(err.Error(), Equals, expectedError.Error())
+}
+
+func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_OnEmptyCache(c *C) {
+	tenantID := "mockTenantId"
+	removed := t.cache.RemoveIfParentChanged(tenantID, "")
+
+	// Nothing should be removed, so the cache should be unchanged
+	c.Assert(removed, Equals, false)
+	t.assertExpectedCacheEntries(c, []servicePath{})
+}
+
+func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_OnCacheMiss(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	expectedPath := "/" + tenantID + "/" + childID
+	initialCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: expectedPath,
+		},
+	}
+	for _, expected := range initialCacheEntries {
+		t.cache.paths[expected.serviceID] = expected
+	}
+
+	uncachedServiceID := "something compleletly differennt"
+	removed := t.cache.RemoveIfParentChanged(uncachedServiceID, tenantID)
+
+	// Nothing should be removed, so the cache should be unchanged
+	c.Assert(removed, Equals, false)
+	t.assertExpectedCacheEntries(c, initialCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_CachedParentMatches(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	expectedPath := "/" + tenantID + "/" + childID
+	initialCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: expectedPath,
+		},
+	}
+	for _, expected := range initialCacheEntries {
+		t.cache.paths[expected.serviceID] = expected
+	}
+
+	removed := t.cache.RemoveIfParentChanged(childID, tenantID)
+
+	// Nothing should be removed, so the cache should be unchanged
+	c.Assert(removed, Equals, false)
+	t.assertExpectedCacheEntries(c, initialCacheEntries)
+}
+
+func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_CachedParentDifferent(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	initialCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID,
+		},
+	}
+	for _, expected := range initialCacheEntries {
+		t.cache.paths[expected.serviceID] = expected
+	}
+
+	removed := t.cache.RemoveIfParentChanged(childID, "newParentId")
+
+	// The child should be removed
+	c.Assert(removed, Equals, true)
+	t.assertExpectedCacheEntries(c, []servicePath{initialCacheEntries[0]})
+}
+
+func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_RemoveMultipleEntries(c *C) {
+	tenantID := "mockTenantId"
+	childID := "mockChildId"
+	grandchildID1 := "mockGrandChildId1"
+	grandchildID2 := "mockGrandChildId2"
+
+	// Load the cache manually
+	initialCacheEntries := []servicePath{
+		servicePath{
+			serviceID:   tenantID,
+			parentID:    "",
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID,
+		},
+		servicePath{
+			serviceID:   childID,
+			parentID:    tenantID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID,
+		},
+		servicePath{
+			serviceID:   grandchildID1,
+			parentID:    childID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID + "/" + grandchildID1,
+		},
+		servicePath{
+			serviceID:   grandchildID2,
+			parentID:    childID,
+			tenantID:    tenantID,
+			servicePath: "/" + tenantID + "/" + childID + "/" + grandchildID2,
+		},
+	}
+	for _, expected := range initialCacheEntries {
+		t.cache.paths[expected.serviceID] = expected
+	}
+
+	removed := t.cache.RemoveIfParentChanged(childID, "newParentId")
+
+	// The item and its descendants should be removed
+	c.Assert(removed, Equals, true)
+	t.assertExpectedCacheEntries(c, []servicePath{initialCacheEntries[0]})
+}
+
+func (t *ServicePathCacheTest) Test_Reset_EmptyCache(c *C) {
+	// should start empty
+	c.Assert(len(t.cache.paths), Equals, 0)
+
+	t.cache.Reset()
+
+	// should start still be empty
+	c.Assert(len(t.cache.paths), Equals, 0)
+}
+
+func (t *ServicePathCacheTest) getService(serviceID string) (service.Service, error) {
+	svc, err := t.serviceStore.Get(t.unusedCTX, serviceID)
+	if err != nil {
+		return service.Service{}, err
+	}
+	return *svc, nil
+}
+
+func (t *ServicePathCacheTest) assertExpectedCacheEntries(c *C, expectedCacheEntries []servicePath) {
+	c.Assert(len(t.cache.paths), Equals, len(expectedCacheEntries))
+	for _, expected := range expectedCacheEntries {
+		actual, ok := t.cache.paths[expected.serviceID]
+		c.Assert(ok, Equals, true)
+		c.Assert(actual.tenantID, Equals, expected.tenantID)
+		c.Assert(actual.parentID, Equals, expected.parentID)
+		c.Assert(actual.servicePath, Equals, expected.servicePath)
+	}
+}


### PR DESCRIPTION
This is a redo of #3033 because I bungled a merge/rebase in the branch for 3033.
----
The Facade tier already had code to cache tenantIDs for a given serviceID, but each time a service was scheduled, it was computing the service path for every config file on every service.  This proved to be very timing consuming with 100s of services.

This code replaces the tenantID cache with a cache of structs that contain tenantID and servicePath.  This change also required an additional call to remove cache entries when a service is removed or it's parent has changed.

Also, since we don't put the entire Service object in ZK any longer, I removed the call to fillServiceConfigs for any scheduleService operation.