### PR TITLE
Refresh authentication token when delegate keys change.

### DIFF
--- a/auth/localkeys.go
+++ b/auth/localkeys.go
@@ -315,3 +315,12 @@ func updateDelegateKeys(pub crypto.PublicKey, priv crypto.PrivateKey) {
 	dKeyCond.L.Unlock()
 	dKeyCond.Broadcast()
 }
+
+func delegateKeysChanged() <-chan interface{} {
+	ch := make(chan interface{})
+	go func() {
+		defer close(ch)
+		dKeyCond.Wait()
+	}()
+	return ch
+}

--- a/auth/localkeys.go
+++ b/auth/localkeys.go
@@ -320,6 +320,8 @@ func delegateKeysChanged() <-chan interface{} {
 	ch := make(chan interface{})
 	go func() {
 		defer close(ch)
+		dKeyCond.L.Lock()
+		defer dKeyCond.L.Unlock()
 		dKeyCond.Wait()
 	}()
 	return ch

--- a/auth/localkeys.go
+++ b/auth/localkeys.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/control-center/serviced/utils"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -34,7 +35,7 @@ var (
 	delegateKeys HostKeys
 	masterKeys   MasterKeys
 	mKeyLock     sync.RWMutex
-	dKeyCond     = &sync.Cond{L: &sync.Mutex{}}
+	dKeyCond     = utils.NewChannelCond()
 )
 
 type HostKeys struct {
@@ -82,8 +83,8 @@ func (m *MasterKeys) Verify(message, signature []byte) error {
 // SignAsDelegate signs the given message with the private key local
 // to the delegate running this process.
 func SignAsDelegate(message []byte) ([]byte, error) {
-	dKeyCond.L.Lock()
-	defer dKeyCond.L.Unlock()
+	dKeyCond.RLock()
+	defer dKeyCond.RUnlock()
 	if delegateKeys.localPrivate == nil {
 		return nil, ErrNoPrivateKey
 	}
@@ -108,8 +109,8 @@ func VerifyMasterSignature(message, signature []byte) error {
 		return err
 	}
 
-	dKeyCond.L.Lock()
-	defer dKeyCond.L.Unlock()
+	dKeyCond.RLock()
+	defer dKeyCond.RUnlock()
 	if delegateKeys.masterPublic == nil {
 		return ErrNoPublicKey
 	}
@@ -135,8 +136,8 @@ func GetMasterPublicKey() (crypto.PublicKey, error) {
 		return key, err
 	}
 
-	dKeyCond.L.Lock()
-	defer dKeyCond.L.Unlock()
+	dKeyCond.RLock()
+	defer dKeyCond.RUnlock()
 	if delegateKeys.masterPublic == nil {
 		return nil, ErrNoPublicKey
 	}
@@ -200,10 +201,10 @@ func CreateOrLoadMasterKeys(filename string) error {
 		return err
 	}
 
-	return LoadMasterKeyFile(filename)	
+	return LoadMasterKeyFile(filename)
 }
 
-// LoadMasterKeyFile will load the master keys from disk if 
+// LoadMasterKeyFile will load the master keys from disk if
 //  the file exists.  If the file does not exist, it will
 //  return an error
 func LoadMasterKeyFile(filename string) error {
@@ -271,17 +272,27 @@ func ClearKeys() {
 }
 
 // WaitForDelegateKeys blocks until delegate keys are defined.
-func WaitForDelegateKeys() {
-	dKeyCond.L.Lock()
-	defer dKeyCond.L.Unlock()
-	for delegateKeys.localPrivate == nil || delegateKeys.masterPublic == nil {
-		dKeyCond.Wait()
-	}
+func WaitForDelegateKeys(cancel <-chan interface{}) <-chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		for delegateKeys.localPrivate == nil || delegateKeys.masterPublic == nil {
+			select {
+			case <-dKeyCond.Wait():
+			case <-cancel: // Receive from nil channel never returns, so this is fine
+			}
+		}
+		close(ch)
+	}()
+	return ch
+}
+
+func NotifyOnKeyChange() <-chan struct{} {
+	return dKeyCond.Wait()
 }
 
 // WatchDelegateKeyFile watches the delegate key file on the filesystem and
 // updates the internal delegate keys when changes are detected.
-func WatchDelegateKeyFile(filename string, cancel chan interface{}) error {
+func WatchDelegateKeyFile(filename string, cancel <-chan interface{}) error {
 	filename = filepath.Clean(filename)
 
 	log := log.WithFields(logrus.Fields{
@@ -310,19 +321,8 @@ func WatchDelegateKeyFile(filename string, cancel chan interface{}) error {
 }
 
 func updateDelegateKeys(pub crypto.PublicKey, priv crypto.PrivateKey) {
-	dKeyCond.L.Lock()
+	dKeyCond.Lock()
 	delegateKeys = HostKeys{pub, priv}
-	dKeyCond.L.Unlock()
+	dKeyCond.Unlock()
 	dKeyCond.Broadcast()
-}
-
-func delegateKeysChanged() <-chan interface{} {
-	ch := make(chan interface{})
-	go func() {
-		defer close(ch)
-		dKeyCond.L.Lock()
-		defer dKeyCond.L.Unlock()
-		dKeyCond.Wait()
-	}()
-	return ch
 }

--- a/auth/mux.go
+++ b/auth/mux.go
@@ -40,7 +40,8 @@ var (
 
 func BuildMuxHeader(address []byte) ([]byte, error) {
 	// get current host token
-	return BuildAuthMuxHeader(address, AuthToken())
+	token := <-AuthToken(nil)
+	return BuildAuthMuxHeader(address, token)
 }
 
 func BuildAuthMuxHeader(address []byte, token string) ([]byte, error) {

--- a/auth/mux.go
+++ b/auth/mux.go
@@ -38,12 +38,6 @@ var (
 	ErrBadMuxHeader  = errors.New("Bad mux header")
 )
 
-func BuildMuxHeader(address []byte) ([]byte, error) {
-	// get current host token
-	token := <-AuthToken(nil)
-	return BuildAuthMuxHeader(address, token)
-}
-
 func BuildAuthMuxHeader(address []byte, token string) ([]byte, error) {
 	if len(address) != ADDRESS_BYTES {
 		return nil, ErrBadMuxAddress

--- a/auth/token.go
+++ b/auth/token.go
@@ -15,10 +15,10 @@ package auth
 
 import (
 	"io/ioutil"
-	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/control-center/serviced/utils"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -37,7 +37,7 @@ var (
 	currentIdentity Identity
 	zerotime        time.Time
 	expiration      time.Time
-	cond            = &sync.Cond{L: &sync.Mutex{}}
+	cond            = utils.NewChannelCond()
 )
 
 // TokenFunc is a function that can return an authentication token and its
@@ -58,18 +58,27 @@ func RefreshToken(f TokenFunc, filename string) (int64, error) {
 
 // AuthToken returns an unexpired auth token, blocking if necessary until
 // authenticated
-func AuthToken() string {
-	cond.L.Lock()
-	defer cond.L.Unlock()
-	for expired() {
-		cond.Wait()
-	}
-	return currentToken
+func AuthToken(cancel <-chan interface{}) <-chan string {
+	ch := make(chan string)
+	go func() {
+		defer close(ch)
+		for expired() {
+			select {
+			case <-cond.Wait():
+			case <-cancel:
+				return
+			}
+		}
+		ch <- currentToken
+	}()
+	return ch
 }
 
 // A non-blocking call to get an unexpired auth token.  Returns an error
 //  If no token exists or if the token is expired
 func AuthTokenNonBlocking() (string, error) {
+	cond.RLock()
+	defer cond.RUnlock()
 	if currentToken == "" {
 		return "", ErrNotAuthenticated
 	}
@@ -105,8 +114,8 @@ func MasterToken() (string, error) {
 // CurrentIdentity returns the identity represented by the currently-live token,
 // or nil if the token is not yet available
 func CurrentIdentity() Identity {
-	cond.L.Lock()
-	defer cond.L.Unlock()
+	cond.RLock()
+	defer cond.RUnlock()
 	return currentIdentity
 }
 
@@ -171,11 +180,11 @@ func WatchTokenFile(tokenfile string, done <-chan interface{}) error {
 
 // ClearToken wipes the current state
 func ClearToken() {
-	cond.L.Lock()
+	cond.Lock()
 	currentToken = ""
 	currentIdentity = nil
 	expiration = zerotime
-	cond.L.Unlock()
+	cond.Unlock()
 	cond.Broadcast()
 }
 
@@ -204,14 +213,14 @@ func updateToken(token string, expires time.Time, filename string) {
 		log.WithField("timeout", "1s").Error("No delegate keys were available to parse the token within the timeout")
 		return
 	}
-	cond.L.Lock()
+	cond.Lock()
 	currentToken = token
 	currentIdentity = getIdentityFromToken(token)
 	expiration = expires
 	if filename != "" {
 		ioutil.WriteFile(filename, []byte(token), 0660)
 	}
-	cond.L.Unlock()
+	cond.Unlock()
 	cond.Broadcast()
 }
 

--- a/auth/token.go
+++ b/auth/token.go
@@ -115,6 +115,7 @@ func CurrentIdentity() Identity {
 // setting the result as the current live token, until the done channel is
 // closed.
 func TokenLoop(f TokenFunc, tokenfile string, done <-chan interface{}) {
+
 	for {
 		expires, err := RefreshToken(f, tokenfile)
 		if err != nil {
@@ -133,6 +134,7 @@ func TokenLoop(f TokenFunc, tokenfile string, done <-chan interface{}) {
 		case <-done:
 			return
 		case <-time.After(refresh):
+		case <-delegateKeysChanged():
 		}
 	}
 }

--- a/auth/token.go
+++ b/auth/token.go
@@ -52,7 +52,7 @@ func RefreshToken(f TokenFunc, filename string) (int64, error) {
 		return 0, err
 	}
 	updateToken(token, time.Unix(expires, 0), filename)
-	log.WithField("expiration", expires).Debug("Received new authentication token")
+	log.WithField("expiration", expires).Info("Received new authentication token")
 	return expires, err
 }
 

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -651,7 +651,11 @@ func (d *daemon) startAgent() error {
 
 	go func() {
 		// Wait for delegate keys to exist before trying to authenticate
-		auth.WaitForDelegateKeys()
+		select {
+		case <-auth.WaitForDelegateKeys(d.shutdown):
+		case <-d.shutdown:
+			return
+		}
 
 		// Authenticate against the master
 		getToken := func() (string, int64, error) {

--- a/makefile
+++ b/makefile
@@ -160,7 +160,7 @@ FORCE:
 serviced: $(GO)
 serviced: FORCE
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS}
-	make govet
+	# make govet
 	if [ -n "$(GOBIN)" ]; then cp serviced $(GOBIN)/serviced; fi
 
 serviced-controller: $(GO)

--- a/makefile
+++ b/makefile
@@ -160,7 +160,7 @@ FORCE:
 serviced: $(GO)
 serviced: FORCE
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS}
-	# make govet
+	make govet
 	if [ -n "$(GOBIN)" ]; then cp serviced $(GOBIN)/serviced; fi
 
 serviced-controller: $(GO)

--- a/proxy/mux_test.go
+++ b/proxy/mux_test.go
@@ -142,7 +142,11 @@ func TestTCPMux(t *testing.T) {
 	if err != nil {
 		t.Fail()
 	}
-	header, err = auth.BuildMuxHeader(header)
+	token, err := auth.AuthTokenNonBlocking()
+	if err != nil {
+		t.Fail()
+	}
+	header, err = auth.BuildAuthMuxHeader(header, token)
 	if err != nil {
 		t.Fail()
 	}

--- a/utils/cond.go
+++ b/utils/cond.go
@@ -1,0 +1,46 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "sync"
+
+// ChannelCond provides functionality similar to sync.Cond, but is backed by
+// channels instead of a mutex, allowing it to support timeouts and
+// cancellation.
+type ChannelCond struct {
+	c  chan struct{}
+	mu *sync.RWMutex
+}
+
+// Broadcast notifies all waiting goroutines that this condition has been
+// satisfied
+func (c *ChannelCond) Broadcast() {
+	var old chan struct{}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.c, old = make(chan struct{}), c.c
+	close(old)
+}
+
+// Wait returns a channel that will close when the condition is satisfied.
+func (c *ChannelCond) Wait() <-chan struct{} {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.c
+}
+
+// NewChannelCond returns a new ChannelCond
+func NewChannelCond() *ChannelCond {
+	return &ChannelCond{make(chan struct{}), &sync.RWMutex{}}
+}

--- a/utils/cond.go
+++ b/utils/cond.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package utils
 
 import "sync"
@@ -19,28 +21,28 @@ import "sync"
 // channels instead of a mutex, allowing it to support timeouts and
 // cancellation.
 type ChannelCond struct {
-	c  chan struct{}
-	mu *sync.RWMutex
+	sync.RWMutex
+	c chan struct{}
 }
 
 // Broadcast notifies all waiting goroutines that this condition has been
 // satisfied
 func (c *ChannelCond) Broadcast() {
 	var old chan struct{}
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.Lock()
+	defer c.Unlock()
 	c.c, old = make(chan struct{}), c.c
 	close(old)
 }
 
 // Wait returns a channel that will close when the condition is satisfied.
 func (c *ChannelCond) Wait() <-chan struct{} {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.c
 }
 
 // NewChannelCond returns a new ChannelCond
 func NewChannelCond() *ChannelCond {
-	return &ChannelCond{make(chan struct{}), &sync.RWMutex{}}
+	return &ChannelCond{c: make(chan struct{})}
 }

--- a/utils/cond.go
+++ b/utils/cond.go
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build unit
-
 package utils
 
 import "sync"

--- a/utils/cond_test.go
+++ b/utils/cond_test.go
@@ -44,7 +44,7 @@ func assertAllOpen(c *C, chans ...<-chan struct{}) {
 	var wg sync.WaitGroup
 	for _, ch := range chans {
 		wg.Add(1)
-		go func() {
+		go func(ch <-chan struct{}) {
 			defer wg.Done()
 			select {
 			case <-ch:
@@ -52,7 +52,7 @@ func assertAllOpen(c *C, chans ...<-chan struct{}) {
 			case <-time.After(5 * time.Millisecond):
 
 			}
-		}()
+		}(ch)
 	}
 	wg.Wait()
 }

--- a/utils/cond_test.go
+++ b/utils/cond_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package utils_test
 
 import (

--- a/utils/cond_test.go
+++ b/utils/cond_test.go
@@ -15,14 +15,11 @@ package utils_test
 
 import (
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/control-center/serviced/utils"
 	. "gopkg.in/check.v1"
 )
-
-func TestChannelCond(t *testing.T) { TestingT(t) }
 
 type ChannelCondSuite struct{}
 

--- a/utils/cond_test.go
+++ b/utils/cond_test.go
@@ -1,0 +1,50 @@
+// Copyright 2015 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/control-center/serviced/utils"
+	. "gopkg.in/check.v1"
+)
+
+func TestChannelCond(t *testing.T) { TestingT(t) }
+
+type ChannelCondSuite struct{}
+
+var (
+	_ = Suite(&ChannelCondSuite{})
+)
+
+func (s *ChannelCondSuite) TestChannelCond(c *C) {
+	cond := utils.NewChannelCond()
+	x := make([]bool, 1)
+
+	ch := cond.Wait()
+
+	go func() {
+		<-ch
+		fmt.Println("HJIHIHI")
+		x[0] = true
+	}()
+
+	time.Sleep(1 * time.Second)
+	c.Assert(x[0], Equals, false)
+	cond.Broadcast()
+	time.Sleep(1 * time.Second)
+	c.Assert(x[0], Equals, true)
+}


### PR DESCRIPTION
This also modifies the auth code to allow the functions that block waiting for a token or keys to be cancellable.