### PR TITLE
monitoring profile

### DIFF
--- a/domain/graph.go
+++ b/domain/graph.go
@@ -16,7 +16,9 @@ package domain
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
+	"strings"
 )
 
 //DataPointRateOptions define the rate options for a data point
@@ -124,4 +126,12 @@ type GraphConfig struct {
 // Equals returns if graph equals that graph
 func (graph *GraphConfig) Equals(that *GraphConfig) bool {
 	return reflect.DeepEqual(graph, that)
+}
+
+// ValidEntity ensures that no graph configs have an id with prefix "internal"
+func (graph GraphConfig) ValidEntity() error {
+	if strings.HasPrefix(graph.ID, "internal") {
+		return fmt.Errorf("graph id cannot have prefix 'internal'")
+	}
+	return nil
 }

--- a/domain/metric.go
+++ b/domain/metric.go
@@ -16,6 +16,9 @@
 package domain
 
 import (
+	"fmt"
+
+	"github.com/control-center/serviced/validation"
 	"github.com/zenoss/glog"
 
 	"encoding/json"
@@ -76,6 +79,24 @@ type MetricConfig struct {
 	Description string      // a description of the metrics
 	Query       QueryConfig // the http query to request metrics
 	Metrics     []Metric    // meta-data describing all metrics
+}
+
+// ValidEntity ensures the metric config is not named "metrics"
+func (config MetricConfig) ValidEntity() error {
+	if config.ID == "metrics" {
+		return fmt.Errorf("'metrics' is a reserved word")
+	}
+
+	violations := validation.NewValidationError()
+	for _, m := range config.Metrics {
+		if m.BuiltIn {
+			violations.AddViolation(fmt.Sprintf("config %s: metric %s cannot have built in set to true", config.ID, m.ID))
+		}
+	}
+	if violations.HasError() {
+		return violations
+	}
+	return nil
 }
 
 // Equals equality test for MetricConfig

--- a/domain/monitor.go
+++ b/domain/monitor.go
@@ -14,7 +14,11 @@
 // Package domain defines the monitoring profiles for control center domain objects
 package domain
 
-import "reflect"
+import (
+	"reflect"
+
+	"github.com/control-center/serviced/validation"
+)
 
 //MonitorProfile describes metrics, thresholds and graphs to monitor an object's performance
 type MonitorProfile struct {
@@ -102,4 +106,21 @@ func (profile *MonitorProfile) ReBuild(timeSpan string, tags map[string][]string
 	}
 
 	return &newProfile, nil
+}
+
+// ValidEntity ensures the monitor profile is valid before it is written to the
+// database.
+func (profile MonitorProfile) ValidEntity() error {
+	violations := validation.NewValidationError()
+	for _, mc := range profile.MetricConfigs {
+		violations.Add(mc.ValidEntity())
+	}
+	for _, gc := range profile.GraphConfigs {
+		violations.Add(gc.ValidEntity())
+	}
+
+	if violations.HasError() {
+		return violations
+	}
+	return nil
 }

--- a/domain/service/validation.go
+++ b/domain/service/validation.go
@@ -62,6 +62,9 @@ func (s *Service) ValidEntity() error {
 		}
 	}
 
+	// validate the monitoring profile
+	vErr.Add(s.MonitoringProfile.ValidEntity())
+
 	if vErr.HasError() {
 		return vErr
 	}

--- a/domain/servicedefinition/validation.go
+++ b/domain/servicedefinition/validation.go
@@ -64,6 +64,11 @@ func (sd *ServiceDefinition) validate(context *validationContext) error {
 	}
 	//TODO: validate LogConfigs
 
+	// validate Monitoring Profile
+	if err := sd.MonitoringProfile.ValidEntity(); err != nil {
+		return fmt.Errorf("service definition %v: invalid monitoring profile %s", sd.Name, err)
+	}
+
 	return validServiceDefinitions(&sd.Services, context)
 }
 

--- a/web/hostresource.go
+++ b/web/hostresource.go
@@ -145,6 +145,16 @@ func restGetServiceMonitoringProfile(w *rest.ResponseWriter, r *rest.Request, ct
 		return
 	}
 
