### PR TITLE
CC-2615: Authenticate CC REST API requests made from within containers using the identity token

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -54,6 +54,12 @@ var (
 	ErrNotAuthenticated = errors.New("No authentication token available")
 	// ErrBadToken is thrown when there is a problem extracting a token from a data stream (e.g. mux, rpc, etc)
 	ErrBadToken = errors.New("Could not extract token")
+	// ErrRestTokenExpired is thrown when an rest token is expired
+	ErrRestTokenExpired = errors.New("Rest token expired")
+	// ErrBadRestToken is throwbn when the rest token cant be extracted or parsed
+	ErrBadRestToken = errors.New("Invalid rest token")
+	// ErrRestTokenBadSig is thrown when a rest token has a bad signature
+	ErrRestTokenBadSig = errors.New("Rest token signature cannot be verified")
 
 	log    = logging.PackageLogger()
 	endian = binary.BigEndian

--- a/auth/localkeys.go
+++ b/auth/localkeys.go
@@ -81,6 +81,8 @@ func (m *MasterKeys) Verify(message, signature []byte) error {
 }
 
 func getDelegatePrivateKey() (crypto.PrivateKey, error) {
+	dKeyCond.RLock()
+	defer dKeyCond.RUnlock()
 	if delegateKeys.localPrivate == nil {
 		return nil, ErrNoPrivateKey
 	}

--- a/auth/localkeys.go
+++ b/auth/localkeys.go
@@ -80,6 +80,13 @@ func (m *MasterKeys) Verify(message, signature []byte) error {
 	return verifier.Verify(message, signature)
 }
 
+func getDelegatePrivateKey() (crypto.PrivateKey, error) {
+	if delegateKeys.localPrivate == nil {
+		return nil, ErrNoPrivateKey
+	}
+	return delegateKeys.localPrivate, nil
+}
+
 // SignAsDelegate signs the given message with the private key local
 // to the delegate running this process.
 func SignAsDelegate(message []byte) ([]byte, error) {

--- a/auth/rest.go
+++ b/auth/rest.go
@@ -1,0 +1,55 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+var (
+	ErrBadRestToken = errors.New("Could not extract auth token from REST request header")
+)
+
+func ExtractRestToken(header string) (string, error) {
+	// The expected header value is "Bearer JWT_ToKen"
+	header = strings.TrimSpace(header)
+	splitted := strings.Split(header, " ")
+	if len(splitted) >= 2 {
+		bearer := splitted[0]
+		token := splitted[len(splitted)-1]
+		if strings.ToLower(bearer) == "bearer" && len(token) > 0 {
+			return token, nil
+		}
+	}
+	return "", ErrBadRestToken
+}
+
+func ExtractRestTokenFromHeaders(h http.Header) (string, error) {
+	rawHeader := h.Get("Authorization")
+	if rawHeader != "" {
+		return ExtractRestToken(rawHeader)
+	}
+	return rawHeader, nil //Token not present
+}
+
+func ValidateRestToken(token string) (bool, error) {
+	identity, err := ParseJWTIdentity(token)
+	if err != nil {
+		return false, err
+	}
+	valid := !identity.Expired() && identity.HasAdminAccess()
+	return valid, nil
+}

--- a/auth/rest.go
+++ b/auth/rest.go
@@ -23,7 +23,7 @@ var (
 	ErrBadRestToken = errors.New("Could not extract auth token from REST request header")
 )
 
-func BuildRestToken() string {
+func BuildRestToken(req *http.Request) string {
 	return AuthToken()
 }
 

--- a/auth/rest.go
+++ b/auth/rest.go
@@ -14,26 +14,97 @@
 package auth
 
 import (
-	"errors"
+	"crypto/sha256"
+	"fmt"
 	"net/http"
 	"strings"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
 )
+
+type AuthTokenRetriever func() string
 
 var (
-	ErrBadRestToken = errors.New("Could not extract auth token from REST request header")
+	RequestDelimiter                       = " "
+	RestTokenExpiration                    = 10 * time.Second
+	AuthTokenGetter     AuthTokenRetriever = AuthToken
 )
 
-func BuildRestToken(r *http.Request) string {
-	return AuthToken()
+type RestToken interface {
+	Valid() error
+	Expired() bool
+	AuthToken() string
+	RestToken() string
+	RequestHash() []byte
+	HasAdminAccess() bool
 }
 
-func ValidateRestToken(r *http.Request, token string) (bool, error) {
-	identity, err := ParseJWTIdentity(token)
-	if err != nil {
-		return false, err
+type jwtRestClaims struct {
+	IssuedAt      int64  `json:"iat,omitempty"`
+	ExpiresAt     int64  `json:"exp,omitempty"`
+	DelegateToken string `json:"tkn,omitempty"`
+	ReqHash       []byte `json:"req,omitempty"`
+}
+
+func (t *jwtRestClaims) Valid() error {
+	if t.Expired() {
+		return ErrRestTokenExpired
 	}
-	valid := !identity.Expired() && identity.HasAdminAccess()
-	return valid, nil
+	return nil
+}
+
+func (t *jwtRestClaims) Expired() bool {
+	now := jwt.TimeFunc().UTC().Unix()
+	return now >= t.ExpiresAt
+}
+
+type jwtRestToken struct {
+	*jwtRestClaims
+	authIdentity Identity
+	restToken    string
+}
+
+func (t *jwtRestToken) AuthToken() string {
+	return t.DelegateToken
+}
+
+func (t *jwtRestToken) RequestHash() []byte {
+	return t.ReqHash
+}
+
+func (t *jwtRestToken) HasAdminAccess() bool {
+	return t.authIdentity.HasAdminAccess()
+}
+
+func (t *jwtRestToken) RestToken() string {
+	return t.restToken
+}
+
+func GetRequestHash(r *http.Request) []byte {
+	// Simplified request hash for now
+	req := strings.ToUpper(r.Method) + RequestDelimiter + strings.ToLower(r.RequestURI)
+	hashedReq := sha256.Sum256([]byte(req))
+	return hashedReq[:]
+}
+
+func BuildRestToken(r *http.Request) (string, error) {
+	now := jwt.TimeFunc().UTC()
+	requestHash := GetRequestHash(r)
+	iat := now.Unix()
+	exp := now.Add(RestTokenExpiration).Unix()
+	claims := &jwtRestClaims{iat, exp, AuthTokenGetter(), requestHash}
+	restToken := jwt.NewWithClaims(jwt.SigningMethodPS256, claims)
+	delegatePrivKey, err := getDelegatePrivateKey()
+	if err != nil {
+		return "", err
+	}
+	signedToken, err := restToken.SignedString(delegatePrivKey)
+	return signedToken, err
+}
+
+func AddRestTokenToRequest(r *http.Request, token string) {
+	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 }
 
 func ExtractRestToken(r *http.Request) (string, error) {
@@ -53,4 +124,53 @@ func ExtractRestToken(r *http.Request) (string, error) {
 		}
 		return "", ErrBadRestToken
 	}
+}
+
+func ParseRestToken(token string) (RestToken, error) {
+	claims := &jwtRestClaims{}
+	identity := &jwtIdentity{}
+	parsed, err := jwt.ParseWithClaims(token, claims, func(token *jwt.Token) (interface{}, error) {
+		// Validate the algorithm matches the key
+		if _, ok := token.Method.(*jwt.SigningMethodRSAPSS); !ok {
+			return nil, ErrInvalidSigningMethod
+		}
+		// Get the delegate token and extract the host delegate key
+		id, err := ParseJWTIdentity(claims.DelegateToken)
+		if err != nil {
+			return nil, err
+		}
+		if ji, ok := id.(*jwtIdentity); ok {
+			identity = ji
+			return RSAPublicKeyFromPEM([]byte(ji.PubKey))
+		}
+		return nil, ErrIdentityTokenBadSig
+	})
+	if err != nil {
+		if verr, ok := err.(*jwt.ValidationError); ok {
+			if verr.Inner != nil && (verr.Inner == ErrIdentityTokenExpired || verr.Inner == ErrIdentityTokenBadSig) {
+				return nil, verr.Inner
+			}
+			if verr.Errors&jwt.ValidationErrorExpired != 0 || verr.Inner != nil && verr.Inner == ErrRestTokenExpired {
+				return nil, ErrRestTokenExpired
+			}
+			if verr.Errors&(jwt.ValidationErrorSignatureInvalid|jwt.ValidationErrorUnverifiable) != 0 {
+				return nil, ErrRestTokenBadSig
+			}
+			if verr.Errors&(jwt.ValidationErrorMalformed) != 0 {
+				return nil, ErrBadRestToken
+			}
+			if verr.Inner != nil {
+				return nil, verr.Inner
+			}
+		}
+		return nil, err
+	}
+	if claims, ok := parsed.Claims.(*jwtRestClaims); ok && parsed.Valid {
+		restToken := &jwtRestToken{}
+		restToken.jwtRestClaims = claims
+		restToken.authIdentity = identity
+		restToken.restToken = token
+		return restToken, nil
+	}
+	return nil, ErrIdentityTokenInvalid
 }

--- a/auth/rest.go
+++ b/auth/rest.go
@@ -38,7 +38,7 @@ type RestToken interface {
 	Expired() bool
 	AuthToken() string
 	RestToken() string
-	RequestHash() []byte
+	ValidateRequestHash(r *http.Request) bool
 	HasAdminAccess() bool
 }
 
@@ -71,8 +71,9 @@ func (t *jwtRestToken) AuthToken() string {
 	return t.DelegateToken
 }
 
-func (t *jwtRestToken) RequestHash() []byte {
-	return t.ReqHash
+func (t *jwtRestToken) ValidateRequestHash(r *http.Request) bool {
+	hash := GetRequestHash(r)
+	return bytes.Equal(t.ReqHash, hash)
 }
 
 func (t *jwtRestToken) HasAdminAccess() bool {
@@ -96,7 +97,7 @@ func getRequestBody(r *http.Request) string {
 }
 
 func GetRequestHash(r *http.Request) []byte {
-	req := strings.ToUpper(r.Method) + RequestDelimiter + strings.ToLower(r.URL.String())
+	req := strings.ToUpper(r.Method) + RequestDelimiter + strings.ToLower(r.RequestURI)
 	body := getRequestBody(r)
 	if len(body) > 0 {
 		req = req + RequestDelimiter + body

--- a/auth/rest.go
+++ b/auth/rest.go
@@ -23,6 +23,10 @@ var (
 	ErrBadRestToken = errors.New("Could not extract auth token from REST request header")
 )
 
+func BuildRestToken() string {
+	return AuthToken()
+}
+
 func ExtractRestToken(header string) (string, error) {
 	// The expected header value is "Bearer JWT_ToKen"
 	header = strings.TrimSpace(header)

--- a/auth/rest_test.go
+++ b/auth/rest_test.go
@@ -54,8 +54,8 @@ func (s *TestAuthSuite) TestBuildAndExtractRestToken(c *C) {
 	authToken, _, err := auth.CreateJWTIdentity(cfg.hostID, cfg.poolID, cfg.admin, cfg.dfs, s.delegatePubPEM, cfg.exp)
 	// Create requests
 	req, _ := http.NewRequest(cfg.method, cfg.uri, nil)
-	auth.AuthTokenGetter = func() string {
-		return authToken
+	auth.AuthTokenGetter = func() (string, error) {
+		return authToken, nil
 	}
 	expectedReqHash := auth.GetRequestHash(req)
 	// Create Rest Token
@@ -93,8 +93,8 @@ func (s *TestAuthSuite) TestExpiredRestToken(c *C) {
 	authToken, _, err := auth.CreateJWTIdentity(cfg.hostID, cfg.poolID, cfg.admin, cfg.dfs, s.delegatePubPEM, cfg.exp)
 	// Create requests
 	req, _ := http.NewRequest(cfg.method, cfg.uri, nil)
-	auth.AuthTokenGetter = func() string {
-		return authToken
+	auth.AuthTokenGetter = func() (string, error) {
+		return authToken, nil
 	}
 	auth.RestTokenExpiration = -1 * time.Hour
 	// Create Rest Token
@@ -118,8 +118,8 @@ func (s *TestAuthSuite) TestTamperedRestToken(c *C) {
 	authToken, _, err := auth.CreateJWTIdentity(cfg.hostID, cfg.poolID, cfg.admin, cfg.dfs, s.delegatePubPEM, cfg.exp)
 	// Create requests
 	req, _ := http.NewRequest(cfg.method, cfg.uri, nil)
-	auth.AuthTokenGetter = func() string {
-		return authToken
+	auth.AuthTokenGetter = func() (string, error) {
+		return authToken, nil
 	}
 	// Create Rest Token
 	restToken, err := auth.BuildRestToken(req)
@@ -168,8 +168,8 @@ func (s *TestAuthSuite) TestExpiredAuthToken(c *C) {
 	authToken, _, err := auth.CreateJWTIdentity(cfg.hostID, cfg.poolID, cfg.admin, cfg.dfs, s.delegatePubPEM, cfg.exp)
 	// Create requests
 	req, _ := http.NewRequest(cfg.method, cfg.uri, nil)
-	auth.AuthTokenGetter = func() string {
-		return authToken
+	auth.AuthTokenGetter = func() (string, error) {
+		return authToken, nil
 	}
 	// Create Rest Token
 	restToken, err := auth.BuildRestToken(req)
@@ -193,8 +193,8 @@ func (s *TestAuthSuite) TestTamperedAuthToken(c *C) {
 	authToken = authToken[:40] + "HOLA" + authToken[44:]
 	// Create requests
 	req, _ := http.NewRequest(cfg.method, cfg.uri, nil)
-	auth.AuthTokenGetter = func() string {
-		return authToken
+	auth.AuthTokenGetter = func() (string, error) {
+		return authToken, nil
 	}
 	// Create Rest Token
 	restToken, err := auth.BuildRestToken(req)

--- a/auth/rest_test.go
+++ b/auth/rest_test.go
@@ -1,0 +1,212 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package auth_test
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/control-center/serviced/auth"
+	. "gopkg.in/check.v1"
+)
+
+type restTestConfig struct {
+	hostID string
+	poolID string
+	admin  bool
+	dfs    bool
+	exp    time.Duration
+	method string
+	uri    string
+}
+
+var (
+	originalTokenGetter         = auth.AuthTokenGetter
+	originalRestTokenExpiration = auth.RestTokenExpiration
+)
+
+func restTestCleanup() {
+	auth.AuthTokenGetter = originalTokenGetter
+	auth.RestTokenExpiration = originalRestTokenExpiration
+}
+
+func newTestConfig() restTestConfig {
+	return restTestConfig{"mockHost", "mockPool", true, true, time.Minute, "GET", "/super/fake/request"}
+}
+
+func (s *TestAuthSuite) TestBuildAndExtractRestToken(c *C) {
+	cfg := newTestConfig()
+	// Create auth token
+	authToken, _, err := auth.CreateJWTIdentity(cfg.hostID, cfg.poolID, cfg.admin, cfg.dfs, s.delegatePubPEM, cfg.exp)
+	// Create requests
+	req, _ := http.NewRequest(cfg.method, cfg.uri, nil)
+	auth.AuthTokenGetter = func() string {
+		return authToken
+	}
+	expectedReqHash := auth.GetRequestHash(req)
+	// Create Rest Token
+	restToken, err := auth.BuildRestToken(req)
+	c.Assert(err, IsNil)
+	c.Assert(restToken, NotNil)
+
+	// Add rest token to request header
+	auth.AddRestTokenToRequest(req, restToken)
+	h := req.Header.Get("Authorization")
+	c.Assert(h, DeepEquals, fmt.Sprintf("Bearer %s", restToken))
+
+	// Extract rest token from request
+	extractedToken, err := auth.ExtractRestToken(req)
+	c.Assert(err, IsNil)
+	c.Assert(extractedToken, DeepEquals, restToken)
+
+	// Parse token
+	parsedToken, err := auth.ParseRestToken(extractedToken)
+	c.Assert(err, IsNil)
+	c.Assert(parsedToken, NotNil)
+	c.Assert(parsedToken.RestToken(), DeepEquals, restToken)
+	c.Assert(parsedToken.AuthToken(), DeepEquals, authToken)
+	c.Assert(parsedToken.HasAdminAccess(), Equals, cfg.admin)
+	c.Assert(parsedToken.Expired(), Equals, false)
+	c.Assert(parsedToken.Valid(), IsNil)
+	c.Assert(parsedToken.RequestHash(), DeepEquals, expectedReqHash)
+
+	restTestCleanup()
+}
+
+func (s *TestAuthSuite) TestExpiredRestToken(c *C) {
+	cfg := newTestConfig()
+	// Create auth token
+	authToken, _, err := auth.CreateJWTIdentity(cfg.hostID, cfg.poolID, cfg.admin, cfg.dfs, s.delegatePubPEM, cfg.exp)
+	// Create requests
+	req, _ := http.NewRequest(cfg.method, cfg.uri, nil)
+	auth.AuthTokenGetter = func() string {
+		return authToken
+	}
+	auth.RestTokenExpiration = -1 * time.Hour
+	// Create Rest Token
+	restToken, err := auth.BuildRestToken(req)
+	c.Assert(err, IsNil)
+	// Add rest token to request header
+	auth.AddRestTokenToRequest(req, restToken)
+	// Extract rest token from request
+	extractedToken, err := auth.ExtractRestToken(req)
+	c.Assert(err, IsNil)
+	// Parse token
+	_, err = auth.ParseRestToken(extractedToken)
+	c.Assert(err, Equals, auth.ErrRestTokenExpired)
+
+	restTestCleanup()
+}
+
+func (s *TestAuthSuite) TestTamperedRestToken(c *C) {
+	cfg := newTestConfig()
+	// Create auth token
+	authToken, _, err := auth.CreateJWTIdentity(cfg.hostID, cfg.poolID, cfg.admin, cfg.dfs, s.delegatePubPEM, cfg.exp)
+	// Create requests
+	req, _ := http.NewRequest(cfg.method, cfg.uri, nil)
+	auth.AuthTokenGetter = func() string {
+		return authToken
+	}
+	// Create Rest Token
+	restToken, err := auth.BuildRestToken(req)
+	c.Assert(err, IsNil)
+	// modify token
+	l := len(restToken)
+	restToken = restToken[:l-4] + "HOLA"
+	// Add rest token to request header
+	auth.AddRestTokenToRequest(req, restToken)
+	// Extract rest token from request
+	extractedToken, err := auth.ExtractRestToken(req)
+	c.Assert(err, IsNil)
+	c.Assert(extractedToken, DeepEquals, restToken)
+	// Parse token
+	_, err = auth.ParseRestToken(extractedToken)
+	c.Assert(err, Equals, auth.ErrRestTokenBadSig)
+
+	restTestCleanup()
+}
+
+func (s *TestAuthSuite) TestInvalidRestToken(c *C) {
+	cfg := newTestConfig()
+	req, _ := http.NewRequest(cfg.method, cfg.uri, nil)
+	// Empty token
+	auth.AddRestTokenToRequest(req, "")
+	_, err := auth.ExtractRestToken(req)
+	c.Assert(err, Equals, auth.ErrBadRestToken)
+
+	// Invalid token
+	req, _ = http.NewRequest(cfg.method, cfg.uri, nil)
+	invalidToken := "THIS ISNT A REST TOKEN"
+	auth.AddRestTokenToRequest(req, invalidToken)
+	extractedToken, err := auth.ExtractRestToken(req)
+	c.Assert(err, IsNil)
+	token, err := auth.ParseRestToken(extractedToken)
+	c.Assert(err, Equals, auth.ErrBadRestToken)
+	c.Assert(token, IsNil)
+
+	restTestCleanup()
+}
+
+func (s *TestAuthSuite) TestExpiredAuthToken(c *C) {
+	cfg := newTestConfig()
+	cfg.exp = -1 * time.Hour
+	// Create auth token
+	authToken, _, err := auth.CreateJWTIdentity(cfg.hostID, cfg.poolID, cfg.admin, cfg.dfs, s.delegatePubPEM, cfg.exp)
+	// Create requests
+	req, _ := http.NewRequest(cfg.method, cfg.uri, nil)
+	auth.AuthTokenGetter = func() string {
+		return authToken
+	}
+	// Create Rest Token
+	restToken, err := auth.BuildRestToken(req)
+	c.Assert(err, IsNil)
+	// Add rest token to request header
+	auth.AddRestTokenToRequest(req, restToken)
+	// Extract rest token from request
+	extractedToken, err := auth.ExtractRestToken(req)
+	c.Assert(err, IsNil)
+	// Parse token
+	_, err = auth.ParseRestToken(extractedToken)
+	c.Assert(err, Equals, auth.ErrIdentityTokenExpired)
+
+	restTestCleanup()
+}
+
+func (s *TestAuthSuite) TestTamperedAuthToken(c *C) {
+	cfg := newTestConfig()
+	// Create auth token
+	authToken, _, err := auth.CreateJWTIdentity(cfg.hostID, cfg.poolID, cfg.admin, cfg.dfs, s.delegatePubPEM, cfg.exp)
+	authToken = authToken[:40] + "HOLA" + authToken[44:]
+	// Create requests
+	req, _ := http.NewRequest(cfg.method, cfg.uri, nil)
+	auth.AuthTokenGetter = func() string {
+		return authToken
+	}
+	// Create Rest Token
+	restToken, err := auth.BuildRestToken(req)
+	c.Assert(err, IsNil)
+	// Add rest token to request header
+	auth.AddRestTokenToRequest(req, restToken)
+	// Extract rest token from request
+	extractedToken, err := auth.ExtractRestToken(req)
+	c.Assert(err, IsNil)
+	// Parse token
+	_, err = auth.ParseRestToken(extractedToken)
+	c.Assert(err, Equals, auth.ErrIdentityTokenBadSig)
+
+	restTestCleanup()
+}

--- a/container/cc_api_proxy.go
+++ b/container/cc_api_proxy.go
@@ -21,7 +21,6 @@ package container
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"strconv"
@@ -42,8 +41,11 @@ func newServicedApiProxy() *servicedApiProxy {
 	director := func(req *http.Request) {
 		req.URL.Scheme = "https"
 		req.URL.Host = "localhost:" + strconv.Itoa(ccApiPort)
-		token := auth.BuildRestToken(req)
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+		token, err := auth.BuildRestToken(req)
+		if err != nil {
+			plog.WithError(err).Info("Error building rest token")
+		}
+		auth.AddRestTokenToRequest(req, token)
 	}
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	transport := &http.Transport{TLSClientConfig: tlsConfig}

--- a/container/cc_api_proxy.go
+++ b/container/cc_api_proxy.go
@@ -42,7 +42,7 @@ func newServicedApiProxy() *servicedApiProxy {
 	director := func(req *http.Request) {
 		req.URL.Scheme = "https"
 		req.URL.Host = "localhost:" + strconv.Itoa(ccApiPort)
-		token := auth.BuildRestToken()
+		token := auth.BuildRestToken(req)
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}

--- a/container/cc_api_proxy.go
+++ b/container/cc_api_proxy.go
@@ -1,0 +1,58 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+/*
+ *  Http proxy that injects the auth token in the header when
+ *  sending requests to CC REST API
+ *  It listens on http port and proxies to https
+ */
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"strconv"
+
+	"github.com/control-center/serviced/auth"
+	"github.com/control-center/serviced/node"
+)
+
+type servicedApiProxy struct {
+	proxyPort int
+	ccApiPort int
+	proxy     *httputil.ReverseProxy
+}
+
+func newServicedApiProxy() *servicedApiProxy {
+	proxyPort := node.SERVICED_UI_ENDPOINT_PROXY
+	ccApiPort := node.SERVICED_UI_ENDPOINT
+	director := func(req *http.Request) {
+		req.URL.Scheme = "https"
+		req.URL.Host = "localhost:" + strconv.Itoa(ccApiPort)
+		token := auth.AuthToken() // TODO Sign token
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	transport := &http.Transport{TLSClientConfig: tlsConfig}
+	proxy := &httputil.ReverseProxy{Director: director, Transport: transport}
+
+	return &servicedApiProxy{proxyPort, ccApiPort, proxy}
+}
+
+func (p *servicedApiProxy) run() {
+	port := ":" + strconv.Itoa(p.proxyPort)
+	http.ListenAndServe(port, p.proxy)
+}

--- a/container/cc_api_proxy.go
+++ b/container/cc_api_proxy.go
@@ -42,7 +42,7 @@ func newServicedApiProxy() *servicedApiProxy {
 	director := func(req *http.Request) {
 		req.URL.Scheme = "https"
 		req.URL.Host = "localhost:" + strconv.Itoa(ccApiPort)
-		token := auth.AuthToken() // TODO Sign token
+		token := auth.BuildRestToken()
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}

--- a/container/controller.go
+++ b/container/controller.go
@@ -626,7 +626,7 @@ func (c *Controller) Run() (err error) {
 	c.endpoints.Run(endpointExit)
 
 	// Start CC Rest API Proxy
-	go c.ccApiProxy.run() // TODO how to control shutdown?
+	go c.ccApiProxy.run()
 
 	// HACK: I guess this is how it used to work?  This code is horrible.
 	go func() {

--- a/container/controller.go
+++ b/container/controller.go
@@ -121,6 +121,7 @@ type Controller struct {
 	exitStatus         int
 	endpoints          *ContainerEndpoints
 	healthChecks       map[string]health.HealthCheck
+	ccApiProxy         *servicedApiProxy
 }
 
 // Close shuts down the controller
@@ -422,6 +423,9 @@ func NewController(options ControllerOptions) (*Controller, error) {
 		return c, err
 	}
 
+	// CC Rest API proxy
+	c.ccApiProxy = newServicedApiProxy()
+
 	// check command
 	glog.Infof("command: %v [%d]", options.Service.Command, len(options.Service.Command))
 	if len(options.Service.Command) < 1 {
@@ -620,6 +624,9 @@ func (c *Controller) Run() (err error) {
 	serviceExited := make(chan error, 1)
 	endpointExit := make(chan struct{})
 	c.endpoints.Run(endpointExit)
+
+	// Start CC Rest API Proxy
+	go c.ccApiProxy.run() // TODO how to control shutdown?
 
 	// HACK: I guess this is how it used to work?  This code is horrible.
 	go func() {

--- a/node/agent_proxy.go
+++ b/node/agent_proxy.go
@@ -31,6 +31,11 @@ import (
 	"github.com/zenoss/glog"
 )
 
+const (
+	SERVICED_UI_ENDPOINT       = 5443
+	SERVICED_UI_ENDPOINT_PROXY = 443
+)
+
 // assert that the HostAgent implements the LoadBalancer interface
 var _ LoadBalancer = &HostAgent{}
 
@@ -130,8 +135,10 @@ func (a *HostAgent) addControlPlaneEndpoint(endpoints map[string][]applicationen
 		return
 	}
 	endpoint.ContainerPort = uint16(port)
-	//control center should always be reachable on port 443 in a container
-	endpoint.ProxyPort = uint16(443)
+	// control center should always be reachable in a container on
+	// port SERVICED_UI_ENDPOINT_PROXY via http. SERVICED_UI_ENDPOINT_PROXY
+	// proxies to SERVICED_UI_ENDPOINT via https
+	endpoint.ProxyPort = uint16(SERVICED_UI_ENDPOINT)
 	endpoint.HostPort = uint16(port)
 	endpoint.HostIP = strings.Split(a.master, ":")[0]
 	endpoint.Protocol = "tcp"

--- a/node/agent_proxy_test.go
+++ b/node/agent_proxy_test.go
@@ -24,6 +24,7 @@ package node
 import (
 	"github.com/control-center/serviced/domain/applicationendpoint"
 
+	"fmt"
 	"testing"
 )
 
@@ -33,7 +34,7 @@ var _ LoadBalancer = &HostAgent{}
 func TestAddControlPlaneEndpoints(t *testing.T) {
 	agent := &HostAgent{}
 	agent.master = "127.0.0.1:0"
-	agent.uiport = ":443"
+	agent.uiport = fmt.Sprintf(":%d", SERVICED_UI_ENDPOINT)
 	endpoints := make(map[string][]applicationendpoint.ApplicationEndpoint)
 
 	consumer_endpoint := applicationendpoint.ApplicationEndpoint{}
@@ -50,9 +51,9 @@ func TestAddControlPlaneEndpoints(t *testing.T) {
 	controlplane_endpoint.ServiceID = "controlplane"
 	controlplane_endpoint.Application = "controlplane"
 	controlplane_endpoint.ContainerIP = "127.0.0.1"
-	controlplane_endpoint.ContainerPort = 443
-	controlplane_endpoint.ProxyPort = 443
-	controlplane_endpoint.HostPort = 443
+	controlplane_endpoint.ContainerPort = SERVICED_UI_ENDPOINT
+	controlplane_endpoint.ProxyPort = SERVICED_UI_ENDPOINT
+	controlplane_endpoint.HostPort = SERVICED_UI_ENDPOINT
 	controlplane_endpoint.HostIP = "127.0.0.1"
 	controlplane_endpoint.Protocol = "tcp"
 
@@ -63,23 +64,24 @@ func TestAddControlPlaneEndpoints(t *testing.T) {
 		t.Fatalf(" mapping failed missing key[\"tcp:8444\"]")
 	}
 
-	if _, ok := endpoints["tcp:443"]; !ok {
-		t.Fatalf(" mapping failed missing key[\"tcp:443\"]")
+	ccuiport := fmt.Sprintf("tcp%s", agent.uiport)
+	if _, ok := endpoints[ccuiport]; !ok {
+		t.Fatalf(" mapping failed missing key[\"%s\"]", ccuiport)
 	}
 
 	if len(endpoints["tcp:8444"]) != 1 {
 		t.Fatalf(" mapping failed len(\"tcp:8444\"])=%d expected 1", len(endpoints["tcp:8444"]))
 	}
 
-	if len(endpoints["tcp:443"]) != 1 {
-		t.Fatalf(" mapping failed len(\"tcp:443\"])=%d expected 1", len(endpoints["tcp:443"]))
+	if len(endpoints[ccuiport]) != 1 {
+		t.Fatalf(" mapping failed len(\"%s\"])=%d expected 1", ccuiport, len(endpoints[ccuiport]))
 	}
 
 	if endpoints["tcp:8444"][0] != consumer_endpoint {
 		t.Fatalf(" mapping failed %+v expected %+v", endpoints["tcp:8444"][0], consumer_endpoint)
 	}
 
-	if endpoints["tcp:443"][0] != controlplane_endpoint {
-		t.Fatalf(" mapping failed %+v expected %+v", endpoints["tcp:443"][0], controlplane_endpoint)
+	if endpoints[ccuiport][0] != controlplane_endpoint {
+		t.Fatalf(" mapping failed %+v expected %+v", endpoints[ccuiport][0], controlplane_endpoint)
 	}
 }

--- a/web/session.go
+++ b/web/session.go
@@ -126,16 +126,17 @@ func loginWithBasicAuthOK(r *rest.Request) bool {
 }
 
 func loginWithTokenOK(r *rest.Request, token string) bool {
-	validToken, err := auth.ValidateRestToken(r.Request, token)
+	restToken, err := auth.ParseRestToken(token)
+	//validToken, err := auth.ValidateRestToken(r.Request, token)
 	if err != nil {
-		msg := "Unable to parse auth token"
+		msg := "Unable to parse rest token"
 		plog.WithError(err).Info(msg)
 		return false
-	} else if !validToken {
-		msg := "Could not login with auth token. Expired token or source host without permissions."
-		plog.WithError(err).Info(msg)
+	} else if !restToken.HasAdminAccess() {
+		msg := "Could not login with rest token. Insufficient permissions."
+		plog.Info(msg)
 		return false
-	} else { // We have a valid token
+	} else {
 		return true
 	}
 }

--- a/web/session.go
+++ b/web/session.go
@@ -108,7 +108,6 @@ func loginWithBasicAuthOK(r *rest.Request) bool {
 		glog.V(1).Info("Error getting cookie ", err)
 		return false
 	}
-
 	sessionsLock.Lock()
 	defer sessionsLock.Unlock()
 	value, err := url.QueryUnescape(strings.Replace(cookie.Value, "+", url.QueryEscape("+"), -1))
@@ -127,7 +126,7 @@ func loginWithBasicAuthOK(r *rest.Request) bool {
 }
 
 func loginWithTokenOK(r *rest.Request, token string) bool {
-	validToken, err := auth.ValidateRestToken(token)
+	validToken, err := auth.ValidateRestToken(r.Request, token)
 	if err != nil {
 		msg := "Unable to parse auth token"
 		plog.WithError(err).Info(msg)
@@ -142,7 +141,7 @@ func loginWithTokenOK(r *rest.Request, token string) bool {
 }
 
 func loginOK(r *rest.Request) bool {
-	token, tErr := auth.ExtractRestTokenFromHeaders(r.Header)
+	token, tErr := auth.ExtractRestToken(r.Request)
 	if tErr != nil { // There is a token in the header but we could not extract it
 		msg := "Unable to extract auth token from header"
 		plog.WithError(tErr).Info(msg)
@@ -238,7 +237,7 @@ func restLoginWithBasicAuth(w *rest.ResponseWriter, r *rest.Request, ctx *reques
  * Perform login, return JSON
  */
 func restLogin(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
-	token, tErr := auth.ExtractRestTokenFromHeaders(r.Header)
+	token, tErr := auth.ExtractRestToken(r.Request)
 	if tErr != nil { // There is a token in the header but we could not extract it
 		msg := "Unable to extract auth token from header"
 		plog.WithError(tErr).Warning(msg)

--- a/web/session.go
+++ b/web/session.go
@@ -130,11 +130,11 @@ func loginWithTokenOK(r *rest.Request, token string) bool {
 	//validToken, err := auth.ValidateRestToken(r.Request, token)
 	if err != nil {
 		msg := "Unable to parse rest token"
-		plog.WithError(err).Info(msg)
+		plog.WithError(err).WithField("url", r.URL.String()).Debug(msg)
 		return false
 	} else if !restToken.HasAdminAccess() {
 		msg := "Could not login with rest token. Insufficient permissions."
-		plog.Info(msg)
+		plog.WithField("url", r.URL.String()).Debug(msg)
 		return false
 	} else {
 		return true
@@ -145,7 +145,7 @@ func loginOK(r *rest.Request) bool {
 	token, tErr := auth.ExtractRestToken(r.Request)
 	if tErr != nil { // There is a token in the header but we could not extract it
 		msg := "Unable to extract auth token from header"
-		plog.WithError(tErr).Info(msg)
+		plog.WithError(tErr).WithField("url", r.URL.String()).Debug(msg)
 		return false
 	} else if token != "" {
 		return loginWithTokenOK(r, token)


### PR DESCRIPTION
We have added a reverse proxy in the container controller that injects the rest token in the cc rest api requests.
The rest token basically wraps the auth token signing it with the delegate priv key. The CC rest api validates the rest token sender identity using the delegate's public key which is extracted from the auth token that is signed by the master.