### PR TITLE
Don't authenticate Agent.BuildHost call

### DIFF
--- a/rpc/rpcutils/authcodec.go
+++ b/rpc/rpcutils/authcodec.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	// RPC Calls that do not require authentication or who handle authentication separately:
-	NonAuthenticatingCalls = []string{"Master.AuthenticateHost"}
+	NonAuthenticatingCalls = []string{"Master.AuthenticateHost", "Agent.BuildHost"}
 	// RPC calls that do not require admin access:
 	NonAdminRequiredCalls = []string{}
 	endian                = binary.BigEndian


### PR DESCRIPTION
Fixes CC-2714

Users are unable to add remote hosts if we require the host to already be authenticated.