### PR TITLE
Re-create missing tenant volumes on startup

### DIFF
--- a/volume/devicemapper/devicemapper.go
+++ b/volume/devicemapper/devicemapper.go
@@ -461,6 +461,9 @@ func (d *DeviceMapperDriver) Get(volumeName string) (volume.Volume, error) {
 	vol, err := d.getVolume(volumeName, false)
 	if err != nil {
 		glog.Errorf("Error getting devicemapper volume: %s", err)
+		if err == ErrNoMetadata {
+			err = volume.ErrVolumeNotExists
+		}
 		return nil, err
 	}
 	if mounted, _ := devmapper.Mounted(vol.Path()); !mounted {


### PR DESCRIPTION
Fixes CC-2431
On startup, check to make sure all deployed tenants have a volume.  If one is missing, we log a warning and create a new volume for that tenant.