### PR TITLE
Temporary workaround for failing acceptance tests

### DIFF
--- a/acceptance/ui/features/applications.feature
+++ b/acceptance/ui/features/applications.feature
@@ -169,7 +169,7 @@ Feature: Application Management
 
   @clean_hosts @clean_services
   Scenario: Remove an instance of the default template
-    Given only the default host is added
+    Given PENDING only the default host is added
       And that the "table://applications/defaultApp/template" application with the "table://applications/defaultApp/id" Deployment ID is added
     When I am on the applications page
       And I remove "table://applications/defaultApp/template" from the Applications list

--- a/acceptance/ui/features/cli.feature
+++ b/acceptance/ui/features/cli.feature
@@ -12,60 +12,60 @@ Feature: CLI Validation
 
   @port
   Scenario: List the port public endpoints
-    Given that the "port0" port is added
+    Given PENDING that the "port0" port is added
     Then I should see the port public endpoint "port0" in the list output
 
   @port
   Scenario: Add a new port public endpoint
-    Given that the "port1" port does not exist
+    Given PENDING that the "port1" port does not exist
       And that the "port1" port is added
     Then I should see the port public endpoint "port1" in the service
 
   @port
   Scenario: Delete the port public endpoint
-    Given that the "port0" port is added
+    Given PENDING that the "port0" port is added
       And the port public endpoint "port0" is removed
     Then I should not see the port public endpoint "port0" in the service
 
   @port
   Scenario: Disable a port public endpoint
-    Given that the "port0" port is added
+    Given PENDING that the "port0" port is added
       And that the port public endpoint "port0" is disabled
     Then the port public endpoint "port0" should be "disabled" in the service
 
   @port
   Scenario: Disable and enable a port public endpoint
-    Given that the "port0" port is added
+    Given PENDING that the "port0" port is added
       And that the port public endpoint "port0" is disabled
       And that the port public endpoint "port0" is enabled
     Then the port public endpoint "port0" should be "enabled" in the service
 
   @vhost
   Scenario: List the vhost public endpoints
-    Given that the "vhost0" vhost is added
+    Given PENDING that the "vhost0" vhost is added
     Then I should see the vhost public endpoint "vhost0" in the list output
 
   @vhost
   Scenario: Add a new vhost public endpoint
-    Given that the "vhost1" vhost does not exist
+    Given PENDING that the "vhost1" vhost does not exist
       And that the "vhost1" vhost is added
     Then I should see the vhost public endpoint "vhost1" in the service
 
   @vhost
   Scenario: Delete the vhost public endpoint
-    Given that the "vhost0" vhost is added
+    Given PENDING that the "vhost0" vhost is added
       And the vhost public endpoint "vhost0" is removed
     Then I should not see the vhost public endpoint "vhost0" in the service
 
   @vhost
   Scenario: Disable a port vhost endpoint
-    Given that the "vhost0" vhost is added
+    Given PENDING that the "vhost0" vhost is added
       And that the vhost public endpoint "vhost0" is disabled
     Then the vhost public endpoint "vhost0" should be "disabled" in the service
 
   @vhost
   Scenario: Disable and enable a vhost public endpoint
-    Given that the "vhost0" vhost is added
+    Given PENDING that the "vhost0" vhost is added
       And that the vhost public endpoint "vhost0" is disabled
       And that the vhost public endpoint "vhost0" is enabled
     Then the vhost public endpoint "vhost0" should be "enabled" in the service

--- a/acceptance/ui/features/services_endpoint.feature
+++ b/acceptance/ui/features/services_endpoint.feature
@@ -64,7 +64,7 @@ Feature: Service Endpoints
 
 
   Scenario: Public Endpoint dialog - bad host given
-    When I view the details of "table://services/topService/name" in the "Applications" table
+    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I click the Add Public Endpoint button
       And I should see the Add Public Endpoint dialog
@@ -74,7 +74,7 @@ Feature: Service Endpoints
     Then I should see "no such host"
 
   Scenario: Public Endpoint dialog - add https
-    When I view the details of "table://services/topService/name" in the "Applications" table
+    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I click the Add Public Endpoint button
       And I should see the Add Public Endpoint dialog
@@ -93,7 +93,7 @@ Feature: Service Endpoints
       And I should see the endpoint entry with both "table://services/childServiceWithVHost/port_https" and "table://services/childServiceWithVHost/host"
 
   Scenario: Public Endpoint dialog - add http
-    When I view the details of "table://services/topService/name" in the "Applications" table
+    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I click the Add Public Endpoint button
       And I should see the Add Public Endpoint dialog
@@ -112,7 +112,7 @@ Feature: Service Endpoints
       And I should see the endpoint entry with both "table://services/childServiceWithVHost/port_http" and "table://services/childServiceWithVHost/host"
 
   Scenario: Public Endpoint dialog - add tls
-    When I view the details of "table://services/topService/name" in the "Applications" table
+    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I click the Add Public Endpoint button
       And I should see the Add Public Endpoint dialog
@@ -131,7 +131,7 @@ Feature: Service Endpoints
       And I should see the endpoint entry with both "table://services/childServiceWithVHost/port_tls" and "table://services/childServiceWithVHost/host"
 
   Scenario: Public Endpoint dialog - add other
-    When I view the details of "table://services/topService/name" in the "Applications" table
+    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I click the Add Public Endpoint button
       And I should see the Add Public Endpoint dialog
@@ -150,31 +150,31 @@ Feature: Service Endpoints
       And I should see the endpoint entry with both "table://services/childServiceWithVHost/port_other" and "table://services/childServiceWithVHost/host"
 
   Scenario: Public Endpoint dialog - remove https
-    When I view the details of "table://services/topService/name" in the "Applications" table
+    When PENDING  I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I delete Endpoint "table://services/childServiceWithVHost/port_https"
     Then I should not see "table://services/childServiceWithVHost/port_https"
 
   Scenario: Public Endpoint dialog - remove http
-    When I view the details of "table://services/topService/name" in the "Applications" table
+    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I delete Endpoint "table://services/childServiceWithVHost/port_http"
     Then I should not see "table://services/childServiceWithVHost/port_http"
 
   Scenario: Public Endpoint dialog - remove tls
-    When I view the details of "table://services/topService/name" in the "Applications" table
+    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I delete Endpoint "table://services/childServiceWithVHost/port_tls"
     Then I should not see "table://services/childServiceWithVHost/port_tls"
 
   Scenario: Public Endpoint dialog - remove other
-    When I view the details of "table://services/topService/name" in the "Applications" table
+    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I delete Endpoint "table://services/childServiceWithVHost/port_other"
     Then I should not see "table://services/childServiceWithVHost/port_other"
 
   Scenario: Public Endpoint dialog - Re-add https again
-    When I view the details of "table://services/topService/name" in the "Applications" table
+    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I click the Add Public Endpoint button
       And I should see the Add Public Endpoint dialog
@@ -193,7 +193,7 @@ Feature: Service Endpoints
       And I should see the endpoint entry with both "table://services/childServiceWithVHost/port_https" and "table://services/childServiceWithVHost/host"
 
   Scenario: Public Endpoint dialog - remove https
-    When I view the details of "table://services/topService/name" in the "Applications" table
+    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I delete Endpoint "table://services/childServiceWithVHost/port_https"
     Then I should not see "table://services/childServiceWithVHost/port_https"


### PR DESCRIPTION
Disable acceptance tests which are failing due to problems associated with CC-2759. 
Once CC-2759 is fixed, these tests will be re-enabled