+	// load the internal monitoring data
+	config, err := getInternalMetrics()
+	if err != nil {
+		glog.Errorf("Could not get internal monitoring metrics: %s", err)
+		restServerError(w, err)
+		return
+	}
+	mp.MetricConfigs = append(mp.MetricConfigs, *config)
+	mp.GraphConfigs = append(mp.GraphConfigs, getInternalGraphConfigs(serviceID)...)
+
 	glog.V(4).Infof("restGetServiceMonitoringProfile: id %s, monitoring profile %#v", serviceID, mp)
 	w.WriteJson(&mp)
 }

--- a/web/resources.go
+++ b/web/resources.go
@@ -139,7 +139,17 @@ func restPostServicesForMigration(w *rest.ResponseWriter, r *rest.Request, clien
 	w.WriteJson(&simpleResponse{"Migrated services.", []link{}})
 }
 
+// DEPRECATED
 func restGetAllServices(w *rest.ResponseWriter, r *rest.Request, client *daoclient.ControlClient) {
+
+	// load the internal monitoring data
+	config, err := getInternalMetrics()
+	if err != nil {
+		glog.Errorf("Could not get internal monitoring metrics: %s", err)
+		restServerError(w, err)
+		return
+	}
+
 	tenantID := r.URL.Query().Get("tenantID")
 	if tags := r.URL.Query().Get("tags"); tags != "" {
 		nmregex := r.URL.Query().Get("name")
@@ -150,7 +160,8 @@ func restGetAllServices(w *rest.ResponseWriter, r *rest.Request, client *daoclie
 		}
 
 		for ii, _ := range result {
-			fillBuiltinMetrics(&result[ii])
+			result[ii].MonitoringProfile.MetricConfigs = append(result[ii].MonitoringProfile.MetricConfigs, *config)
+			result[ii].MonitoringProfile.GraphConfigs = append(result[ii].MonitoringProfile.GraphConfigs, getInternalGraphConfigs(result[ii].ID)...)
 		}
 		w.WriteJson(&result)
 		return
@@ -164,7 +175,8 @@ func restGetAllServices(w *rest.ResponseWriter, r *rest.Request, client *daoclie
 		}
 
 		for ii, _ := range result {
-			fillBuiltinMetrics(&result[ii])
+			result[ii].MonitoringProfile.MetricConfigs = append(result[ii].MonitoringProfile.MetricConfigs, *config)
+			result[ii].MonitoringProfile.GraphConfigs = append(result[ii].MonitoringProfile.GraphConfigs, getInternalGraphConfigs(result[ii].ID)...)
 		}
 		w.WriteJson(&result)
 		return
@@ -202,7 +214,8 @@ func restGetAllServices(w *rest.ResponseWriter, r *rest.Request, client *daoclie
 	}
 
 	for ii, _ := range result {
-		fillBuiltinMetrics(&result[ii])
+		result[ii].MonitoringProfile.MetricConfigs = append(result[ii].MonitoringProfile.MetricConfigs, *config)
+		result[ii].MonitoringProfile.GraphConfigs = append(result[ii].MonitoringProfile.GraphConfigs, getInternalGraphConfigs(result[ii].ID)...)
 	}
 	w.WriteJson(&result)
 }
@@ -305,7 +318,16 @@ func restGetTopServices(w *rest.ResponseWriter, r *rest.Request, client *daoclie
 	w.WriteJson(&topServices)
 }
 
+// DEPRECATED
 func restGetService(w *rest.ResponseWriter, r *rest.Request, client *daoclient.ControlClient) {
+	// load the internal monitoring data
+	config, err := getInternalMetrics()
+	if err != nil {
+		glog.Errorf("Could not get internal monitoring metrics: %s", err)
+		restServerError(w, err)
+		return
+	}
+
 	serviceID, err := url.QueryUnescape(r.PathParam("serviceId"))
 	if err != nil {
 		restBadRequest(w, err)
@@ -337,7 +359,8 @@ func restGetService(w *rest.ResponseWriter, r *rest.Request, client *daoclient.C
 	}
 
 	if svc.ID == serviceID {
-		fillBuiltinMetrics(&svc)
+		svc.MonitoringProfile.MetricConfigs = append(svc.MonitoringProfile.MetricConfigs, *config)
+		svc.MonitoringProfile.GraphConfigs = append(svc.MonitoringProfile.GraphConfigs, getInternalGraphConfigs(svc.ID)...)
 		w.WriteJson(&svc)
 		return
 	}


### PR DESCRIPTION
All calls to /api/v2/:serviceId/monitoringprofile returns default internal metrics.  I am shifting the responsibility of the UI to determine whether it makes sense to poll for this data based on information they retrieve about the service.