### PR TITLE
Optimize registry sync with Zookeeper

### DIFF
--- a/zzk/registry/registry.go
+++ b/zzk/registry/registry.go
@@ -423,6 +423,7 @@ func buildVhostCache(conn client.Connection, tx client.Transaction) error {
 				ServiceID: vhost.ServiceID,
 			}
 			vhostCache[entry.ServiceID] = append(vhostCache[entry.ServiceID], entry)
+			addrLogger.Debug("Creating virtual address subdomain")
 		}
 	}
 
@@ -496,6 +497,7 @@ func buildPublicPortCache(conn client.Connection, tx client.Transaction) error {
 				ServiceID: pub.ServiceID,
 			}
 			publicPortCache[entry.ServiceID] = append(publicPortCache[entry.ServiceID], entry)
+			addrLogger.Debug("Creating public port address")
 		}
 	}
 

--- a/zzk/registry/registry_test.go
+++ b/zzk/registry/registry_test.go
@@ -18,6 +18,7 @@ package registry_test
 import (
 	"path"
 
+	"github.com/control-center/serviced/coordinator/client"
 	"github.com/control-center/serviced/zzk"
 	. "github.com/control-center/serviced/zzk/registry"
 	. "gopkg.in/check.v1"
@@ -28,39 +29,56 @@ func (t *ZZKTest) TestSyncRegistry(c *C) {
 	c.Assert(err, IsNil)
 
 	// test create
-	pub1Key := PublicPortKey{HostID: "master", PortAddress: ":2181"}
-	pub1 := PublicPort{
+	pub1aKey := PublicPortKey{HostID: "master", PortAddress: ":2181"}
+	pub1a := PublicPort{
 		TenantID:    "tenantid",
-		Application: "app1",
+		Application: "app1a",
 		ServiceID:   "serviceid1",
 		Protocol:    "http",
 		UseTLS:      false,
 	}
-	pubs1 := map[PublicPortKey]PublicPort{pub1Key: pub1}
+	pubs1 := map[PublicPortKey]PublicPort{pub1aKey: pub1a}
 
-	vhost1Key := VHostKey{HostID: "master", Subdomain: "test1"}
-	vhost1 := VHost{
+	vhost1aKey := VHostKey{HostID: "master", Subdomain: "test1a"}
+	vhost1a := VHost{
 		TenantID:    "tenantid",
-		Application: "app1",
+		Application: "app1a",
 		ServiceID:   "serviceid1",
 	}
-	vhosts1 := map[VHostKey]VHost{vhost1Key: vhost1}
+	vhosts1 := map[VHostKey]VHost{vhost1aKey: vhost1a}
 
-	err = SyncServiceRegistry(conn, "serviceid1", pubs1, vhosts1)
+	c.Logf("Create initial registry entries")
+	err = SyncServiceRegistry(conn, "serviceid1", copyPublicPortMap(pubs1), copyVHostMap(vhosts1))
 	c.Assert(err, IsNil)
 
-	actualpub := &PublicPort{}
-	err = conn.Get("/net/pub/master/:2181", actualpub)
-	c.Assert(err, IsNil)
-	actualpub.SetVersion(nil)
-	c.Check(*actualpub, DeepEquals, pub1)
+	t.assertRegistryContents(c, conn, pubs1, vhosts1)
 
-	actualvhost := &VHost{}
-	err = conn.Get("/net/vhost/master/test1", actualvhost)
-	c.Assert(err, IsNil)
-	actualvhost.SetVersion(nil)
-	c.Check(*actualvhost, DeepEquals, vhost1)
+	// test create/update for a service that's already cached
+	pub1bKey := PublicPortKey{HostID: "master", PortAddress: ":2182"}
+	pub1b := PublicPort{
+		TenantID:    "tenantid",
+		Application: "app1b",
+		ServiceID:   "serviceid1",
+		Protocol:    "http",
+		UseTLS:      false,
+	}
+	pubs1 = map[PublicPortKey]PublicPort{pub1aKey: pub1a, pub1bKey: pub1b}
 
+	vhost1bKey := VHostKey{HostID: "master", Subdomain: "test1b"}
+	vhost1b := VHost{
+		TenantID:    "tenantid",
+		Application: "app1b",
+		ServiceID:   "serviceid1",
+	}
+	vhosts1 = map[VHostKey]VHost{vhost1aKey: vhost1a, vhost1bKey: vhost1b}
+
+	c.Logf("Update/add registry entries for an existing service")
+	err = SyncServiceRegistry(conn, "serviceid1", copyPublicPortMap(pubs1), copyVHostMap(vhosts1))
+	c.Assert(err, IsNil)
+
+	t.assertRegistryContents(c, conn, pubs1, vhosts1)
+
+	// Create additional entries for a new service, "serviceid2"
 	pub2Key := PublicPortKey{HostID: "master", PortAddress: ":22181"}
 	pub2 := PublicPort{
 		TenantID:    "tenantid",
@@ -79,98 +97,111 @@ func (t *ZZKTest) TestSyncRegistry(c *C) {
 	}
 	vhosts2 := map[VHostKey]VHost{vhost2Key: vhost2}
 
-	err = SyncServiceRegistry(conn, "serviceid2", pubs2, vhosts2)
+	c.Logf("Create additional registry entries")
+	err = SyncServiceRegistry(conn, "serviceid2", copyPublicPortMap(pubs2), copyVHostMap(vhosts2))
 	c.Assert(err, IsNil)
 
-	actualpub = &PublicPort{}
-	err = conn.Get("/net/pub/master/:2181", actualpub)
-	c.Assert(err, IsNil)
-	actualpub.SetVersion(nil)
-	c.Check(*actualpub, DeepEquals, pub1)
-
-	actualvhost = &VHost{}
-	err = conn.Get("/net/vhost/master/test1", actualvhost)
-	c.Assert(err, IsNil)
-	actualvhost.SetVersion(nil)
-	c.Check(*actualvhost, DeepEquals, vhost1)
-
-	actualpub = &PublicPort{}
-	err = conn.Get("/net/pub/master/:22181", actualpub)
-	c.Assert(err, IsNil)
-	actualpub.SetVersion(nil)
-	c.Check(*actualpub, DeepEquals, pub2)
-
-	actualvhost = &VHost{}
-	err = conn.Get("/net/vhost/master/test2", actualvhost)
-	c.Assert(err, IsNil)
-	actualvhost.SetVersion(nil)
-	c.Check(*actualvhost, DeepEquals, vhost2)
+	t.assertRegistryContents(c, conn, pubs1, vhosts1)
+	t.assertRegistryContents(c, conn, pubs2, vhosts2)
 
 	// test update
-	pub1Key = PublicPortKey{HostID: "master", PortAddress: ":2181"}
-	pub1 = PublicPort{
+	pub1aKey = PublicPortKey{HostID: "master", PortAddress: ":2181"}
+	pub1a = PublicPort{
 		TenantID:    "tenantid",
 		Application: "app1",
 		ServiceID:   "serviceid1",
 		Protocol:    "",
 		UseTLS:      true,
 	}
-	pubs1 = map[PublicPortKey]PublicPort{pub1Key: pub1}
+	pubs1 = map[PublicPortKey]PublicPort{pub1aKey: pub1a}
 
-	vhost1Key = VHostKey{HostID: "master", Subdomain: "test1"}
-	vhost1 = VHost{
+	vhost1aKey = VHostKey{HostID: "master", Subdomain: "test1a"}
+	vhost1a = VHost{
 		TenantID:    "tenantid",
-		Application: "app1",
+		Application: "app1a",
 		ServiceID:   "serviceid1",
 	}
-	vhosts1 = map[VHostKey]VHost{vhost1Key: vhost1}
+	vhosts1 = map[VHostKey]VHost{vhost1aKey: vhost1a}
 
-	err = SyncServiceRegistry(conn, "serviceid1", pubs1, vhosts1)
+	c.Logf("Update selected registry entries")
+	err = SyncServiceRegistry(conn, "serviceid1", copyPublicPortMap(pubs1), copyVHostMap(vhosts1))
 	c.Assert(err, IsNil)
 
-	actualpub = &PublicPort{}
-	err = conn.Get("/net/pub/master/:2181", actualpub)
-	c.Assert(err, IsNil)
-	actualpub.SetVersion(nil)
-	c.Check(*actualpub, DeepEquals, pub1)
+	t.assertRegistryContents(c, conn, pubs1, vhosts1)
+	t.assertRegistryContents(c, conn, pubs2, vhosts2)
 
-	actualvhost = &VHost{}
-	err = conn.Get("/net/vhost/master/test1", actualvhost)
+	// test delete some things for one service
+	c.Logf("Delete some registry entries")
+	err = SyncServiceRegistry(conn, "serviceid1", copyPublicPortMap(pubs1), copyVHostMap(vhosts1))
 	c.Assert(err, IsNil)
-	actualvhost.SetVersion(nil)
-	c.Check(*actualvhost, DeepEquals, vhost1)
 
-	actualpub = &PublicPort{}
-	err = conn.Get("/net/pub/master/:22181", actualpub)
+	t.assertRegistryContents(c, conn, pubs1, vhosts1)		// '1a' entries for 'serviceid1' remain unchanged
+	t.assertRegistryContents(c, conn, pubs2, vhosts2)		// all entries for 'serviceid2' remain unchanged
+
+	// '1b' entries for 'serviceid1' were removed.
+	ok, err := conn.Exists(path.Join("/net/pub", pub1bKey.HostID, pub1bKey.PortAddress))
 	c.Assert(err, IsNil)
-	actualpub.SetVersion(nil)
-	c.Check(*actualpub, DeepEquals, pub2)
+	c.Check(ok, Equals, false)
 
-	actualvhost = &VHost{}
-	err = conn.Get("/net/vhost/master/test2", actualvhost)
+	ok, err = conn.Exists(path.Join("/net/vhost", vhost1bKey.HostID, vhost1bKey.Subdomain))
 	c.Assert(err, IsNil)
-	actualvhost.SetVersion(nil)
-	c.Check(*actualvhost, DeepEquals, vhost2)
+	c.Check(ok, Equals, false)
 
-	// test delete
+
+	// test delete everything for one service
+	c.Logf("Delete all registry entries")
 	err = SyncServiceRegistry(conn, "serviceid2", make(map[PublicPortKey]PublicPort), make(map[VHostKey]VHost))
 	c.Assert(err, IsNil)
 
-	actualpub = &PublicPort{}
-	err = conn.Get("/net/pub/master/:2181", actualpub)
-	actualpub.SetVersion(nil)
-	c.Check(*actualpub, DeepEquals, pub1)
+	t.assertRegistryContents(c, conn, pubs1, vhosts1)		// entries for 'servicedid1' remain unchanged
 
-	actualvhost = &VHost{}
-	err = conn.Get("/net/vhost/master/test1", actualvhost)
-	actualvhost.SetVersion(nil)
-	c.Check(*actualvhost, DeepEquals, vhost1)
-
-	ok, err := conn.Exists(path.Join("/net/pub", pub2Key.HostID, pub2Key.PortAddress))
+	ok, err = conn.Exists(path.Join("/net/pub", pub2Key.HostID, pub2Key.PortAddress))
 	c.Assert(err, IsNil)
 	c.Check(ok, Equals, false)
 
 	ok, err = conn.Exists(path.Join("/net/vhost", vhost2Key.HostID, vhost2Key.Subdomain))
 	c.Assert(err, IsNil)
 	c.Check(ok, Equals, false)
+}
+
+func (t *ZZKTest) assertRegistryContents(c *C, conn client.Connection, pubs map[PublicPortKey]PublicPort, vhosts map[VHostKey]VHost) {
+	for portKey, expectedPort := range pubs {
+		expectedPath := path.Join("/net/pub", portKey.HostID, portKey.PortAddress)
+		c.Logf("\tChecking expected path %s", expectedPath)
+
+		actualpub := &PublicPort{}
+		err := conn.Get(expectedPath, actualpub)
+		c.Assert(err, IsNil)
+		actualpub.SetVersion(nil)
+		c.Check(*actualpub, DeepEquals, expectedPort)
+	}
+
+	for vhostKey, expectedVhost := range vhosts {
+		expectedPath :=  path.Join("/net/vhost", vhostKey.HostID, vhostKey.Subdomain)
+		c.Logf("\tChecking expected path %s", expectedPath)
+
+		actualvhost := &VHost{}
+		err := conn.Get(expectedPath, actualvhost)
+		c.Assert(err, IsNil)
+		actualvhost.SetVersion(nil)
+		c.Check(*actualvhost, DeepEquals, expectedVhost)
+	}
+}
+
+// SyncServiceRegistry modifies the input map, so the test uses this method to keep a copy of the original inputs
+func copyPublicPortMap(src map[PublicPortKey]PublicPort) map[PublicPortKey]PublicPort {
+	target := make(map[PublicPortKey]PublicPort)
+	for key, value := range src {
+		target[key] = value
+	}
+	return target
+}
+
+// SyncServiceRegistry modifies the input map, so the test uses this method to keep a copy of the original inputs
+func copyVHostMap(src map[VHostKey]VHost) map[VHostKey]VHost {
+	target := make(map[VHostKey]VHost)
+	for key, value := range src {
+		target[key] = value
+	}
+	return target
 }


### PR DESCRIPTION
In timing StartService, we found approximately 25% of time was spent in `SyncServiceRegistry` in `zzk/registry/registry.go`.  That find was true for ~177 or ~326 services even though the number of public port addresses and vhosts was constant in both cases (0 and 3 respectively).

This change caches data by service ID so that each schedule-service operation does not have to examine the ZK namespace if there was nothing previously cached for a given serviceID. 

A major assumption here is that only the master can add/chg/delete these entries in zookeeper.