### PR TITLE
force read to fill the buffer

### DIFF
--- a/auth/mux.go
+++ b/auth/mux.go
@@ -16,6 +16,7 @@ package auth
 import (
 	"bytes"
 	"errors"
+	"io"
 	"net"
 )
 
@@ -124,14 +125,14 @@ func ExtractMuxHeader(rawHeader []byte) ([]byte, Identity, error) {
 func ReadMuxHeader(conn net.Conn) ([]byte, error) {
 	// Read token Length
 	tokenLenBuff := make([]byte, TOKEN_LEN_BYTES)
-	_, err := conn.Read(tokenLenBuff)
+	_, err := io.ReadFull(conn, tokenLenBuff)
 	if err != nil {
 		return nil, err
 	}
 	tokenLen := endian.Uint32(tokenLenBuff)
 	// Read rest of the header
 	remainderBuff := make([]byte, tokenLen+ADDRESS_BYTES+SIGNATURE_BYTES)
-	_, err = conn.Read(remainderBuff)
+	_, err = io.ReadFull(conn, remainderBuff)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
conn.Read has an internal buffer read limit, so we need to call io.ReadFull to make sure it fills the byte buffer before returning.