### PR TITLE
Mount ETC and ISVCS paths into client container

### DIFF
--- a/acceptance/runUIAcceptance.sh
+++ b/acceptance/runUIAcceptance.sh
@@ -204,6 +204,8 @@ docker run --rm --name ui_acceptance \
     -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
     ${DEBUG_OPTION} \
     -v `pwd`/ui:/capybara:rw \
+    -v ${SERVICED_ETC_PATH}:/opt/serviced/etc \
+    -v ${SERVICED_ISVCS_PATH}:/opt/serviced/var/isvcs \
     ${LIB_DEVMAPPER_MOUNT} \
     -e CALLER_UID=${CALLER_UID} \
     -e CALLER_GID=${CALLER_GID} \

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -213,7 +213,9 @@ func (c *ServicedCli) cmdInit(ctx *cli.Context) error {
 func (c *ServicedCli) authenticateHost(options *config.Options) error {
 	// Try to load the master keys, fail silently if they don't exist
 	masterKeyFile := filepath.Join(options.IsvcsPath, auth.MasterKeyFileName)
-	auth.LoadMasterKeyFile(masterKeyFile)
+	if err := auth.LoadMasterKeyFile(masterKeyFile); err != nil {
+		log.WithError(err).Debug("Unable to load master keys")
+	}
 
 	// Load the delegate keys
 	delegateKeyFile := filepath.Join(options.EtcPath, auth.DelegateKeyFileName)


### PR DESCRIPTION
Fixes failing acceptance test by making sure the docker container that runs the master client CLI commands has the ETC and ISVCS paths mounted in from the host where the master daemon is running.