### PR TITLE
Fix acceptance failures related to public endpoints

### DIFF
--- a/acceptance/ui/features/applications.feature
+++ b/acceptance/ui/features/applications.feature
@@ -169,7 +169,7 @@ Feature: Application Management
 
   @clean_hosts @clean_services
   Scenario: Remove an instance of the default template
-    Given PENDING only the default host is added
+    Given only the default host is added
       And that the "table://applications/defaultApp/template" application with the "table://applications/defaultApp/id" Deployment ID is added
     When I am on the applications page
       And I remove "table://applications/defaultApp/template" from the Applications list

--- a/acceptance/ui/features/cli.feature
+++ b/acceptance/ui/features/cli.feature
@@ -12,60 +12,60 @@ Feature: CLI Validation
 
   @port
   Scenario: List the port public endpoints
-    Given PENDING that the "port0" port is added
+    Given that the "port0" port is added
     Then I should see the port public endpoint "port0" in the list output
 
   @port
   Scenario: Add a new port public endpoint
-    Given PENDING that the "port1" port does not exist
+    Given that the "port1" port does not exist
       And that the "port1" port is added
     Then I should see the port public endpoint "port1" in the service
 
   @port
   Scenario: Delete the port public endpoint
-    Given PENDING that the "port0" port is added
+    Given that the "port0" port is added
       And the port public endpoint "port0" is removed
     Then I should not see the port public endpoint "port0" in the service
 
   @port
   Scenario: Disable a port public endpoint
-    Given PENDING that the "port0" port is added
+    Given that the "port0" port is added
       And that the port public endpoint "port0" is disabled
     Then the port public endpoint "port0" should be "disabled" in the service
 
   @port
   Scenario: Disable and enable a port public endpoint
-    Given PENDING that the "port0" port is added
+    Given that the "port0" port is added
       And that the port public endpoint "port0" is disabled
       And that the port public endpoint "port0" is enabled
     Then the port public endpoint "port0" should be "enabled" in the service
 
   @vhost
   Scenario: List the vhost public endpoints
-    Given PENDING that the "vhost0" vhost is added
+    Given that the "vhost0" vhost is added
     Then I should see the vhost public endpoint "vhost0" in the list output
 
   @vhost
   Scenario: Add a new vhost public endpoint
-    Given PENDING that the "vhost1" vhost does not exist
+    Given that the "vhost1" vhost does not exist
       And that the "vhost1" vhost is added
     Then I should see the vhost public endpoint "vhost1" in the service
 
   @vhost
   Scenario: Delete the vhost public endpoint
-    Given PENDING that the "vhost0" vhost is added
+    Given that the "vhost0" vhost is added
       And the vhost public endpoint "vhost0" is removed
     Then I should not see the vhost public endpoint "vhost0" in the service
 
   @vhost
   Scenario: Disable a port vhost endpoint
-    Given PENDING that the "vhost0" vhost is added
+    Given that the "vhost0" vhost is added
       And that the vhost public endpoint "vhost0" is disabled
     Then the vhost public endpoint "vhost0" should be "disabled" in the service
 
   @vhost
   Scenario: Disable and enable a vhost public endpoint
-    Given PENDING that the "vhost0" vhost is added
+    Given that the "vhost0" vhost is added
       And that the vhost public endpoint "vhost0" is disabled
       And that the vhost public endpoint "vhost0" is enabled
     Then the vhost public endpoint "vhost0" should be "enabled" in the service

--- a/acceptance/ui/features/pages/service.rb
+++ b/acceptance/ui/features/pages/service.rb
@@ -79,11 +79,24 @@ class Service < SitePrism::Page
     end
 
     def check_endpoint_find?(c1, c2)
-        self.page.all(:xpath, "//table[@data-config='publicEndpointsTable']//tr").each do |tr|
-            line=tr.text.upcase()
-            if  line.include?(c1) && line.include?(c2)
-                return true
+        delay = 3   # seconds
+        maxRetries = 2
+        begin
+            retries ||= 0
+            self.page.all(:xpath, "//table[@data-config='publicEndpointsTable']//tr").each do |tr|
+                line=tr.text.upcase()
+                if  line.include?(c1) && line.include?(c2)
+                    return true
+                end
             end
+
+        # For whatever reason, this method sometimes fails with a 'stale element reference' error, which can mean
+        # that in between the time we find an element and try to reference, it's been deleted.
+        # So we use a retry here as a work around.
+        # For more information, google "selenium stale element reference".
+        rescue Selenium::WebDriver::Error::StaleElementReferenceError
+            sleep delay
+            retry if (retries += 1) < maxRetries
         end
         return false
     end

