### PR TITLE
Delete hostkey from store on host remove

### DIFF
--- a/facade/host.go
+++ b/facade/host.go
@@ -213,6 +213,11 @@ func (f *Facade) RemoveHost(ctx datastore.Context, hostID string) (err error) {
 		return err
 	}
 
+	// remove host from hostkey datastore
+	if err = f.hostkeyStore.Delete(ctx, _host.ID); err != nil {
+		return err
+	}
+
 	//remove host from datastore
 	if err = f.hostStore.Delete(ctx, host.HostKey(hostID)); err != nil {
 		return err

--- a/facade/host_unit_test.go
+++ b/facade/host_unit_test.go
@@ -159,6 +159,25 @@ func (ft *FacadeUnitTest) Test_AddHost_HappyPath(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (ft *FacadeUnitTest) Test_RemoveHost_HappyPath(c *C) {
+	h := getTestHost()
+
+	ft.hostStore.On("Get", ft.ctx, host.HostKey(h.ID), mock.AnythingOfType("*host.Host")).Return(nil).Run(
+		func(args mock.Arguments) {
+			*args.Get(2).(*host.Host) = h
+		})
+	ft.zzk.On("RemoveHost", &h).Return(nil)
+	ft.hostkeyStore.On("Delete", ft.ctx, h.ID).Return(nil)
+	ft.hostStore.On("Delete", ft.ctx, host.HostKey(h.ID)).Return(nil)
+
+	err := ft.Facade.RemoveHost(ft.ctx, h.ID)
+
+	c.Assert(err, IsNil)
+	ft.hostStore.AssertExpectations(c)
+	ft.hostkeyStore.AssertExpectations(c)
+	ft.zzk.AssertExpectations(c)
+}
+
 func (ft *FacadeUnitTest) Test_ResetHostKey_HappyPath(c *C) {
 	h := getTestHost()
 


### PR DESCRIPTION

Prior to this change, we were not removing host key from elastic when removing the host.

 * When a host is removed, delete the corresponding host key.
 * Add hostRemove unit test confirming that the host key is deleted.