### PR TITLE
CC-2762: Rewrite serviced-storage create-thin-pool to make better choices

### DIFF
--- a/makefile
+++ b/makefile
@@ -160,7 +160,7 @@ FORCE:
 serviced: $(GO)
 serviced: FORCE
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS}
-	make govet
+	# make govet
 	if [ -n "$(GOBIN)" ]; then cp serviced $(GOBIN)/serviced; fi
 
 serviced-controller: $(GO)

--- a/makefile
+++ b/makefile
@@ -160,13 +160,13 @@ FORCE:
 serviced: $(GO)
 serviced: FORCE
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS}
-	# make govet
-	if [ -n "$(GOBIN)" ]; then cp serviced $(GOBIN)/serviced; fi
+	make govet
+	if [ -n "$(GOBIN)" ]; then mkdir -p $(GOBIN); cp serviced $(GOBIN)/serviced; fi
 
 serviced-controller: $(GO)
 serviced-controller: FORCE
 	cd serviced-controller && $(GO) build $(GOBUILD_FLAGS) ${LDFLAGS}
-	if [ -n "$(GOBIN)" ]; then cp serviced-controller/serviced-controller $(GOBIN)/serviced-controller; fi
+	if [ -n "$(GOBIN)" ]; then mkdir -p $(GOBIN); cp serviced-controller/serviced-controller $(GOBIN)/serviced-controller; fi
 
 
 tools: serviced-storage
@@ -174,7 +174,7 @@ tools: serviced-storage
 serviced-storage: $(GO)
 serviced-storage: FORCE
 	cd tools/serviced-storage && $(GO) build $(GOBUILD_FLAGS) ${LDFLAGS}
-	if [ -n "$(GOBIN)" ]; then cp tools/serviced-storage/serviced-storage $(GOBIN)/serviced-storage; fi
+	if [ -n "$(GOBIN)" ]; then mkdir -p $(GOBIN); cp tools/serviced-storage/serviced-storage $(GOBIN)/serviced-storage; fi
 
 #
 # BUILD_VERSION is the version of the serviced-build docker image

--- a/tools/serviced-storage/thinpool.go
+++ b/tools/serviced-storage/thinpool.go
@@ -31,7 +31,7 @@ type ThinPoolCreate struct {
 		Purpose string   `description:"Purpose of the thin pool (docker|serviced)"`
 		Devices []string `description:"Block devices to use" required:"1"`
 	} `positional-args:"yes" required:"yes"`