--- a/acceptance/ui/features/services_endpoint.feature
+++ b/acceptance/ui/features/services_endpoint.feature
@@ -64,7 +64,7 @@ Feature: Service Endpoints
 
 
   Scenario: Public Endpoint dialog - bad host given
-    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
+    When I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I click the Add Public Endpoint button
       And I should see the Add Public Endpoint dialog
@@ -74,7 +74,7 @@ Feature: Service Endpoints
     Then I should see "no such host"
 
   Scenario: Public Endpoint dialog - add https
-    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
+    When I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I click the Add Public Endpoint button
       And I should see the Add Public Endpoint dialog
@@ -93,7 +93,7 @@ Feature: Service Endpoints
       And I should see the endpoint entry with both "table://services/childServiceWithVHost/port_https" and "table://services/childServiceWithVHost/host"
 
   Scenario: Public Endpoint dialog - add http
-    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
+    When I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I click the Add Public Endpoint button
       And I should see the Add Public Endpoint dialog
@@ -112,7 +112,7 @@ Feature: Service Endpoints
       And I should see the endpoint entry with both "table://services/childServiceWithVHost/port_http" and "table://services/childServiceWithVHost/host"
 
   Scenario: Public Endpoint dialog - add tls
-    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
+    When I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I click the Add Public Endpoint button
       And I should see the Add Public Endpoint dialog
@@ -131,7 +131,7 @@ Feature: Service Endpoints
       And I should see the endpoint entry with both "table://services/childServiceWithVHost/port_tls" and "table://services/childServiceWithVHost/host"
 
   Scenario: Public Endpoint dialog - add other
-    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
+    When I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I click the Add Public Endpoint button
       And I should see the Add Public Endpoint dialog
@@ -150,31 +150,31 @@ Feature: Service Endpoints
       And I should see the endpoint entry with both "table://services/childServiceWithVHost/port_other" and "table://services/childServiceWithVHost/host"
 
   Scenario: Public Endpoint dialog - remove https
-    When PENDING  I view the details of "table://services/topService/name" in the "Applications" table
+    When I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I delete Endpoint "table://services/childServiceWithVHost/port_https"
     Then I should not see "table://services/childServiceWithVHost/port_https"
 
   Scenario: Public Endpoint dialog - remove http
-    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
+    When I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I delete Endpoint "table://services/childServiceWithVHost/port_http"
     Then I should not see "table://services/childServiceWithVHost/port_http"
 
   Scenario: Public Endpoint dialog - remove tls
-    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
+    When I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I delete Endpoint "table://services/childServiceWithVHost/port_tls"
     Then I should not see "table://services/childServiceWithVHost/port_tls"
 
   Scenario: Public Endpoint dialog - remove other
-    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
+    When I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I delete Endpoint "table://services/childServiceWithVHost/port_other"
     Then I should not see "table://services/childServiceWithVHost/port_other"
 
   Scenario: Public Endpoint dialog - Re-add https again
-    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
+    When I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I click the Add Public Endpoint button
       And I should see the Add Public Endpoint dialog
@@ -193,7 +193,7 @@ Feature: Service Endpoints
       And I should see the endpoint entry with both "table://services/childServiceWithVHost/port_https" and "table://services/childServiceWithVHost/host"
 
   Scenario: Public Endpoint dialog - remove https
-    When PENDING I view the details of "table://services/topService/name" in the "Applications" table
+    When I view the details of "table://services/topService/name" in the "Applications" table
       And I view the details of "table://services/childServiceWithVHost/name" in the "Services" table
       And I delete Endpoint "table://services/childServiceWithVHost/port_https"
     Then I should not see "table://services/childServiceWithVHost/port_https"

--- a/coordinator/client/zookeeper/errors.go
+++ b/coordinator/client/zookeeper/errors.go
@@ -51,6 +51,8 @@ func xlateError(err error) error {
 		return client.ErrSessionMoved
 	case zklib.ErrNoServer:
 		return client.ErrNoServer
+	case zklib.ErrAPIError:
+		return client.ErrAPIError
 	}
 	return err
 }


### PR DESCRIPTION
Fixes CC-2759

The test failures were introduced as part of the optimizations for 100s of services, which had 2 problems:

1. Through some GO pointer oversight, the updates to the ZK namespace on a fresh install (i.e. when running the acceptance tests) was overwriting the data for the first public endpoint by port/vhost with data from the last public endpoint by port/vhost. As a result, attempts to update/sync the first endpoint would fail.
1. The impl for ZK update/sync was using a mix of ZK transactions, plus `CreateIfExists `which means that the first new public endpoint by port/vhost would be created in the transaction, and all others would be created outside of the transaction as a side-effect of calling CreateIfExists.  However, we want all of them created in the transaction so they all get rolled back together if there's a problem. The solution to do that was to decouple the creation of the HostID parent directory from the creation of the actual nodes