### PR TITLE
Feature/cc 2711 3

### DIFF
--- a/auth/hostregistry.go
+++ b/auth/hostregistry.go
@@ -20,7 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 var (
@@ -57,7 +58,7 @@ func (reg *HostExpirationRegistry) Expired(hostid string) (bool, error) {
 		// if it doesnt exist, I guess it's expired
 		return true, ErrMissingHost
 	}
-	now := time.Now().Unix()
+	now := jwt.TimeFunc().Unix()
 	return now >= expiration, nil
 }
 

--- a/auth/hostregistry.go
+++ b/auth/hostregistry.go
@@ -45,6 +45,13 @@ func (reg *HostExpirationRegistry) Set(hostid string, expires int64) {
 	reg.registry[hostid] = expires
 }
 
+// Remove removes a host from the expiration registry
+func (reg *HostExpirationRegistry) Remove(hostid string) {
+	reg.Lock()
+	defer reg.Unlock()
+	delete(reg.registry, hostid)
+}
+
 // IsExpired checks if a give host's auth has expired
 // and returns a bool or an error if the host isn't
 // in the registry

--- a/auth/hostregistry.go
+++ b/auth/hostregistry.go
@@ -1,0 +1,76 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// maintains a map of authenticated hosts and their
+// authentication token expiration time
+
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+var (
+	hostExpirationRegistry = &HostExpirationRegistry{registry: make(map[string]int64)}
+	// ErrMissingHost indicates if a host does not
+	// exist in the host expiration registry
+	ErrMissingHost = errors.New("Host is not present in host expiration registry")
+)
+
+// HostExpirationRegistry is a threadsafe map of
+// host id to auth expiration time. NOTE: expired hosts
+// are not removed from the registry
+type HostExpirationRegistry struct {
+	registry map[string]int64
+	sync.Mutex
+}
+
+// Set adds a host to the expiration registry by its
+// id and sets its auth expiration time
+func (reg *HostExpirationRegistry) Set(hostid string, expires int64) {
+	reg.Lock()
+	defer reg.Unlock()
+	reg.registry[hostid] = expires
+}
+
+// Expired checks if a give host's auth has expired
+// and returns a bool or an error if the host isn't
+// in the registry
+func (reg *HostExpirationRegistry) Expired(hostid string) (bool, error) {
+	reg.Lock()
+	defer reg.Unlock()
+	expiration, ok := reg.registry[hostid]
+	if !ok {
+		// if it doesnt exist, I guess it's expired
+		return true, ErrMissingHost
+	}
+	now := time.Now().Unix()
+	return now >= expiration, nil
+}
+
+// SetHostExpiration adds a host and its auth expiration
+// time to the host expiration registry
+func SetHostExpiration(id string, expires int64) {
+	fmt.Printf("settin host expiry for %s to %d", id, expires)
+	hostExpirationRegistry.Set(id, expires)
+}
+
+// HostExpired checks if a host's auth has expired
+func HostExpired(id string) bool {
+	expired, _ := hostExpirationRegistry.Expired(id)
+	fmt.Printf("host %s expired is %t", id, expired)
+	return expired
+}