-	Size string `short:"s" long:"size" default:"90%FREE" description:"Size of the thin pool to be created. May be specified either as a fixed amount (e.g., \"20G\") or a percentage of the free space in the volume group (e.g., \"90%\")"`
+	Size string `short:"s" long:"size" default:"90%" description:"Size of the thin pool to be created. May be specified either as a fixed amount (e.g., \"20G\") or a percentage of the free space in the volume group (e.g., \"90%\")"`
 }
 
 type LogicalVolumeInfo struct {

--- a/tools/serviced-storage/thinpool.go
+++ b/tools/serviced-storage/thinpool.go
@@ -14,10 +14,8 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -25,6 +23,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/control-center/serviced/utils"
+	"github.com/docker/go-units"
 )
 
 type ThinPoolCreate struct {
@@ -32,6 +31,7 @@ type ThinPoolCreate struct {
 		Purpose string   `description:"Purpose of the thin pool (docker|serviced)"`
 		Devices []string `description:"Block devices to use" required:"1"`
 	} `positional-args:"yes" required:"yes"`
+	Size string `short:"s" long:"size" default:"90%FREE" description:"Size of the thin pool to be created. May be specified either as a fixed amount (e.g., \"20G\") or a percentage of the free space in the volume group (e.g., \"90%\")"`
 }
 
 type LogicalVolumeInfo struct {
@@ -72,61 +72,142 @@ func (c *ThinPoolCreate) Execute(args []string) error {
 	App.initializeLogging()
 	purpose := c.Args.Purpose
 	devices := c.Args.Devices
+	size := c.Size
 	logger := log.WithFields(log.Fields{
 		"purpose": purpose,
 		"devices": devices,
 	})
+
+	// Validate the purpose
 	if purpose != "serviced" && purpose != "docker" {
 		logger.Fatal("Purpose must be one of (docker, serviced)")
 	}
 
-	logger.Info("Creating thin-pool")
-	thinPoolName, err := createThinPool(purpose, devices)
-	if err != nil {
-		logger.Fatal(err)
+	// Validate the devices
+	if len(devices) == 0 {
+		logger.Fatal("Must specify devices or a volume group in which to create a pool")
 	}
 
-	fmt.Printf("Created thin-pool device '%s'\n", thinPoolName)
+	// Validate the size
+	if _, err := strconv.Atoi(strings.TrimSuffix(size, "%")); err != nil {
+		if _, err := units.RAMInBytes(size); err != nil {
+			logger.WithField("size", size).Fatal("Invalid size. Please specify size either in bytes (e.g. \"60GB\") or as a percentage of free space in the volume group (e.g. \"90%\")")
+		}
+	}
 
+	var vg string
+	if len(devices) > 1 || !IsVolumeGroup(devices[0]) {
+		if err := createVolumeGroup(purpose, devices); err != nil {
+			logger.WithError(err).Fatal("Unable to create volume group")
+		}
+		vg = purpose
+		logger = log.WithField("volumegroup", purpose)
+		logger.Info("Created volume group")
+	} else {
+		vg = devices[0]
+		logger = log.WithField("volumegroup", vg)
+		logger.Info("Using specified volume group")
+	}
+
+	thinPoolName, err := createThinPool(purpose, vg, c.Size)
+	if err != nil {
+		logger.WithError(err).Fatal("Unable to create thin pool")
+	}
+
+	logger.WithField("thinpool", thinPoolName).Info("Created thin pool")
 	return nil
 }
 
-func createThinPool(purpose string, devices []string) (string, error) {
-
+func createVolumeGroup(name string, devices []string) error {
+	// Make sure we don't create a volume group on top of LVs
 	if err := EnsureNotLogicalVolumes(devices); err != nil {
-		return "", err
+		return err
 	}
 
+	// Make sure we can create LVM2 PVs from the devices passed in
 	if err := EnsurePhysicalDevices(devices); err != nil {
-		return "", err
+		return err
 	}
 
-	volumeGroup := purpose
-	if err := CreateVolumeGroup(volumeGroup, devices); err != nil {
-		return "", err
+	// Create the volume group
+	if err := CreateVolumeGroup(name, devices); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getMetadataSize(purpose string, dataSize int64) int64 {
+	// The default metadata calculation used by lvcreate is, very roughly,
+	//
+	//     metadataSize = floor(dataSize/4) / 1024
+	//
+	// We want to pad that number by a considerable margin, depending on
+	// whether the pool being created is for docker or serviced.
+	// We'll use the default for pools less than 25GB, then ~1% for serviced
+	// pools, ~2% for Docker pools.
+	if dataSize <= 25*units.GiB {
+		return -1
 	}
 
-	// TODO: Rather than creating separate data and metadata volumes, then
-	//  converting the data volume to a thin pool, we should simplify and use
-	//  a single command to do it all:
-	//     sudo lvcreate --type thin-pool -L 20G --poolmetadatasize 1G vg0/tp1
-	// http://man7.org/linux/man-pages/man7/lvmthin.7.html
-	metadataVolume, err := CreateMetadataVolume(volumeGroup)
+	var ds int64
+	if purpose == "docker" {
+		ds = dataSize / 50
+	} else {
+		ds = dataSize / 100
+	}
+	return (ds + 511) &^ 511
+}
+
+func createThinPool(purpose, volumeGroup, size string) (string, error) {
+	logger := log.WithFields(log.Fields{
+		"purpose":     purpose,
+		"volumegroup": volumeGroup,
+		"size":        size,
+	})
+
+	args := []string{"lvcreate", "-T"}
+
+	vgSize, err := getVolumeGroupSize(volumeGroup, "b")
 	if err != nil {
 		return "", err
 	}
 
-	dataVolume, err := CreateDataVolume(volumeGroup)
-	if err != nil {
+	var dataSize int64
+
+	if strings.HasSuffix(size, "%") {
+		// Size is a percentage of free space
+		percentage, err := strconv.Atoi(strings.TrimSuffix(size, "%"))
+		if err != nil {
+			return "", err
+		}
+		dataSize = int64(vgSize) * int64(percentage) / 100
+		args = append(args, "-l", fmt.Sprintf("%sFREE", size))
+	} else {
+		// Size is an absolute amount
+		dataSize, _ = units.RAMInBytes(size)
+		args = append(args, "-L", size)
+
+	}
+
+	mdbytes := getMetadataSize(purpose, dataSize)
+	if mdbytes > -1 {
+		args = append(args, "--poolmetadatasize", fmt.Sprintf("%dB", mdbytes))
+	}
+
+	poolName := fmt.Sprintf("%s-pool", purpose)
+	fullName := fmt.Sprintf("%s/%s", volumeGroup, poolName)
+	args = append(args, fullName)
+
+	logger.WithFields(log.Fields{
+		"command": strings.Join(args, " "),
+		"pool":    fullName,
+	}).Debug("Creating thin pool")
+	cmd := exec.Command(args[0], args[1:]...)
+	if _, _, err := checkCommand(cmd); err != nil {
 		return "", err
 	}
 
-	err = ConvertToThinPool(volumeGroup, dataVolume, metadataVolume)
-	if err != nil {
-		return "", err
-	}
-
-	lvInfo, err := GetInfoForLogicalVolume(dataVolume)
+	lvInfo, err := GetInfoForLogicalVolume(poolName)
 	if err != nil {
 		return "", err
 	}
@@ -139,6 +220,12 @@ func createThinPool(purpose string, devices []string) (string, error) {
 	return thinPoolName, nil
 }
 
+func IsVolumeGroup(device string) bool {
+	cmd := exec.Command("vgs", device)
+	_, _, rc, _ := runCommand(cmd)
+	return rc == 0
+}
+
 func EnsureNotLogicalVolumes(devices []string) error {
 	for _, device := range devices {
 		args := []string{
@@ -149,7 +236,6 @@ func EnsureNotLogicalVolumes(devices []string) error {
 			"lv_name,vg_name",
 			device,
 		}
-		log.Info(strings.Join(args, " "))
 		cmd := exec.Command(args[0], args[1:]...)
 		stdout, _, _ := checkCommand(cmd)
 		lvsCheck := strings.Split(strings.Trim(stdout, " "), ",")
@@ -172,85 +258,22 @@ func EnsurePhysicalDevices(devices []string) error {
 		}
 
 		args := []string{"pvcreate", device}
-		log.Info(strings.Join(args, " "))
 		cmd = exec.Command(args[0], args[1:]...)
-		stdout, _, err := checkCommand(cmd)
+		_, _, err = checkCommand(cmd)
 		if err != nil {
 			return err
 		}
-		log.Info(stdout)
 	}
 	return nil
 }
 
 func CreateVolumeGroup(volumeGroup string, devices []string) error {
 	args := append([]string{"vgcreate", volumeGroup}, devices...)
-	log.Info(strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	_, _, err := checkCommand(cmd)
 	if err != nil {
 		return err
 	}
-	return nil
-}
-
-func CreateMetadataVolume(volumeGroup string) (string, error) {
-	units := "s" // volume size will be measured in sectors
-	totalSize, err := getVolumeGroupSize(volumeGroup, units)
-	if err != nil {
-		return "", err
-	}
-	metadataSize := (totalSize + 999) / 1000
-	metadataName := volumeGroup + "-meta"
-
-	args := []string{"lvcreate",
-		"--size", fmt.Sprintf("%d%s", metadataSize, units),
-		"--name", metadataName,
-		volumeGroup}
-	log.Info(strings.Join(args, " "))
-	cmd := exec.Command(args[0], args[1:]...)
-	stdout, _, err := checkCommand(cmd)
-	if err != nil {
-		return "", err
-	}
-	log.Info(stdout)
-	return metadataName, err
-}
-
-func CreateDataVolume(volumeGroup string) (string, error) {
-	units := "b" // volume size will be measured in bytes
-	totalSize, err := getVolumeGroupSize(volumeGroup, units)
-	dataSize := (totalSize*90/100 + 511) &^ 511
-	dataName := volumeGroup + "-pool"
-
-	args := []string{"lvcreate",
-		"--size", fmt.Sprintf("%d%s", dataSize, units),
-		"--name", dataName,
-		volumeGroup}
-	log.Info(strings.Join(args, " "))
-	cmd := exec.Command(args[0], args[1:]...)
-	stdout, _, err := checkCommand(cmd)
-	if err != nil {
-		return "", err
-	}
-	log.Info(stdout)
-	return dataName, err
-}
-
-func ConvertToThinPool(volumeGroup, dataVolume string, metadataVolume string) error {
-	args := []string{"lvconvert",
-		"-y",
-		"--zero", "n",
-		"--thinpool", fmt.Sprintf("%s/%s", volumeGroup, dataVolume),
-		"--poolmetadata", fmt.Sprintf("%s/%s", volumeGroup, metadataVolume),
-	}
-	log.Info(strings.Join(args, " "))
-	cmd := exec.Command(args[0], args[1:]...)
-	stdout, _, err := checkCommand(cmd)
-	if err != nil {
-		return err
-	}
-	log.Info(stdout)
 	return nil
 }
 
@@ -285,7 +308,6 @@ func GetInfoForLogicalVolume(logicalVolume string) (LogicalVolumeInfo, error) {
 		"--nameprefixes",
 		"--options", "lv_name,vg_name,lv_kernel_major,lv_kernel_minor",
 	}
-	log.Info(strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	stdout, _, err := checkCommand(cmd)
 	if err != nil {
@@ -348,30 +370,9 @@ func GetInfoForLogicalVolume(logicalVolume string) (LogicalVolumeInfo, error) {
 }
 
 func (info *LogicalVolumeInfo) GetThinpoolName() (string, error) {
-	filename := fmt.Sprintf("/sys/dev/block/%d:%d/dm/name",
-		info.KernelMajor, info.KernelMinor)
-	contents, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return "", fmt.Errorf("Error reading %s: %s", filename, err)
-	}
-	// Get the base name
-	basename := strings.TrimSpace(string(contents))
-	// Now figure out if it's the pool itself or a subdevice called -tpool
-	out, err := exec.Command("dmsetup", "ls", "--target", "thin-pool").CombinedOutput()
+	out, err := exec.Command("dmsetup", "info", "-c", "-j", fmt.Sprintf("%d", info.KernelMajor), "-m", fmt.Sprintf("%d", info.KernelMinor), "-o", "name", "--noheadings").CombinedOutput()
 	if err != nil {
 		return "", err
 	}
-	scanner := bufio.NewScanner(bytes.NewReader(out))
-	var devname string
-	for scanner.Scan() {
-		s := scanner.Text()
-		if strings.HasPrefix(s, basename) {
-			devname = strings.Fields(s)[0]
-			break
-		}
-	}
-	if devname == "" {
-		return "", fmt.Errorf("Unable to determine thin pool name")
-	}
-	return "/dev/mapper/" + devname, nil
+	return fmt.Sprintf("/dev/mapper/%s", bytes.TrimSpace(out)), nil
 }


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-2762

This PR adds the ability to specify a volume group instead of devices, as well as the ability to set the size of the resulting pool absolutely or by percentage of free space. It also pads the metadata volume to 1% for serviced and 2% for docker, for pools larger than 25GB.

DEMO:
```
$ sudo vgs
  VG     #PV #LV #SN Attr   VSize   VFree  
  devian   2   3   0 wz--n- 795.14g 383.54g
$ sudo ./serviced-storage -v create-thin-pool serviced devian --size 10G
INFO[0000] Using specified volume group                  volumegroup=devian
INFO[0000] Created thin pool                             thinpool=/dev/mapper/devian-serviced--pool volumegroup=devian
$ sudo lvs -a 
  LV                    VG     Attr       LSize   Pool    Origin       Data%  Meta%  Move Log Cpy%Sync Convert                                                          
  serviced-pool         devian twi-a-tz--  10.00g                      0.00   0.62                            
  [serviced-pool_tdata] devian Twi-ao----  10.00g                                                             
  [serviced-pool_tmeta] devian ewi-ao----  12.00m                                                                                                                  
$ sudo lvremove -f devian/serviced-pool
  Logical volume "serviced-pool" successfully removed
$ sudo ./serviced-storage -v create-thin-pool serviced devian --size 100G
INFO[0000] Using specified volume group                  volumegroup=devian
INFO[0000] Created thin pool                             thinpool=/dev/mapper/devian-serviced--pool volumegroup=devian
$ sudo lvs -a 
  LV                    VG     Attr       LSize   Pool    Origin       Data%  Meta%  Move Log Cpy%Sync Convert
  serviced-pool         devian twi-a-tz-- 100.00g                      0.00   0.05                            
  [serviced-pool_tdata] devian Twi-ao---- 100.00g                                                             
  [serviced-pool_tmeta] devian ewi-ao----   1.00g                                                             
$ sudo lvremove -f devian/serviced-pool
  Logical volume "serviced-pool" successfully removed
$ sudo ./serviced-storage -v create-thin-pool serviced devian --size 90%
INFO[0000] Using specified volume group                  volumegroup=devian
INFO[0000] Created thin pool                             thinpool=/dev/mapper/devian-serviced--pool volumegroup=devian
$ sudo lvs -a 
  LV                    VG     Attr       LSize   Pool    Origin       Data%  Meta%  Move Log Cpy%Sync Convert
  serviced-pool         devian twi-a-tz-- 338.27g                      0.00   0.04                            
  [serviced-pool_tdata] devian Twi-ao---- 338.27g                                                             
  [serviced-pool_tmeta] devian ewi-ao----   3.45g                                                             
```