### PR TITLE
ZEN-24721: Zope shells cause zope/0 healthchecks to fail

### DIFF
--- a/container/controller.go
+++ b/container/controller.go
@@ -601,7 +601,11 @@ func (c *Controller) Run() (err error) {
 	go c.reapZombies(rpcDead)
 	healthExit := make(chan struct{})
 	defer close(healthExit)
-	c.kickOffHealthChecks(healthExit)
+
+	if os.Getenv("SERVICED_IS_SERVICE_SHELL") != "true" {
+		c.kickOffHealthChecks(healthExit)
+	}
+
 	doRegisterEndpoints := true
 	exited := false
 


### PR DESCRIPTION
this is port from: https://github.com/control-center/serviced/pull/2919

demo in https://jira.zenoss.com/browse/ZEN-24721