--- a/auth/hostregistry.go
+++ b/auth/hostregistry.go
@@ -34,7 +34,7 @@ var (
 // are not removed from the registry
 type HostExpirationRegistry struct {
 	registry map[string]int64
-	sync.Mutex
+	sync.RWMutex
 }
 
 // Set adds a host to the expiration registry by its
@@ -56,8 +56,8 @@ func (reg *HostExpirationRegistry) Remove(hostid string) {
 // and returns a bool or an error if the host isn't
 // in the registry
 func (reg *HostExpirationRegistry) IsExpired(hostid string) (bool, error) {
-	reg.Lock()
-	defer reg.Unlock()
+	reg.RLock()
+	defer reg.RUnlock()
 	expiration, ok := reg.registry[hostid]
 	if !ok {
 		// if it doesnt exist, I guess it's expired

--- a/auth/hostregistry.go
+++ b/auth/hostregistry.go
@@ -18,14 +18,12 @@ package auth
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	jwt "github.com/dgrijalva/jwt-go"
 )
 
 var (
-	hostExpirationRegistry = &HostExpirationRegistry{registry: make(map[string]int64)}
 	// ErrMissingHost indicates if a host does not
 	// exist in the host expiration registry
 	ErrMissingHost = errors.New("Host is not present in host expiration registry")
@@ -47,10 +45,10 @@ func (reg *HostExpirationRegistry) Set(hostid string, expires int64) {
 	reg.registry[hostid] = expires
 }
 
-// Expired checks if a give host's auth has expired
+// IsExpired checks if a give host's auth has expired
 // and returns a bool or an error if the host isn't
 // in the registry
-func (reg *HostExpirationRegistry) Expired(hostid string) (bool, error) {
+func (reg *HostExpirationRegistry) IsExpired(hostid string) (bool, error) {
 	reg.Lock()
 	defer reg.Unlock()
 	expiration, ok := reg.registry[hostid]
@@ -62,16 +60,9 @@ func (reg *HostExpirationRegistry) Expired(hostid string) (bool, error) {
 	return now >= expiration, nil
 }
 
-// SetHostExpiration adds a host and its auth expiration
-// time to the host expiration registry
-func SetHostExpiration(id string, expires int64) {
-	fmt.Printf("settin host expiry for %s to %d", id, expires)
-	hostExpirationRegistry.Set(id, expires)
-}
-
-// HostExpired checks if a host's auth has expired
-func HostExpired(id string) bool {
-	expired, _ := hostExpirationRegistry.Expired(id)
-	fmt.Printf("host %s expired is %t", id, expired)
-	return expired
+// NewHostExpirationRegistry creates a new HostExpirationRegistry
+func NewHostExpirationRegistry() *HostExpirationRegistry {
+	return &HostExpirationRegistry{
+		registry: make(map[string]int64),
+	}
 }

--- a/auth/hostregistry_test.go
+++ b/auth/hostregistry_test.go
@@ -23,22 +23,24 @@ import (
 )
 
 func (s *TestAuthSuite) TestHostExpired(c *C) {
+	reg := auth.NewHostExpirationRegistry()
 	hostid := "fakehost"
 	expires := jwt.TimeFunc().Add(time.Minute).Unix()
-	auth.SetHostExpiration(hostid, expires)
+	reg.Set(hostid, expires)
 
-	hasExpired := auth.HostExpired(hostid)
+	hasExpired, _ := reg.IsExpired(hostid)
 	c.Assert(hasExpired, Equals, false)
 }
 
 func (s *TestAuthSuite) TestHostExpiredExpires(c *C) {
+	reg := auth.NewHostExpirationRegistry()
 	hostid := "fakehost"
 	expires := jwt.TimeFunc().Add(time.Second).Unix()
-	auth.SetHostExpiration(hostid, expires)
+	reg.Set(hostid, expires)
 
 	fakenow := jwt.TimeFunc().Add(time.Minute)
 	auth.At(fakenow, func() {
-		hasExpired := auth.HostExpired(hostid)
+		hasExpired, _ := reg.IsExpired(hostid)
 		c.Assert(hasExpired, Equals, true)
 	})
 }

--- a/auth/hostregistry_test.go
+++ b/auth/hostregistry_test.go
@@ -1,0 +1,44 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package auth_test
+
+import (
+	"github.com/control-center/serviced/auth"
+	jwt "github.com/dgrijalva/jwt-go"
+	. "gopkg.in/check.v1"
+	"time"
+)
+
+func (s *TestAuthSuite) TestHostExpired(c *C) {
+	hostid := "fakehost"
+	expires := jwt.TimeFunc().Add(time.Minute).Unix()
+	auth.SetHostExpiration(hostid, expires)
+
+	hasExpired := auth.HostExpired(hostid)
+	c.Assert(hasExpired, Equals, false)
+}
+
+func (s *TestAuthSuite) TestHostExpiredExpires(c *C) {
+	hostid := "fakehost"
+	expires := jwt.TimeFunc().Add(time.Second).Unix()
+	auth.SetHostExpiration(hostid, expires)
+
+	fakenow := jwt.TimeFunc().Add(time.Minute)
+	auth.At(fakenow, func() {
+		hasExpired := auth.HostExpired(hostid)
+		c.Assert(hasExpired, Equals, true)
+	})
+}

--- a/auth/hostregistry_test.go
+++ b/auth/hostregistry_test.go
@@ -32,6 +32,13 @@ func (s *TestAuthSuite) TestHostExpired(c *C) {
 	c.Assert(hasExpired, Equals, false)
 }
 
+func (s *TestAuthSuite) TestNonexistentHostExpired(c *C) {
+	reg := auth.NewHostExpirationRegistry()
+	hasExpired, err := reg.IsExpired("unicorn")
+	c.Assert(err, Equals, auth.ErrMissingHost)
+	c.Assert(hasExpired, Equals, true)
+}
+
 func (s *TestAuthSuite) TestHostRemove(c *C) {
 	reg := auth.NewHostExpirationRegistry()
 	hostid := "fakehost"

--- a/auth/hostregistry_test.go
+++ b/auth/hostregistry_test.go
@@ -32,6 +32,22 @@ func (s *TestAuthSuite) TestHostExpired(c *C) {
 	c.Assert(hasExpired, Equals, false)
 }
 
+func (s *TestAuthSuite) TestHostRemove(c *C) {
+	reg := auth.NewHostExpirationRegistry()
+	hostid := "fakehost"
+	expires := jwt.TimeFunc().Add(time.Minute).Unix()
+	reg.Set(hostid, expires)
+
+	hasExpired, _ := reg.IsExpired(hostid)
+	c.Assert(hasExpired, Equals, false)
+
+	reg.Remove(hostid)
+	hasExpired, err := reg.IsExpired(hostid)
+
+	c.Assert(err, Equals, auth.ErrMissingHost)
+	c.Assert(hasExpired, Equals, true)
+}
+
 func (s *TestAuthSuite) TestHostExpiredExpires(c *C) {
 	reg := auth.NewHostExpirationRegistry()
 	hostid := "fakehost"

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -25,6 +25,9 @@ var (
 	_ jwt.Claims = &jwtIdentity{}
 )
 
+// At sets a fake time, executes the provided
+// function, then restores the default time getter,
+// making it possible to test time-sensitive stuff
 func At(t time.Time, f func()) {
 	defer func() {
 		jwt.TimeFunc = time.Now

--- a/domain/host/host.go
+++ b/domain/host/host.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain"
+	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/servicedversion"
 	"github.com/control-center/serviced/utils"
 	"github.com/zenoss/glog"
@@ -91,6 +92,13 @@ type ReadServiced struct {
 	Version string
 	Date    string
 	Release string
+}
+
+type HostStatus struct {
+	HostID        string
+	MemoryUsage   service.Usage
+	Active        bool
+	Authenticated bool
 }
 
 func (a *Host) TotalRAM() (mem uint64) {

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -16,6 +16,7 @@ package facade
 import (
 	"time"
 
+	"github.com/control-center/serviced/auth"
 	"github.com/control-center/serviced/dfs"
 	"github.com/control-center/serviced/domain/host"
 	"github.com/control-center/serviced/domain/hostkey"
@@ -52,6 +53,7 @@ func New() *Facade {
 		templateStore: servicetemplate.NewStore(),
 		userStore:     user.NewStore(),
 		serviceCache:  NewServiceCache(),
+		hostRegistry:  auth.NewHostExpirationRegistry(),
 		zzk:           getZZK(),
 	}
 }
@@ -72,6 +74,7 @@ type Facade struct {
 	hcache        *health.HealthStatusCache
 	metricsClient MetricsClient
 	serviceCache  *serviceCache
+	hostRegistry  *auth.HostExpirationRegistry
 
 	isvcsPath string
 }

--- a/facade/host.go
+++ b/facade/host.go
@@ -294,8 +294,13 @@ func (f *Facade) ResetHostKey(ctx datastore.Context, hostID string) ([]byte, err
 // SetHostExpiration sets a host's auth token
 // expiration time in the HostExpirationRegistry
 func (f *Facade) SetHostExpiration(ctx datastore.Context, hostid string, expiration int64) {
-	//defer ctx.Metrics().Stop(ctx.Metrics().Start("GetHosts"))
 	f.hostRegistry.Set(hostid, expiration)
+}
+
+// RemoveHostExpiration removes a host from the
+// HostExpirationRegistry
+func (f *Facade) RemoveHostExpiration(ctx datastore.Context, hostid string) {
+	f.hostRegistry.Remove(hostid)
 }
 
 // GetHosts returns a list of all registered hosts

--- a/facade/host.go
+++ b/facade/host.go
@@ -291,6 +291,13 @@ func (f *Facade) ResetHostKey(ctx datastore.Context, hostID string) ([]byte, err
 	return f.generateDelegateKey(ctx, &value)
 }
 
+// SetHostExpiration sets a host's auth token
+// expiration time in the HostExpirationRegistry
+func (f *Facade) SetHostExpiration(ctx datastore.Context, hostid string, expiration int64) {
+	//defer ctx.Metrics().Stop(ctx.Metrics().Start("GetHosts"))
+	f.hostRegistry.Set(hostid, expiration)
+}
+
 // GetHosts returns a list of all registered hosts
 func (f *Facade) GetHosts(ctx datastore.Context) ([]host.Host, error) {
 	defer ctx.Metrics().Stop(ctx.Metrics().Start("GetHosts"))
@@ -370,6 +377,9 @@ func (f *Facade) GetHostStatuses(ctx datastore.Context, hostIDs []string, since 
 			continue
 		}
 		status.Active = active
+
+		authed, _ := f.hostRegistry.IsExpired(h.ID)
+		status.Authenticated = !authed
 
 		instances, err := f.GetHostInstances(ctx, since, id)
 		if err != nil {

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -85,6 +85,8 @@ type FacadeInterface interface {
 
 	SetHostExpiration(ctx datastore.Context, hostID string, expiration int64)
 
+	RemoveHostExpiration(ctx datastore.Context, hostID string)
+
 	GetActiveHostIDs(ctx datastore.Context) ([]string, error)
 
 	UpdateHost(ctx datastore.Context, entity *host.Host) error

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -174,4 +174,6 @@ type FacadeInterface interface {
 	UpdateServiceConfig(ctx datastore.Context, fileID string, conf servicedefinition.ConfigFile) error
 
 	DeleteServiceConfig(ctx datastore.Context, fileID string) error
+
+	GetHostStatuses(ctx datastore.Context, hostIDs []string, since time.Time) ([]host.HostStatus, error)
 }

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -83,6 +83,8 @@ type FacadeInterface interface {
 
 	ResetHostKey(ctx datastore.Context, hostID string) ([]byte, error)
 
+	SetHostExpiration(ctx datastore.Context, hostID string, expiration int64)
+
 	GetActiveHostIDs(ctx datastore.Context) ([]string, error)
 
 	UpdateHost(ctx datastore.Context, entity *host.Host) error

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -455,6 +455,12 @@ func (_m *FacadeInterface) ResetHostKey(ctx datastore.Context, hostID string) ([
 
 	return r0, r1
 }
+func (_m *FacadeInterface) SetHostExpiration(ctx datastore.Context, hostID string, expiration int64) {
+	_m.Called(ctx, hostID, expiration)
+}
+func (_m *FacadeInterface) RemoveHostExpiration(ctx datastore.Context, hostID string) {
+	_m.Called(ctx, hostID)
+}
 func (_m *FacadeInterface) GetActiveHostIDs(ctx datastore.Context) ([]string, error) {
 	ret := _m.Called(ctx)
 

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -1242,3 +1242,24 @@ func (_m *FacadeInterface) DeleteServiceConfig(ctx datastore.Context, fileID str
 
 	return r0
 }
+func (_m *FacadeInterface) GetHostStatuses(ctx datastore.Context, hostIDs []string, since time.Time) ([]host.HostStatus, error) {
+	ret := _m.Called(ctx, hostIDs, since)
+
+	var r0 []host.HostStatus
+	if rf, ok := ret.Get(0).(func(datastore.Context, []string, time.Time) []host.HostStatus); ok {
+		r0 = rf(ctx, hostIDs, since)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]host.HostStatus)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, []string, time.Time) error); ok {
+		r1 = rf(ctx, hostIDs, since)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/facade/mocks/ZZK.go
+++ b/facade/mocks/ZZK.go
@@ -2,14 +2,12 @@ package mocks
 
 import "github.com/stretchr/testify/mock"
 
+import "github.com/control-center/serviced/datastore"
 import "github.com/control-center/serviced/domain/host"
 import "github.com/control-center/serviced/domain/pool"
 import "github.com/control-center/serviced/domain/registry"
 import "github.com/control-center/serviced/domain/service"
-import (
-	zkservice "github.com/control-center/serviced/zzk/service"
-	"github.com/control-center/serviced/datastore"
-)
+import zkservice "github.com/control-center/serviced/zzk/service"
 
 type ZZK struct {
 	mock.Mock
@@ -187,19 +185,19 @@ func (_m *ZZK) GetActiveHosts(poolID string, hosts *[]string) error {
 
 	return r0
 }
-func (_m *ZZK) IsHostActive(poolID string, hostID string) (bool, error) {
-	ret := _m.Called(poolID, hostID)
+func (_m *ZZK) IsHostActive(poolID string, hostId string) (bool, error) {
+	ret := _m.Called(poolID, hostId)
 
 	var r0 bool
 	if rf, ok := ret.Get(0).(func(string, string) bool); ok {
-		r0 = rf(poolID, hostID)
+		r0 = rf(poolID, hostId)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(poolID, hostID)
+		r1 = rf(poolID, hostId)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/facade/mocks/ZZK.go
+++ b/facade/mocks/ZZK.go
@@ -184,6 +184,25 @@ func (_m *ZZK) GetActiveHosts(poolID string, hosts *[]string) error {
 
 	return r0
 }
+func (_m *ZZK) IsHostActive(poolID string, hostID string) (bool, error) {
+	ret := _m.Called(poolID, hostID)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, string) bool); ok {
+		r0 = rf(poolID, hostID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(poolID, hostID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
 func (_m *ZZK) UpdateResourcePool(_pool *pool.ResourcePool) error {
 	ret := _m.Called(_pool)
 

--- a/facade/zkapi.go
+++ b/facade/zkapi.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	zkimgregistry "github.com/control-center/serviced/dfs/registry"
 	"github.com/control-center/serviced/coordinator/client"
+	zkimgregistry "github.com/control-center/serviced/dfs/registry"
 	"github.com/control-center/serviced/domain/host"
 	"github.com/control-center/serviced/domain/pool"
 	"github.com/control-center/serviced/domain/registry"
@@ -39,7 +39,7 @@ func getZZK() ZZK {
 }
 
 type zkf struct {
-	svcRegistry  *serviceRegistryCache
+	svcRegistry *serviceRegistryCache
 }
 
 // UpdateService updates the service object and exposed public endpoints that
@@ -342,6 +342,14 @@ func (z *zkf) GetActiveHosts(poolID string, hosts *[]string) error {
 	}
 	*hosts, err = zks.GetCurrentHosts(conn, poolID)
 	return err
+}
+
+func (z *zkf) IsHostActive(poolID string, hostID string) (bool, error) {
+	conn, err := zzk.GetLocalConnection("/")
+	if err != nil {
+		return false, err
+	}
+	return zks.IsHostOnline(conn, poolID, hostID)
 }
 
 func (z *zkf) UpdateResourcePool(pool *pool.ResourcePool) error {
@@ -733,7 +741,7 @@ func (zk *zkf) SyncServiceRegistry(tenantID string, svc *service.Service) error 
 	}
 
 	// Update our local cache now that we know that ZK was updated successfully
-	 zk.svcRegistry.UpdateRegistry(syncRequest.ServiceID, syncRequest.PortsToPublish, syncRequest.VHostsToPublish)
+	zk.svcRegistry.UpdateRegistry(syncRequest.ServiceID, syncRequest.PortsToPublish, syncRequest.VHostsToPublish)
 
 	logger.Debug("Updated the service's public endpoints in zookeeper")
 	return nil

--- a/facade/zzk.go
+++ b/facade/zzk.go
@@ -34,6 +34,7 @@ type ZZK interface {
 	UpdateHost(_host *host.Host) error
 	RemoveHost(_host *host.Host) error
 	GetActiveHosts(poolID string, hosts *[]string) error
+	IsHostActive(poolID string, hostId string) (bool, error)
 	UpdateResourcePool(_pool *pool.ResourcePool) error
 	RemoveResourcePool(poolID string) error
 	AddVirtualIP(vip *pool.VirtualIP) error

--- a/rpc/master/hosts_server.go
+++ b/rpc/master/hosts_server.go
@@ -149,6 +149,7 @@ func (s *Server) AuthenticateHost(req HostAuthenticationRequest, resp *HostAuthe
 	if err != nil {
 		return err
 	}
+	auth.SetHostExpiration(host.ID, expires)
 	*resp = HostAuthenticationResponse{signed, expires}
 	return nil
 }

--- a/rpc/master/hosts_server.go
+++ b/rpc/master/hosts_server.go
@@ -149,7 +149,7 @@ func (s *Server) AuthenticateHost(req HostAuthenticationRequest, resp *HostAuthe
 	if err != nil {
 		return err
 	}
-	auth.SetHostExpiration(host.ID, expires)
+	s.f.SetHostExpiration(s.context(), host.ID, expires)
 	*resp = HostAuthenticationResponse{signed, expires}
 	return nil
 }

--- a/rpc/master/hosts_server.go
+++ b/rpc/master/hosts_server.go
@@ -124,9 +124,11 @@ func (req HostAuthenticationRequest) valid(publicKeyPEM []byte) error {
 func (s *Server) AuthenticateHost(req HostAuthenticationRequest, resp *HostAuthenticationResponse) error {
 	keypem, err := s.f.GetHostKey(s.context(), req.HostID)
 	if err != nil {
+		s.f.RemoveHostExpiration(s.context(), req.HostID)
 		return err
 	}
 	if err := req.valid(keypem); err != nil {
+		s.f.RemoveHostExpiration(s.context(), req.HostID)
 		return err
 	}
 	host, err := s.f.GetHost(s.context(), req.HostID)
@@ -147,6 +149,7 @@ func (s *Server) AuthenticateHost(req HostAuthenticationRequest, resp *HostAuthe
 	dfsAccess := p.Permissions&pool.DFSAccess != 0
 	signed, expires, err := auth.CreateJWTIdentity(host.ID, host.PoolID, adminAccess, dfsAccess, keypem, s.expiration)
 	if err != nil {
+		s.f.RemoveHostExpiration(s.context(), host.ID)
 		return err
 	}
 	s.f.SetHostExpiration(s.context(), host.ID, expires)

--- a/web/routes.go
+++ b/web/routes.go
@@ -135,6 +135,7 @@ func (sc *ServiceConfig) getRoutes() []rest.Route {
 		rest.Route{"GET", "/api/v2/services/:serviceId/context", gz(sc.checkAuth(getServiceContext))},
 		rest.Route{"PUT", "/api/v2/services/:serviceId/context", gz(sc.checkAuth(putServiceContext))},
 		rest.Route{"GET", "/api/v2/statuses", gz(sc.checkAuth(restGetAggregateServices))},
+		rest.Route{"GET", "/api/v2/hoststatuses", gz(sc.checkAuth(getHostStatuses))},
 
 		rest.Route{"GET", "/api/v2/services/:serviceId/serviceconfigs", gz(sc.checkAuth(restGetServiceConfigFiles))},
 		rest.Route{"POST", "/api/v2/services/:serviceId/serviceconfigs", gz(sc.checkAuth(restAddServiceConfigFile))},

--- a/web/ui/src/Hosts/HostDetailsController.js
+++ b/web/ui/src/Hosts/HostDetailsController.js
@@ -6,8 +6,13 @@
 (function() {
     'use strict';
 
-    controlplane.controller("HostDetailsController", ["$scope", "$routeParams", "$location", "resourcesFactory", "authService", "$modalService", "$translate", "miscUtils", "hostsFactory", "$notification", "instancesFactory", "servicesFactory",
-    function($scope, $routeParams, $location, resourcesFactory, authService, $modalService, $translate, utils, hostsFactory, $notification, instancesFactory, servicesFactory){
+    controlplane.controller("HostDetailsController", [
+    "$scope", "$routeParams", "$location", "resourcesFactory", "authService",
+    "$modalService", "$translate", "miscUtils", "hostsFactory", "$notification",
+    "instancesFactory", "servicesFactory", "$interval",
+    function($scope, $routeParams, $location, resourcesFactory, authService,
+    $modalService, $translate, utils, hostsFactory, $notification,
+    instancesFactory, servicesFactory, $interval){
         // Ensure logged in
         authService.checkLogin($scope);
 
@@ -158,6 +163,42 @@
             });
         };
 
+        // TODO - move this to Host.js when v2 stuff drops
+        // provide a way for hostIcon to get statuses
+        $scope.getHostStatus = function(id){
+            if($scope.hostStatuses){
+                return $scope.hostStatuses[id];
+            }
+        };
+        $scope.getHostStatusClass = function(host){
+            if(!host){
+                return "unknown";
+            }
+
+            let status = $scope.getHostStatus(host.id);
+
+            // stuff hasnt loaded, so unknown
+            if(!status){
+                return "unknown";
+            }
+
+            let active = status.Active,
+                authed = status.Authenticated;
+
+            // connected and authenticated
+            if(active && authed){
+                return "passed";
+
+            // connected but not yet authenticated
+            } else if(active && !authed){
+                // TODO - something more clearly related to auth
+                return "unknown";
+
+            // not connected
+            } else {
+                return "failed";
+            }
+        };
 
         init();
 
@@ -185,6 +226,19 @@
                 }
             };
 
+            // TODO - remove this and consolidate with v2
+            // status polling
+            $scope.hostStatusInterval = $interval(() => {
+                resourcesFactory.getHostStatuses()
+                    .then(data => {
+                        let statuses = {};
+                        data.forEach(s => statuses[s.HostID] = s);
+                        $scope.hostStatuses = statuses;
+                    }, err => {
+                        console.log("err", err); 
+                    });
+            }, 3000);
+
             // kick off hostsFactory updating
             // TODO - update loop here
             hostsFactory.update()
@@ -198,6 +252,7 @@
         $scope.$on("$destroy", function(){
             hostsFactory.deactivate();
             servicesFactory.deactivate();
+            $interval.cancel($scope.hostStatusInterval);
         });
     }]);
 })();

--- a/web/ui/src/Hosts/hostIconDirective.js
+++ b/web/ui/src/Hosts/hostIconDirective.js
@@ -1,0 +1,174 @@
+/* hostIconDirective
+ * directive for displaying status of a host
+ */
+(function() {
+    'use strict';
+
+    angular.module('hostIcon', [])
+    .directive('hostIcon', [function() {
+        var template = `
+            <div ng-class="vm.getHostStatusClass()" style="position: relative; height: 22px;">
+                <i class="healthIcon glyphicon"></i>
+            </div>`;
+
+        let popoverContentTemplate = m => {
+            return `
+                <div class='healthTooltipDetailRow ${m.getHostActiveStatusClass()}'>
+                    <i class='healthIcon glyphicon'></i>
+                    <div class='healthTooltipDetailName'>Active</div>
+                </div>
+                <div class='healthTooltipDetailRow ${m.getHostAuthStatusClass()}'>
+                    <i class='healthIcon glyphicon'></i>
+                    <div class='healthTooltipDetailName'>Authenticated</div>
+                </div>
+            `;
+        };
+          
+        class Controller {
+            constructor(){
+                // hi.
+            }
+            _getHostStatus(){
+                if(!this.host){
+                    return {active: null, authed: null};
+                }
+
+                let status = this.getHostStatus(this.host.id);
+
+                if(!status){
+                    return {active: null, authed: null};
+                }
+
+                let active = status.Active,
+                    authed = status.Authenticated;
+
+                return {active, authed};
+            }
+
+            getHostStatusClass(){
+                let {active, authed} = this._getHostStatus();
+
+                // stuff hasnt loaded, so unknown
+                if(active === null && authed === null){
+                    return "unknown";
+                }
+
+                // connected and authenticated
+                if(active && authed){
+                    return "passed";
+
+                // connected but not yet authenticated
+                } else if(active && !authed){
+                    // TODO - something more clearly related to auth
+                    return "failed";
+
+                // not connected
+                } else {
+                    return "not_running";
+                }
+            }
+
+            getHostActiveStatusClass(){
+                let {active} = this._getHostStatus(),
+                    status;
+
+                if(active === true){
+                    status = "passed";
+                } else if(active === false){
+                    status = "not_running";
+                } else {
+                    status = "unknown";
+                }
+
+                return status;
+            }
+
+            getHostAuthStatusClass(){
+                let {active, authed} = this._getHostStatus(),
+                    status;
+
+                if(authed === true){
+                    status = "passed";
+                } else if(active === true && authed === false){
+                    status = "failed";
+                } else if(active === false && authed === false){
+                    status = "not_running";
+                } else {
+                    status = "unknown";
+                }
+
+                return status;
+            }
+
+            updatePopover(){
+                let p = this.popover;
+                p.options.content = popoverContentTemplate(this);
+                p.setContent();
+
+                // if the popover is currently visible, update
+                // it immediately, but turn off animation to
+                // prevent it fading in
+                if(p.$tip.is(":visible")){
+                    p.options.animation = false;
+                    p.show();
+                    p.options.animation = true;
+                }
+            }
+        }
+      
+        return {
+            restrict: "EA",
+            scope: {
+                host: "=",
+                getHostStatus: "="
+            },
+            controller: Controller,
+            controllerAs: "vm",
+            bindToController: true,
+            template: template,
+            link: function(scope, element, attrs) {
+                let $icon = $(element).find(".healthIcon");
+                $icon.popover({
+                    trigger: "hover",
+                    placement: "right",
+                    delay: 0,
+                    html: true
+                });
+                // NOTE: directly accessing the bootstrap popover
+                // data object here.
+                scope.vm.popover = $icon.data("bs.popover");
+                scope.vm.updatePopover();
+
+                // use a bitfield to describe host state as a 
+                // single value to determine if we need to
+                // update the view
+                var ACTIVE = 1 << 1,
+                    AUTHED = 1 << 2;
+
+                scope.$watch(function(){
+                    let {active, authed} = scope.vm._getHostStatus(),
+                        val = 0;
+
+                    // no results have come back yet
+                    if(active === null && authed === null){
+                        return -1;
+                    }
+
+                    // results, so lets smoosh em
+                    // into a single value
+                    if(active){
+                        val = val ^ ACTIVE;
+                    }
+                    if(authed){
+                        val = val ^ AUTHED;
+                    }
+
+                    return val;
+                }, function(newVal, oldVal){
+                    scope.vm.updatePopover();
+                });
+            }
+        };
+  }]);
+
+}());

--- a/web/ui/src/Hosts/view-host-details.html
+++ b/web/ui/src/Hosts/view-host-details.html
@@ -4,8 +4,7 @@
     <div class="serviceControls" sticky sticky-class="stickied">
 
         <h2 class="serviceTitle">
-            <div ng-if="currentHost.active" class="passed" style="position: absolute; top: 6px; left: 4px; height: 22px;"><i class="healthIcon glyphicon"></i></div>
-            <div ng-if="!currentHost.active" class="failed" style="position: absolute; top: 6px; left: 4px; height: 22px;"><i class="healthIcon glyphicon"></i></div>
+            <host-icon data-get-host-status="getHostStatus" data-host="currentHost" style="position: absolute; top: 6px; left: 4px; height: 22px;"></host-icon>
             <span style="position: relative; top: 0; left: 35px;"> {{currentHost.name}}</span>
         </h2>
 

--- a/web/ui/src/Hosts/view-hosts.html
+++ b/web/ui/src/Hosts/view-hosts.html
@@ -17,9 +17,8 @@
           {{host.name}}
           <div class="overcomIndicator" ng-class="{'bad': !host.resourcesGood()}" title="This host's resources are oversubscribed."></div>
       </td>
-      <td data-title="'label_active'|translate" sortable="'active'" style="text-align:center;">
-        <div ng-if="host.active" class="passed" style="position: relative; height: 22px;"><i class="healthIcon glyphicon"></i></div>
-        <div ng-if="!host.active" class="failed" style="position: relative; height: 22px;"><i class="healthIcon glyphicon"></i></div>
+      <td data-title="'label_active'|translate" sortable="'active'" class="host-stat-cell" style="text-align:center; position: relative;">
+          <host-icon data-get-host-status="getHostStatus" data-host="host"></host-icon>
       </td>
       <td data-title="'label_pool_name'|translate" sortable="'model.PoolID'" ng-click="clickPool(host.model.PoolID)" class="link">{{host.model.PoolID|cut:true:50}}</td>
       <td data-title="'label_host_memory'|translate" sortable="'model.Memory'">{{host.model.Memory | toGB}}</td>

--- a/web/ui/src/app.js
+++ b/web/ui/src/app.js
@@ -27,7 +27,7 @@ var controlplane = angular.module('controlplane', [
     'sticky', 'graphPanel', 'servicesFactory', 'healthIcon', 'publicEndpointLink',
     'authService', 'miscUtils', 'hostsFactory', 'poolsFactory', 'instancesFactory', 'baseFactory',
     'ngTable', 'jellyTable', 'ngLocationUpdate', 'CCUIState', 'servicedConfig', 'areUIReady', 'log',
-    'LogSearch'
+    'LogSearch', 'hostIcon'
 ]);
 
 controlplane.

--- a/web/ui/src/common/resourcesFactory.js
+++ b/web/ui/src/common/resourcesFactory.js
@@ -69,6 +69,12 @@
                 method: GET,
                 url: id => `/api/v2/pools/${id}/hosts`
             },
+            // TODO - MOVE THIS WHEN THE V2 API
+            // OBJECT IS IN!
+            getHostStatuses: {
+                method: GET,
+                url: id => `/api/v2/hoststatuses`
+            },
             addVHost: {
                 method: PUT,
                 url: (serviceID, serviceName, endpointName, vhostName) => {

--- a/web/ui/static/css/main.css
+++ b/web/ui/static/css/main.css
@@ -916,6 +916,7 @@ input.startup {
 .popover .healthTooltipDetailRow {
     position: relative;
     font-size: 12px;
+    white-space: nowrap;
 }
 .popover .healthTooltipDetailRow .healthTooltipDetailName {
     display: inline-block;
@@ -1266,23 +1267,22 @@ health-icon {
 
 /* NOTE: hardcoding glyphicon glyphs here to make CSS simpler.
  * Changes to glyphicons or angular could cause this to break */
-.passed .healthIcon:before{
+.passed>.healthIcon:before{
     color: #0084DB;
     content: "\e084";
 }
-.failed .healthIcon:before{
+.failed>.healthIcon:before{
     color: #9C1200;
     content: "\e101";
 }
-.unknown .healthIcon:before{
+.unknown>.healthIcon:before{
     color: #94C0DB;
     content: "\e085";
 }
-.not_running .healthIcon:before{
+.not_running>.healthIcon:before{
     color: #AAA;
     content: "\e082";
 }
-
 
 h3 health-icon {
     top: 2px;


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-2711

Makes host status icon not only show if a host is active, but also if it is authenticated.

![unauthedhost](https://cloud.githubusercontent.com/assets/1927558/19322974/a06e02a0-9080-11e6-9740-10facf4e4d6b.png)

With the additional of auth and host keys, it is easy to have a host that is connected, but cannot operate because its auth token is invalid. This makes it more obvious if that is the case, so that the user can resolve the issue.