### PR TITLE
cache public endpoints in facade to optimize interactions with ZK

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -946,8 +946,6 @@ func initMetricsClient() *metrics.Client {
 func (d *daemon) initFacade() *facade.Facade {
 	options := config.GetOptions()
 	f := facade.New()
-	zzk := facade.GetFacadeZZK(f)
-	f.SetZZK(zzk)
 	index := registry.NewRegistryIndexClient(f)
 	dfs := dfs.NewDistributedFilesystem(d.docker, index, d.reg, d.disk, d.net, time.Duration(options.MaxDFSTimeout)*time.Second)
 	dfs.SetTmp(os.Getenv("TMP"))

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -52,6 +52,7 @@ func New() *Facade {
 		templateStore: servicetemplate.NewStore(),
 		userStore:     user.NewStore(),
 		serviceCache:  NewServiceCache(),
+		zzk:           getZZK(),
 	}
 }
 

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -45,6 +45,8 @@ type FacadeInterface interface {
 
 	GetTenantID(ctx datastore.Context, serviceID string) (string, error)
 
+	SyncServiceRegistry(ctx datastore.Context, svc *service.Service) error
+
 	MigrateServices(ctx datastore.Context, request dao.ServiceMigrationRequest) error
 
 	RemoveService(ctx datastore.Context, id string) error

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -134,6 +134,18 @@ func (_m *FacadeInterface) GetTenantID(ctx datastore.Context, serviceID string) 
 
 	return r0, r1
 }
+func (_m *FacadeInterface) SyncServiceRegistry(ctx datastore.Context, svc *service.Service) error {
+	ret := _m.Called(ctx, svc)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, *service.Service) error); ok {
+		r0 = rf(ctx, svc)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
 func (_m *FacadeInterface) MigrateServices(ctx datastore.Context, request dao.ServiceMigrationRequest) error {
 	ret := _m.Called(ctx, request)
 

--- a/facade/mocks/ZZK.go
+++ b/facade/mocks/ZZK.go
@@ -24,6 +24,18 @@ func (_m *ZZK) UpdateService(tenantID string, svc *service.Service, setLockOnCre
 
 	return r0
 }
+func (_m *ZZK) SyncServiceRegistry(tenantID string, svc *service.Service) error {
+	ret := _m.Called(tenantID, svc)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *service.Service) error); ok {
+		r0 = rf(tenantID, svc)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
 func (_m *ZZK) RemoveService(poolID string, serviceID string) error {
 	ret := _m.Called(poolID, serviceID)
 

--- a/facade/serviceregistry_cache.go
+++ b/facade/serviceregistry_cache.go
@@ -1,0 +1,152 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package facade
+
+import (
+	"sync"
+
+	zkr "github.com/control-center/serviced/zzk/registry"
+	"github.com/control-center/serviced/domain/service"
+)
+
+type serviceRegistryCache struct {
+	mutex     *sync.Mutex
+	registry  map[string]*serviceRegistry
+}
+
+// serviceRegistry holds cached information used to optimize the registry sync process
+type serviceRegistry struct {
+	ServiceID   string
+	PublicPorts map[zkr.PublicPortKey]zkr.PublicPort
+	VHosts      map[zkr.VHostKey]zkr.VHost
+}
+
+type ServiceRegistrySyncRequest struct {
+	ServiceID       string
+	PortsToDelete   []zkr.PublicPortKey
+	PortsToPublish  map[zkr.PublicPortKey]zkr.PublicPort
+	VHostsToDelete  []zkr.VHostKey
+	VHostsToPublish map[zkr.VHostKey]zkr.VHost
+}
+
+func NewServiceRegistryCache() *serviceRegistryCache {
+	return &serviceRegistryCache{
+		mutex:    &sync.Mutex{},
+		registry: make(map[string]*serviceRegistry, 0),
+	}
+}
+
+func (sc *serviceRegistryCache) Lock() {
+	sc.mutex.Lock()
+}
+
+func (sc *serviceRegistryCache) Unlock() {
+	sc.mutex.Unlock()
+}
+
+// BuildCache creates a new service registry cache from the specified data
+func (sc *serviceRegistryCache) BuildCache(publicPorts map[zkr.PublicPortKey]zkr.PublicPort, vhosts map[zkr.VHostKey]zkr.VHost) {
+	sc.registry = make(map[string]*serviceRegistry, 0)
+	for key, value := range publicPorts {
+		serviceRegistry := sc.GetRegistryForService(value.ServiceID)
+		serviceRegistry.PublicPorts[key] = value
+	}
+	for key, value := range vhosts {
+		serviceRegistry := sc.GetRegistryForService(value.ServiceID)
+		serviceRegistry.VHosts[key] = value
+	}
+	return
+}
+
+func (sc *serviceRegistryCache) BuildSyncRequest(tenantID string, svc *service.Service) zkr.ServiceRegistrySyncRequest {
+	request := zkr.ServiceRegistrySyncRequest{
+		ServiceID:      svc.ID,
+		PortsToDelete:  []zkr.PublicPortKey{},
+		PortsToPublish: make(map[zkr.PublicPortKey]zkr.PublicPort),
+		VHostsToDelete: []zkr.VHostKey{},
+		VHostsToPublish: make(map[zkr.VHostKey]zkr.VHost),
+	}
+
+	for _, ep := range svc.Endpoints {
+		// map the public ports
+		for _, p := range ep.PortList {
+			if p.Enabled {
+				key := zkr.PublicPortKey{
+					HostID:      "master",
+					PortAddress: p.PortAddr,
+				}
+				pub := zkr.PublicPort{
+					TenantID:    tenantID,
+					Application: ep.Application,
+					ServiceID:   svc.ID,
+					Protocol:    p.Protocol,
+					UseTLS:      p.UseTLS,
+				}
+				request.PortsToPublish[key] = pub
+			}
+		}
+
+		// map the vhosts
+		for _, v := range ep.VHostList {
+			if v.Enabled {
+				key := zkr.VHostKey{
+					HostID:    "master",
+					Subdomain: v.Name,
+				}
+				vh := zkr.VHost{
+					TenantID:    tenantID,
+					Application: ep.Application,
+					ServiceID:   svc.ID,
+				}
+				request.VHostsToPublish[key] = vh
+			}
+		}
+	}
+
+	// Request deletes for any cached values that are not in the maps we just built
+	if serviceRegistry, ok := sc.registry[svc.ID]; ok {
+		for key, _ := range serviceRegistry.PublicPorts {
+			_, ok := request.PortsToPublish[key]
+			if !ok {
+				request.PortsToDelete = append(request.PortsToDelete, key)
+			}
+		}
+		for key, _ := range serviceRegistry.VHosts {
+			_, ok := request.VHostsToPublish[key]
+			if !ok {
+				request.VHostsToDelete = append(request.VHostsToDelete, key)
+			}
+		}
+	}
+	return request
+}
+func (sc *serviceRegistryCache) UpdateRegistry(serviceID string, publicPorts map[zkr.PublicPortKey]zkr.PublicPort, vhosts map[zkr.VHostKey]zkr.VHost) {
+	serviceRegistry := sc.GetRegistryForService(serviceID)
+	serviceRegistry.PublicPorts = publicPorts
+	serviceRegistry.VHosts = vhosts
+}
+
+// getRegistryForService returns the registry entry for the spcified service. If the service is not already in the
+// cache, then an empty entry is added to the cache and returned
+func (sc *serviceRegistryCache) GetRegistryForService(serviceID string) *serviceRegistry {
+	registry, ok := sc.registry[serviceID]
+	if !ok {
+		registry = &serviceRegistry{
+			ServiceID:   serviceID,
+			PublicPorts: make(map[zkr.PublicPortKey]zkr.PublicPort, 0),
+			VHosts:      make(map[zkr.VHostKey]zkr.VHost, 0),
+		}
+		sc.registry[serviceID] = registry
+	}
+	return registry
+}

--- a/facade/serviceregistry_cache_test.go
+++ b/facade/serviceregistry_cache_test.go
@@ -1,0 +1,460 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package facade
+
+import (
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/domain/servicedefinition"
+	zkr "github.com/control-center/serviced/zzk/registry"
+
+	. "gopkg.in/check.v1"
+)
+
+var _ = Suite(&ServiceRegistryCacheTest{})
+
+type ServiceRegistryCacheTest struct {
+	cache        *serviceRegistryCache
+}
+
+func (t *ServiceRegistryCacheTest) SetUpTest(c *C) {
+	t.cache = NewServiceRegistryCache()
+}
+
+func (t *ServiceRegistryCacheTest) TearDownTest(c *C) {
+	t.cache = nil
+}
+
+func (t *ServiceRegistryCacheTest) Test_GetRegistryForService_CreatesCache(c *C) {
+	service1 := "service1"
+	svcRegistry := t.cache.GetRegistryForService(service1)
+
+	c.Assert(len(t.cache.registry), Equals, 1)
+
+	_, ok := t.cache.registry[service1]
+	c.Assert(ok, Equals, true)
+
+	c.Assert(svcRegistry.ServiceID, Equals, service1)
+	t.assertPortMapsEqual(c, svcRegistry.PublicPorts, map[zkr.PublicPortKey]zkr.PublicPort{})
+	t.assertVHostMapsEqual(c, svcRegistry.VHosts, map[zkr.VHostKey]zkr.VHost{})
+
+	service2 := "service2"
+	svcRegistry = t.cache.GetRegistryForService(service2)
+
+	c.Assert(len(t.cache.registry), Equals, 2)
+
+	_, ok = t.cache.registry[service2]
+	c.Assert(ok, Equals, true)
+
+	c.Assert(svcRegistry.ServiceID, Equals, service2)
+	t.assertPortMapsEqual(c, svcRegistry.PublicPorts, map[zkr.PublicPortKey]zkr.PublicPort{})
+	t.assertVHostMapsEqual(c, svcRegistry.VHosts, map[zkr.VHostKey]zkr.VHost{})
+}
+
+func (t *ServiceRegistryCacheTest) Test_BuildCache_ForEmptyValues(c *C) {
+	publicPorts := make(map[zkr.PublicPortKey]zkr.PublicPort)
+	vhosts := make(map[zkr.VHostKey]zkr.VHost)
+
+	t.cache.BuildCache(publicPorts, vhosts)
+
+	c.Assert(len(t.cache.registry), Equals, 0)
+}
+
+func (t *ServiceRegistryCacheTest) Test_BuildCache_ForSomeValues(c *C) {
+	// "service1" - only has public ports
+	// "service2" - has public ports and vhosts
+	// "service3" - has only vhosts
+	publicPorts := t.getExpectedPortsForService1()
+	for key, value := range  t.getExpectedPortsForService2() {
+		publicPorts[key] = value
+	}
+	vhosts :=  t.getExpectedVHostsForService2()
+	for key, value := range  t.getExpectedVHostsForService3() {
+		vhosts[key] = value
+	}
+	t.cache.BuildCache(publicPorts, vhosts)
+
+	c.Assert(len(t.cache.registry), Equals, 3)
+
+	svc1, ok := t.cache.registry["service1"]
+	c.Assert(ok, Equals, true)
+	c.Assert(svc1.ServiceID, Equals, "service1")
+	t.assertPortMapsEqual(c,  svc1.PublicPorts, t.getExpectedPortsForService1())
+	t.assertVHostMapsEqual(c, svc1.VHosts,      map[zkr.VHostKey]zkr.VHost{})
+
+	svc2, ok := t.cache.registry["service2"]
+	c.Assert(ok, Equals, true)
+	c.Assert(svc2.ServiceID, Equals, "service2")
+	t.assertPortMapsEqual(c,  svc2.PublicPorts, t.getExpectedPortsForService2())
+	t.assertVHostMapsEqual(c, svc2.VHosts,      t.getExpectedVHostsForService2())
+
+	svc3, ok := t.cache.registry["service3"]
+	c.Assert(ok, Equals, true)
+	c.Assert(svc3.ServiceID, Equals, "service3")
+	t.assertPortMapsEqual(c,  svc3.PublicPorts, map[zkr.PublicPortKey]zkr.PublicPort{})
+	t.assertVHostMapsEqual(c, svc3.VHosts,      t.getExpectedVHostsForService3())
+}
+
+func (t *ServiceRegistryCacheTest) Test_UpdateRegistry_WithEmptyValues(c *C) {
+	// Load the cache with values for both ports and vhosts
+	serviceID := "service2"
+	t.cache.BuildCache(t.getExpectedPortsForService2(), t.getExpectedVHostsForService2())
+
+	emptyPublicPorts := make(map[zkr.PublicPortKey]zkr.PublicPort)
+	emptyVHosts := make(map[zkr.VHostKey]zkr.VHost)
+
+	t.cache.UpdateRegistry(serviceID, emptyPublicPorts, emptyVHosts)
+
+	svcRegistry := t.cache.GetRegistryForService(serviceID)
+	c.Assert(len(svcRegistry.PublicPorts), Equals, 0)
+	c.Assert(len(svcRegistry.VHosts), Equals, 0)
+}
+
+func (t *ServiceRegistryCacheTest) Test_UpdateRegistry_WithSomeValues(c *C) {
+	// Load the cache with values for both ports and vhosts
+	t.cache.BuildCache(t.getExpectedPortsForService2(), t.getExpectedVHostsForService2())
+
+	emptyPublicPorts := make(map[zkr.PublicPortKey]zkr.PublicPort)
+	emptyVHosts := make(map[zkr.VHostKey]zkr.VHost)
+	t.cache.UpdateRegistry("service1", t.getExpectedPortsForService1(), emptyVHosts)
+
+	c.Assert(len(t.cache.registry), Equals, 2)
+
+	// "service1" should be match the values specified by the UpdateRegistry call
+	svc1 := t.cache.GetRegistryForService( "service1")
+	c.Assert(svc1.ServiceID, Equals, "service1")
+	t.assertPortMapsEqual(c,  svc1.PublicPorts, t.getExpectedPortsForService1())
+	t.assertVHostMapsEqual(c, svc1.VHosts,      map[zkr.VHostKey]zkr.VHost{})
+
+	// "service2" should be unchanged from what was added by BuildCache
+	svc2 := t.cache.GetRegistryForService( "service2")
+	c.Assert(svc2.ServiceID, Equals, "service2")
+	t.assertPortMapsEqual(c,  svc2.PublicPorts, t.getExpectedPortsForService2())
+	t.assertVHostMapsEqual(c, svc2.VHosts,      t.getExpectedVHostsForService2())
+
+	t.cache.UpdateRegistry("service3", emptyPublicPorts, t.getExpectedVHostsForService3())
+
+	c.Assert(len(t.cache.registry), Equals, 3)
+
+	svc3 := t.cache.GetRegistryForService( "service3")
+	c.Assert(svc3.ServiceID, Equals, "service3")
+	t.assertPortMapsEqual(c,  svc3.PublicPorts, map[zkr.PublicPortKey]zkr.PublicPort{})
+	t.assertVHostMapsEqual(c, svc3.VHosts,      t.getExpectedVHostsForService3())
+}
+
+func (t *ServiceRegistryCacheTest) Test_BuildSyncRequest_NoEndpoints(c *C) {
+	svc := service.Service{
+		ID: "service1",
+	}
+	result := t.cache.BuildSyncRequest("tenantID", &svc)
+
+	c.Assert(len(result.PortsToDelete), Equals, 0)
+	c.Assert(len(result.PortsToPublish), Equals, 0)
+	c.Assert(len(result.VHostsToDelete), Equals, 0)
+	c.Assert(len(result.VHostsToPublish), Equals, 0)
+
+	// Verify that the cache is unchanged by the BuildSyncRequest
+	c.Assert(len(t.cache.registry), Equals, 0)
+}
+
+// Verify that the new, enabled endpoints are added to the request object
+func (t *ServiceRegistryCacheTest) Test_BuildSyncRequest_AddsEndpoints(c *C) {
+	svc := t.getTestService()
+
+	tenantID := "expectedTenantID"
+	result := t.cache.BuildSyncRequest(tenantID, &svc)
+
+	c.Assert(len(result.PortsToDelete), Equals, 0)
+	c.Assert(len(result.PortsToPublish), Equals, 1)
+	c.Assert(len(result.VHostsToDelete), Equals, 0)
+	c.Assert(len(result.VHostsToPublish), Equals, 1)
+
+	portKey := zkr.PublicPortKey{
+		HostID:      "master",
+		PortAddress: svc.Endpoints[0].PortList[0].PortAddr,
+	}
+	port := zkr.PublicPort{
+		TenantID:    tenantID,
+		ServiceID:   svc.ID,
+		Application: svc.Endpoints[0].Application,
+		Protocol:    svc.Endpoints[0].PortList[0].Protocol,
+		UseTLS:      svc.Endpoints[0].PortList[0].UseTLS,
+	}
+	expectedPorts := map[zkr.PublicPortKey]zkr.PublicPort{}
+	expectedPorts[portKey] = port
+	t.assertPortMapsEqual(c, result.PortsToPublish, expectedPorts)
+
+	vhostKey := zkr.VHostKey{
+		HostID:    "master",
+		Subdomain: svc.Endpoints[1].VHostList[0].Name,
+	}
+	vhost := zkr.VHost{
+		TenantID:    tenantID,
+		ServiceID:   svc.ID,
+		Application: svc.Endpoints[1].Application,
+	}
+	expectedVHosts := map[zkr.VHostKey]zkr.VHost{}
+	expectedVHosts[vhostKey] = vhost
+
+	t.assertVHostMapsEqual(c, result.VHostsToPublish, expectedVHosts)
+}
+
+// Verify that the cached endpoints flagged for removal if all endpoints are disabled
+func (t *ServiceRegistryCacheTest) Test_BuildSyncRequest_EndpointsDisabled(c *C) {
+	// Based on the test service, seed the cache with some initial values
+	tenantID := "expectedTenantID"
+	svc := t.getTestService()
+	portKey := zkr.PublicPortKey{
+		HostID:      "master",
+		PortAddress: svc.Endpoints[0].PortList[0].PortAddr,
+	}
+	port := zkr.PublicPort{
+		TenantID:    tenantID,
+		ServiceID:   svc.ID,
+		Application: svc.Endpoints[0].Application,
+		Protocol:    svc.Endpoints[0].PortList[0].Protocol,
+		UseTLS:      svc.Endpoints[0].PortList[0].UseTLS,
+	}
+	initialPorts := map[zkr.PublicPortKey]zkr.PublicPort{}
+	initialPorts[portKey] = port
+
+	vhostKey := zkr.VHostKey{
+		HostID:    "master",
+		Subdomain: svc.Endpoints[1].VHostList[0].Name,
+	}
+	vhost := zkr.VHost{
+		TenantID:    tenantID,
+		ServiceID:   svc.ID,
+		Application: svc.Endpoints[1].Application,
+	}
+	initialVHosts := map[zkr.VHostKey]zkr.VHost{}
+	initialVHosts[vhostKey] = vhost
+
+	// Load the initial values into the cache
+	t.cache.BuildCache(initialPorts, initialVHosts)
+
+	// Now simulate disabling all of the endpoints
+	svc = t.getTestService()
+	svc.Endpoints[0].PortList[0].Enabled = false
+	svc.Endpoints[1].VHostList[0].Enabled = false
+
+	result := t.cache.BuildSyncRequest(tenantID, &svc)
+
+	// Verify that the previously cached values were flagged for removal
+	c.Assert(len(result.PortsToDelete), Equals, 1)
+	c.Assert(len(result.PortsToPublish), Equals, 0)
+	c.Assert(len(result.VHostsToDelete), Equals, 1)
+	c.Assert(len(result.VHostsToPublish), Equals, 0)
+
+	for _, key := range result.PortsToDelete {
+		_, ok := initialPorts[key]
+		c.Assert(ok, Equals, true)
+	}
+	for _, key := range result.VHostsToDelete {
+		_, ok := initialVHosts[key]
+		c.Assert(ok, Equals, true)
+	}
+}
+
+func (t *ServiceRegistryCacheTest) Test_BuildSyncRequest_ReplaceAllEndpoints(c *C) {
+	// Based on the test service, seed the cache with some initial values
+	tenantID := "expectedTenantID"
+	svc := t.getTestService()
+	portKey := zkr.PublicPortKey{
+		HostID:      "master",
+		PortAddress: svc.Endpoints[0].PortList[0].PortAddr,
+	}
+	port := zkr.PublicPort{
+		TenantID:    tenantID,
+		ServiceID:   svc.ID,
+		Application: svc.Endpoints[0].Application,
+		Protocol:    svc.Endpoints[0].PortList[0].Protocol,
+		UseTLS:      svc.Endpoints[0].PortList[0].UseTLS,
+	}
+	initialPorts := map[zkr.PublicPortKey]zkr.PublicPort{}
+	initialPorts[portKey] = port
+
+	vhostKey := zkr.VHostKey{
+		HostID:    "master",
+		Subdomain: svc.Endpoints[1].VHostList[0].Name,
+	}
+	vhost := zkr.VHost{
+		TenantID:    tenantID,
+		ServiceID:   svc.ID,
+		Application: svc.Endpoints[1].Application,
+	}
+	initialVHosts := map[zkr.VHostKey]zkr.VHost{}
+	initialVHosts[vhostKey] = vhost
+
+	// Load the initial values into the cache
+	t.cache.BuildCache(initialPorts, initialVHosts)
+
+	// Now simulate modifying the key values for all of the endpoints (e.g. a service edit or migration might do this)
+	svc = t.getTestService()
+	svc.Endpoints[0].PortList[0].PortAddr = ":9999"
+	svc.Endpoints[1].VHostList[0].Name = "somethingCompletelyDifferent"
+
+	result := t.cache.BuildSyncRequest(tenantID, &svc)
+
+	// Verify  the old keys are flagged for removal
+	c.Assert(len(result.PortsToDelete), Equals, 1)
+	for _, key := range result.PortsToDelete {
+		_, ok := initialPorts[key]
+		c.Assert(ok, Equals, true)
+	}
+
+	c.Assert(len(result.VHostsToDelete), Equals, 1)
+	for _, key := range result.VHostsToDelete {
+		_, ok := initialVHosts[key]
+		c.Assert(ok, Equals, true)
+	}
+
+	// Verify the modified values are in the to-be-published lists
+	c.Assert(len(result.PortsToPublish), Equals, 1)
+	portKey.PortAddress = svc.Endpoints[0].PortList[0].PortAddr
+	expectedPorts := map[zkr.PublicPortKey]zkr.PublicPort{}
+	expectedPorts[portKey] = port
+	t.assertPortMapsEqual(c, result.PortsToPublish, expectedPorts)
+
+	c.Assert(len(result.VHostsToPublish), Equals, 1)
+	vhostKey.Subdomain = svc.Endpoints[1].VHostList[0].Name
+	expectedVHosts := map[zkr.VHostKey]zkr.VHost{}
+	expectedVHosts[vhostKey] = vhost
+	t.assertVHostMapsEqual(c, result.VHostsToPublish, expectedVHosts)
+}
+
+func (t *ServiceRegistryCacheTest) getExpectedPortsForService1() (expected map[zkr.PublicPortKey]zkr.PublicPort) {
+	portKey1 := zkr.PublicPortKey{
+		HostID:      "host1",
+		PortAddress: ":1281",
+	}
+	port1 := zkr.PublicPort{
+		ServiceID: "service1",
+		Protocol:  "tcp",
+	}
+	portKey2 := zkr.PublicPortKey{
+		HostID:      "host1",
+		PortAddress: ":1282",
+	}
+	port2 := zkr.PublicPort{
+		ServiceID: "service1",
+		Protocol:  "http",
+	}
+	expected = map[zkr.PublicPortKey]zkr.PublicPort{}
+	expected[portKey1] = port1
+	expected[portKey2] = port2
+	return expected
+}
+func (t *ServiceRegistryCacheTest) getExpectedPortsForService2() (expected map[zkr.PublicPortKey]zkr.PublicPort) {
+
+	portKey3 := zkr.PublicPortKey{
+		HostID:      "host2",
+		PortAddress: ":1282",
+	}
+	port3 := zkr.PublicPort{
+		ServiceID: "service2",
+		Protocol:  "http",
+	}
+	expected = map[zkr.PublicPortKey]zkr.PublicPort{}
+	expected[portKey3] = port3
+	return expected
+}
+
+func (t *ServiceRegistryCacheTest) getExpectedVHostsForService2() (expected map[zkr.VHostKey]zkr.VHost) {
+	vhostKey1 := zkr.VHostKey{
+		HostID:      "host1",
+		Subdomain:   "domain1",
+	}
+	vhost1 := zkr.VHost{
+		ServiceID:   "service2",
+		Application: "app1",
+	}
+	vhostKey2 := zkr.VHostKey{
+		HostID:      "host1",
+		Subdomain:   "domain2",
+	}
+	vhost2 := zkr.VHost{
+		ServiceID:   "service2",
+		Application: "app2",
+	}
+
+	expected = map[zkr.VHostKey]zkr.VHost{}
+	expected[vhostKey1] = vhost1
+	expected[vhostKey2] = vhost2
+	return expected
+}
+
+func (t *ServiceRegistryCacheTest) getExpectedVHostsForService3() (expected map[zkr.VHostKey]zkr.VHost) {
+	vhostKey3 := zkr.VHostKey{
+		HostID:      "host2",
+		Subdomain:   "domain3",
+	}
+	vhost3 := zkr.VHost{
+		ServiceID:   "service3",
+		Application: "app3",
+	}
+
+	expected = map[zkr.VHostKey]zkr.VHost{}
+	expected[vhostKey3] = vhost3
+	return expected
+}
+
+func (t *ServiceRegistryCacheTest) getTestService() service.Service {
+	return service.Service{
+		ID: "service1",
+		Endpoints: []service.ServiceEndpoint{
+			service.ServiceEndpoint{
+				Name:        "ep1",
+				Application: "app1",
+				PortList:    []servicedefinition.Port{
+					servicedefinition.Port{
+						Enabled:  true,
+						PortAddr: ":1281",
+						Protocol: "http",
+						UseTLS:   true,
+					},
+				},
+			},
+			service.ServiceEndpoint{
+				Name:        "ep2",
+				Application: "app2",
+				VHostList:    []servicedefinition.VHost{
+					servicedefinition.VHost{
+						Enabled:  true,
+						Name:     "vhost1",
+					},
+				},
+			},
+		},
+	}
+}
+func (t *ServiceRegistryCacheTest) assertPortMapsEqual(c *C, actual, expected map[zkr.PublicPortKey]zkr.PublicPort) {
+	c.Assert(len(actual), Equals, len(expected))
+	for key, value := range expected {
+		actualValue, ok := actual[key]
+		c.Assert(ok, Equals, true)
+		c.Assert(actualValue, Equals, value)
+	}
+}
+
+func (t *ServiceRegistryCacheTest) assertVHostMapsEqual(c *C, actual, expected map[zkr.VHostKey]zkr.VHost) {
+	c.Assert(len(actual), Equals, len(expected))
+	for key, value := range expected {
+		actualValue, ok := actual[key]
+		c.Assert(ok, Equals, true)
+		c.Assert(actualValue, Equals, value)
+	}
+}
+

--- a/facade/zkapi.go
+++ b/facade/zkapi.go
@@ -21,6 +21,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	zkimgregistry "github.com/control-center/serviced/dfs/registry"
+	"github.com/control-center/serviced/coordinator/client"
 	"github.com/control-center/serviced/domain/host"
 	"github.com/control-center/serviced/domain/pool"
 	"github.com/control-center/serviced/domain/registry"
@@ -33,12 +34,12 @@ import (
 	"github.com/zenoss/glog"
 )
 
-func getZZK(f *Facade) ZZK {
-	return &zkf{f}
+func getZZK() ZZK {
+	return &zkf{NewServiceRegistryCache()}
 }
 
 type zkf struct {
-	f *Facade
+	svcRegistry  *serviceRegistryCache
 }
 
 // UpdateService updates the service object and exposed public endpoints that
@@ -52,59 +53,10 @@ func (zk *zkf) UpdateService(tenantID string, svc *service.Service, setLockOnCre
 		"poolid":      svc.PoolID,
 	})
 
-	// get the root-based connection to update the service's endpoints
-	rootconn, err := zzk.GetLocalConnection("/")
-	if err != nil {
-		logger.WithError(err).Debug("Could not acquire a root-based connection to update the service's public endpoints in zookeeper")
+	if err := zk.SyncServiceRegistry(tenantID, svc); err != nil {
+		logger.WithError(err).Debug("Could not sync public endpoints in zookeeper")
 		return err
 	}
-
-	// map all the public endpoints on the service
-	pubmap := make(map[zkr.PublicPortKey]zkr.PublicPort)
-	vhmap := make(map[zkr.VHostKey]zkr.VHost)
-
-	for _, ep := range svc.Endpoints {
-		// map the public ports
-		for _, p := range ep.PortList {
-			if p.Enabled {
-				key := zkr.PublicPortKey{
-					HostID:      "master",
-					PortAddress: p.PortAddr,
-				}
-				pub := zkr.PublicPort{
-					TenantID:    tenantID,
-					Application: ep.Application,
-					ServiceID:   svc.ID,
-					Protocol:    p.Protocol,
-					UseTLS:      p.UseTLS,
-				}
-				pubmap[key] = pub
-			}
-		}
-
-		// map the vhosts
-		for _, v := range ep.VHostList {
-			if v.Enabled {
-				key := zkr.VHostKey{
-					HostID:    "master",
-					Subdomain: v.Name,
-				}
-				vh := zkr.VHost{
-					TenantID:    tenantID,
-					Application: ep.Application,
-					ServiceID:   svc.ID,
-				}
-				vhmap[key] = vh
-			}
-		}
-	}
-
-	// sync the registry
-	if err := zkr.SyncServiceRegistry(rootconn, svc.ID, pubmap, vhmap); err != nil {
-		logger.WithError(err).Debug("Could not update the service's public endpoints in zookeeper")
-		return err
-	}
-	logger.Debug("Updated the service's public endpoints in zookeeper")
 
 	// get the pool-based connection to update the service
 	poolconn, err := zzk.GetLocalConnection(path.Join("/pools", svc.PoolID))
@@ -155,14 +107,41 @@ func (zk *zkf) RemoveServiceEndpoints(serviceID string) error {
 		return err
 	}
 
-	// delete the public endpoints for this service
-	pubs := make(map[zkr.PublicPortKey]zkr.PublicPort)
-	vhosts := make(map[zkr.VHostKey]zkr.VHost)
+	zk.svcRegistry.Lock()
+	defer zk.svcRegistry.Unlock()
+	if zk.svcRegistry.registry == nil {
+		err = zk.buildServiceRegistryCache(rootconn)
+		if err != nil {
+			logger.WithError(err).Debug("Could not build cache of the service registry")
+			return err
+		}
+	}
 
-	if err := zkr.SyncServiceRegistry(rootconn, serviceID, pubs, vhosts); err != nil {
+	// delete the public endpoints for this service
+	syncRequest := zkr.ServiceRegistrySyncRequest{
+		ServiceID:       serviceID,
+		PortsToPublish:  make(map[zkr.PublicPortKey]zkr.PublicPort),
+		PortsToDelete:   []zkr.PublicPortKey{},
+		VHostsToPublish: make(map[zkr.VHostKey]zkr.VHost),
+		VHostsToDelete:  []zkr.VHostKey{},
+	}
+
+	serviceRegistry := zk.svcRegistry.GetRegistryForService(serviceID)
+	for key, _ := range serviceRegistry.PublicPorts {
+		syncRequest.PortsToDelete = append(syncRequest.PortsToDelete, key)
+	}
+	for key, _ := range serviceRegistry.VHosts {
+		syncRequest.VHostsToDelete = append(syncRequest.VHostsToDelete, key)
+	}
+
+	// sync the registry
+	if err := zkr.SyncServiceRegistry(rootconn, syncRequest); err != nil {
 		logger.WithError(err).Debug("Could not delete the service's public endpoints in zookeeper")
 		return err
 	}
+
+	// Update our local cache now that we know that ZK was updated successfully
+	zk.svcRegistry.UpdateRegistry(serviceID, syncRequest.PortsToPublish, syncRequest.VHostsToPublish)
 	logger.Debug("Deleted the service's public endpoints in zookeeper")
 	return nil
 }
@@ -719,4 +698,57 @@ func (zk *zkf) GetServiceStateIDs(poolID, serviceID string) ([]zks.StateRequest,
 	}
 
 	return zks.GetServiceStateIDs(conn, poolID, serviceID)
+}
+
+func (zk *zkf) SyncServiceRegistry(tenantID string, svc *service.Service) error {
+	logger := plog.WithFields(log.Fields{
+		"tenantid":    tenantID,
+		"serviceid":   svc.ID,
+		"servicename": svc.Name,
+		"poolid":      svc.PoolID,
+	})
+
+	// get the root-based connection to update the service's endpoints
+	rootconn, err := zzk.GetLocalConnection("/")
+	if err != nil {
+		logger.WithError(err).Debug("Could not acquire a root-based connection to update the service's public endpoints in zookeeper")
+		return err
+	}
+
+	zk.svcRegistry.Lock()
+	defer zk.svcRegistry.Unlock()
+	if zk.svcRegistry == nil {
+		err = zk.buildServiceRegistryCache(rootconn)
+		if err != nil {
+			logger.WithError(err).Debug("Could not build cache of the service registry")
+			return err
+		}
+	}
+
+	// sync the registry
+	syncRequest := zk.svcRegistry.BuildSyncRequest(tenantID, svc)
+	if err := zkr.SyncServiceRegistry(rootconn, syncRequest); err != nil {
+		logger.WithError(err).Debug("Could not update the service's public endpoints in zookeeper")
+		return err
+	}
+
+	// Update our local cache now that we know that ZK was updated successfully
+	 zk.svcRegistry.UpdateRegistry(syncRequest.ServiceID, syncRequest.PortsToPublish, syncRequest.VHostsToPublish)
+
+	logger.Debug("Updated the service's public endpoints in zookeeper")
+	return nil
+}
+
+// buildServiceRegistryCache builds the cache of public endpoints based on data in zookeeper
+func (zk *zkf) buildServiceRegistryCache(conn client.Connection) error {
+	publicPorts, err := zkr.GetPublicPorts(conn)
+	if err != nil {
+		return err
+	}
+	vhosts, err := zkr.GetVHosts(conn)
+	if err != nil {
+		return err
+	}
+	zk.svcRegistry.BuildCache(publicPorts, vhosts)
+	return nil
 }

--- a/facade/zzk.go
+++ b/facade/zzk.go
@@ -23,6 +23,7 @@ import (
 
 type ZZK interface {
 	UpdateService(tenantID string, svc *service.Service, setLockOnCreate, setLockOnUpdate bool) error
+	SyncServiceRegistry(tenantID string, svc *service.Service) error
 	RemoveService(poolID, serviceID string) error
 	RemoveServiceEndpoints(serviceID string) error
 	RemoveTenantExports(tenantID string) error
@@ -51,8 +52,4 @@ type ZZK interface {
 	StopServiceInstances(poolID, serviceID string) error
 	SendDockerAction(poolID, serviceID string, instanceID int, command string, args []string) error
 	GetServiceStateIDs(poolID, serviceID string) ([]zkservice.StateRequest, error)
-}
-
-func GetFacadeZZK(f *Facade) ZZK {
-	return &zkf{f: f}
 }

--- a/scheduler/localsync_test.go
+++ b/scheduler/localsync_test.go
@@ -79,8 +79,6 @@ func (lst *LocalSyncTest) SetUpSuite(c *C) {
 	lst.CTX = datastore.Get()
 
 	lst.facade = facade.New()
-	fzzk := facade.GetFacadeZZK(lst.facade)
-	lst.facade.SetZZK(fzzk)
 	regindex := registry.NewRegistryIndexClient(lst.facade)
 	dockerclient, err := docker.NewDockerClient()
 	if err != nil {

--- a/zzk/registry/registry.go
+++ b/zzk/registry/registry.go
@@ -48,6 +48,14 @@ type VHostKey struct {
 	Subdomain string
 }
 
+type ServiceRegistrySyncRequest struct {
+	ServiceID       string
+	PortsToDelete   []PublicPortKey
+	PortsToPublish  map[PublicPortKey]PublicPort
+	VHostsToDelete  []VHostKey
+	VHostsToPublish map[VHostKey]VHost
+}
+
 // DeleteExports deletes all export data for a tenant id
 func DeleteExports(conn client.Connection, tenantID string) error {
 	pth := path.Join("/net/export", tenantID)
@@ -100,6 +108,72 @@ func GetPublicPort(conn client.Connection, key PublicPortKey) (string, string, e
 	return pub.ServiceID, pub.Application, nil
 }
 
+func GetPublicPorts(conn client.Connection) (map[PublicPortKey]PublicPort, error) {
+	ports := make(map[PublicPortKey]PublicPort, 0)
+
+	pth := "/net/pub"
+	logger := plog.WithField("zkpath", pth)
+
+	hostIDs, err := conn.Children(pth)
+	if err == client.ErrNoNode {
+		conn.CreateDir(pth)
+	} else if err != nil {
+		logger.WithError(err).Debug("Could not look up public port path")
+		return nil, &RegistryError{
+			Action:  "get",
+			Path:    pth,
+			Message: "could not look up public ports path",
+		}
+	}
+
+	// get all the public ports for each host
+	for _, hostID := range hostIDs {
+		hostpth := path.Join(pth, hostID)
+		hostLogger := logger.WithFields(log.Fields{
+			"hostid": hostID,
+			"zkpath": hostpth,
+		})
+
+		portAddrs, err := conn.Children(hostpth)
+		if err == client.ErrNoNode {
+			hostLogger.Debug("Host has been deleted for public ports")
+		} else if err != nil {
+			hostLogger.WithError(err).Debug("Could not look up public ports for host id")
+			return nil, &RegistryError{
+				Action:  "get",
+				Path:    hostpth,
+				Message: "could not look up public ports for host id",
+			}
+		}
+
+		for _, portAddr := range portAddrs {
+			addrpth := path.Join(hostpth, portAddr)
+			addrLogger := hostLogger.WithFields(log.Fields{
+				"portaddress": portAddr,
+				"zkpath":    addrpth,
+			})
+
+			pub := &PublicPort{}
+			if err := conn.Get(addrpth, pub); err == client.ErrNoNode {
+				addrLogger.Debug("Port address has been deleted for public port")
+				continue
+			} else if err != nil {
+				addrLogger.WithError(err).Debug("could not look up public port")
+				return nil, &RegistryError{
+					Action:  "get",
+					Path:    addrpth,
+					Message: "could not look up public port address",
+				}
+			}
+
+			key := PublicPortKey{HostID: hostID, PortAddress: portAddr}
+			ports[key] = *pub
+		}
+	}
+
+	return ports, nil
+}
+
 // GetVHost returns the service id and application of the vhost
 func GetVHost(conn client.Connection, key VHostKey) (string, string, error) {
 	pth := path.Join("/net/vhost", key.HostID, key.Subdomain)
@@ -132,154 +206,25 @@ func GetVHost(conn client.Connection, key VHostKey) (string, string, error) {
 	return vhost.ServiceID, vhost.Application, nil
 }
 
-// SyncServiceRegistry syncs all vhosts and public ports to those of a matching
-// service.
-// FIXME: need to optimize
-func SyncServiceRegistry(conn client.Connection, serviceID string, pubs map[PublicPortKey]PublicPort, vhosts map[VHostKey]VHost) error {
-	logger := plog.WithField("serviceid", serviceID)
+func GetVHosts(conn client.Connection) (map[VHostKey]VHost, error) {
+	vhosts := make(map[VHostKey]VHost, 0)
 
-	tx := conn.NewTransaction()
-
-	if err := syncServicePublicPorts(conn, tx, serviceID, pubs); err != nil {
-		return err
-	}
-
-	if err := syncServiceVHosts(conn, tx, serviceID, vhosts); err != nil {
-		return err
-	}
-
-	if err := tx.Commit(); err != nil {
-		logger.WithError(err).Debug("Could not sync registry for service")
-
-		// TODO: wrap error?
-		return err
-	}
-
-	logger.Debug("Updated registry for service")
-	return nil
-}
-
-// syncServicePublicPorts updates the transaction to include public port updates
-func syncServicePublicPorts(conn client.Connection, tx client.Transaction, serviceID string, pubs map[PublicPortKey]PublicPort) error {
-	logger := plog.WithField("serviceid", serviceID)
-
-	// pull all the hosts of all the public ports
-	pth := "/net/pub"
-	logger = logger.WithField("zkpath", pth)
-
-	hostIDs, err := conn.Children(pth)
-	if err == client.ErrNoNode {
-		conn.CreateDir(pth)
-	} else if err != nil {
-		logger.WithError(err).Debug("Could not look up public ports path")
-		return &RegistryError{
-			Action:  "sync",
-			Path:    pth,
-			Message: "could not look up public ports path",
-		}
-	}
-
-	// get all the public ports for each host
-	for _, hostID := range hostIDs {
-		hostpth := path.Join(pth, hostID)
-		hostLogger := logger.WithFields(log.Fields{
-			"hostid": hostID,
-			"zkpath": hostpth,
-		})
-
-		portAddrs, err := conn.Children(hostpth)
-		if err == client.ErrNoNode {
-			hostLogger.Debug("Host has been deleted for public ports")
-		} else if err != nil {
-			hostLogger.WithError(err).Debug("Could not look up public ports for host id")
-			return &RegistryError{
-				Action:  "sync",
-				Path:    hostpth,
-				Message: "could not look up public ports for host id",
-			}
-		}
-
-		for _, portAddr := range portAddrs {
-			key := PublicPortKey{HostID: hostID, PortAddress: portAddr}
-			addrpth := path.Join(hostpth, portAddr)
-			addrLogger := hostLogger.WithFields(log.Fields{
-				"portaddress": portAddr,
-				"zkpath":      addrpth,
-			})
-
-			pub := &PublicPort{}
-			if err := conn.Get(addrpth, pub); err == client.ErrNoNode {
-				addrLogger.Debug("Port address has been deleted for public port")
-				continue
-			} else if err != nil {
-				addrLogger.WithError(err).Debug("could not look up public port address")
-				return &RegistryError{
-					Action:  "sync",
-					Path:    addrpth,
-					Message: "could not look up public port address",
-				}
-			}
-
-			// Update the public address if the service matches and there is a
-			// key reference.  Otherwise, delete the public address if the
-			// service matches.
-			val, ok := pubs[key]
-			if ok {
-				delete(pubs, key)
-			}
-
-			if pub.ServiceID == serviceID {
-				if ok {
-					addrLogger.Debug("Updating public port address")
-					val.SetVersion(pub.Version())
-					tx.Set(addrpth, &val)
-				} else {
-					addrLogger.Debug("Deleting public port address")
-					tx.Delete(addrpth)
-				}
-			}
-		}
-	}
-
-	// create the remaining public ports
-	for key := range pubs {
-		val := pubs[key]
-		conn.CreateDir(path.Join(pth, key.HostID))
-		addrpth := path.Join(pth, key.HostID, key.PortAddress)
-		val.SetVersion(nil)
-		logger.WithFields(log.Fields{
-			"hostid":      key.HostID,
-			"portaddress": key.PortAddress,
-			"zkpath":      addrpth,
-		}).Debug("Creating public port address")
-		tx.Create(addrpth, &val)
-	}
-
-	logger.Debug("Updated transaction to sync public ports for service")
-	return nil
-}
-
-// syncServiceVHosts updates the transaction to include virtual host updates
-func syncServiceVHosts(conn client.Connection, tx client.Transaction, serviceID string, vhosts map[VHostKey]VHost) error {
-	logger := plog.WithField("serviceid", serviceID)
-
-	// pull all the hosts of all the virtual hosts
 	pth := "/net/vhost"
-	logger = logger.WithField("zkpath", pth)
+	logger := plog.WithField("zkpath", pth)
 
 	hostIDs, err := conn.Children(pth)
 	if err == client.ErrNoNode {
 		conn.CreateDir(pth)
 	} else if err != nil {
 		logger.WithError(err).Debug("Could not look up virtual hosts path")
-		return &RegistryError{
-			Action:  "sync",
+		return nil, &RegistryError{
+			Action:  "get",
 			Path:    pth,
 			Message: "could not look up virtual hosts path",
 		}
 	}
 
-	// get all the virtual host subdomains for each host
+	// get all the public ports for each host
 	for _, hostID := range hostIDs {
 		hostpth := path.Join(pth, hostID)
 		hostLogger := logger.WithFields(log.Fields{
@@ -292,15 +237,14 @@ func syncServiceVHosts(conn client.Connection, tx client.Transaction, serviceID 
 			hostLogger.Debug("Host has been deleted for virtual hosts")
 		} else if err != nil {
 			hostLogger.WithError(err).Debug("Could not look up virtual hosts for host id")
-			return &RegistryError{
-				Action:  "sync",
+			return nil, &RegistryError{
+				Action:  "get",
 				Path:    hostpth,
 				Message: "could not look up virtual hosts for host id",
 			}
 		}
 
 		for _, subdomain := range subdomains {
-			key := VHostKey{HostID: hostID, Subdomain: subdomain}
 			addrpth := path.Join(hostpth, subdomain)
 			addrLogger := hostLogger.WithFields(log.Fields{
 				"subdomain": subdomain,
@@ -309,49 +253,175 @@ func syncServiceVHosts(conn client.Connection, tx client.Transaction, serviceID 
 
 			vhost := &VHost{}
 			if err := conn.Get(addrpth, vhost); err == client.ErrNoNode {
-				addrLogger.Debug("Subdomain has been deleted for virtual host")
+				addrLogger.Debug("Port address has been deleted for virtual host")
 				continue
 			} else if err != nil {
-				addrLogger.WithError(err).Debug("could not look up virtual host subdomain")
+				addrLogger.WithError(err).Debug("could not look up virtaul host")
+				return nil, &RegistryError{
+					Action:  "get",
+					Path:    addrpth,
+					Message: "could not look up virtual host subdomaion",
+				}
+			}
+
+			key := VHostKey{HostID: hostID, Subdomain: subdomain}
+			vhosts[key] = *vhost
+		}
+	}
+
+	return vhosts, nil
+}
+
+// SyncServiceRegistry syncs all vhosts and public ports to those of a matching
+// service.
+func SyncServiceRegistry(conn client.Connection, request ServiceRegistrySyncRequest) error {
+	logger := plog.WithField("serviceid", request.ServiceID)
+
+	if len(request.PortsToDelete) == 0 &&
+	   len(request.PortsToPublish) == 0 &&
+	   len(request.VHostsToDelete) == 0 &&
+	   len(request.VHostsToPublish) == 0 {
+		// Don't even create a transaction if there's nothing to do (which is typical for many kinds of services)
+		return nil
+	}
+
+	tx := conn.NewTransaction()
+
+	if err := syncServicePublicPorts(conn, tx, request); err != nil {
+		logger.WithError(err).Debug("Could not sync public ports for service")
+		return err
+	}
+	if err := syncServiceVHosts(conn, tx, request); err != nil {
+		logger.WithError(err).Debug("Could not sync virtual hosts for service")
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		logger.WithError(err).Debug("Could not sync registry for service")
+		// TODO: wrap error?
+		return err
+	}
+
+	logger.Debug("Updated registry for service")
+	return nil
+}
+
+// syncServicePublicPorts updates the transaction to include public port updates
+func syncServicePublicPorts(conn client.Connection, tx client.Transaction, request ServiceRegistrySyncRequest) error {
+	logger := plog.WithField("serviceid", request.ServiceID)
+	pth := "/net/pub"
+
+	for _, pubKey := range request.PortsToDelete {
+		addrpth := path.Join(pth, pubKey.HostID, pubKey.PortAddress)
+		addrLogger := logger.WithFields(log.Fields{
+			"hostid":      pubKey.HostID,
+			"portaddress": pubKey.PortAddress,
+			"zkpath":      addrpth,
+		})
+		tx.Delete(addrpth)
+		addrLogger.Debug("Deleted public port address")
+	}
+
+	for pubKey, pubValue := range request.PortsToPublish {
+		addrpth := path.Join(pth, pubKey.HostID, pubKey.PortAddress)
+		addrLogger := logger.WithFields(log.Fields{
+			"hostid":      pubKey.HostID,
+			"portaddress": pubKey.PortAddress,
+			"zkpath":      addrpth,
+		})
+		err := conn.CreateIfExists(addrpth, &pubValue)
+		if err == client.ErrNoNode {
+			if err := conn.CreateDir(path.Join(pth, pubKey.HostID)); err != nil {
+				return &RegistryError{
+					Action:  "sync",
+					Path:    path.Join(pth, pubKey.HostID),
+					Message: "could not register public port address",
+				}
+			}
+			pubValue.SetVersion(nil)
+			tx.Create(addrpth, &pubValue)
+			addrLogger.Debug("Created public port address")
+		} else if err == client.ErrNodeExists {
+			existingPub := &PublicPort{}
+			if err := conn.Get(addrpth, existingPub); err != nil {
 				return &RegistryError{
 					Action:  "sync",
 					Path:    addrpth,
-					Message: "could not look up virtual host subdomain",
+					Message: "could not read current public port address",
 				}
 			}
-
-			// update the virtual host if there is a key reference and the
-			// services match, otherwise delete it if the service matches.
-			val, ok := vhosts[key]
-			if ok {
-				delete(vhosts, key)
-			}
-
-			if vhost.ServiceID == serviceID {
-				if ok {
-					addrLogger.Debug("Updating virtual host subdomain")
-					val.SetVersion(vhost.Version())
-					tx.Set(addrpth, &val)
-				} else {
-					addrLogger.Debug("Deleting virtual host subdomain")
-					tx.Delete(addrpth)
-				}
+			pubValue.SetVersion(existingPub.Version())
+			tx.Set(addrpth, &pubValue)
+			addrLogger.Debug("Updated public port address")
+		} else {
+			addrLogger.WithError(err).Debug("skipped public port address because of an unexpected error")
+			return &RegistryError{
+				Action:  "sync",
+				Path:   addrpth,
+				Message: "could not register public port address",
 			}
 		}
 	}
 
-	// create the remaining public ports if they are enabled
-	for key := range vhosts {
-		val := vhosts[key]
-		conn.CreateDir(path.Join(pth, key.HostID))
-		addrpth := path.Join(pth, key.HostID, key.Subdomain)
-		val.SetVersion(nil)
-		logger.WithFields(log.Fields{
-			"hostid":    key.HostID,
-			"subdomain": key.Subdomain,
+	logger.Debug("Updated transaction to sync public ports for service")
+	return nil
+}
+
+// syncServiceVHosts updates the transaction to include virtual host updates
+func syncServiceVHosts(conn client.Connection, tx client.Transaction, request ServiceRegistrySyncRequest) error {
+	logger := plog.WithField("serviceid", request.ServiceID)
+	pth := "/net/vhost"
+
+	for _, vhostKey := range request.VHostsToDelete {
+		addrpth := path.Join(pth, vhostKey.HostID, vhostKey.Subdomain)
+		addrLogger := logger.WithFields(log.Fields{
+			"hostid":    vhostKey.HostID,
+			"subdomain": vhostKey.Subdomain,
 			"zkpath":    addrpth,
-		}).Debug("Creating virtual address subdomain")
-		tx.Create(addrpth, &val)
+		})
+		tx.Delete(addrpth)
+		addrLogger.Debug("Deleted virtual host")
+	}
+
+	for vhostKey, vhost := range request.VHostsToPublish {
+		addrpth := path.Join(pth, vhostKey.HostID, vhostKey.Subdomain)
+		addrLogger := logger.WithFields(log.Fields{
+			"hostid":    vhostKey.HostID,
+			"subdomain": vhostKey.Subdomain,
+			"zkpath":    addrpth,
+		})
+		err := conn.CreateIfExists(addrpth, &vhost)
+		if err == client.ErrNoNode {
+			if err := conn.CreateDir(path.Join(pth, vhostKey.HostID)); err != nil {
+				return &RegistryError{
+					Action:  "sync",
+					Path:    path.Join(pth, vhostKey.HostID),
+					Message: "could not register virtual host",
+				}
+			}
+			vhost.SetVersion(nil)
+			tx.Create(addrpth, &vhost)
+			addrLogger.Debug("Created public port address")
+		} else if err == client.ErrNodeExists {
+			existingVHost := &VHost{}
+			if err := conn.Get(addrpth, existingVHost); err != nil {
+				return &RegistryError{
+					Action:  "sync",
+					Path:    addrpth,
+					Message: "could not read current virtual host",
+				}
+			}
+			vhost.SetVersion(existingVHost.Version())
+			tx.Set(addrpth, &vhost)
+			addrLogger.Debug("Updated virtual host")
+		} else {
+			addrLogger.WithError(err).Debug("skipped virtual host because of an unexpected error")
+			return &RegistryError{
+				Action:  "sync",
+				Path:   addrpth,
+				Message: "could not register public port address",
+			}
+		}
 	}
 
 	logger.Debug("Updated transaction to sync virtual hosts for service")

--- a/zzk/registry/registry_test.go
+++ b/zzk/registry/registry_test.go
@@ -16,161 +16,131 @@
 package registry_test
 
 import (
-	"path"
+	//"path"
 
 	"github.com/control-center/serviced/zzk"
 	. "github.com/control-center/serviced/zzk/registry"
 	. "gopkg.in/check.v1"
 )
 
-func (t *ZZKTest) TestSyncRegistry(c *C) {
+// If the request is empty, then the ZK namespace should remain unchanged
+func (t *ZZKTest) TestSyncRegistry_NOOP(c *C) {
 	conn, err := zzk.GetLocalConnection("/")
 	c.Assert(err, IsNil)
 
-	// test create
-	pub1Key := PublicPortKey{HostID: "master", PortAddress: ":2181"}
-	pub1 := PublicPort{
+	request := ServiceRegistrySyncRequest{}
+
+	err = SyncServiceRegistry(conn, request)
+	c.Assert(err, IsNil)
+
+	ok, err := conn.Exists("/net/pub")
+	c.Assert(err, IsNil)
+	c.Check(ok, Equals, false)
+
+	ok, err = conn.Exists("/net/vhosts")
+	c.Assert(err, IsNil)
+	c.Check(ok, Equals, false)
+}
+
+func (t *ZZKTest) TestSyncRegistry_ForPublicPorts(c *C) {
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+
+	// Verify adding a public port
+	portKey := PublicPortKey{HostID: "master", PortAddress: ":2181"}
+	port := PublicPort{
 		TenantID:    "tenantid",
 		Application: "app1",
 		ServiceID:   "serviceid1",
 		Protocol:    "http",
 		UseTLS:      false,
 	}
-	pubs1 := map[PublicPortKey]PublicPort{pub1Key: pub1}
-
-	vhost1Key := VHostKey{HostID: "master", Subdomain: "test1"}
-	vhost1 := VHost{
-		TenantID:    "tenantid",
-		Application: "app1",
-		ServiceID:   "serviceid1",
+	request := ServiceRegistrySyncRequest{
+		ServiceID:      "serviceid1",
+		PortsToPublish: map[PublicPortKey]PublicPort{portKey: port},
 	}
-	vhosts1 := map[VHostKey]VHost{vhost1Key: vhost1}
 
-	err = SyncServiceRegistry(conn, "serviceid1", pubs1, vhosts1)
+	err = SyncServiceRegistry(conn, request)
 	c.Assert(err, IsNil)
 
-	actualpub := &PublicPort{}
-	err = conn.Get("/net/pub/master/:2181", actualpub)
+	actualPublicPort := &PublicPort{}
+	err = conn.Get("/net/pub/master/:2181", actualPublicPort)
 	c.Assert(err, IsNil)
-	actualpub.SetVersion(nil)
-	c.Check(*actualpub, DeepEquals, pub1)
+	actualPublicPort.SetVersion(nil)
+	c.Check(*actualPublicPort, DeepEquals, port)
 
-	actualvhost := &VHost{}
-	err = conn.Get("/net/vhost/master/test1", actualvhost)
-	c.Assert(err, IsNil)
-	actualvhost.SetVersion(nil)
-	c.Check(*actualvhost, DeepEquals, vhost1)
+	// Verify updating a public port
+	port.UseTLS = false
+	port.Protocol = "tcp"
+	request.PortsToPublish[portKey] = port
 
-	pub2Key := PublicPortKey{HostID: "master", PortAddress: ":22181"}
-	pub2 := PublicPort{
-		TenantID:    "tenantid",
-		Application: "app2",
-		ServiceID:   "serviceid2",
-		Protocol:    "https",
-		UseTLS:      true,
-	}
-	pubs2 := map[PublicPortKey]PublicPort{pub2Key: pub2}
-
-	vhost2Key := VHostKey{HostID: "master", Subdomain: "test2"}
-	vhost2 := VHost{
-		TenantID:    "tenantid",
-		Application: "app2",
-		ServiceID:   "serviceid2",
-	}
-	vhosts2 := map[VHostKey]VHost{vhost2Key: vhost2}
-
-	err = SyncServiceRegistry(conn, "serviceid2", pubs2, vhosts2)
+	err = SyncServiceRegistry(conn, request)
 	c.Assert(err, IsNil)
 
-	actualpub = &PublicPort{}
-	err = conn.Get("/net/pub/master/:2181", actualpub)
+	actualPublicPort = &PublicPort{}
+	err = conn.Get("/net/pub/master/:2181", actualPublicPort)
 	c.Assert(err, IsNil)
-	actualpub.SetVersion(nil)
-	c.Check(*actualpub, DeepEquals, pub1)
+	actualPublicPort.SetVersion(nil)
+	c.Check(*actualPublicPort, DeepEquals, port)
 
-	actualvhost = &VHost{}
-	err = conn.Get("/net/vhost/master/test1", actualvhost)
-	c.Assert(err, IsNil)
-	actualvhost.SetVersion(nil)
-	c.Check(*actualvhost, DeepEquals, vhost1)
+	// Verify deleting a public port
+	delete(request.PortsToPublish, portKey)
+	request.PortsToDelete = append(request.PortsToDelete, portKey)
 
-	actualpub = &PublicPort{}
-	err = conn.Get("/net/pub/master/:22181", actualpub)
-	c.Assert(err, IsNil)
-	actualpub.SetVersion(nil)
-	c.Check(*actualpub, DeepEquals, pub2)
-
-	actualvhost = &VHost{}
-	err = conn.Get("/net/vhost/master/test2", actualvhost)
-	c.Assert(err, IsNil)
-	actualvhost.SetVersion(nil)
-	c.Check(*actualvhost, DeepEquals, vhost2)
-
-	// test update
-	pub1Key = PublicPortKey{HostID: "master", PortAddress: ":2181"}
-	pub1 = PublicPort{
-		TenantID:    "tenantid",
-		Application: "app1",
-		ServiceID:   "serviceid1",
-		Protocol:    "",
-		UseTLS:      true,
-	}
-	pubs1 = map[PublicPortKey]PublicPort{pub1Key: pub1}
-
-	vhost1Key = VHostKey{HostID: "master", Subdomain: "test1"}
-	vhost1 = VHost{
-		TenantID:    "tenantid",
-		Application: "app1",
-		ServiceID:   "serviceid1",
-	}
-	vhosts1 = map[VHostKey]VHost{vhost1Key: vhost1}
-
-	err = SyncServiceRegistry(conn, "serviceid1", pubs1, vhosts1)
+	err = SyncServiceRegistry(conn, request)
 	c.Assert(err, IsNil)
 
-	actualpub = &PublicPort{}
-	err = conn.Get("/net/pub/master/:2181", actualpub)
-	c.Assert(err, IsNil)
-	actualpub.SetVersion(nil)
-	c.Check(*actualpub, DeepEquals, pub1)
-
-	actualvhost = &VHost{}
-	err = conn.Get("/net/vhost/master/test1", actualvhost)
-	c.Assert(err, IsNil)
-	actualvhost.SetVersion(nil)
-	c.Check(*actualvhost, DeepEquals, vhost1)
-
-	actualpub = &PublicPort{}
-	err = conn.Get("/net/pub/master/:22181", actualpub)
-	c.Assert(err, IsNil)
-	actualpub.SetVersion(nil)
-	c.Check(*actualpub, DeepEquals, pub2)
-
-	actualvhost = &VHost{}
-	err = conn.Get("/net/vhost/master/test2", actualvhost)
-	c.Assert(err, IsNil)
-	actualvhost.SetVersion(nil)
-	c.Check(*actualvhost, DeepEquals, vhost2)
-
-	// test delete
-	err = SyncServiceRegistry(conn, "serviceid2", make(map[PublicPortKey]PublicPort), make(map[VHostKey]VHost))
-	c.Assert(err, IsNil)
-
-	actualpub = &PublicPort{}
-	err = conn.Get("/net/pub/master/:2181", actualpub)
-	actualpub.SetVersion(nil)
-	c.Check(*actualpub, DeepEquals, pub1)
-
-	actualvhost = &VHost{}
-	err = conn.Get("/net/vhost/master/test1", actualvhost)
-	actualvhost.SetVersion(nil)
-	c.Check(*actualvhost, DeepEquals, vhost1)
-
-	ok, err := conn.Exists(path.Join("/net/pub", pub2Key.HostID, pub2Key.PortAddress))
+	ok, err := conn.Exists("/net/pub/master/:2181")
 	c.Assert(err, IsNil)
 	c.Check(ok, Equals, false)
+}
 
-	ok, err = conn.Exists(path.Join("/net/vhost", vhost2Key.HostID, vhost2Key.Subdomain))
+func (t *ZZKTest) TestSyncRegistry_ForVHosts(c *C) {
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+
+	// Verify adding a vhost
+	vhostKey := VHostKey{HostID: "master", Subdomain: "subdomain"}
+	vhost := VHost{
+		TenantID:    "tenantid",
+		Application: "app1",
+		ServiceID:   "serviceid1",
+	}
+	request := ServiceRegistrySyncRequest{
+		ServiceID:      "serviceid1",
+		VHostsToPublish: map[VHostKey]VHost{vhostKey: vhost},
+	}
+
+	err = SyncServiceRegistry(conn, request)
+	c.Assert(err, IsNil)
+
+	actualVHost := &VHost{}
+	err = conn.Get("/net/vhost/master/subdomain", actualVHost)
+	c.Assert(err, IsNil)
+	actualVHost.SetVersion(nil)
+	c.Check(*actualVHost, DeepEquals, vhost)
+
+	// Verify updating a vhost
+	vhost.Application = "someOtherApp"
+	request.VHostsToPublish[vhostKey] = vhost
+
+	err = SyncServiceRegistry(conn, request)
+	c.Assert(err, IsNil)
+
+	actualVHost = &VHost{}
+	err = conn.Get("/net/vhost/master/subdomain", actualVHost)
+	c.Assert(err, IsNil)
+	actualVHost.SetVersion(nil)
+	c.Check(*actualVHost, DeepEquals, vhost)
+
+	// Verify deleting a vhost
+	delete(request.VHostsToPublish, vhostKey)
+	request.VHostsToDelete = append(request.VHostsToDelete, vhostKey)
+
+	err = SyncServiceRegistry(conn, request)
+	c.Assert(err, IsNil)
+
+	ok, err := conn.Exists("/net/vhost/master/subdomain")
 	c.Assert(err, IsNil)
 	c.Check(ok, Equals, false)
 }


### PR DESCRIPTION
In benchmarking the previous impl for 100s of services, approx 1/4-1/3 of the time was spent in `zzk/registry/registry.go::SyncServiceRegistry` method

This PR introduces `facade/serviceregistry_cache.go` to cache public endpoint data (public ports and vhosts) in the facade so that no ZK interactions are required for services that do not have any public endpoint data that needs to be updated in ZK.

A major assumption here is that only the master can add/chg/delete these entries in zookeeper.
