### PR TITLE
Make path to master key readable

### DIFF
--- a/auth/localkeys.go
+++ b/auth/localkeys.go
@@ -193,7 +193,7 @@ func LoadMasterKeys(public crypto.PublicKey, private crypto.PrivateKey) {
 //  write them to disk.
 func CreateOrLoadMasterKeys(filename string) error {
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
-		if err = os.MkdirAll(path.Dir(filename), os.ModeDir|0700); err != nil {
+		if err = os.MkdirAll(path.Dir(filename), os.ModeDir|0755); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Because we do not have a proper serviced user group, we made the master
host key file world readable.  However, the directory in which that file
exists is not world readable, so the file cannot be read by other
processes (CLI commands in particular).  Make the directory readable.

Per Ian.