### PR TITLE
Make CC UI not rely on full application state

### DIFF
--- a/web/ui/.jshintrc
+++ b/web/ui/.jshintrc
@@ -60,7 +60,7 @@
     "shadow"        : true,     // true: Allows re-define variables later in code e.g. `var x=1; x=2;`
     "sub"           : true,     // true: Tolerate using `[]` notation when it can still be expressed in dot notation
     "supernew"      : false,     // true: Tolerate `new function () { ... };` and `new Object;`
-    "validthis"     : false,     // true: Tolerate using this in a non-constructor function
+    "validthis"     : true,     // true: Tolerate using this in a non-constructor function
 
     // Environments
     "browser"       : true,     // Web Browser (window, document, etc)

--- a/web/ui/src/Health/serviceHealth.js
+++ b/web/ui/src/Health/serviceHealth.js
@@ -46,9 +46,7 @@
                     service.desiredState);
 
                 // refresh list of instances
-                if (service.fetchInstances) {
-                    service.fetchInstances();
-                }
+                service.fetchInstances();
 
                 // if this service has instances, evaluate their health
                 service.instances.forEach(instance => {

--- a/web/ui/src/Health/serviceHealth.js
+++ b/web/ui/src/Health/serviceHealth.js
@@ -43,10 +43,12 @@
                 serviceStatus = new Status(
                     serviceId,
                     service.name,
-                    service.model.DesiredState);
+                    service.desiredState);
 
                 // refresh list of instances
-                service.getServiceInstances();
+                if (service.fetchInstances) {
+                    service.fetchInstances();
+                }
 
                 // if this service has instances, evaluate their health
                 service.instances.forEach(instance => {
@@ -56,7 +58,7 @@
                     instanceStatus = new Status(
                         instanceUniqueId,
                         service.name +" "+ instance.id,
-                        service.model.DesiredState);
+                        service.desiredState);
 
                     // evalute instance healthchecks and roll em up
                     instanceStatus.evaluateHealthChecks(instance.healthChecks);

--- a/web/ui/src/Health/serviceHealth.js
+++ b/web/ui/src/Health/serviceHealth.js
@@ -46,7 +46,11 @@
                     service.desiredState);
 
                 // refresh list of instances
-                service.fetchInstances();
+                // TODO - this "if" is a workaround for old servicesFactory
+                // services and should be removed along with servicesFactory
+                if(service.fetchInstances){
+                    service.fetchInstances();
+                }
 
                 // if this service has instances, evaluate their health
                 service.instances.forEach(instance => {

--- a/web/ui/src/Instances/Instance.js
+++ b/web/ui/src/Instances/Instance.js
@@ -20,6 +20,9 @@
                 RAMCommitment: utils.parseEngineeringNotation(instance.RAMCommitment)
             };
 
+            // the instance model data comes in with health and
+            // memory stats, so use that to do an initial instace
+            // status update
             this.updateState({
                 HealthStatus: instance.HealthStatus,
                 MemoryUsage: instance.MemoryUsage
@@ -30,11 +33,11 @@
             return this.resources.RAMLast < this.resources.RAMCommitment;
         }
 
+        // update fast-moving instance state
         updateState(status) {
             this.resources.RAMAverage = Math.max(0, status.MemoryUsage.Avg);
             this.resources.RAMLast = Math.max(0, status.MemoryUsage.Cur);
             this.resources.RAMMax = Math.max(0, status.MemoryUsage.Max);
-            // console.log(`Setting health property on instance`);
             this.healthChecks = status.HealthStatus;
         }
 

--- a/web/ui/src/Instances/Instance.js
+++ b/web/ui/src/Instances/Instance.js
@@ -1,0 +1,53 @@
+(function () {
+    'use strict';
+
+    // share angular services outside of angular context
+    let utils;
+
+    controlplane.factory('Instance', InstanceFactory);
+
+    function buildStateId(hostid, serviceid, instanceid) {
+        return `${hostid}-${serviceid}-${instanceid}`;
+    }
+
+    class Instance {
+
+        constructor(instance) {
+            this.model = Object.freeze(instance);
+            this.id = buildStateId(this.model.HostID, this.model.ServiceID, this.model.InstanceID);
+
+            this.resources = {
+                RAMCommitment: utils.parseEngineeringNotation(instance.RAMCommitment)
+            };
+
+            this.updateState({
+                HealthStatus: instance.HealthStatus,
+                MemoryUsage: instance.MemoryUsage
+            });
+        }
+
+        resourcesGood() {
+            return this.resources.RAMLast < this.resources.RAMCommitment;
+        }
+
+        updateState(status) {
+            this.resources.RAMAverage = Math.max(0, status.MemoryUsage.Avg);
+            this.resources.RAMLast = Math.max(0, status.MemoryUsage.Cur);
+            this.resources.RAMMax = Math.max(0, status.MemoryUsage.Max);
+            // console.log(`Setting health property on instance`);
+            this.healthChecks = status.HealthStatus;
+        }
+
+    }
+
+
+    InstanceFactory.$inject = ['miscUtils'];
+
+    function InstanceFactory(_utils) {
+
+        // api access via angular context
+        utils = _utils;
+
+        return Instance;
+    }
+})();

--- a/web/ui/src/Pools/PoolsController.js
+++ b/web/ui/src/Pools/PoolsController.js
@@ -21,7 +21,7 @@
         // of permissions
         $scope.permissions = POOL_PERMISSIONS;
 
-        $scope.click_pool = function(id) {
+        $scope.clickPool = function(id) {
             resourcesFactory.routeToPool(id);
         };
 

--- a/web/ui/src/Pools/view-pools.html
+++ b/web/ui/src/Pools/view-pools.html
@@ -13,7 +13,7 @@
 
 <table jelly-table data-data="pools" data-config="poolsTable" class="table">
   <tr ng-repeat="pool in $data">
-    <td data-title="'pools_tbl_id'|translate" sortable="'id'" ng-click="click_pool(pool.id)" class="link">{{pool.id | cut:true:50}}</td>
+    <td data-title="'pools_tbl_id'|translate" sortable="'id'" ng-click="clickPool(pool.id)" class="link">{{pool.id | cut:true:50}}</td>
     <td data-title="'core_capacity'|translate" sortable="'model.CoreCapacity'">{{pool.model.CoreCapacity}}</td>
     <td data-title="'memory_usage'|translate" sortable="'model.MemoryCommitment'"><span ng-class="{error: pool.model.MemoryCommitment>pool.model.MemoryCapacity}">{{pool.model.MemoryCommitment | toGB}}</span> / {{pool.model.MemoryCapacity | toGB}}</td>
     <td data-title="'Permissions'|translate">

--- a/web/ui/src/Services/Service.js
+++ b/web/ui/src/Services/Service.js
@@ -1,0 +1,360 @@
+(function () {
+    'use strict';
+
+    // share angular services outside of angular context
+    let $notification, serviceHealth, $q, resourcesFactory, utils, Instance;
+
+    controlplane.factory('Service', ServiceFactory);
+
+    // DesiredState enum
+    var START = 1,
+        STOP = 0,
+        RESTART = -1;
+
+    // service types
+    var ISVC = "isvc",           // internal service
+        APP = "app",             // service with no parent
+        META = "meta",           // service with children but no startup command
+        DEPLOYING = "deploying"; // service whose parent is still being deployed
+
+    function fetch(methodName, propertyName, force) {
+        let deferred = $q.defer();
+
+        if (this[propertyName] && !force) {
+            deferred.resolve();
+            return deferred.promise;
+        }
+        // NOTE: V2 API only
+        // TODO: make sure methodName exists
+        // TODO: error callback
+        resourcesFactory.v2[methodName](this.id)
+            .then(data => {
+                // console.log(`fetched ${data.length} ${propertyName} from ${methodName} for id ${this.id}`);
+                this[propertyName] = data;
+                this.touch();
+                deferred.resolve();
+            },
+            error => {
+                deferred.reject(error);
+                console.warn(error);
+            });
+
+        return deferred.promise;
+    }
+
+    function getDescendents(descendents, service) {
+        if (service.subservices) {
+            service.subservices.forEach(svc => getDescendents(descendents, svc));
+        }
+        descendents[service.id] = service;
+        return descendents;
+    }
+
+    class Service {
+
+        constructor(model) {
+            this.subservices = [];
+            this.instances = [];
+            this.update(model);
+        }
+
+        update(model) {
+            // basically new-up with exisiting children and instances
+            this.name = model.Name;
+            this.id = model.ID;
+            this.desiredState = model.DesiredState;
+            this.model = Object.freeze(model);
+            this.evaluateServiceType();
+            this.touch();   
+        }
+
+        evaluateServiceType() {
+            // infer service type
+            this.type = [];
+            if (this.model.ID.indexOf("isvc-") !== -1) {
+                this.type.push(ISVC);
+            }
+
+            if (!this.model.ParentServiceID) {
+                this.type.push(APP);
+            }
+
+            if (this.subservices.length && !this.model.Startup) {
+                this.type.push(META);
+            }
+
+            if (this.parent && this.parent.isDeploying()) {
+                this.type.push(DEPLOYING);
+            }
+        }
+
+        // fills out service object
+        fetchAll(force) {
+            this.fetchEndpoints(force);
+            this.fetchAddresses(force);
+            this.fetchConfigs(force);
+            // forced fetch-children discards existing tree services
+            this.fetchServiceChildren();
+            this.fetchMonitoringProfile(force);
+            this.fetchExportEndpoints(force);
+        }
+
+        fetchAddresses(force) {
+            fetch.call(this, "getServiceIpAssignments", "addresses", force);
+        }
+
+        fetchConfigs(force) {
+            fetch.call(this, "getServiceConfigs", "configs", force);
+        }
+
+        fetchEndpoints(force) {
+            // populate publicEndpoints property
+            fetch.call(this, "getServicePublicEndpoints", "publicEndpoints", force);
+        }
+
+        fetchExportEndpoints(force) {
+            // fetch.call(this, "getServiceExportEndpoints", "exportedServiceEndpoints", force);
+            let deferred = $q.defer();
+            resourcesFactory.v2.getServiceExportEndpoints(this.id)
+                .then(response => {
+                    console.log(`fetched ${response.length} exportEndpoints for id ${this.id}`);
+                    let tcpEndpoints = response.filter(function(ept) { return ept.Protocol === "tcp"; });
+                    tcpEndpoints.forEach(ept => ept.Value = ept.ServiceName + " - " + ept.Application);
+                    this.exportedServiceEndpoints = tcpEndpoints;
+                    deferred.resolve();
+                },
+                error => {
+                    console.warn(error);
+                    deferred.reject();
+                });
+
+            return deferred.promise;
+        }
+
+        fetchMonitoringProfile(force) {
+            fetch.call(this, "getServiceMonitoringProfile", "monitoringProfile", force);
+        }
+
+        fetchInstances() {
+            let deferred = $q.defer();
+            resourcesFactory.v2.getServiceInstances(this.id)
+                .then(data => {
+                    // console.log(`fetched ${data.length} instances for ${this.id}`);
+                    this.instances = data.map(i => new Instance(i));
+                    deferred.resolve();
+                },
+                error => {
+                    console.warn(error);
+                    deferred.reject();
+                });
+
+            return deferred.promise;
+        }
+
+        fetchServiceChildren(force) {
+            let deferred = $q.defer();
+            // fetch.call(this, "getServiceChildren", "subservices", force);
+            if (this.subservices.length && !force) {
+                deferred.resolve();
+            }
+            resourcesFactory.v2.getServiceChildren(this.id)
+                .then(data => {
+                    this.subservices = data.map(s => new Service(s));
+                    this.touch();
+                    deferred.resolve();
+                },
+                error => {
+                    console.warn(error);
+                    deferred.reject();
+                });
+            return deferred.promise;
+        }
+
+        // fast-moving state for this service and its instances
+        // note: returns a promise that resolves with a single status object
+        getStatus() {
+            let deferred = $q.defer();
+
+            resourcesFactory.v2.getServiceStatus(this.id)
+                .then(results => {
+                    if (results.length && !results[0].NotFound) {
+                        deferred.resolve(results[0]);
+                    } else {
+                        deferred.reject(`Could not get service status for id ${this.id}`);
+                    }
+                }, error => {
+                    deferred.reject(error);
+                });
+            return deferred.promise;
+        }
+
+        updateDescendentStatuses() {
+            let deferred = $q.defer();
+
+            let descendents = getDescendents({}, this);
+            let ids = Object.keys(descendents);
+            console.log(`Healthcheck: FETCH --------------- ${ids.length} services`);
+
+            resourcesFactory.v2.getServiceStatuses(ids)
+                .then(results => {
+                    if (results.length) {
+                        // iterate through results and call updateState(status) on each service
+                        results.forEach(stat => {
+                            let svc = descendents[stat.ServiceID];
+                            svc.updateState(stat);
+                            // console.log(`Healthcheck: ${descendents[stat.ServiceID].name}`);
+                        });
+                        deferred.resolve();
+                    } else {
+                        deferred.reject(`Healthcheck: ID not found ${this.id}`);
+                    }
+                }, error => {
+                    deferred.reject(error);
+                });
+            return deferred.promise;
+        }
+
+        hasInstances() {
+            return !!this.instances.length;
+        }
+
+        isIsvc() {
+            return !!~this.type.indexOf(ISVC);
+        }
+
+        hasChildren() {
+            return this.model.HasChildren;
+        }
+
+        resourcesGood() {
+            for (var i = 0; i < this.instances.length; i++) {
+                if (!this.instances[i].resourcesGood()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // start, stop, or restart this service
+        start(skipChildren) {
+            var promise = resourcesFactory.startService(this.id, skipChildren),
+                oldDesiredState = this.desiredState;
+
+            this.desiredState = START;
+
+            // if something breaks, return desired
+            // state to its previous value
+            return promise.error(() => {
+                this.desiredState = oldDesiredState;
+            });
+        }
+
+        stop(skipChildren) {
+            var promise = resourcesFactory.stopService(this.id, skipChildren),
+                oldDesiredState = this.desiredState;
+
+            this.desiredState = STOP;
+
+            // if something breaks, return desired
+            // state to its previous value
+            return promise.error(() => {
+                this.desiredState = oldDesiredState;
+            });
+        }
+
+        restart(skipChildren) {
+            var promise = resourcesFactory.restartService(this.id, skipChildren),
+                oldDesiredState = this.desiredState;
+
+            this.desiredState = RESTART;
+
+            // if something breaks, return desired
+            // state to its previous value
+            return promise.error(() => {
+                this.desiredState = oldDesiredState;
+            });
+        }
+
+        stopInstance(instance) {
+            resourcesFactory.killRunning(instance.model.HostID, instance.id)
+                .success(() => {
+                    this.touch();
+                })
+                .error((data, status) => {
+                    $notification.create("Stop Instance failed", data.Detail).error();
+                });
+        }
+
+
+        // mark services updated to trigger render via $watch
+        touch() {
+            this.lastUpdate = new Date().getTime();
+        }
+
+        // kicks off request to update fast-moving instances and service state
+        fetchAllStates() {
+            return $q.all([this.fetchInstances(), this.getStatus()])
+                .then(results => {
+                    this.updateState(results[1]);
+                }, error => {
+                    console.log("Unable to update instance states");
+                    // TODO: Error
+                });
+        }
+
+        // updates service state and instances states        
+        updateState(status) {
+
+            // update service status
+            this.desiredState = status.DesiredState;
+
+            // update public endpoints
+            if (this.publicEndpoints) {
+                this.publicEndpoints.forEach(ept => {
+                    if (ept.ServiceID === this.id) {
+                        ept.desiredState = this.desiredState;
+                    } else {
+                        // console.log("Whose kid is this? Not mine!");
+                    }
+                });
+            }
+            let statusMap = {};
+            status.Status.forEach(s => statusMap[s.InstanceID] = s);
+
+            // update instance status
+            this.instances.forEach(i => {
+                let s = statusMap[i.model.InstanceID];
+                // make sure status exists for instance
+                if (!s) {
+                    console.log(`Service instance ${i.model.ServiceName} has no instance`);
+                    return;
+                }
+                i.updateState(s);
+            });
+
+            // TODO: pass myself into health status and get my health status back
+            // update my health icon
+
+            serviceHealth.update({ [this.id]: this });
+            this.status = serviceHealth.get(this.id);
+            // console.log(`Healthcheck: ${this.name} is ${this.status.status}`);
+            this.touch();
+        }
+
+    }
+
+    ServiceFactory.$inject = ['$notification', '$serviceHealth', '$q', 'resourcesFactory', 'miscUtils', 'Instance'];
+    function ServiceFactory(_$notification, _serviceHealth, _$q, _resourcesFactory, _utils, _Instance) {
+
+        // api access via angular context
+        $notification = _$notification;
+        serviceHealth = _serviceHealth;
+        $q = _$q;
+        resourcesFactory = _resourcesFactory;
+        utils = _utils;
+        Instance = _Instance;
+
+        return Service;
+
+    }
+})();

--- a/web/ui/src/Services/ServiceDetailsController.js
+++ b/web/ui/src/Services/ServiceDetailsController.js
@@ -3,1076 +3,1402 @@
 /* ServiceDetailsController
  * Displays details of a specific service
  */
-(function() {
+(function () {
     'use strict';
 
-    controlplane.controller("ServiceDetailsController",
-    ["$scope", "$q", "$routeParams", "$location", "resourcesFactory",
-    "authService", "$modalService", "$translate", "$notification",
-    "$timeout", "servicesFactory", "miscUtils", "hostsFactory",
-    "poolsFactory", "CCUIState", "$cookies", "areUIReady", "LogSearch",
-    function($scope, $q, $routeParams, $location, resourcesFactory,
-    authService, $modalService, $translate, $notification,
-    $timeout, servicesFactory, utils, hostsFactory,
-    poolsFactory, CCUIState, $cookies, areUIReady, LogSearch){
+    // share angular services outside of angular context
+    var $q, resourcesFactory, utils;
 
-        // Ensure logged in
-        authService.checkLogin($scope);
-        $scope.resourcesFactory = resourcesFactory;
-        $scope.hostsFactory = hostsFactory;
+    // service types
+    var ISVC = "isvc",           // internal service
+        APP = "app",             // service with no parent
+        META = "meta",           // service with children but no startup command
+        DEPLOYING = "deploying"; // service whose parent is still being deployed
 
-        $scope.defaultHostAlias = $location.host();
-        if(utils.needsHostAlias($location.host())){
-            resourcesFactory.getHostAlias().success(function(data) {
-                $scope.defaultHostAlias = data.hostalias;
+    class Instance {
+
+        constructor(instance) {
+            this.name = instance.Name;
+            this.id = instance.ID;
+            this.model = Object.freeze(instance);
+
+            this.resources = {
+                RAMCommitment: utils.parseEngineeringNotation(instance.RAMCommitment)
+            };
+
+            this.updateState({
+                Health: instance.HealthStatus,
+                MemoryUsage: instance.MemoryUsage
             });
         }
 
-        //add Public Endpoint data
-        $scope.publicEndpoints = { add: {} };
+        resourcesGood() {
+            return this.resources.RAMLast < this.resources.RAMCommitment;
+        }
 
-        //add service endpoint data
-        $scope.exportedServiceEndpoints = { };
+        updateState(status) {
+            this.resources.RAMAverage = Math.max(0, status.MemoryUsage.Avg);
+            this.resources.RAMLast = Math.max(0, status.MemoryUsage.Cur);
+            this.resources.RAMMax = Math.max(0, status.MemoryUsage.Max);
 
-        $scope.click_pool = function(id) {
-            resourcesFactory.routeToPool(id);
-        };
+            // var hc = {};
+            // for (var name in instance.HealthChecks) {
+            //     hc[name] = instance.HealthChecks[name].Status;
+            // }
+            // this.healthChecks = hc;
+        }
 
-        $scope.click_host = function(id) {
-            resourcesFactory.routeToHost(id);
-        };
+    }
 
+    class Service {
+        constructor(service) {
+            // these properties are for convenience
+            this.name = service.Name;
+            this.id = service.ID;
+            // NOTE: desiredState is mutable to improve UX
+            this.desiredState = service.DesiredState;
+            this.children = [];
+            this.instances = [];
 
-        $scope.modalAddPublicEndpoint = function() {
-            areUIReady.lock();
-            $scope.protocols = [];
-            $scope.protocols.push({ Label: "HTTPS", UseTLS: true, Protocol: "https" });
-            $scope.protocols.push({ Label: "HTTP", UseTLS: false, Protocol: "http" });
-            $scope.protocols.push({ Label: "Other, secure (TLS)", UseTLS: true, Protocol: "" });
-            $scope.protocols.push({ Label: "Other, non-secure", UseTLS: false, Protocol: "" });            
-            
-            // default public endpoint options
-            $scope.publicEndpoints.add = {
-                type: "port",
-                app_ep: $scope.exportedServiceEndpoints.data[0],
-                name: "",
-                host: $scope.defaultHostAlias,
-                port: "",
-                protocol: $scope.protocols[0],
-            };
+            // make service immutable
+            this.model = Object.freeze(service);
+            this.evaluateServiceType();
+            this.touch();
+        }
 
-            // returns an error string if newPublicEndpoint's vhost is invalid
-            var validateVHost = function(newPublicEndpoint){
-                var name = newPublicEndpoint.name;
+        evaluateServiceType() {
+            // infer service type
+            this.type = [];
+            if (this.model.ID.indexOf("isvc-") !== -1) {
+                this.type.push(ISVC);
+            }
 
-                // if no port
-                if(!name || !name.length){
-                    return "Missing Name";
-                }
+            if (!this.model.ParentServiceID) {
+                this.type.push(APP);
+            }
 
-                // if name already exists
-                for (var i in $scope.publicEndpoints.data) {
-                    if (name === $scope.publicEndpoints.data[i].Name) {
-                        return "Name already exists: "+ newPublicEndpoint.name;
+            if (this.children.length && !this.model.Startup) {
+                this.type.push(META);
+            }
+
+            if (this.parent && this.parent.isDeploying()) {
+                this.type.push(DEPLOYING);
+            }
+        }
+
+        // fills out service object
+        fetchAll() {
+            this.fetchEndpoints();
+            this.fetchAddresses();
+            this.fetchConfigs();
+            this.fetchServiceChildren();
+        }
+
+        fetchAddresses(force) {
+            fetch.call(this, "getServiceIpAssignments", "addresses", force);
+        }
+
+        fetchConfigs(force) {
+            fetch.call(this, "getServiceConfigs", "configs", force);
+        }
+
+        fetchEndpoints(force) {
+            fetch.call(this, "getServicePublicEndpoints", "publicEndpoints", force);
+        }
+
+        fetchInstances() {
+            let deferred = $q.defer();
+            resourcesFactory.v2.getServiceInstances(this.id)
+                .then(data => {
+                    console.log(`fetched ${data.length} instances from getServiceInstances for id ${this.id}`);
+                    this.instances = data.map(i => new Instance(i));
+                    this.touch();
+                    deferred.resolve();
+                },
+                error => {
+                    console.warn(error);
+                    deferred.reject();
+                });
+
+            return deferred.promise;
+        }
+
+        fetchServiceChildren(force) {
+            // fetch.call(this, "getServiceChildren", "subservices", force);
+            if (this.subservices) {
+                return;
+            }
+            resourcesFactory.v2.getServiceChildren(this.id)
+                .then(data => {
+                    console.log(`fetched ${data.length} children services from getServiceChildren for id ${this.id}`);
+                    this.subservices = data.map(s => new Service(s));
+                    this.touch();
+                },
+                error => {
+                    console.warn(error);
+                });
+        }
+
+        // fast-moving state for this service and its instances
+        // note: returns a promise that resolves with a single status object
+        getStatus() {
+            let deferred = $q.defer();
+
+            resourcesFactory.v2.getServiceStatus(this.id)
+                .then(results => {
+                    if (results.length && !results[0].NotFound) {
+                        deferred.resolve(results[0]);
+                    } else {
+                        deferred.reject(`Could not get service status for id ${this.id}`);
                     }
+                }, error => {
+                    deferred.reject(error);
+                });
+            return deferred.promise;
+        }
+
+        hasInstances() {
+            return !!this.instances.length;
+        }
+
+        isIsvc() {
+            return !!~this.type.indexOf(ISVC);
+        }
+
+        hasChildren() {
+            return this.model.HasChildren;
+        }
+
+        // mark services updated to trigger render via $watch
+        touch() {
+            this.lastUpdate = new Date().getTime();
+        }
+
+        // kicks off request to update instances and service state
+        fetchAllStates() {
+            $q.all([this.fetchInstances(), this.getStatus()])
+                .then(results => {
+                    this.updateState(results[1]);
+                }, error => {
+                    console.log("Unable to update instance states");
+                    // TODO: Error
+                });
+        }
+
+        // updates service state and instances states        
+        updateState(status) {
+
+            // update service status
+            this.desiredState = status.DesiredState;
+
+            let statusMap = {};
+            status.Status.forEach(s => statusMap[s.InstanceID] = s);
+
+            // update instance status
+            this.instances.forEach(i => {
+                let s = statusMap[i.id];
+                // make sure status exists for instance
+                if (!s) {
+                    console.log(`Service instance ${i.id} has no status. Skipping status update.`);
+                    return;
+                }
+                i.updateState(s);
+            });
+
+            this.touch();
+        }
+
+    }
+
+    function fetch(methodName, propertyName, force) {
+        let deferred = $q.defer();
+
+        if (this[propertyName] && !force) {
+            deferred.resolve();
+            return deferred.promise;
+        }
+        // NOTE: V2 API only
+        // TODO: make sure methodName exists
+        // TODO: error callback
+        resourcesFactory.v2[methodName](this.id)
+            .then(data => {
+                console.log(`fetched ${data.length} ${propertyName} from ${methodName} for id ${this.id}`);
+                this[propertyName] = data;
+                this.touch();
+                deferred.resolve();
+            },
+            error => {
+                deferred.reject(error);
+                console.warn(error);
+            });
+
+        return deferred.promise;
+    }
+
+
+    controlplane.controller("ServiceDetailsController",
+        ["$scope", "$q", "$routeParams", "$location", "resourcesFactory",
+            "authService", "$modalService", "$translate", "$notification",
+            "$timeout", "miscUtils", "hostsFactory",
+            "poolsFactory", "CCUIState", "$cookies", "areUIReady", "LogSearch",
+            function ($scope, _$q, $routeParams, $location, _resourcesFactory,
+                authService, $modalService, $translate, $notification,
+                $timeout, _utils, hostsFactory,
+                poolsFactory, CCUIState, $cookies, areUIReady, LogSearch) {
+
+                // api access via angular context
+                $q = _$q;
+                resourcesFactory = _resourcesFactory;
+                utils = _utils;
+
+                // Ensure logged in
+                authService.checkLogin($scope);
+                $scope.resourcesFactory = resourcesFactory;
+                $scope.hostsFactory = hostsFactory;
+
+                $scope.defaultHostAlias = $location.host();
+                if (utils.needsHostAlias($location.host())) {
+                    resourcesFactory.getHostAlias().success(function (data) {
+                        $scope.defaultHostAlias = data.hostalias;
+                    });
                 }
 
-                // if invalid characters
-                var re = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
-                if(!re.test(name)){
-                    return $translate.instant("vhost_name_invalid") + " " + newPublicEndpoint.name;
-                }
-            };
+                //add Public Endpoint data
+                $scope.publicEndpoints = { add: {} };
 
-            // returns an error string if newPublicEndpoint's port is invalid
-            var validatePort = function(newPublicEndpoint){
-                var host = newPublicEndpoint.host;
-                var port = newPublicEndpoint.port;
+                //add service endpoint data
+                $scope.exportedServiceEndpoints = {};
 
-                if(!host || !host.length){
-                    return "Missing host name";
-                }
+                $scope.click_pool = function (id) {
+                    resourcesFactory.routeToPool(id);
+                };
 
-                // if invalid characters
-                var re = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
-                if(!re.test(host)){
-                    return $translate.instant("host_name_invalid") + ": " + host;
-                }                
+                $scope.click_host = function (id) {
+                    resourcesFactory.routeToHost(id);
+                };
 
-                // if no port
-                if(!port || !port.length){
-                    return "Missing port";
-                }
 
-                if(+port < 1 || +port > 65536){
-                    return "Port must be between 1 and 65536";
-                }
-            };
+                $scope.modalAddPublicEndpoint = function () {
+                    areUIReady.lock();
+                    $scope.protocols = [];
+                    $scope.protocols.push({ Label: "HTTPS", UseTLS: true, Protocol: "https" });
+                    $scope.protocols.push({ Label: "HTTP", UseTLS: false, Protocol: "http" });
+                    $scope.protocols.push({ Label: "Other, secure (TLS)", UseTLS: true, Protocol: "" });
+                    $scope.protocols.push({ Label: "Other, non-secure", UseTLS: false, Protocol: "" });
 
-            $modalService.create({
-                templateUrl: "add-public-endpoint.html",
-                model: $scope,
-                title: "add_public_endpoint",
-                actions: [
-                    {
-                        role: "cancel",
-                        action: function(){
-                            this.close();
+                    // default public endpoint options
+                    $scope.publicEndpoints.add = {
+                        type: "port",
+                        app_ep: $scope.exportedServiceEndpoints.data[0],
+                        name: "",
+                        host: $scope.defaultHostAlias,
+                        port: "",
+                        protocol: $scope.protocols[0],
+                    };
+
+                    // returns an error string if newPublicEndpoint's vhost is invalid
+                    var validateVHost = function (newPublicEndpoint) {
+                        var name = newPublicEndpoint.name;
+
+                        // if no port
+                        if (!name || !name.length) {
+                            return "Missing Name";
                         }
-                    },{
-                        role: "ok",
-                        label: "add_public_endpoint_confirm",
-                        action: function(){
-                            var newPublicEndpoint = $scope.publicEndpoints.add;
 
-                            if(this.validate(newPublicEndpoint)){
-                                // disable ok button, and store the re-enable function
-                                var enableSubmit = this.disableSubmitButton();
-
-                                $scope.addPublicEndpoint(newPublicEndpoint)
-                                    .success(function(data, status){
-                                        $notification.create("Added public endpoint").success();
-                                        this.close();
-                                    }.bind(this))
-                                    .error(function(data, status){
-                                        this.createNotification("Unable to add public endpoint", data.Detail).error();
-                                        enableSubmit();
-                                    }.bind(this));
-
+                        // if name already exists
+                        for (var i in $scope.publicEndpoints.data) {
+                            if (name === $scope.publicEndpoints.data[i].Name) {
+                                return "Name already exists: " + newPublicEndpoint.name;
                             }
                         }
-                    }
-                ],
 
-                validate: function(newPublicEndpoint){
-                    // if no service endpoint selected
-                    if(!newPublicEndpoint.app_ep){
-                        this.createNotification("Unable to add Public Endpoint", "No service endpoint selected").error();
-                        return false;
-                    }
-
-
-                    // perform type specific validation
-                    if(newPublicEndpoint.type === "vhost"){
-                        var err = validateVHost(newPublicEndpoint);
-                        if(err){
-                            this.createNotification("Unable to add Public Endpoint", err).error();
-                        } else {
-                            return true;
+                        // if invalid characters
+                        var re = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
+                        if (!re.test(name)) {
+                            return $translate.instant("vhost_name_invalid") + " " + newPublicEndpoint.name;
                         }
-                    } else if(newPublicEndpoint.type === "port"){
-                        var err = validatePort(newPublicEndpoint);
-                        if(err){
-                            this.createNotification("Unable to add Public Endpoint", err).error();
-                            return false;
-                        } else {
-                            return true;
+                    };
+
+                    // returns an error string if newPublicEndpoint's port is invalid
+                    var validatePort = function (newPublicEndpoint) {
+                        var host = newPublicEndpoint.host;
+                        var port = newPublicEndpoint.port;
+
+                        if (!host || !host.length) {
+                            return "Missing host name";
                         }
+
+                        // if invalid characters
+                        var re = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
+                        if (!re.test(host)) {
+                            return $translate.instant("host_name_invalid") + ": " + host;
+                        }
+
+                        // if no port
+                        if (!port || !port.length) {
+                            return "Missing port";
+                        }
+
+                        if (+port < 1 || +port > 65536) {
+                            return "Port must be between 1 and 65536";
+                        }
+                    };
+
+                    $modalService.create({
+                        templateUrl: "add-public-endpoint.html",
+                        model: $scope,
+                        title: "add_public_endpoint",
+                        actions: [
+                            {
+                                role: "cancel",
+                                action: function () {
+                                    this.close();
+                                }
+                            }, {
+                                role: "ok",
+                                label: "add_public_endpoint_confirm",
+                                action: function () {
+                                    var newPublicEndpoint = $scope.publicEndpoints.add;
+
+                                    if (this.validate(newPublicEndpoint)) {
+                                        // disable ok button, and store the re-enable function
+                                        var enableSubmit = this.disableSubmitButton();
+
+                                        $scope.addPublicEndpoint(newPublicEndpoint)
+                                            .success(function (data, status) {
+                                                $notification.create("Added public endpoint").success();
+                                                this.close();
+                                            }.bind(this))
+                                            .error(function (data, status) {
+                                                this.createNotification("Unable to add public endpoint", data.Detail).error();
+                                                enableSubmit();
+                                            }.bind(this));
+
+                                    }
+                                }
+                            }
+                        ],
+
+                        validate: function (newPublicEndpoint) {
+                            // if no service endpoint selected
+                            if (!newPublicEndpoint.app_ep) {
+                                this.createNotification("Unable to add Public Endpoint", "No service endpoint selected").error();
+                                return false;
+                            }
+
+
+                            // perform type specific validation
+                            if (newPublicEndpoint.type === "vhost") {
+                                var err = validateVHost(newPublicEndpoint);
+                                if (err) {
+                                    this.createNotification("Unable to add Public Endpoint", err).error();
+                                } else {
+                                    return true;
+                                }
+                            } else if (newPublicEndpoint.type === "port") {
+                                var err = validatePort(newPublicEndpoint);
+                                if (err) {
+                                    this.createNotification("Unable to add Public Endpoint", err).error();
+                                    return false;
+                                } else {
+                                    return true;
+                                }
+                            }
+                        },
+                        onShow: () => {
+                            areUIReady.unlock();
+                        }
+                    });
+                };
+
+
+                $scope.addPublicEndpoint = function (newPublicEndpoint) {
+                    var serviceId = newPublicEndpoint.app_ep.ApplicationId;
+                    var serviceName = newPublicEndpoint.app_ep.Application;
+                    var serviceEndpoint = newPublicEndpoint.app_ep.ServiceEndpoint;
+                    if (newPublicEndpoint.type === "vhost") {
+                        var vhostName = newPublicEndpoint.name;
+                        return resourcesFactory.addVHost(serviceId, serviceName, serviceEndpoint, vhostName);
+                    } else if (newPublicEndpoint.type === "port") {
+                        var port = newPublicEndpoint.host + ":" + newPublicEndpoint.port;
+                        var usetls = newPublicEndpoint.protocol.UseTLS;
+                        var protocol = newPublicEndpoint.protocol.Protocol;
+                        return resourcesFactory.addPort(serviceId, serviceName, serviceEndpoint, port, usetls, protocol);
                     }
-                },
-                onShow: () => {
-                    areUIReady.unlock();
-                }
-            });
-        };
+                };
+
+                // modalAssignIP opens a modal view to assign an ip address to a service
+                $scope.modalAssignIP = function (ip, poolID) {
+                    $scope.ips.assign = { 'ip': ip, 'value': null };
+                    resourcesFactory.getPoolIPs(poolID)
+                        .success(function (data) {
+                            var options = [{ 'Value': 'Automatic', 'IPAddr': '' }];
+
+                            var i, IPAddr, value;
+                            //host ips
+                            if (data && data.HostIPs) {
+                                for (i = 0; i < data.HostIPs.length; ++i) {
+                                    IPAddr = data.HostIPs[i].IPAddress;
+                                    value = 'Host: ' + IPAddr + ' - ' + data.HostIPs[i].InterfaceName;
+                                    options.push({ 'Value': value, 'IPAddr': IPAddr });
+                                    // set the default value to the currently assigned value
+                                    if ($scope.ips.assign.ip.IPAddr === IPAddr) {
+                                        $scope.ips.assign.value = options[options.length - 1];
+                                    }
+                                }
+                            }
+
+                            //virtual ips
+                            if (data && data.VirtualIPs) {
+                                for (i = 0; i < data.VirtualIPs.length; ++i) {
+                                    IPAddr = data.VirtualIPs[i].IP;
+                                    value = "Virtual IP: " + IPAddr;
+                                    options.push({ 'Value': value, 'IPAddr': IPAddr });
+                                    // set the default value to the currently assigned value
+                                    if ($scope.ips.assign.ip.IPAddr === IPAddr) {
+                                        $scope.ips.assign.value = options[options.length - 1];
+                                    }
+                                }
+                            }
+
+                            //default to automatic
+                            if (!$scope.ips.assign.value) {
+                                $scope.ips.assign.value = options[0];
+
+                            }
+                            $scope.ips.assign.options = options;
+
+                            $modalService.create({
+                                templateUrl: "assign-ip.html",
+                                model: $scope,
+                                title: "assign_ip",
+                                actions: [
+                                    {
+                                        role: "cancel"
+                                    }, {
+                                        role: "ok",
+                                        label: "assign_ip",
+                                        action: function () {
+                                            if (this.validate()) {
+                                                // disable ok button, and store the re-enable function
+                                                var enableSubmit = this.disableSubmitButton();
+
+                                                $scope.assignIP()
+                                                    .success(function (data, status) {
+                                                        $notification.create("Added IP", data.Detail).success();
+                                                        this.close();
+                                                    }.bind(this))
+                                                    .error(function (data, status) {
+                                                        this.createNotification("Unable to Assign IP", data.Detail).error();
+                                                        enableSubmit();
+                                                    }.bind(this));
+                                            }
+                                        }
+                                    }
+                                ]
+                            });
+                        })
+                        .error((data, status) => {
+                            $notification.create("Unable to retrieve IPs", data.Detail).error();
+                        });
+                };
+
+                $scope.anyServicesExported = function (service) {
+                    // if(service){
+                    //     for (var i in service.Endpoints) {
+                    //         if (service.Endpoints[i].Purpose === "export") {
+                    //             return true;
+                    //         }
+                    //     }
+                    //     for (var j in service.children) {
+                    //         if ($scope.anyServicesExported(service.children[j])) {
+                    //             return true;
+                    //         }
+                    //     }
+                    // }
+                    // return false;
+                    return true;
+                };
 
 
-        $scope.addPublicEndpoint = function(newPublicEndpoint) {
-            var serviceId = newPublicEndpoint.app_ep.ApplicationId;
-            var serviceName = newPublicEndpoint.app_ep.Application;
-            var serviceEndpoint = newPublicEndpoint.app_ep.ServiceEndpoint;
-            if(newPublicEndpoint.type === "vhost"){
-                var vhostName = newPublicEndpoint.name;
-                return resourcesFactory.addVHost(serviceId, serviceName, serviceEndpoint, vhostName);
-            } else if(newPublicEndpoint.type === "port"){
-                var port = newPublicEndpoint.host + ":" + newPublicEndpoint.port;
-                var usetls = newPublicEndpoint.protocol.UseTLS;
-                var protocol = newPublicEndpoint.protocol.Protocol;
-                return resourcesFactory.addPort(serviceId, serviceName, serviceEndpoint, port, usetls, protocol);
-            }
-        };
+                $scope.assignIP = function () {
+                    var serviceID = $scope.ips.assign.ip.ServiceID;
+                    var IP = $scope.ips.assign.value.IPAddr;
+                    return resourcesFactory.assignIP(serviceID, IP)
+                        .success(function (data, status) {
+                            // HACK: update(true) forces a full update to
+                            // work around issue https://jira.zenoss.com/browse/CC-939
+                            // servicesFactory.update(true);
+                        });
+                };
 
-        // modalAssignIP opens a modal view to assign an ip address to a service
-        $scope.modalAssignIP = function(ip, poolID) {
-          $scope.ips.assign = {'ip':ip, 'value':null};
-          resourcesFactory.getPoolIPs(poolID)
-              .success(function(data) {
-                var options= [{'Value':'Automatic', 'IPAddr':''}];
 
-                var i, IPAddr, value;
-                //host ips
-                if (data && data.HostIPs) {
-                  for(i = 0; i < data.HostIPs.length; ++i) {
-                    IPAddr = data.HostIPs[i].IPAddress;
-                    value = 'Host: ' + IPAddr + ' - ' + data.HostIPs[i].InterfaceName;
-                    options.push({'Value': value, 'IPAddr':IPAddr});
-                    // set the default value to the currently assigned value
-                    if ($scope.ips.assign.ip.IPAddr === IPAddr) {
-                      $scope.ips.assign.value = options[ options.length-1];
+                $scope.publicEndpointProtocol = function (publicEndpoint) {
+                    if (publicEndpoint.type === "vhost") {
+                        return "https";
+                    } else {
+                        if (publicEndpoint.Protocol !== "") {
+                            return publicEndpoint.Protocol;
+                        }
+                        if (publicEndpoint.UseTLS) {
+                            return "other (TLS)";
+                        }
+                        return "other";
                     }
-                  }
-                }
+                };
 
-                //virtual ips
-                if (data && data.VirtualIPs) {
-                  for(i = 0; i < data.VirtualIPs.length; ++i) {
-                    IPAddr = data.VirtualIPs[i].IP;
-                    value =  "Virtual IP: " + IPAddr;
-                    options.push({'Value': value, 'IPAddr':IPAddr});
-                    // set the default value to the currently assigned value
-                    if ($scope.ips.assign.ip.IPAddr === IPAddr) {
-                      $scope.ips.assign.value = options[ options.length-1];
+                $scope.indent = function (depth) {
+                    return { 'padding-left': (15 * depth) + "px" };
+                };
+
+                // sets a service to start, stop or restart state
+                $scope.setServiceState = function (service, state, skipChildren) {
+                    service[state](skipChildren).error(function (data, status) {
+                        $notification.create("Unable to " + state + " service", data.Detail).error();
+                    });
+                };
+
+                // filters to be used when counting how many descendent
+                // services will be affected by a state change
+                var serviceStateChangeFilters = {
+                    // only stopped services will be started
+                    "start": service => service.desiredState === 0,
+                    // only started services will be stopped
+                    "stop": service => service.desiredState === 1,
+                    // only started services will be restarted
+                    "restart": service => service.desiredState === 1
+                };
+
+                // clicks to a service's start, stop, or restart
+                // button should first determine if the service has
+                // children and ask the user to choose to start all
+                // children or only the top service
+                $scope.clickRunning = function (service, state) {
+                    var filterFn = serviceStateChangeFilters[state];
+                    var childCount = utils.countTheKids(service, filterFn);
+
+                    // if the service has affected children, check if the user
+                    // wants to start just the service, or the service and children
+                    if (childCount > 0) {
+                        $scope.modal_confirmSetServiceState(service, state, childCount);
+
+                        // if no children, just start the service
+                    } else {
+                        $scope.setServiceState(service, state);
                     }
-                  }
-                }
+                    // servicesFactory.updateHealth();
+                };
 
-                //default to automatic
-                if(!$scope.ips.assign.value) {
-                  $scope.ips.assign.value = options[0];
+                // verifies if use wants to start parent service, or parent
+                // and all children
+                $scope.modal_confirmSetServiceState = function (service, state, childCount) {
+                    $modalService.create({
+                        template: ["<h4>" + $translate.instant("choose_services_" + state) + "</h4><ul>",
+                            "<li>" + $translate.instant(state + "_service_name", { name: "<strong>" + service.name + "</strong>" }) + "</li>",
+                            "<li>" + $translate.instant(state + "_service_name_and_children", { name: "<strong>" + service.name + "</strong>", count: "<strong>" + childCount + "</strong>" }) + "</li></ul>"
+                        ].join(""),
+                        model: $scope,
+                        title: $translate.instant(state + "_service"),
+                        actions: [
+                            {
+                                role: "cancel"
+                            }, {
+                                role: "ok",
+                                classes: " ",
+                                label: $translate.instant(state + "_service"),
+                                action: function () {
+                                    // the arg here explicitly prevents child services
+                                    // from being started
+                                    $scope.setServiceState(service, state, true);
+                                    this.close();
+                                }
+                            }, {
+                                role: "ok",
+                                label: $translate.instant(state + "_service_and_children", { count: childCount }),
+                                action: function () {
+                                    $scope.setServiceState(service, state);
+                                    this.close();
+                                }
+                            }
+                        ]
+                    });
+                };
 
-                }
-                $scope.ips.assign.options = options;
 
-                $modalService.create({
-                    templateUrl: "assign-ip.html",
-                    model: $scope,
-                    title: "assign_ip",
-                    actions: [
-                        {
-                            role: "cancel"
-                        },{
-                            role: "ok",
-                            label: "assign_ip",
-                            action: function(){
-                                if(this.validate()){
+                $scope.clickEndpointEnable = function (publicEndpoint) {
+                    if (publicEndpoint.type === "vhost") {
+                        resourcesFactory.enableVHost(publicEndpoint.ApplicationId, publicEndpoint.Application, publicEndpoint.ServiceEndpoint, publicEndpoint.Name)
+                            .error((data, status) => {
+                                $notification.create("Enable Public Endpoint failed", data.Detail).error();
+                            });
+                    } else if (publicEndpoint.type === "port") {
+                        resourcesFactory.enablePort(publicEndpoint.ApplicationId, publicEndpoint.Application, publicEndpoint.ServiceEndpoint, publicEndpoint.PortAddr)
+                            .error((data, status) => {
+                                $notification.create("Enable Public Endpoint failed", data.Detail).error();
+                            });
+                    }
+                };
+
+
+                $scope.clickEndpointDisable = function (publicEndpoint) {
+                    if (publicEndpoint.type === "vhost") {
+                        resourcesFactory.disableVHost(publicEndpoint.ApplicationId, publicEndpoint.Application, publicEndpoint.ServiceEndpoint, publicEndpoint.Name)
+                            .error((data, status) => {
+                                $notification.create("Disable Public Endpoint failed", data.Detail).error();
+                            });
+                    } else if (publicEndpoint.type === "port") {
+                        resourcesFactory.disablePort(publicEndpoint.ApplicationId, publicEndpoint.Application, publicEndpoint.ServiceEndpoint, publicEndpoint.PortAddr)
+                            .error((data, status) => {
+                                $notification.create("Disable Public Endpoint failed", data.Detail).error();
+                            });
+                    }
+                };
+
+                $scope.clickEditContext = function () {
+                    //set editor options for context editing
+                    $scope.codemirrorOpts = {
+                        lineNumbers: true,
+                        mode: "properties"
+                    };
+
+                    $scope.editableService = angular.copy($scope.services.current.model);
+                    $scope.editableContext = makeEditableContext($scope.editableService.Context);
+
+                    $modalService.create({
+                        templateUrl: "edit-context.html",
+                        model: $scope,
+                        title: $translate.instant("edit_context"),
+                        actions: [
+                            {
+                                role: "cancel"
+                            }, {
+                                role: "ok",
+                                label: $translate.instant("btn_save_changes"),
+                                action: function () {
                                     // disable ok button, and store the re-enable function
                                     var enableSubmit = this.disableSubmitButton();
 
-                                    $scope.assignIP()
-                                        .success(function(data, status){
-                                            $notification.create("Added IP", data.Detail).success();
+                                    $scope.editableService.Context = makeStorableContext($scope.editableContext);
+
+                                    $scope.updateService($scope.editableService)
+                                        .success(function (data, status) {
+                                            $notification.create("Updated service", $scope.editableService.ID).success();
                                             this.close();
                                         }.bind(this))
-                                        .error(function(data, status){
-                                            this.createNotification("Unable to Assign IP", data.Detail).error();
+                                        .error(function (data, status) {
+                                            this.createNotification("Update service failed", data.Detail).error();
                                             enableSubmit();
                                         }.bind(this));
                                 }
                             }
+                        ],
+                        onShow: function () {
+                            $scope.codemirrorRefresh = true;
+                        },
+                        onHide: function () {
+                            $scope.codemirrorRefresh = false;
                         }
-                    ]
-                });
-              })
-              .error((data, status) => {
-                $notification.create("Unable to retrieve IPs", data.Detail).error();
-              });
-        };
-
-        $scope.anyServicesExported = function(service) {
-            if(service){
-                for (var i in service.Endpoints) {
-                    if (service.Endpoints[i].Purpose === "export") {
-                        return true;
-                    }
-                }
-                for (var j in service.children) {
-                    if ($scope.anyServicesExported(service.children[j])) {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        };
-
-
-        $scope.assignIP = function() {
-            var serviceID = $scope.ips.assign.ip.ServiceID;
-            var IP = $scope.ips.assign.value.IPAddr;
-            return resourcesFactory.assignIP(serviceID, IP)
-                .success(function(data, status){
-                    // HACK: update(true) forces a full update to
-                    // work around issue https://jira.zenoss.com/browse/CC-939
-                    servicesFactory.update(true);
-                });
-        };
-
-        
-        $scope.publicEndpointProtocol = function(publicEndpoint) {
-            if(publicEndpoint.type === "vhost"){
-                return "https";
-            } else {
-                if (publicEndpoint.Protocol !== "") {
-                    return publicEndpoint.Protocol;
-                }
-                if (publicEndpoint.UseTLS) {
-                    return "other (TLS)";
-                }
-                return "other";
-            }
-        };
-
-        $scope.indent = function(depth){
-            return {'padding-left': (15*depth) + "px"};
-        };
-
-        // sets a service to start, stop or restart state
-        $scope.setServiceState = function(service, state, skipChildren){
-            service[state](skipChildren).error(function(data, status){
-                $notification.create("Unable to " + state + " service", data.Detail).error();
-            });
-        };
-
-        // filters to be used when counting how many descendent
-        // services will be affected by a state change
-        var serviceStateChangeFilters = {
-            // only stopped services will be started
-            "start": service => service.desiredState === 0,
-            // only started services will be stopped
-            "stop": service => service.desiredState === 1,
-            // only started services will be restarted
-            "restart": service => service.desiredState === 1
-        };
-
-        // clicks to a service's start, stop, or restart
-        // button should first determine if the service has
-        // children and ask the user to choose to start all
-        // children or only the top service
-        $scope.clickRunning = function(service, state){
-            var filterFn = serviceStateChangeFilters[state];
-            var childCount = utils.countTheKids(service, filterFn);
-
-            // if the service has affected children, check if the user
-            // wants to start just the service, or the service and children
-            if(childCount > 0){
-                $scope.modal_confirmSetServiceState(service, state, childCount);
-
-            // if no children, just start the service
-            } else {
-                $scope.setServiceState(service, state);
-            }
-            servicesFactory.updateHealth();
-        };
-
-        // verifies if use wants to start parent service, or parent
-        // and all children
-        $scope.modal_confirmSetServiceState = function(service, state, childCount){
-            $modalService.create({
-                template: ["<h4>"+ $translate.instant("choose_services_"+ state) +"</h4><ul>",
-                    "<li>"+ $translate.instant(state +"_service_name", {name: "<strong>"+service.name+"</strong>"}) +"</li>",
-                    "<li>"+ $translate.instant(state +"_service_name_and_children", {name: "<strong>"+service.name+"</strong>", count: "<strong>"+childCount+"</strong>"}) +"</li></ul>"
-                ].join(""),
-                model: $scope,
-                title: $translate.instant(state +"_service"),
-                actions: [
-                    {
-                        role: "cancel"
-                    },{
-                        role: "ok",
-                        classes: " ",
-                        label: $translate.instant(state +"_service"),
-                        action: function(){
-                            // the arg here explicitly prevents child services
-                            // from being started
-                            $scope.setServiceState(service, state, true);
-                            this.close();
-                        }
-                    },{
-                        role: "ok",
-                        label: $translate.instant(state +"_service_and_children", {count: childCount}),
-                        action: function(){
-                            $scope.setServiceState(service, state);
-                            this.close();
-                        }
-                    }
-                ]
-            });
-        };
-
-
-        $scope.clickEndpointEnable= function(publicEndpoint){
-            if(publicEndpoint.type === "vhost"){
-                resourcesFactory.enableVHost(publicEndpoint.ApplicationId, publicEndpoint.Application, publicEndpoint.ServiceEndpoint, publicEndpoint.Name)
-                    .error((data, status) => {
-                        $notification.create("Enable Public Endpoint failed", data.Detail).error();
                     });
-            } else if(publicEndpoint.type === "port"){
-                resourcesFactory.enablePort(publicEndpoint.ApplicationId,  publicEndpoint.Application, publicEndpoint.ServiceEndpoint, publicEndpoint.PortAddr)
-                    .error((data, status) => {
-                        $notification.create("Enable Public Endpoint failed", data.Detail).error();
-                    });
-            }
-        };
+                };
 
-
-        $scope.clickEndpointDisable = function(publicEndpoint){
-            if(publicEndpoint.type === "vhost"){
-                resourcesFactory.disableVHost(publicEndpoint.ApplicationId, publicEndpoint.Application, publicEndpoint.ServiceEndpoint, publicEndpoint.Name)
-                    .error((data, status) => {
-                        $notification.create("Disable Public Endpoint failed", data.Detail).error();
-                    });
-            } else if(publicEndpoint.type === "port"){
-                resourcesFactory.disablePort(publicEndpoint.ApplicationId, publicEndpoint.Application, publicEndpoint.ServiceEndpoint, publicEndpoint.PortAddr)
-                    .error((data, status) => {
-                        $notification.create("Disable Public Endpoint failed", data.Detail).error();
-                    });
-            }
-        };
-
-        $scope.clickEditContext = function() {
-            //set editor options for context editing
-            $scope.codemirrorOpts = {
-                lineNumbers: true,
-                mode: "properties"
-            };
-
-            $scope.editableService = angular.copy($scope.services.current.model);
-            $scope.editableContext = makeEditableContext($scope.editableService.Context);
-
-            $modalService.create({
-                templateUrl: "edit-context.html",
-                model: $scope,
-                title: $translate.instant("edit_context"),
-                actions: [
-                    {
-                        role: "cancel"
-                    },{
-                        role: "ok",
-                        label: $translate.instant("btn_save_changes"),
-                        action: function(){
-                            // disable ok button, and store the re-enable function
-                            var enableSubmit = this.disableSubmitButton();
-
-                            $scope.editableService.Context = makeStorableContext($scope.editableContext);
-
-                            $scope.updateService($scope.editableService)
-                                .success(function(data, status){
-                                    $notification.create("Updated service", $scope.editableService.ID).success();
-                                    this.close();
-                                }.bind(this))
-                                .error(function(data, status){
-                                    this.createNotification("Update service failed", data.Detail).error();
-                                    enableSubmit();
-                                }.bind(this));
-                        }
+                function makeEditableContext(context) {
+                    var editableContext = "";
+                    for (var key in context) {
+                        editableContext += key + " " + context[key] + "\n";
                     }
-                ],
-            onShow: function(){
-                $scope.codemirrorRefresh = true;
-            },
-            onHide: function(){
-                $scope.codemirrorRefresh = false;
-            }
-            });
-        };
-
-        function makeEditableContext(context){
-            var editableContext = "";
-            for(var key in context){
-                editableContext += key + " " + context[key] + "\n";
-            }
-            if(!editableContext){ editableContext = ""; }
-            return editableContext;
-        }
-        function makeStorableContext(context){
-            //turn editableContext into a JSON object
-            var lines = context.split("\n"),
-                storable = {};
-
-            lines.forEach(function(line){
-                var delimitIndex, key, val;
-
-                if(line !== ""){
-                    delimitIndex = line.indexOf(" ");
-                    if(delimitIndex !== -1){
-                        key = line.substr(0, delimitIndex);
-                        val = line.substr(delimitIndex + 1);
-                        storable[key] = val;
-                    } else {
-                        context[line] = "";
-                    }
+                    if (!editableContext) { editableContext = ""; }
+                    return editableContext;
                 }
-            });
+                function makeStorableContext(context) {
+                    //turn editableContext into a JSON object
+                    var lines = context.split("\n"),
+                        storable = {};
 
-            return storable;
-        }
+                    lines.forEach(function (line) {
+                        var delimitIndex, key, val;
 
-
-        $scope.clickRemovePublicEndpoint = function(publicEndpoint) {
-
-            $modalService.create({
-                template: $translate.instant("remove_public_endpoint") + ": <strong>"+
-                          (publicEndpoint.Name ? publicEndpoint.Name : "port " + publicEndpoint.PortAddr) + "</strong><br><br>",
-                model: $scope,
-                title: "remove_public_endpoint",
-                actions: [
-                    {
-                        role: "cancel"
-                    },{
-                        role: "ok",
-                        label: "remove_public_endpoint_confirm",
-                        classes: "btn-danger",
-                        action: function(){
-                            if(publicEndpoint.type === "vhost"){
-                                resourcesFactory.removeVHost( publicEndpoint.ApplicationId, publicEndpoint.ServiceEndpoint, publicEndpoint.Name)
-                                    .success(() => {
-                                        servicesFactory.update();
-                                        $notification.create("Removed Public Endpoint", publicEndpoint.Name).success();
-                                    })
-                                    .error((data, status) => {
-                                        $notification.create("Remove Public Endpoint failed", data.Detail).error();
-                                    });
-                            } else if(publicEndpoint.type === "port"){
-                                resourcesFactory.removePort(publicEndpoint.ApplicationId, publicEndpoint.ServiceEndpoint, publicEndpoint.PortAddr)
-                                    .success(() => {
-                                        servicesFactory.update();
-                                        $notification.create("Removed Public Endpoint", publicEndpoint.PortName).success();
-                                    })
-                                    .error((data, status) => {
-                                        $notification.create("Remove Public Endpoint failed", data.Detail).error();
-                                    });
-                            }
-                            this.close();
-                        }
-                    }
-                ]
-            });
-        };
-
-        $scope.editConfig = function(config) {
-            $scope.editableService = angular.copy($scope.services.current.model);
-            $scope.selectedConfig = config;
-
-            //set editor options for context editing
-            $scope.codemirrorOpts = {
-                lineNumbers: true,
-                mode: utils.getModeFromFilename($scope.selectedConfig)
-            };
-
-            $modalService.create({
-                templateUrl: "edit-config.html",
-                model: $scope,
-                title: $translate.instant("title_edit_config") +" - "+ $scope.selectedConfig,
-                bigModal: true,
-                actions: [
-                    {
-                        role: "cancel"
-                    },{
-                        role: "ok",
-                        label: "save",
-                        action: function(){
-                            if(this.validate()){
-                                // disable ok button, and store the re-enable function
-                                var enableSubmit = this.disableSubmitButton();
-
-                                $scope.updateService($scope.editableService)
-                                    .success(function(data, status){
-                                        $notification.create("Updated service", $scope.editableService.ID).success();
-                                        this.close();
-                                    }.bind(this))
-                                    .error(function(data, status){
-                                        this.createNotification("Update service failed", data.Detail).error();
-                                        enableSubmit();
-                                    }.bind(this));
+                        if (line !== "") {
+                            delimitIndex = line.indexOf(" ");
+                            if (delimitIndex !== -1) {
+                                key = line.substr(0, delimitIndex);
+                                val = line.substr(delimitIndex + 1);
+                                storable[key] = val;
+                            } else {
+                                context[line] = "";
                             }
                         }
-                    }
-                ],
-                validate: function(){
-                    // TODO - actually validate
-                    return true;
-                },
-                onShow: function(){
-                    $scope.codemirrorRefresh = true;
-                },
-                onHide: function(){
-                    $scope.codemirrorRefresh = false;
+                    });
+
+                    return storable;
                 }
-            });
-        };
 
-        $scope.viewLog = function(instance) {
-            $scope.editService = angular.copy(instance);
 
-            resourcesFactory.getInstanceLogs(instance.model.ServiceID, instance.model.ID)
-                .success(function(log) {
-                    $scope.editService.log = log.Detail;
+                $scope.clickRemovePublicEndpoint = function (publicEndpoint) {
+
                     $modalService.create({
-                        templateUrl: "view-log.html",
+                        template: $translate.instant("remove_public_endpoint") + ": <strong>" +
+                        (publicEndpoint.Name ? publicEndpoint.Name : "port " + publicEndpoint.PortAddr) + "</strong><br><br>",
                         model: $scope,
-                        title: "title_log",
+                        title: "remove_public_endpoint",
+                        actions: [
+                            {
+                                role: "cancel"
+                            }, {
+                                role: "ok",
+                                label: "remove_public_endpoint_confirm",
+                                classes: "btn-danger",
+                                action: function () {
+                                    if (publicEndpoint.type === "vhost") {
+                                        resourcesFactory.removeVHost(publicEndpoint.ApplicationId, publicEndpoint.ServiceEndpoint, publicEndpoint.Name)
+                                            .success(() => {
+                                                // servicesFactory.update();
+                                                $notification.create("Removed Public Endpoint", publicEndpoint.Name).success();
+                                            })
+                                            .error((data, status) => {
+                                                $notification.create("Remove Public Endpoint failed", data.Detail).error();
+                                            });
+                                    } else if (publicEndpoint.type === "port") {
+                                        resourcesFactory.removePort(publicEndpoint.ApplicationId, publicEndpoint.ServiceEndpoint, publicEndpoint.PortAddr)
+                                            .success(() => {
+                                                // servicesFactory.update();
+                                                $notification.create("Removed Public Endpoint", publicEndpoint.PortName).success();
+                                            })
+                                            .error((data, status) => {
+                                                $notification.create("Remove Public Endpoint failed", data.Detail).error();
+                                            });
+                                    }
+                                    this.close();
+                                }
+                            }
+                        ]
+                    });
+                };
+
+                $scope.editConfig = function (config) {
+                    $scope.editableService = angular.copy($scope.services.current.model);
+                    $scope.selectedConfig = config;
+
+                    //set editor options for context editing
+                    $scope.codemirrorOpts = {
+                        lineNumbers: true,
+                        mode: utils.getModeFromFilename($scope.selectedConfig)
+                    };
+
+                    $modalService.create({
+                        templateUrl: "edit-config.html",
+                        model: $scope,
+                        title: $translate.instant("title_edit_config") + " - " + $scope.selectedConfig,
                         bigModal: true,
                         actions: [
                             {
-                                role: "cancel",
-                                label: "close"
-                            },{
-                                classes: "btn-primary",
-                                label: "refresh",
-                                icon: "glyphicon-repeat",
-                                action: function() {
-                                    var textarea = this.$el.find("textarea");
-                                    resourcesFactory.getInstanceLogs(instance.model.ServiceID, instance.id)
-                                        .success(function(log) {
-                                            $scope.editService.log = log.Detail;
-                                            textarea.scrollTop(textarea[0].scrollHeight - textarea.height());
-                                        })
-                                        .error((data, status) => {
-                                            this.createNotification("Unable to fetch logs", data.Detail).error();
-                                        });
+                                role: "cancel"
+                            }, {
+                                role: "ok",
+                                label: "save",
+                                action: function () {
+                                    if (this.validate()) {
+                                        // disable ok button, and store the re-enable function
+                                        var enableSubmit = this.disableSubmitButton();
+
+                                        $scope.updateService($scope.editableService)
+                                            .success(function (data, status) {
+                                                $notification.create("Updated service", $scope.editableService.ID).success();
+                                                this.close();
+                                            }.bind(this))
+                                            .error(function (data, status) {
+                                                this.createNotification("Update service failed", data.Detail).error();
+                                                enableSubmit();
+                                            }.bind(this));
+                                    }
                                 }
-                            },{
-                                classes: "btn-primary",
-                                label: "download",
-                                action: function(){
-                                    utils.downloadFile('/services/' + instance.model.ServiceID + '/' + instance.model.ID + '/logs/download');
-                                },
-                                icon: "glyphicon-download"
                             }
                         ],
-                        onShow: function(){
-                            var textarea = this.$el.find("textarea");
-                            textarea.scrollTop(textarea[0].scrollHeight - textarea.height());
+                        validate: function () {
+                            // TODO - actually validate
+                            return true;
+                        },
+                        onShow: function () {
+                            $scope.codemirrorRefresh = true;
+                        },
+                        onHide: function () {
+                            $scope.codemirrorRefresh = false;
                         }
                     });
-                })
-                .error(function(data, status){
-                    $notification.create("Unable to fetch logs", data.Detail).error();
-                });
-        };
+                };
 
-        $scope.validateService = function() {
-          // TODO: Validate name and startup command
-          var svc = $scope.services.current.model,
-              max = svc.InstanceLimits.Max,
-              min = svc.InstanceLimits.Min,
-              num = svc.Instances;
-          if (typeof num === 'undefined' || (max > 0 && num > max) || (min > 0 && num < min)) {
-            var msg = $translate.instant("instances_invalid") + " ";
-            if (min > 0) {
-              msg += $translate.instant("minimum") + " " + min;
-              if (max > 0) {
-                msg += ", ";
-              }
-            }
-            if (max > 0) {
-              msg += $translate.instant("maximum") + " " + max;
-            }
-            $notification.create("", msg).error();
-            return false;
-          }
-          return true;
-        };
+                $scope.viewLog = function (instance) {
+                    $scope.editService = angular.copy(instance);
 
-        $scope.updateService = function(newService) {
-            if ($scope.validateService()) {
-                return resourcesFactory.updateService($scope.services.current.model.ID, newService)
-                    .success((data, status) => {
-                        servicesFactory.update();
-                        this.editableService = {};
-                    });
-            }
-        };
+                    resourcesFactory.getInstanceLogs(instance.model.ServiceID, instance.model.ID)
+                        .success(function (log) {
+                            $scope.editService.log = log.Detail;
+                            $modalService.create({
+                                templateUrl: "view-log.html",
+                                model: $scope,
+                                title: "title_log",
+                                bigModal: true,
+                                actions: [
+                                    {
+                                        role: "cancel",
+                                        label: "close"
+                                    }, {
+                                        classes: "btn-primary",
+                                        label: "refresh",
+                                        icon: "glyphicon-repeat",
+                                        action: function () {
+                                            var textarea = this.$el.find("textarea");
+                                            resourcesFactory.getInstanceLogs(instance.model.ServiceID, instance.id)
+                                                .success(function (log) {
+                                                    $scope.editService.log = log.Detail;
+                                                    textarea.scrollTop(textarea[0].scrollHeight - textarea.height());
+                                                })
+                                                .error((data, status) => {
+                                                    this.createNotification("Unable to fetch logs", data.Detail).error();
+                                                });
+                                        }
+                                    }, {
+                                        classes: "btn-primary",
+                                        label: "download",
+                                        action: function () {
+                                            utils.downloadFile('/services/' + instance.model.ServiceID + '/' + instance.model.ID + '/logs/download');
+                                        },
+                                        icon: "glyphicon-download"
+                                    }
+                                ],
+                                onShow: function () {
+                                    var textarea = this.$el.find("textarea");
+                                    textarea.scrollTop(textarea[0].scrollHeight - textarea.height());
+                                }
+                            });
+                        })
+                        .error(function (data, status) {
+                            $notification.create("Unable to fetch logs", data.Detail).error();
+                        });
+                };
 
-        $scope.subNavClick = function(crumb){
-            if(crumb.id){
-                $scope.routeToService(crumb.id);
-            } else {
-                // TODO - just call subnavs usual function
-                $location.path(crumb.url);
-            }
-        };
-
-        // grab default kibana search configs and adjust
-        // the query to look for this specific service
-        $scope.getServiceLogURL = function(service){
-            if(!service){
-                return "";
-            }
-            let appConfig = LogSearch.getDefaultAppConfig(),
-                globalConfig = LogSearch.getDefaultGlobalConfig();
-
-            appConfig.query = {
-                query_string: {
-                    analyze_wildcard: true,
-                    query: `fields.service:${service.id} AND fields.instance:* AND message:*`
-                }
-            };
-            appConfig.columns = ["fields.instance","message"];
-
-            return LogSearch.getURL(appConfig, globalConfig);
-        };
-
-        // grab default kibana search configs and adjust
-        // the query to look for this specific service instance
-        $scope.getInstanceLogURL = function(instance){
-            let appConfig = LogSearch.getDefaultAppConfig(),
-                globalConfig = LogSearch.getDefaultGlobalConfig();
-
-            appConfig.query = {
-                query_string: {
-                    analyze_wildcard: true,
-                    query: `fields.service:${instance.model.ServiceID} AND fields.instance:${instance.model.InstanceID} AND message:*`
-                }
-            };
-            appConfig.columns = ["message"];
-
-            return LogSearch.getURL(appConfig, globalConfig);
-
-        };
-
-        $scope.routeToService = function(id, e){
-            // if an event is present, we may
-            // need to prevent it from performing
-            // default navigation behavior
-            if(e){
-                // ctrl click opens in new tab,
-                // so allow that to happen and don't
-                // bother routing the current view
-                if(e.ctrlKey){
-                    return;
-                }
-
-                // if middle click, don't update
-                // current view
-                if(e.button === 1){
-                    return;
-                }
-
-                // otherwise, prevent default so
-                // we can handle the view routing
-                e.preventDefault();
-            }
-
-            $location.update_path("/services/"+id, true);
-            $scope.params.serviceId = id;
-            $scope.services.current = servicesFactory.get($scope.params.serviceId);
-            $scope.update();
-        };
-
-        $scope.update = function(){
-            if($scope.services.current){
-                $scope.services.subservices = $scope.services.current.descendents;
-                $scope.publicEndpoints.data = $scope.services.current.publicEndpoints;
-                $scope.exportedServiceEndpoints.data = $scope.services.current.exportedServiceEndpoints;
-                $scope.ips.data = $scope.services.current.addresses;
-
-                // update instances
-                $scope.services.current.getServiceInstances();
-
-                // setup breadcrumbs
-                $scope.breadcrumbs = makeCrumbs($scope.services.current);
-
-                // update serviceTreeState
-                $scope.serviceTreeState = CCUIState.get($cookies.get("ZUsername"), "serviceTreeState");
-
-                // update pools
-                $scope.pools = poolsFactory.poolList;
-
-                // create an entry in tree state for the
-                // current service
-                if(!($scope.services.current.id in $scope.serviceTreeState)){
-                    $scope.serviceTreeState[$scope.services.current.id] = {};
-
-                    var treeState = $scope.serviceTreeState[$scope.services.current.id];
-
-                    // create default entries from all descendents
-                    $scope.services.current.descendents.forEach(descendent => {
-                        // TODO - formalize this state object
-                        treeState[descendent.id] = {
-                            hidden: false,
-                            collapsed: false
-                        };
-                    });
-                }
-
-                // property for view to bind for tree state
-                $scope.services.currentTreeState = $scope.serviceTreeState[$scope.services.current.id];
-            }
-
-            servicesFactory.updateHealth();
-        };
-
-        // restart all running instances for this service
-        $scope.killRunningInstances = function(app){
-            resourcesFactory.restartService(app.ID)
-                .error((data, status) => {
-                    $notification.create("Stop Service failed", data.Detail).error();
-                });
-        };
-
-        $scope.startTerminal = function(app) {
-            window.open("http://" + window.location.hostname + ":50000");
-        };
-
-
-
-        $scope.getHostName = function(id){
-            if(hostsFactory.get(id)){
-                return hostsFactory.get(id).name;
-            } else {
-                // TODO - if unknown host, dont make linkable
-                // and use custom css to show unknown
-                return "unknown";
-            }
-        };
-
-        // expand/collapse state of service tree nodes
-        $scope.serviceTreeState = CCUIState.get($cookies.get("ZUsername"), "serviceTreeState");
-        // servicedTreeState is a collection of objects
-        // describing if nodes in a service tree are hidden or collapsed.
-        // It is first keyed by the id of the current service context (the
-        // service who's name is at the top of the page), then keyed by
-        // the service in question. eg:
-        //
-        // current service id
-        //      -> child service id
-        //          -> hidden
-        //          -> collapsed
-        //      -> child service id
-        //          -> hidden
-        //          -> collapsed
-        //      ...
-
-        $scope.toggleChildren = function(service){
-            if(!$scope.services.current){
-                console.warn("Cannot store toggle state: no current service");
-                return;
-            }
-
-            // stored state for the current service's
-            // service tree
-            var treeState = $scope.services.currentTreeState;
-
-            // if this service is marked as collapsed in
-            // this particular tree view, show its children
-            if(treeState[service.id].collapsed){
-                treeState[service.id].collapsed = false;
-                $scope.showChildren(service);
-
-            // otherwise, hide its children
-            } else {
-                treeState[service.id].collapsed = true;
-                $scope.hideChildren(service);
-            }
-        };
-
-        $scope.hideChildren = function(service){
-            // get the state of the current service's tree
-            var treeState = $scope.services.currentTreeState;
-
-            service.children.forEach(function(child){
-                treeState[child.id].hidden = true;
-                $scope.hideChildren(child);
-            });
-        };
-
-        $scope.showChildren = function(service){
-            var treeState = $scope.services.currentTreeState;
-
-            service.children.forEach(function(child){
-                treeState[child.id].hidden = false;
-
-                // if this child service is not marked
-                // as collapsed, show its children
-                if(!treeState[child.id].collapsed){
-                    $scope.showChildren(child);
-                }
-            });
-        };
-
-        //we need to bring this function into scope so we can use ng-hide if an object is empty
-        $scope.isEmptyObject = function(obj){
-            return angular.equals({}, obj);
-        };
-
-        $scope.isIsvc = function(service){
-            return service.isIsvc();
-        };
-
-        $scope.hasCurrentInstances = function(){
-            return $scope.services && $scope.services.current && $scope.services.current.hasInstances();
-        };
-
-        $scope.editCurrentService = function(){
-
-            // clone service for editing
-            $scope.editableService = angular.copy($scope.services.current.model);
-
-            $modalService.create({
-                templateUrl: "edit-service.html",
-                model: $scope,
-                title: "title_edit_service",
-                actions: [
-                    {
-                        role: "cancel"
-                    },{
-                        role: "ok",
-                        label: "btn_save_changes",
-                        action: function(){
-                            if(this.validate()){
-
-                                // disable ok button, and store the re-enable function
-                                var enableSubmit = this.disableSubmitButton();
-
-                                // update service with recently edited service
-                                $scope.updateService($scope.editableService)
-                                    .success(function(data, status){
-                                        $notification.create("Updated service", $scope.editableService.ID).success();
-                                        this.close();
-                                    }.bind(this))
-                                    .error(function(data, status){
-                                        this.createNotification("Update service failed", data.Detail).error();
-                                        enableSubmit();
-                                    }.bind(this));
+                $scope.validateService = function () {
+                    // TODO: Validate name and startup command
+                    var svc = $scope.services.current.model,
+                        max = svc.InstanceLimits.Max,
+                        min = svc.InstanceLimits.Min,
+                        num = svc.Instances;
+                    if (typeof num === 'undefined' || (max > 0 && num > max) || (min > 0 && num < min)) {
+                        var msg = $translate.instant("instances_invalid") + " ";
+                        if (min > 0) {
+                            msg += $translate.instant("minimum") + " " + min;
+                            if (max > 0) {
+                                msg += ", ";
                             }
                         }
-                    }
-                ],
-                validate: function(){
-                    if($scope.editableService.InstanceLimits.Min > $scope.editableService.Instances || $scope.editableService.Instances === undefined){
+                        if (max > 0) {
+                            msg += $translate.instant("maximum") + " " + max;
+                        }
+                        $notification.create("", msg).error();
                         return false;
                     }
-
                     return true;
-                }
-            });
-        };
+                };
 
-        // TODO - clean up magic numbers
-        $scope.calculateIndent = function(service){
-            var indent = service.depth,
-                offset = 1;
+                $scope.updateService = function (newService) {
+                    if ($scope.validateService()) {
+                        return resourcesFactory.updateService($scope.services.current.model.ID, newService)
+                            .success((data, status) => {
+                                // servicesFactory.update();
+                                this.editableService = {};
+                            });
+                    }
+                };
 
-            if($scope.services.current && $scope.services.current.parent){
-                offset = $scope.services.current.parent.depth + 2;
-            }
+                $scope.subNavClick = function (crumb) {
+                    if (crumb.id) {
+                        $scope.routeToService(crumb.id);
+                    } else {
+                        // TODO - just call subnavs usual function
+                        $location.path(crumb.url);
+                    }
+                };
 
-            return $scope.indent(indent - offset);
-        };
+                // grab default kibana search configs and adjust
+                // the query to look for this specific service
+                $scope.getServiceLogURL = function (service) {
+                    if (!service) {
+                        return "";
+                    }
+                    let appConfig = LogSearch.getDefaultAppConfig(),
+                        globalConfig = LogSearch.getDefaultGlobalConfig();
 
-
-        function init(){
-            $scope.name = "servicedetails";
-            $scope.params = $routeParams;
-
-            $scope.breadcrumbs = [
-                { label: 'breadcrumb_deployed', url: '/apps' }
-            ];
-
-            $scope.publicEndpointsTable = {
-                sorting: {
-                    ServiceEndpoint: "asc"
-                }
-            };
-            $scope.ipsTable = {
-                sorting: {
-                    ServiceName: "asc"
-                }
-            };
-            $scope.configTable = {
-                sorting: {
-                    Filename: "asc"
-                }
-            };
-            $scope.instancesTable = {
-                sorting: {
-                    "model.InstanceID": "asc"
-                },
-                // instead of watching for a change, always
-                // reload at a specified interval
-                watchExpression: (function(){
-                    var last = new Date().getTime(),
-                        now,
-                        interval = 1000;
-
-                    return function(){
-                        now = new Date().getTime();
-                        if(now - last > interval){
-                            last = now;
-                            return now;
+                    appConfig.query = {
+                        query_string: {
+                            analyze_wildcard: true,
+                            query: `fields.service:${service.id} AND fields.instance:* AND message:*`
                         }
                     };
-                })()
-            };
+                    appConfig.columns = ["fields.instance", "message"];
 
-            // servicesTable should not be sortable since it
-            // is a hierarchy.
-            $scope.servicesTable = {
-                disablePagination: true
-            };
+                    return LogSearch.getURL(appConfig, globalConfig);
+                };
 
-            // setup initial state
-            $scope.services = {
-                data: servicesFactory.serviceTree,
-                mapped: servicesFactory.serviceMap,
-                current: servicesFactory.get($scope.params.serviceId)
-            };
+                // grab default kibana search configs and adjust
+                // the query to look for this specific service instance
+                $scope.getInstanceLogURL = function (instance) {
+                    let appConfig = LogSearch.getDefaultAppConfig(),
+                        globalConfig = LogSearch.getDefaultGlobalConfig();
 
-            $scope.ips = {};
-            $scope.pools = [];
+                    appConfig.query = {
+                        query_string: {
+                            analyze_wildcard: true,
+                            query: `fields.service:${instance.model.ServiceID} AND fields.instance:${instance.model.InstanceID} AND message:*`
+                        }
+                    };
+                    appConfig.columns = ["message"];
 
-            // if the current service changes, update
-            // various service controller thingies
-            $scope.$watch(function() {
-                // if no current service is set, try to set one
-                if(!$scope.services.current) {
-                    $scope.services.current = servicesFactory.get($scope.params.serviceId);
-                }
+                    return LogSearch.getURL(appConfig, globalConfig);
 
-                if($scope.services.current) {
-                    return $scope.services.current.isDirty();
-                } else {
-                    // there is no current service
-                    console.warn("current service not yet available");
-                    return undefined;
-                }
-            }, $scope.update);
+                };
 
-            hostsFactory.activate();
-            hostsFactory.update();
+                $scope.routeToService = function (id, e) {
+                    // if an event is present, we may
+                    // need to prevent it from performing
+                    // default navigation behavior
+                    if (e) {
+                        // ctrl click opens in new tab,
+                        // so allow that to happen and don't
+                        // bother routing the current view
+                        if (e.ctrlKey) {
+                            return;
+                        }
 
-            servicesFactory.activate();
-            servicesFactory.update();
+                        // if middle click, don't update
+                        // current view
+                        if (e.button === 1) {
+                            return;
+                        }
 
-            poolsFactory.activate();
-            poolsFactory.update();
+                        // otherwise, prevent default so
+                        // we can handle the view routing
+                        e.preventDefault();
+                    }
 
-            $scope.$on("$destroy", function() {
-                servicesFactory.deactivate();
-                hostsFactory.deactivate();
-                poolsFactory.deactivate();
-            });
-        }
+                    $location.update_path("/services/" + id, true);
+                    $scope.params.serviceId = id;
+                    // $scope.services.current = servicesFactory.get($scope.params.serviceId);
+                    $scope.update();
+                };
 
-        // kick off controller
-        init();
+                // restart all running instances for this service
+                $scope.killRunningInstances = function (app) {
+                    resourcesFactory.restartService(app.ID)
+                        .error((data, status) => {
+                            $notification.create("Stop Service failed", data.Detail).error();
+                        });
+                };
+
+                $scope.startTerminal = function (app) {
+                    window.open("http://" + window.location.hostname + ":50000");
+                };
 
 
 
-        function makeCrumbs(current){
-            var crumbs = [{
-                label: current.name,
-                itemClass: "active",
-                id: current.id
-            }];
+                $scope.getHostName = function (id) {
+                    if (hostsFactory.get(id)) {
+                        return hostsFactory.get(id).name;
+                    } else {
+                        // TODO - if unknown host, dont make linkable
+                        // and use custom css to show unknown
+                        return "unknown";
+                    }
+                };
 
-            (function recurse(service){
-                if(service){
-                    crumbs.unshift({
-                        label: service.name,
-                        url: "/services/"+ service.id,
-                        id: service.id
+                // expand/collapse state of service tree nodes
+                $scope.serviceTreeState = CCUIState.get($cookies.get("ZUsername"), "serviceTreeState");
+                // servicedTreeState is a collection of objects
+                // describing if nodes in a service tree are hidden or collapsed.
+                // It is first keyed by the id of the current service context (the
+                // service who's name is at the top of the page), then keyed by
+                // the service in question. eg:
+                //
+                // current service id
+                //      -> child service id
+                //          -> hidden
+                //          -> collapsed
+                //      -> child service id
+                //          -> hidden
+                //          -> collapsed
+                //      ...
+
+                $scope.toggleChildren = function (service) {
+                    if (!$scope.services.current) {
+                        console.warn("Cannot store toggle state: no current service");
+                        return;
+                    }
+
+                    // stored state for the current service's
+                    // service tree
+                    var treeState = $scope.services.currentTreeState;
+
+                    // if this service is marked as collapsed in
+                    // this particular tree view, show its children
+                    if (treeState[service].collapsed) {
+                        treeState[service].collapsed = false;
+                        console.log("expand  " + service);
+                        // TODO: create Service object for [service]
+                        // TODO: call fetchServiceChildren() on it.
+
+                        // otherwise, hide its children
+                    } else {
+                        treeState[service].collapsed = true;
+                        console.log("retract " + service);
+                        $scope.hideChildren(service);
+                    }
+                };
+
+                $scope.getService = function (id) {
+                    let deferred = $q.defer();
+                    $scope.resourcesFactory.v2.getService(id)
+                        .then(function (data) {
+                            console.log("got service id=" + id);
+                            deferred.resolve(data);
+                        },
+                        function (error) {
+                            console.warn(error);
+                            deferred.reject(error);
+                        });
+                    return deferred.promise;
+                };
+
+                // $scope.getServiceChildren = function(id) {
+                //     $scope.resourcesFactory.v2.getServiceChildren(id)
+                //         .success(function(data){
+                //             console.log(data.length + " children returned.");
+                //             $scope.services.current.children = data;
+                //             // $scope.insertTreeChildren(data.results);
+                //         });
+                // };
+
+                $scope.getServiceEndpoints = function (id) {
+                    let deferred = $q.defer();
+                    $scope.resourcesFactory.v2.getServiceEndpoints(id)
+                        .then(function (response) {
+                            console.log("got service endpoints for id=" + id);
+                            deferred.resolve(response.data);
+                        },
+                        function (response) {
+                            console.warn(response.status + " " + response.statusText);
+                            deferred.reject(response.statusText);
+                        });
+                    return deferred.promise;
+                };
+
+                $scope.getServices = function () {
+                    $scope.resourcesFactory.v2.getServices()
+                        .success(function (data) {
+                            console.log(data.length + " top level children.");
+                            // $scope.services.current = data.results;
+                        });
+                };
+
+                $scope.insertTreeChildren = function (subservices) {
+                    var par = subservices[0].ParentServiceID;
+                    var index = $scope.services.data.findIndex(svc => svc.id === par);
+
+
+
+
+
+
+
+                };
+
+                $scope.hideChildren = function (service) {
+                    // get the state of the current service's tree
+                    var treeState = $scope.services.currentTreeState;
+
+                    if (service.children) {
+                        service.children.forEach(function (child) {
+                            treeState[child.id].hidden = true;
+                            $scope.hideChildren(child);
+                        });
+                    }
+                };
+
+                $scope.showChildren = function (service) {
+                    var treeState = $scope.services.currentTreeState;
+
+                    if (service.children) {
+                        service.children.forEach(function (child) {
+                            treeState[child.id].hidden = false;
+
+                            // if this child service is not marked
+                            // as collapsed, show its children
+                            if (!treeState[child.id].collapsed) {
+                                $scope.showChildren(child);
+                            }
+                        });
+                    }
+                };
+
+                //we need to bring this function into scope so we can use ng-hide if an object is empty
+                $scope.isEmptyObject = function (obj) {
+                    return angular.equals({}, obj);
+                };
+
+                $scope.isIsvc = function (service) {
+                    return service.isIsvc();
+                };
+
+                $scope.hasCurrentInstances = function () {
+                    return $scope.services && $scope.services.current && $scope.services.current.hasInstances();
+                };
+
+                $scope.editCurrentService = function () {
+
+                    // clone service for editing
+                    $scope.editableService = angular.copy($scope.services.current.model);
+
+                    $modalService.create({
+                        templateUrl: "edit-service.html",
+                        model: $scope,
+                        title: "title_edit_service",
+                        actions: [
+                            {
+                                role: "cancel"
+                            }, {
+                                role: "ok",
+                                label: "btn_save_changes",
+                                action: function () {
+                                    if (this.validate()) {
+
+                                        // disable ok button, and store the re-enable function
+                                        var enableSubmit = this.disableSubmitButton();
+
+                                        // update service with recently edited service
+                                        $scope.updateService($scope.editableService)
+                                            .success(function (data, status) {
+                                                $notification.create("Updated service", $scope.editableService.ID).success();
+                                                this.close();
+                                            }.bind(this))
+                                            .error(function (data, status) {
+                                                this.createNotification("Update service failed", data.Detail).error();
+                                                enableSubmit();
+                                            }.bind(this));
+                                    }
+                                }
+                            }
+                        ],
+                        validate: function () {
+                            if ($scope.editableService.InstanceLimits.Min > $scope.editableService.Instances || $scope.editableService.Instances === undefined) {
+                                return false;
+                            }
+
+                            return true;
+                        }
                     });
-                    recurse(service.parent);
+                };
+
+                // TODO - clean up magic numbers
+                $scope.calculateIndent = function (service) {
+                    var indent = service.depth,
+                        offset = 1;
+
+                    if ($scope.services.current && $scope.services.current.parent) {
+                        offset = $scope.services.current.parent.depth + 2;
+                    }
+
+                    return $scope.indent(indent - offset);
+                };
+
+                $scope.update = function () {
+
+                    console.log("UPDATE --------------");
+
+                    if ($scope.services.current) {
+
+                        $scope.services.current.fetchAll();
+                        // setup breadcrumbs
+                        $scope.breadcrumbs = makeCrumbs($scope.services.current);
+
+                        // update serviceTreeState
+                        $scope.serviceTreeState = CCUIState.get($cookies.get("ZUsername"), "serviceTreeState");
+
+                        // update pools
+                        $scope.pools = poolsFactory.poolList;
+
+                        // create an entry in tree state for the
+                        // current service
+                        if (!($scope.services.current.id in $scope.serviceTreeState)) {
+                            $scope.serviceTreeState[$scope.services.current.id] = {};
+                        }
+                        var treeState = $scope.serviceTreeState[$scope.services.current.id];
+
+                        // initialize services as collapsed
+                        if ($scope.services.current.subservices) {
+                            $scope.services.current.subservices.forEach(svc => {
+                                if (!treeState[svc.ID]) {
+                                    console.log(`setting serviceTreeState[${svc.ID}] to collapsed`);
+                                    treeState[svc.ID] = {
+                                        hidden: false,
+                                        collapsed: true
+                                    };
+                                }
+                            });
+                        }
+
+                        // property for view to bind for tree state
+                        $scope.services.currentTreeState = $scope.serviceTreeState[$scope.services.current.id];
+
+                    }
+
+                };
+
+
+                function init() {
+                    $scope.name = "servicedetails";
+                    $scope.params = $routeParams;
+
+                    $scope.breadcrumbs = [
+                        { label: 'breadcrumb_deployed', url: '/apps' }
+                    ];
+
+                    $scope.publicEndpointsTable = {
+                        sorting: {
+                            ServiceEndpoint: "asc"
+                        }
+                    };
+                    $scope.ipsTable = {
+                        sorting: {
+                            ServiceName: "asc"
+                        }
+                    };
+                    $scope.configTable = {
+                        sorting: {
+                            Filename: "asc"
+                        }
+                    };
+                    $scope.instancesTable = {
+                        sorting: {
+                            "model.InstanceID": "asc"
+                        },
+                        // instead of watching for a change, always
+                        // reload at a specified interval
+                        watchExpression: (function () {
+                            var last = new Date().getTime(),
+                                now,
+                                interval = 1000;
+
+                            return function () {
+                                now = new Date().getTime();
+                                if (now - last > interval) {
+                                    last = now;
+                                    return now;
+                                }
+                            };
+                        })()
+                    };
+
+                    // servicesTable should not be sortable since it
+                    // is a hierarchy.
+                    $scope.servicesTable = {
+                        disablePagination: true
+                    };
+
+                    // setup initial state
+                    $scope.services = {
+                        // data: servicesFactory.serviceTree,
+                        // mapped: servicesFactory.serviceMap,
+                        // current: servicesFactory.get($scope.params.serviceId)
+                    };
+
+                    // $scope.getServices();
+
+                    $scope.ips = {};
+                    $scope.pools = [];
+
+                    // if the current service changes, update
+                    // various service controller thingies
+
+
+                    // $scope.$watch(function() {
+                    //     // if no current service is set, try to set one
+                    //     if(!$scope.services.current) {
+                    //         // v2 call with id = $scope.params.serviceId
+                    //         $scope.getService($scope.params.serviceId)
+                    //             .then( function(model){
+                    //                 $scope.services.current = new Service(model);
+                    //             });
+                    //         // $scope.services.current = servicesFactory.get($scope.params.serviceId);
+                    //     }
+
+                    //     if($scope.services.current) {
+                    //         return $scope.services.current.isDirty();
+                    //     } else {
+                    //         // there is no current service
+                    //         console.warn("current service not yet available");
+                    //         return undefined;
+                    //     }
+                    // }, $scope.update);
+
+
+                    $scope.getService($scope.params.serviceId)
+                        .then(function (model) {
+                            $scope.services.current = new Service(model);
+                        });
+
+                    $scope.$watch("services.current.lastUpdate", $scope.update);
+
+                    hostsFactory.activate();
+                    hostsFactory.update();
+
+                    setInterval(function () {
+                        if ($scope.services.current) {
+                            $scope.services.current.fetchAllStates();
+                        }
+                    }, 5000);
+
+                    // servicesFactory.activate();
+                    // servicesFactory.update();
+
+                    poolsFactory.activate();
+                    poolsFactory.update();
+
+                    $scope.$on("$destroy", function () {
+                        // servicesFactory.deactivate();
+                        hostsFactory.deactivate();
+                        poolsFactory.deactivate();
+                    });
+
+
+
                 }
-            })(current.parent);
 
-            crumbs.unshift({
-                label: "Applications",
-                url: "/apps"
-            });
+                // kick off controller
+                init();
 
-            return crumbs;
-        }
-    }]);
+
+
+                function makeCrumbs(current) {
+                    var crumbs = [{
+                        label: current.name,
+                        itemClass: "active",
+                        id: current.id
+                    }];
+
+                    (function recurse(service) {
+                        if (service) {
+                            crumbs.unshift({
+                                label: service.name,
+                                url: "/services/" + service.id,
+                                id: service.id
+                            });
+                            recurse(service.parent);
+                        }
+                    })(current.parent);
+
+                    crumbs.unshift({
+                        label: "Applications",
+                        url: "/apps"
+                    });
+
+                    return crumbs;
+                }
+            }]);
 })();

--- a/web/ui/src/Services/ServiceDetailsController.js
+++ b/web/ui/src/Services/ServiceDetailsController.js
@@ -43,11 +43,11 @@
                 //add service endpoint data
                 $scope.exportedServiceEndpoints = {};
 
-                $scope.click_pool = function (id) {
+                $scope.clickPool = function (id) {
                     resourcesFactory.routeToPool(id);
                 };
 
-                $scope.click_host = function (id) {
+                $scope.clickHost = function (id) {
                     resourcesFactory.routeToHost(id);
                 };
 
@@ -63,7 +63,7 @@
                     // default public endpoint options
                     $scope.publicEndpoints.add = {
                         type: "port",
-                        app_ep: $scope.currentService.exportedServiceEndpoints[0],
+                        endpoint: $scope.currentService.exportedServiceEndpoints[0],
                         name: "",
                         host: $scope.defaultHostAlias,
                         port: "",
@@ -155,7 +155,7 @@
 
                         validate: function (newPublicEndpoint) {
                             // if no service endpoint selected
-                            if (!newPublicEndpoint.app_ep) {
+                            if (!newPublicEndpoint.endpoint) {
                                 this.createNotification("Unable to add Public Endpoint", "No service endpoint selected").error();
                                 return false;
                             }
@@ -187,9 +187,9 @@
 
 
                 $scope.addPublicEndpoint = function (newPublicEndpoint) {
-                    var serviceId = newPublicEndpoint.app_ep.ServiceID;
-                    var serviceName = newPublicEndpoint.app_ep.ServiceName;
-                    var serviceEndpoint = newPublicEndpoint.app_ep.Application;
+                    var serviceId = newPublicEndpoint.endpoint.ServiceID;
+                    var serviceName = newPublicEndpoint.endpoint.ServiceName;
+                    var serviceEndpoint = newPublicEndpoint.endpoint.Application;
                     if (newPublicEndpoint.type === "vhost") {
                         var vhostName = newPublicEndpoint.name;
                         return resourcesFactory.addVHost(serviceId, serviceName, serviceEndpoint, vhostName);

--- a/web/ui/src/Services/ServiceDetailsController.js
+++ b/web/ui/src/Services/ServiceDetailsController.js
@@ -28,7 +28,6 @@
 
                 // Ensure logged in
                 authService.checkLogin($scope);
-                $scope.resourcesFactory = resourcesFactory;
                 $scope.hostsFactory = hostsFactory;
 
                 $scope.defaultHostAlias = $location.host();
@@ -261,9 +260,12 @@
                                                 // disable ok button, and store the re-enable function
                                                 var enableSubmit = this.disableSubmitButton();
 
-                                                $scope.assignIP()
+                                                var serviceID = modalScope.assignments.ip.ServiceID;
+                                                var IP = modalScope.assignments.value.IPAddr;
+                                                resourcesFactory.assignIP(serviceID, IP)
                                                     .success(function (data, status) {
                                                         $notification.create("Added IP", data.Detail).success();
+                                                        update();
                                                         this.close();
                                                     }.bind(this))
                                                     .error(function (data, status) {
@@ -282,32 +284,12 @@
                 };
 
                 $scope.anyServicesExported = function (service) {
-                    // if(service){
-                    //     for (var i in service.Endpoints) {
-                    //         if (service.Endpoints[i].Purpose === "export") {
-                    //             return true;
-                    //         }
-                    //     }
-                    //     for (var j in service.children) {
-                    //         if ($scope.anyServicesExported(service.children[j])) {
-                    //             return true;
-                    //         }
-                    //     }
-                    // }
-                    // return false;
-                    return true;
+                    if($scope.currentService && $scope.currentService.exportedServiceEndpoints){
+                        return $scope.currentService.exportedServiceEndpoints.length > 0;
+                    } else {
+                        return false;
+                    }
                 };
-
-
-                $scope.assignIP = function () {
-                    var serviceID = $scope.ips.assign.ip.ServiceID;
-                    var IP = $scope.ips.assign.value.IPAddr;
-                    return resourcesFactory.assignIP(serviceID, IP)
-                        .success(function (data, status) {
-                            update();
-                        });
-                };
-
 
                 $scope.publicEndpointProtocol = function (publicEndpoint) {
                     if (publicEndpoint.type === "vhost") {
@@ -329,6 +311,8 @@
 
                 // sets a service to start, stop or restart state
                 $scope.setServiceState = function (service, state, skipChildren) {
+                    // service[state]() ends up translating to something like
+                    // service.start() or service.stop()
                     service[state](skipChildren).error(function (data, status) {
                         $notification.create("Unable to " + state + " service", data.Detail).error();
                     });
@@ -437,7 +421,7 @@
                     //edit variables (context) of current service
                     let modalScope = $scope.$new(true);
 
-                    $scope.resourcesFactory.v2.getServiceContext(contextFileId)
+                    resourcesFactory.v2.getServiceContext(contextFileId)
                         .then(function (data) {
 
                             //set editor options for context editing
@@ -465,7 +449,7 @@
                                             let enableSubmit = this.disableSubmitButton();
                                             let storableContext = makeStorableContext(modalScope.Context);
 
-                                            $scope.resourcesFactory.v2.updateServiceContext(contextFileId, storableContext)
+                                            resourcesFactory.v2.updateServiceContext(contextFileId, storableContext)
                                                 .success(function (data, status) {
                                                     $notification.create("Updated variables for", $scope.currentService.name).success();
                                                     this.close();
@@ -563,8 +547,9 @@
                 $scope.editConfig = function (configFileId) {
                     let modalScope = $scope.$new(true);
 
-                    // get the configfile 
-                    $scope.resourcesFactory.v2.getServiceConfig(configFileId)
+                    // TODO - pop the modal up FIRST and show
+                    // a loading animation while the request is filled
+                    resourcesFactory.v2.getServiceConfig(configFileId)
                         .then(function (data) {
 
                             //set editor options for context editing
@@ -593,7 +578,7 @@
                                                 // disable ok button, and store the re-enable function
                                                 var enableSubmit = this.disableSubmitButton();
 
-                                                $scope.resourcesFactory.v2.updateServiceConfig(configFileId, modalScope)
+                                                resourcesFactory.v2.updateServiceConfig(configFileId, modalScope)
                                                     .success(function (data, status) {
                                                         $notification.create("Updated configuation file", data.Filename).success();
                                                         this.close();
@@ -672,41 +657,6 @@
                         });
                 };
 
-                $scope.validateService = function () {
-                    alert("Thought to be Unused validateService");
-                    // TODO: Validate name and startup command
-                    var svc = $scope.currentService.model,
-                        max = svc.InstanceLimits.Max,
-                        min = svc.InstanceLimits.Min,
-                        num = svc.Instances;
-                    if (typeof num === 'undefined' || (max > 0 && num > max) || (min > 0 && num < min)) {
-                        var msg = $translate.instant("instances_invalid") + " ";
-                        if (min > 0) {
-                            msg += $translate.instant("minimum") + " " + min;
-                            if (max > 0) {
-                                msg += ", ";
-                            }
-                        }
-                        if (max > 0) {
-                            msg += $translate.instant("maximum") + " " + max;
-                        }
-                        $notification.create("", msg).error();
-                        return false;
-                    }
-                    return true;
-                };
-
-                $scope.updateService = function (newService) {
-                    alert("Thought to be Unused updateService");
-                    if ($scope.validateService()) {
-                        return resourcesFactory.updateService($scope.currentService.model.ID, newService)
-                            .success((data, status) => {
-                                update();
-                                this.editableService = {};
-                            });
-                    }
-                };
-
                 $scope.subNavClick = function (crumb) {
                     if (crumb.id) {
                         $scope.routeToService(crumb.id);
@@ -735,17 +685,6 @@
 
                     return LogSearch.getURL(appConfig, globalConfig);
                 };
-
-                // $scope.cachedServiceStatuses = {};
-
-                // $scope.getServiceStatus = function (id) {
-                //     if (!(id in $scope.cachedServiceStatuses)) {
-                //         // returning object allows object property inspection
-                //         // without throwing a null reference error
-                //         $scope.cachedServiceStatuses[id] = {};
-                //     }
-                //     return $scope.cachedServiceStatuses[id];
-                // };
 
                 // grab default kibana search configs and adjust
                 // the query to look for this specific service instance
@@ -802,11 +741,6 @@
                         });
                 };
 
-                $scope.startTerminal = function (app) {
-                    window.open("http://" + window.location.hostname + ":50000");
-                };
-
-
 
                 $scope.getHostName = function (id) {
                     if (hostsFactory.get(id)) {
@@ -840,44 +774,28 @@
                         console.warn("Cannot store toggle state: no current service");
                         return;
                     }
-                    // console.log(`TOGGLE ------------------`);
-
                     if ($scope.currentTreeState[service.id].collapsed) {
                         $scope.currentTreeState[service.id].collapsed = false;
 
-                        if (service.subservices) {
+                        if (service.subservices.length) {
                             $scope.showChildren(service);
                         } else {
-                            service.fetchServiceChildren().then(
-                                function () {
-                                    // console.log(`fetched children for ${service.name} and got ${service.subservices.length} children back`);
-                                    $scope.flattenServicesTree();
-                                });
+                            service.fetchServiceChildren().then(() => {
+                                $scope.flattenServicesTree();
+                                $scope.currentService.updateDescendentStatuses();
+                            });
                         }
                     } else {
                         $scope.currentTreeState[service.id].collapsed = true;
                         $scope.flattenServicesTree();
+                        $scope.currentService.updateDescendentStatuses();
                         $scope.hideChildren(service);
                     }
-
-                };
-
-                $scope.getService = function (id) {
-                    let deferred = $q.defer();
-                    $scope.resourcesFactory.v2.getService(id)
-                        .then(function (data) {
-                            deferred.resolve(data);
-                        },
-                        function (error) {
-                            console.warn(error);
-                            deferred.reject(error);
-                        });
-                    return deferred.promise;
                 };
 
                 $scope.getServiceEndpoints = function (id) {
                     let deferred = $q.defer();
-                    $scope.resourcesFactory.v2.getServiceEndpoints(id)
+                    resourcesFactory.v2.getServiceEndpoints(id)
                         .then(function (response) {
                             console.log("got service endpoints for id " + id);
                             deferred.resolve(response.data);
@@ -889,18 +807,11 @@
                     return deferred.promise;
                 };
 
-                $scope.getServices = function () {
-                    $scope.resourcesFactory.v2.getServices()
-                        .success(function (data) {
-                            console.log(data.length + " top level children.");
-                        });
-                };
-
                 $scope.hideChildren = function (service) {
                     // get the state of the current service's tree
                     var treeState = $scope.currentTreeState;
 
-                    if (service.subservices) {
+                    if (service.subservices.length) {
                         service.subservices.forEach(function (child) {
                             treeState[child.id].hidden = true;
                             $scope.hideChildren(child);
@@ -911,7 +822,7 @@
                 $scope.showChildren = function (service) {
                     var treeState = $scope.currentTreeState;
 
-                    if (service.subservices) {
+                    if (service.subservices.length) {
                         service.subservices.forEach(function (child) {
                             treeState[child.id].hidden = false;
 
@@ -959,7 +870,7 @@
                                         var enableSubmit = this.disableSubmitButton();
 
                                         // update service with recently edited service
-                                        $scope.resourcesFactory.v2.updateService($scope.editableService.ID, $scope.editableService)
+                                        resourcesFactory.v2.updateService($scope.editableService.ID, $scope.editableService)
                                             .success(function (data, status) {
                                                 $notification.create("Updated service", $scope.editableService.Name).success();
                                                 update();
@@ -1008,6 +919,8 @@
                             };
                         }
                         let rowState = treeState[service.id];
+                        // TODO - merge rather than overwrite to avoid
+                        // causing the entire tree to bounce
                         let rowItem = {
                             service: service,
                             depth: depth,
@@ -1015,17 +928,17 @@
                             hidden: rowState.hidden
                         };
                         rows.push(rowItem);
-                        // console.log(`${depth} : ${service.name} `);
-                        if (service.subservices) {
+                        if (service.subservices.length) {
                             service.subservices.forEach(svc => flatten(svc, depth + 1));
                         }
                     })($scope.currentService, 0);
-                    // remove top-level service
+                    // rows[0] is always the top level service, so 
+                    // slice that off
                     $scope.currentDescendents = rows.slice(1);
                 };
 
                 $scope.fetchBreadcrumbs = function () {
-                    $scope.resourcesFactory.v2.getServiceAncestors($scope.currentService.id)
+                    resourcesFactory.v2.getServiceAncestors($scope.currentService.id)
                         .then(current => {
                             $scope.breadcrumbs = makeCrumbs(current);
                         },
@@ -1034,18 +947,19 @@
                         });
                 };
 
+                // constructs a new current service
                 $scope.setCurrentService = function () {
-
                     $scope.currentService = undefined;
-                    $scope.getService($scope.params.serviceId)
+                    resourcesFactory.v2.getService($scope.params.serviceId)
                         .then(function (model) {
-                            console.log("SET CURRENT SERVICE --------------");
-
                             $scope.currentService = new Service(model);
 
                             $scope.currentDescendents = [];
                             $scope.currentService.fetchServiceChildren()
-                                .then($scope.flattenServicesTree);
+                                .then(() => {
+                                    $scope.flattenServicesTree();
+                                    $scope.currentService.updateDescendentStatuses();
+                                });
 
                             // sets $scope.breadcrumbs
                             $scope.fetchBreadcrumbs();
@@ -1056,31 +970,29 @@
                             // property for view to bind for tree state NOTE: WHA????
                             $scope.currentTreeState = $scope.serviceTreeState[$scope.currentService.id];
 
-                            update();
+                            // fetchAll() will trigger update at completion
+                            $scope.currentService.fetchAll(true);
+
+                            // update fast-moving statuses
+                            $scope.currentService.fetchAllStates();
                         });
                 };
 
                 function update() {
-                    
-                    $scope.getService($scope.params.serviceId)
+                    // update service model data
+                    resourcesFactory.v2.getService($scope.params.serviceId)
                         .then(function (model) {
                             console.log("SET CURRENT SERVICE --------------");
 
                             $scope.currentService.update(model);
                         });
 
-                    // fetchAll() will trigger update at completion
-                    $scope.currentService.fetchAll(true);
-
                     // update fast-moving statuses
                     $scope.currentService.fetchAllStates();
-
-
+                    $scope.currentService.updateDescendentStatuses();
                 }
 
                 function init() {
-
-                    console.log("INIT -----------------------------");
 
                     $scope.name = "servicedetails";
                     $scope.params = $routeParams;
@@ -1139,40 +1051,15 @@
                     // if the current service changes, update
                     // various service controller thingies
                     $scope.$watch("params.serviceId", $scope.setCurrentService);
-                    // $scope.$watch("currentService.lastUpdate", () => {
-                    //     if (!$scope.$$phase) {
-                    //         $scope.$apply();
-                    //     }
-                    // });
 
                     hostsFactory.activate();
                     hostsFactory.update();
 
-                    // TODO: use baseFactory update pattern
-                    // this will fetch health, instances, and memory stats
+                    // TODO - use UI_POLL_INTERVAL
                     let intervalVal = setInterval(function () {
                         if ($scope.currentService) {
-
-                            // make a list of IDs from scope.descendents (with err function of course)
-                            // add new resourcesfactory endpoint to get multiple states
-                            // send list of IDs to that new endpoint. 
-                            // when it comes back, iterate over the scope.descendents list again
-                            // and call each service's service.updateState(status) 
-                            // with the status that was returned for that service
-
                             $scope.currentService.fetchAllStates();
-
-                            // fetchAllStates gathers status on instances
-                            // need to delay a bit to gather stats on services
-                            setTimeout(function () {
-                                $scope.currentService.updateDescendentStatuses()
-                                    .then( () => {
-                                    }, error => {
-                                        console.warn(`Unable to get stats for services`);
-                                    });
-
-                            }, 250);
-
+                            $scope.currentService.updateDescendentStatuses();
                         }
                     }, 3000);
 

--- a/web/ui/src/Services/add-public-endpoint.html
+++ b/web/ui/src/Services/add-public-endpoint.html
@@ -16,7 +16,7 @@
 
 <div class="form-group">
     <label for="add_vhost_application"><span translate>add_vhost_application_endpoint</span>:</label>
-    <select focusme id="add_vhost_application" ng-model="publicEndpoints.add.app_ep" ng-options="opt as opt.Value for opt in exportedServiceEndpoints.data"  class="form-control"></select>
+    <select focusme id="add_vhost_application" ng-model="publicEndpoints.add.app_ep" ng-options="opt as opt.Value for opt in currentService.exportedServiceEndpoints"  class="form-control"></select>
 </div>
 
 <div ng-show="publicEndpoints.add.type === 'vhost'">

--- a/web/ui/src/Services/add-public-endpoint.html
+++ b/web/ui/src/Services/add-public-endpoint.html
@@ -16,7 +16,7 @@
 
 <div class="form-group">
     <label for="add_vhost_application"><span translate>add_vhost_application_endpoint</span>:</label>
-    <select focusme id="add_vhost_application" ng-model="publicEndpoints.add.app_ep" ng-options="opt as opt.Value for opt in currentService.exportedServiceEndpoints"  class="form-control"></select>
+    <select focusme id="add_vhost_application" ng-model="publicEndpoints.add.endpoint" ng-options="opt as opt.Value for opt in currentService.exportedServiceEndpoints"  class="form-control"></select>
 </div>
 
 <div ng-show="publicEndpoints.add.type === 'vhost'">

--- a/web/ui/src/Services/assign-ip.html
+++ b/web/ui/src/Services/assign-ip.html
@@ -1,16 +1,16 @@
 <div class="form-group">
     <label for="assign_ip" translate>label_service</label>
-    <input class="form-control"  value="{{ips.assign.ip.ServiceName}}" disabled>
+    <input class="form-control"  value="{{assignments.ip.ServiceName}}" disabled>
 </div>
 <div class="form-group">
     <label for="assign_ip" translate>label_endpoint</label>
-    <input class="form-control"  value="{{ips.assign.ip.EndpointName}}" disabled>
+    <input class="form-control"  value="{{assignments.ip.EndpointName}}" disabled>
 </div>
 <div class="form-group">
     <label for="assign_ip" translate>label_port</label>
-    <input class="form-control"  value="{{ips.assign.ip.Port}}" disabled>
+    <input class="form-control"  value="{{assignments.ip.Port}}" disabled>
 </div>
 <div class="form-group">
     <label for="assign_ip" translate>label_ip</label>
-    <select id="assign_ip" ng-model="ips.assign.value" ng-options="opt as opt.Value for opt in ips.assign.options" class="form-control"></select>
+    <select id="assign_ip" ng-model="assignments.value" ng-options="opt as opt.Value for opt in assignments.options" class="form-control"></select>
 </div>

--- a/web/ui/src/Services/edit-config.html
+++ b/web/ui/src/Services/edit-config.html
@@ -1,2 +1,2 @@
-<div ng-hide="codemirrorRefresh" style="text-align: center;"><img src="/static/img/loading.gif"></div>
-<textarea ng-hide="!codemirrorRefresh" ui-codemirror ui-codemirror-opts="codemirrorOpts" ui-refresh="codemirrorRefresh" id="editConfig" ng-model="editableService.ConfigFiles[selectedConfig].Content"></textarea>
+<div ng-hide="codemirrorRefresh" style="text-align: center;"><img class="modal-mckracken" src="/static/img/loading.gif"></div>
+<textarea ng-hide="!codemirrorRefresh" ui-codemirror ui-codemirror-opts="codemirrorOpts" ui-refresh="codemirrorRefresh" id="editConfig" ng-model="Content"></textarea>

--- a/web/ui/src/Services/edit-context.html
+++ b/web/ui/src/Services/edit-context.html
@@ -1,5 +1,8 @@
 <div><i translate>context_directions</i></div>
-<div ng-hide="codemirrorRefresh" style="text-align: center;"><img src="/static/img/loading.gif"></div>
-<div ng-hide="!editableContext === undefined"> 
-    <textarea id="editContext" ui-codemirror ui-codemirror-opts="codemirrorOpts" ui-refresh="codemirrorRefresh" ng-model="editableContext" style="min-height: 400px;"></textarea>
+<div ng-hide="codemirrorRefresh" style="text-align: center;"><img class="modal-mckracken" src="/static/img/loading.gif"></div>
+<div class="modal-context">
+<textarea ng-hide="!codemirrorRefresh" ui-codemirror ui-codemirror-opts="codemirrorOpts" ui-refresh="codemirrorRefresh" id="editContext" ng-model="Context"></textarea>
 </div>
+<!--<div ng-show="Context !== undefined"> 
+    <textarea id="editContext" ui-codemirror ui-codemirror-opts="codemirrorOpts" ui-refresh="codemirrorRefresh" ng-model="Context" style="min-height: 400px;"></textarea>
+</div>-->

--- a/web/ui/src/Services/publicEndpointLinkDirective.js
+++ b/web/ui/src/Services/publicEndpointLinkDirective.js
@@ -53,8 +53,8 @@
                 };
                                                                                 
                 var isServiceRunning = function(id){
-                    // if not found, empty service object returned
-                    // Service (Service.js) class adds its own desired state into the endpoint object
+                    // when Service created public endpoints, it attached
+                    // its own desiredState to the public endpoint
                     return publicEndpoint.desiredState === 1;
                 };
                 

--- a/web/ui/src/Services/publicEndpointLinkDirective.js
+++ b/web/ui/src/Services/publicEndpointLinkDirective.js
@@ -8,53 +8,54 @@
 
     angular.module('publicEndpointLink', [])
     .directive("publicEndpointLink", ["$compile", "$location",
-        "servicesFactory", "$translate",
-    function($compile, $location, servicesFactory, $translate){
+        "servicesFactory", "$translate","resourcesFactory",
+    function($compile, $location, servicesFactory, $translate, resourcesFactory){
         return {
             restrict: "E",
             scope: {
                 publicEndpoint: "=",
                 state: "@",
-                hostAlias: "=",
+                hostAlias: "="
             },
             link: function ($scope, element, attrs){
-                var publicEndpoint = $scope.publicEndpoint;
+                let publicEndpoint = $scope.publicEndpoint;
 
                 // A method to return the displayed URL for an endpoint.
                 var getUrl = function(publicEndpoint){
                     // Form the url based on the endpoint properties.
                     var url = "";
-                    if ("Name" in publicEndpoint){
+                    if ("VHostName" in publicEndpoint){
                         var port = $location.port() === "" || +$location.port() === 443 ? "" : ":" + $location.port();
-                        var host = publicEndpoint.Name.indexOf('.') === -1 ?
-                            publicEndpoint.Name + ".{{hostAlias}}" : publicEndpoint.Name;
+                        var host = publicEndpoint.VHostName.indexOf('.') === -1 ?
+                            publicEndpoint.VHostName + ".{{hostAlias}}" : publicEndpoint.VHostName;
                         url = $location.protocol() + "://" + host + port;
-                    } else if ("PortAddr" in publicEndpoint){
+                    } else if ("PortAddress" in publicEndpoint){
                         // Port public endpoint
-                        var portAddr = publicEndpoint.PortAddr;
+                        var portAddress = publicEndpoint.PortAddress;
                         var protocol = publicEndpoint.Protocol.toLowerCase();
-                        if(portAddr.startsWith(":")){
-                            portAddr = "{{hostAlias}}" + portAddr;
+                        if(portAddress.startsWith(":")){
+                            portAddress = "{{hostAlias}}" + portAddress;
                         }
                         // Remove the port for standard http/https ports.
                         if(protocol !== "") {
-                            var parts = portAddr.split(":");
+                            var parts = portAddress.split(":");
                             if (protocol === "http" && parts[1] === "80") {
-                                portAddr = parts[0];
+                                portAddress = parts[0];
                             } else if (protocol === "https" && parts[1] === "443") {
-                                portAddr = parts[0];
+                                portAddress = parts[0];
                             }
-                            url = protocol + "://" + portAddr;
+                            url = protocol + "://" + portAddress;
                         } else {
-                            url = portAddr;
+                            url = portAddress;
                         }                
                     }
                     return url;
                 };
                                                                                 
                 var isServiceRunning = function(id){
-                    var service = servicesFactory.get(id);
-                    return service.desiredState === 1;
+                    // if not found, empty service object returned
+                    // Service (Service.js) class adds its own desired state into the endpoint object
+                    return publicEndpoint.desiredState === 1;
                 };
                 
                 var addPopover = function(element, translation){
@@ -70,11 +71,11 @@
                 var url = getUrl(publicEndpoint);
                 var html = "";
                 var popover = false;
-                
-                // If we have an appid, this is a subservice.
-                if ("ApplicationId" in publicEndpoint){
+
+                // If we have a ServiceID, this is a subservice.
+                if ("ServiceID" in publicEndpoint){
                     // Check the service and endpoint and..
-                    if (!isServiceRunning(publicEndpoint.ApplicationId) || !publicEndpoint.Enabled) {
+                    if (!isServiceRunning(publicEndpoint.ServiceID) || !publicEndpoint.Enabled) {
                         // .. show the url as a url label (not clickable) with a bootstrap popover..
                         html = '<span><b>' + url + '</b></span>';
                         popover = true;

--- a/web/ui/src/Services/view-log.html
+++ b/web/ui/src/Services/view-log.html
@@ -1,1 +1,1 @@
-<textarea ng-model="editService.log" style="width: 100%; height: 400px; line-height: 2em;" readonly></textarea>
+<textarea ng-model="log" style="font-family: consolas, monospace; font-size: 13px; height: 400px; line-height: 2rem; width: 100%;" readonly></textarea>

--- a/web/ui/src/Services/view-subservices.html
+++ b/web/ui/src/Services/view-subservices.html
@@ -64,7 +64,7 @@
           </span>
       </div>
 
-      <table jelly-table data-data="publicEndpoints.data" data-config="publicEndpointsTable" class="table">
+      <table jelly-table data-data="services.current.publicEndpoints" data-config="publicEndpointsTable" class="table">
           <tr ng-repeat="publicEndpoint in $data">
               <td data-title="'vhost_application'|translate" sortable="'Application'">
                   <a href="#/services/{{publicEndpoint.ApplicationId}}" class="link" ng-click="routeToService(publicEndpoint.ApplicationId, $event)">{{publicEndpoint.Application}}</a>
@@ -96,7 +96,7 @@
     <!-- IP Assignments -->
     <div ng-show="!services.current.isIsvc()">
         <h3 class="pull-left" translate>label_ip_assignments</h3>
-        <table jelly-table data-data="ips.data" data-config="ipsTable" class="table">
+        <table jelly-table data-data="services.current.addresses" data-config="ipsTable" class="table">
             <tr ng-repeat="ip in $data">
                 <td data-title="'tbl_virtual_ip_service'|translate" sortable="'ServiceName'">
                     <a href="#/services/{{ip.ServiceID}}" class="link" ng-click="routeToService(ip.ServiceID, $event)">{{ip.ServiceName}}</a>
@@ -118,8 +118,8 @@
     <!-- Config Files -->
     <div ng-show="!services.current.isIsvc()">
         <h3 class="pull-left" translate>title_config_files</h3>
-        <table jelly-table data-data="services.current.model.ConfigFiles" data-config="configTable" class="table">
-            <tr ng-repeat="configFile in services.current.model.ConfigFiles">
+        <table jelly-table data-data="services.current.configs" data-config="configTable" class="table">
+            <tr ng-repeat="configFile in services.current.configs">
                 <td data-title="'path'|translate" sortable="'Filename'">{{ configFile.Filename }}</td>
                 <td data-title="'running_tbl_actions'|translate">
                     <button ng-click="editConfig(configFile.Filename)" class="btn btn-link action">
@@ -132,9 +132,9 @@
     </div>
 
     <!-- SERVICES -->
-    <div ng-show="services.subservices.length">
+    <div ng-show="services.current.subservices.length">
         <h3 translate>title_services</h3>
-        <table jelly-table data-data="services.subservices" data-config="servicesTable" class="table">
+        <table jelly-table data-data="services.current.subservices" data-config="servicesTable" class="table">
             <thead>
                 <tr>
                   <th style="width: 200px;" translate>label_service</th>
@@ -143,24 +143,24 @@
                   <th style="width: 210px;" ng-if="!services.current.isIsvc()" translate>running_tbl_actions</th>
                 </tr>
             </thead>
-            <tr ng-repeat="app in $data" data-id="{{app.model.ID}}" ng-hide="services.currentTreeState[app.id].hidden">
+            <tr ng-repeat="app in $data" data-id="{{app.id}}" ng-hide="services.currentTreeState[app.id].hidden">
               <td data-title="'label_service'|translate" style="overflow: hidden; white-space: nowrap;">
                 <span ng-style="calculateIndent(app)"></span>
-                <span ng-if="app.children.length" ng-click="toggleChildren(app)" class="table-collapse glyphicon" ng-class="services.currentTreeState[app.id].collapsed ? 'glyphicon-chevron-right' : 'glyphicon-chevron-down'"></span>
-                <span ng-if="!app.children.length" ng-style="indent(1)"></span>
-                <a href="#/services/{{app.model.ID}}" ng-click="routeToService(app.model.ID, $event)" class="link">
-                    {{app.model.Name}}
+                <span ng-if="app.hasChildren()" ng-click="toggleChildren(app.id)" class="table-collapse glyphicon" ng-class="services.currentTreeState[app.id].collapsed ? 'glyphicon-chevron-right' : 'glyphicon-chevron-down'"></span>
+                <span ng-if="!app.hasChildren()" ng-style="indent(1)"></span>
+                <a href="#/services/{{app.id}}" ng-click="routeToService(app.id, $event)" class="link">
+                    {{app.name}}
                     <div class="overcomIndicator" ng-class="{'bad': !app.resourcesGood() && !app.isIsvc()}" title="An instance is oversubscribed."></div>
                     <span class="version" ng-show="app.model.Version"> (v{{app.model.Version}})</span>
                 </a>
               </td>
               <td data-title="'Instances'" style="text-align:center;">
-                <div ng-if="!app.children.length">
+                <div ng-if="!app.hasChildren()">
                     <health-icon data-status="app.status"></health-icon>
                 </div>
               </td>
               <td data-title="'deployed_tbl_description'|translate">
-                <input style="border:none; background:rgba(0,0,0,0); width:100%; outline: none;" readonly type="text" value="{{app.model.Description}}">
+                <input style="border:none; background:rgba(0,0,0,0); width:100%; outline: none;" readonly type="text" value="{{app.Description}}">
               </td>
               <td data-title="'running_tbl_actions'|translate" ng-if="!services.current.isIsvc()">
                 <div ng-if="!app.isIsvc()">
@@ -190,33 +190,33 @@
     <!-- This table has running instances -->
     <div ng-show="hasCurrentInstances() && !services.current.isIsvc()">
         <h3 translate>running_tbl_instances</h3>
-        <table jelly-table data-data="services.current.getServiceInstances()" data-config="instancesTable" class="table">
-            <tr ng-repeat="app in $data" data-id="{{app.id}}.{{app.model.InstanceID}}">
-                <td data-title="'running_tbl_instance_id'|translate" sortable="'model.InstanceID'">{{app.model.InstanceID}}</td>
-                <td data-title="'label_service_name'|translate" sortable="'name'">{{app.name}}</td>
+        <table jelly-table data-data="services.current.instances" data-config="instancesTable" class="table">
+            <tr ng-repeat="instance in $data" data-id="{{instance.id}}.{{instance.model.InstanceID}}">
+                <td data-title="'running_tbl_instance_id'|translate" sortable="'model.InstanceID'">{{instance.model.InstanceID}}</td>
+                <td data-title="'label_service_name'|translate" sortable="'name'">{{instance.name}}</td>
                 <td data-title="'label_service_status'|translate" sortable="'status.status'" style="text-align:center;">
-                    <health-icon data-status="app.status"></health-icon>
+                    <health-icon data-status="instance.status"></health-icon>
                 </td>
                 <td data-title="'RAM Commitment'" style="text-align:left;">
-                    <span ng-show="app.resources.RAMCommitment===0">N/A</span>
-                    <span ng-show="app.resources.RAMCommitment!==0" ng-class="{'bad': !app.resourcesGood()}" class="overcomText">{{app.resources.RAMCommitment|toMB}}</span>
+                    <span ng-show="instance.resources.RAMCommitment===0">N/A</span>
+                    <span ng-show="instance.resources.RAMCommitment!==0" ng-class="{'bad': !instance.resourcesGood()}" class="overcomText">{{instance.resources.RAMCommitment|toMB}}</span>
                 </td>
                 <td data-title="'RAM Cur/Max/Avg'" style="text-align:left;">
-                    <span ng-show="app.resources.RAMCommitment===0">N/A</span>
-                    <span ng-show="app.resources.RAMCommitment!==0" ng-class="{'bad': !app.resourcesGood()}" class="overcomText">{{app.resources.RAMLast|toMB:true}} / {{app.resources.RAMMax|toMB:true}} / {{app.resources.RAMAverage|toMB:true}} MB</span>
+                    <span ng-show="instance.resources.RAMCommitment===0">N/A</span>
+                    <span ng-show="instance.resources.RAMCommitment!==0" ng-class="{'bad': !instance.resourcesGood()}" class="overcomText">{{instance.resources.RAMLast|toMB:true}} / {{instance.resources.RAMMax|toMB:true}} / {{instance.resources.RAMAverage|toMB:true}} MB</span>
                 </td>
-                <td data-title="'host'|translate" sortable="'getHostName(app.model.HostID)'" ng-click="click_host(app.model.HostID)" class="link">{{getHostName(app.model.HostID)}}</td>
-                <td data-title="'running_tbl_docker_id'|translate" sortable="'model.DockerID'">{{app.model.DockerID|cut:false:12:"..."}}</td>
+                <td data-title="'host'|translate" sortable="'getHostName(instance.model.HostID)'" ng-click="click_host(instance.model.HostID)" class="link">{{getHostName(instance.model.HostID)}}</td>
+                <td data-title="'running_tbl_docker_id'|translate" sortable="'model.DockerID'">{{instance.model.DockerID|cut:false:12:"..."}}</td>
                 <td data-title="'running_tbl_actions'|translate">
-                    <button ng-click="viewLog(app)" class="btn btn-link action">
+                    <button ng-click="viewLog(instance)" class="btn btn-link action">
                         <i class="glyphicon glyphicon-list-alt"></i>
                         <span translate>action_view_container_log</span>
                     </button>
-                    <a target="_blank" ng-href="{{getInstanceLogURL(app)}}" class="btn btn-link action">
+                    <a target="_blank" ng-href="{{getInstanceLogURL(instance)}}" class="btn btn-link action">
                         <i class="glyphicon glyphicon-list-alt"></i>
                         <span translate>action_view_instance_log</span>
                     </a>
-                    <button ng-click="app.stop()" class="btn btn-link action">
+                    <button ng-click="instance.stop()" class="btn btn-link action">
                         <i class="glyphicon glyphicon-refresh"></i>
                         <span translate>action_restart</span>
                     </button>

--- a/web/ui/src/Services/view-subservices.html
+++ b/web/ui/src/Services/view-subservices.html
@@ -18,7 +18,7 @@
 
                 <div style="display: inline-block; padding-left: 10px; border-left: 1px solid #CCC; height: 1em; "></div>
                 <button ng-click="editCurrentService()" class="btn btn-link action"><i class="glyphicon glyphicon-edit"></i> <span translate>title_edit_service</span></button>
-                <button ng-click="clickEditContext(currentService.id.toString())" class="btn btn-link action">
+                <button ng-click="clickEditContext(currentService.id)" class="btn btn-link action">
                     <i class="glyphicon glyphicon-edit"></i>
                     <span translate>edit_context</span>
                 </button>

--- a/web/ui/src/Services/view-subservices.html
+++ b/web/ui/src/Services/view-subservices.html
@@ -105,8 +105,8 @@
                     <a href="#/services/{{ip.ServiceID}}" class="link" ng-click="routeToService(ip.ServiceID, $event)">{{ip.ServiceName}}</a>
                 </td>
                 <td data-title="'tbl_virtual_ip_assignment_type'|translate" sortable="'AssignmentType'">{{ip.Type}}</td>
-                <td data-title="'tbl_virtual_ip_host'|translate" sortable="'HostID'" ng-click="click_host(ip.HostID)" class="link">{{getHostName(ip.HostID)}}</td>
-                <td data-title="'tbl_virtual_ip_pool'|translate" sortable="'PoolID'" ng-click="click_pool(ip.PoolID)" class="link">{{ip.PoolID|cut:true:50}}</td>
+                <td data-title="'tbl_virtual_ip_host'|translate" sortable="'HostID'" ng-click="clickHost(ip.HostID)" class="link">{{getHostName(ip.HostID)}}</td>
+                <td data-title="'tbl_virtual_ip_pool'|translate" sortable="'PoolID'" ng-click="clickPool(ip.PoolID)" class="link">{{ip.PoolID|cut:true:50}}</td>
                 <td data-title="'tbl_virtual_ip'|translate">{{ip.IPAddress}}:{{ip.Port}}</td>
                 <td data-title="'actions'|translate">
                     <button ng-click="modalAssignIP(ip, ip.PoolID)" class="btn btn-link action">
@@ -207,7 +207,7 @@
                     <span ng-show="instance.resources.RAMCommitment===0">N/A</span>
                     <span ng-show="instance.resources.RAMCommitment!==0" ng-class="{'bad': !instance.resourcesGood()}" class="overcomText">{{instance.resources.RAMLast|toMB:true}} / {{instance.resources.RAMMax|toMB:true}} / {{instance.resources.RAMAverage|toMB:true}} MB</span>
                 </td>
-                <td data-title="'host'|translate" sortable="'getHostName(instance.model.HostID)'" ng-click="click_host(instance.model.HostID)" class="link">{{getHostName(instance.model.HostID)}}</td>
+                <td data-title="'host'|translate" sortable="'getHostName(instance.model.HostID)'" ng-click="clickHost(instance.model.HostID)" class="link">{{getHostName(instance.model.HostID)}}</td>
                 <td data-title="'running_tbl_docker_id'|translate" sortable="'instance.model.ContainerID'">{{instance.model.ContainerID|cut:false:12:"..."}}</td>
                 <td data-title="'running_tbl_actions'|translate">
                     <button ng-click="viewLog(instance)" class="btn btn-link action">

--- a/web/ui/src/Services/view-subservices.html
+++ b/web/ui/src/Services/view-subservices.html
@@ -5,41 +5,41 @@
         <div class="serviceControls" sticky sticky-class="stickied">
 
             <h2 class="serviceTitle">
-                <health-icon ng-if="services.current.model.Startup" data-status="services.current.status" style="display: inline-block; font-size: 0.6em;"></health-icon>
-                {{services.current.model.Name}}
-                <span class="version" ng-show="services.current.model.Version"> (v{{services.current.model.Version}})</span>
+                <health-icon ng-if="currentService.model.Startup" data-status="currentService.status" style="display: inline-block; font-size: 0.6em;"></health-icon>
+                {{currentService.model.Name}}
+                <span class="version" ng-show="currentService.model.Version"> (v{{currentService.model.Version}})</span>
             </h2>
 
-            <div class="serviceActions" ng-hide="services.current.isIsvc()">
-                <a target="_blank" ng-href="{{getServiceLogURL(services.current)}}" class="btn btn-link action">
+            <div class="serviceActions" ng-hide="currentService.isIsvc()">
+                <a target="_blank" ng-href="{{getServiceLogURL(currentService)}}" class="btn btn-link action">
                     <i class="glyphicon glyphicon-list-alt"></i>
                     <span translate>action_view_service_logs</span>
                 </a>
 
                 <div style="display: inline-block; padding-left: 10px; border-left: 1px solid #CCC; height: 1em; "></div>
                 <button ng-click="editCurrentService()" class="btn btn-link action"><i class="glyphicon glyphicon-edit"></i> <span translate>title_edit_service</span></button>
-                <button ng-click="clickEditContext()" class="btn btn-link action">
+                <button ng-click="clickEditContext(currentService.id.toString())" class="btn btn-link action">
                     <i class="glyphicon glyphicon-edit"></i>
                     <span translate>edit_context</span>
                 </button>
 
                 <div style="display: inline-block; padding-left: 10px; border-left: 1px solid #CCC; height: 1em; "></div>
-                <div ng-if="services.current.desiredState !== 2" style="display: inline-block;">
-                    <button ng-click="clickRunning(services.current, 'start')" class="btn btn-link action">
+                <div ng-if="currentService.desiredState !== 2" style="display: inline-block;">
+                    <button ng-click="clickRunning(currentService, 'start')" class="btn btn-link action">
                         <i class="glyphicon glyphicon-play"></i>
                         <span translate>start</span>
                     </button>
-                    <button ng-click="clickRunning(services.current, 'stop')" class="btn btn-link action">
+                    <button ng-click="clickRunning(currentService, 'stop')" class="btn btn-link action">
                         <i class="glyphicon glyphicon-stop"></i>
                         <span translate>stop</span>
                     </button>
-                    <button ng-class="{disabled: services.current.desiredState === 0}" ng-click="clickRunning(services.current, 'restart')" class="btn btn-link action">
+                    <button ng-class="{disabled: currentService.desiredState === 0}" ng-click="clickRunning(currentService, 'restart')" class="btn btn-link action">
                         <i class="glyphicon glyphicon-refresh"></i>
                         <span translate>action_restart</span>
                     </button>
                 </div>
 
-                <div ng-if="services.current.desiredState === 2" style="display: inline-block;">
+                <div ng-if="currentService.desiredState === 2" style="display: inline-block;">
                     <span class="btn btn-link action disabled"><i class="glyphicon glyphicon-pause"></i> Paused</span>
                 </div>
             </div>
@@ -48,12 +48,12 @@
 
 
         <div class="serviceDescription">
-            {{services.current.model.Description}}
+            {{currentService.model.Description}}
         </div>
     </div>
 
     <!-- Public Endpoints -->
-    <div ng-show="!services.current.isIsvc() && anyServicesExported(services.current.model)">
+    <div ng-show="!currentService.isIsvc() && anyServicesExported(currentService.model)">
       <h3 class="pull-left" translate>label_public_endpoints</h3>
       <div class="control-buttons pull-right">
           <span class="add-control">
@@ -64,16 +64,19 @@
           </span>
       </div>
 
-      <table jelly-table data-data="services.current.publicEndpoints" data-config="publicEndpointsTable" class="table">
+      <table jelly-table data-data="currentService.publicEndpoints" data-config="publicEndpointsTable" class="table">
           <tr ng-repeat="publicEndpoint in $data">
               <td data-title="'vhost_application'|translate" sortable="'Application'">
-                  <a href="#/services/{{publicEndpoint.ApplicationId}}" class="link" ng-click="routeToService(publicEndpoint.ApplicationId, $event)">{{publicEndpoint.Application}}</a>
+                  <a href="#/services/{{publicEndpoint.ServiceID}}" class="link" ng-click="routeToService(publicEndpoint.ServiceID, $event)">{{publicEndpoint.ServiceName}}</a>
               </td>
-              <td data-title="'endpoint'|translate" sortable="'ServiceEndpoint'">{{publicEndpoint.ServiceEndpoint}}</td>
-              <td data-title="'public_endpoint_type'|translate" sortable="'type'">{{publicEndpoint.type}}</td>
-              <td data-title="'public_endpoint_protocol'|translate">{{publicEndpointProtocol(publicEndpoint)}}</td>
+              <td data-title="'endpoint'|translate" sortable="'ServiceEndpoint'">{{publicEndpoint.Application}}</td>
+              <td data-title="'public_endpoint_type'|translate" sortable="'type'">{{getEndpointType(publicEndpoint)}}</td>
+              <td data-title="'public_endpoint_protocol'|translate">{{publicEndpoint.Protocol}}</td>
               <td data-title="'public_endpoint_url'|translate">
-                  <public-endpoint-link data-public-endpoint="publicEndpoint" data-host-alias="defaultHostAlias"></public-endpoint-link>
+                  <public-endpoint-link 
+                    data-public-endpoint="publicEndpoint" 
+                    data-host-alias="defaultHostAlias"
+                  ></public-endpoint-link>
               </td>
               <td data-title="'actions'|translate">
                   <button ng-class="{disabled: publicEndpoint.Enabled }" ng-click="clickEndpointEnable(publicEndpoint)" class="btn btn-link action">
@@ -94,17 +97,17 @@
     </div>
 
     <!-- IP Assignments -->
-    <div ng-show="!services.current.isIsvc()">
+    <div ng-show="!currentService.isIsvc()">
         <h3 class="pull-left" translate>label_ip_assignments</h3>
-        <table jelly-table data-data="services.current.addresses" data-config="ipsTable" class="table">
+        <table jelly-table data-data="currentService.addresses" data-config="ipsTable" class="table">
             <tr ng-repeat="ip in $data">
                 <td data-title="'tbl_virtual_ip_service'|translate" sortable="'ServiceName'">
                     <a href="#/services/{{ip.ServiceID}}" class="link" ng-click="routeToService(ip.ServiceID, $event)">{{ip.ServiceName}}</a>
                 </td>
-                <td data-title="'tbl_virtual_ip_assignment_type'|translate" sortable="'AssignmentType'">{{ip.AssignmentType}}</td>
+                <td data-title="'tbl_virtual_ip_assignment_type'|translate" sortable="'AssignmentType'">{{ip.Type}}</td>
                 <td data-title="'tbl_virtual_ip_host'|translate" sortable="'HostID'" ng-click="click_host(ip.HostID)" class="link">{{getHostName(ip.HostID)}}</td>
                 <td data-title="'tbl_virtual_ip_pool'|translate" sortable="'PoolID'" ng-click="click_pool(ip.PoolID)" class="link">{{ip.PoolID|cut:true:50}}</td>
-                <td data-title="'tbl_virtual_ip'|translate">{{ip.IPAddr}}:{{ip.Port}}</td>
+                <td data-title="'tbl_virtual_ip'|translate">{{ip.IPAddress}}:{{ip.Port}}</td>
                 <td data-title="'actions'|translate">
                     <button ng-click="modalAssignIP(ip, ip.PoolID)" class="btn btn-link action">
                         <i class="glyphicon glyphicon-link"></i>
@@ -116,13 +119,13 @@
     </div>
 
     <!-- Config Files -->
-    <div ng-show="!services.current.isIsvc()">
+    <div ng-show="!currentService.isIsvc()">
         <h3 class="pull-left" translate>title_config_files</h3>
-        <table jelly-table data-data="services.current.configs" data-config="configTable" class="table">
-            <tr ng-repeat="configFile in services.current.configs">
+        <table jelly-table data-data="currentService.configs" data-config="configTable" class="table">
+            <tr ng-repeat="configFile in currentService.configs">
                 <td data-title="'path'|translate" sortable="'Filename'">{{ configFile.Filename }}</td>
                 <td data-title="'running_tbl_actions'|translate">
-                    <button ng-click="editConfig(configFile.Filename)" class="btn btn-link action">
+                    <button ng-click="editConfig(configFile.ID)" class="btn btn-link action">
                         <i class="glyphicon glyphicon-edit"></i>
                         <span translate>label_edit</span>
                     </button>
@@ -131,54 +134,54 @@
         </table>
     </div>
 
-    <!-- SERVICES -->
-    <div ng-show="services.current.subservices.length">
+    <!-- Services -->
+    <div ng-show="currentDescendents.length" class="jelly-treetable">
         <h3 translate>title_services</h3>
-        <table jelly-table data-data="services.current.subservices" data-config="servicesTable" class="table">
+        <table jelly-table data-data="currentDescendents" data-config="servicesTable" class="table">
             <thead>
                 <tr>
                   <th style="width: 200px;" translate>label_service</th>
                   <th style="width: 75px; line-height: 11px;">Instances <span style="font-size: .75em;">healthy/total</span></th>
                   <th translate>deployed_tbl_description</th>
-                  <th style="width: 210px;" ng-if="!services.current.isIsvc()" translate>running_tbl_actions</th>
+                  <th style="width: 210px;" ng-if="!currentService.isIsvc()" translate>running_tbl_actions</th>
                 </tr>
             </thead>
-            <tr ng-repeat="app in $data" data-id="{{app.id}}" ng-hide="services.currentTreeState[app.id].hidden">
+            <tr ng-repeat="row in $data" data-id="{{row.service.id}}" ng-hide="currentTreeState[row.service.id].hidden">
               <td data-title="'label_service'|translate" style="overflow: hidden; white-space: nowrap;">
-                <span ng-style="calculateIndent(app)"></span>
-                <span ng-if="app.hasChildren()" ng-click="toggleChildren(app.id)" class="table-collapse glyphicon" ng-class="services.currentTreeState[app.id].collapsed ? 'glyphicon-chevron-right' : 'glyphicon-chevron-down'"></span>
-                <span ng-if="!app.hasChildren()" ng-style="indent(1)"></span>
-                <a href="#/services/{{app.id}}" ng-click="routeToService(app.id, $event)" class="link">
-                    {{app.name}}
-                    <div class="overcomIndicator" ng-class="{'bad': !app.resourcesGood() && !app.isIsvc()}" title="An instance is oversubscribed."></div>
-                    <span class="version" ng-show="app.model.Version"> (v{{app.model.Version}})</span>
+                <span ng-style="calculateIndent(row.depth)"></span>
+                <span ng-if="row.service.model.HasChildren" ng-click="toggleChildren(row.service)" class="table-collapse glyphicon" ng-class="currentTreeState[row.service.id].collapsed ? 'glyphicon-chevron-right' : 'glyphicon-chevron-down'"></span>
+                <span ng-if="!row.service.model.HasChildren" ng-style="indent(1)"></span>
+                <a href="#/services/{{row.service.id}}" ng-click="routeToService(row.service.id, $event)" class="link">
+                    {{row.service.name}}
+                    <div class="overcomIndicator" ng-class="{'bad': !row.service.resourcesGood() && !row.service.isIsvc()}" title="An instance is oversubscribed."></div>
+                    <span class="version" ng-show="row.service.model.Version"> (v{{row.service.model.Version}})</span>
                 </a>
               </td>
               <td data-title="'Instances'" style="text-align:center;">
-                <div ng-if="!app.hasChildren()">
-                    <health-icon data-status="app.status"></health-icon>
+                <div ng-if="!row.service.model.HasChildren">
+                    <health-icon data-status="row.service.status"></health-icon>
                 </div>
               </td>
               <td data-title="'deployed_tbl_description'|translate">
-                <input style="border:none; background:rgba(0,0,0,0); width:100%; outline: none;" readonly type="text" value="{{app.Description}}">
+                <input style="border:none; background:rgba(0,0,0,0); width:100%; outline: none;" readonly type="text" value="{{row.service.model.Description}}">
               </td>
-              <td data-title="'running_tbl_actions'|translate" ng-if="!services.current.isIsvc()">
-                <div ng-if="!app.isIsvc()">
-                  <div ng-if="app.desiredState !== 2">
-                    <button ng-class="{disabled: app.desiredState === 1}" ng-click="clickRunning(app, 'start')" class="btn btn-link action">
+              <td data-title="'running_tbl_actions'|translate" ng-if="!currentService.isIsvc()">
+                <div ng-if="!row.service.isIsvc()">
+                  <div ng-if="row.service.desiredState !== 2">
+                    <button ng-class="{disabled: row.service.desiredState === 1}" ng-click="clickRunning(row.service, 'start')" class="btn btn-link action">
                         <i class="glyphicon glyphicon-play"></i>
                         <span translate>start</span>
                     </button>
-                    <button ng-class="{disabled: app.desiredState === 0}" ng-click="clickRunning(app, 'stop')" class="btn btn-link action">
+                    <button ng-class="{disabled: row.service.desiredState === 0}" ng-click="clickRunning(row.service, 'stop')" class="btn btn-link action">
                         <i class="glyphicon glyphicon-stop"></i>
                         <span translate>stop</span>
                     </button>
-                    <button ng-class="{disabled: app.desiredState === 0}" ng-click="clickRunning(app, 'restart')" class="btn btn-link action">
+                    <button ng-class="{disabled: row.service.desiredState === 0}" ng-click="clickRunning(row.service, 'restart')" class="btn btn-link action">
                         <i class="glyphicon glyphicon-refresh"></i>
                         <span translate>action_restart</span>
                     </button>
                   </div>
-                  <div ng-if="app.desiredState === 2">
+                  <div ng-if="row.service.desiredState === 2">
                     <span class="btn btn-link action disabled"><i class="glyphicon glyphicon-pause"></i> Paused</span>
                   </div>
                 </div>
@@ -187,13 +190,12 @@
         </table>
     </div>
 
-    <!-- This table has running instances -->
-    <div ng-show="hasCurrentInstances() && !services.current.isIsvc()">
+    <!-- Instances -->
+    <div ng-show="hasCurrentInstances() && !currentService.isIsvc()"> 
         <h3 translate>running_tbl_instances</h3>
-        <table jelly-table data-data="services.current.instances" data-config="instancesTable" class="table">
+        <table jelly-table data-data="currentService.instances" data-config="instancesTable" class="table">
             <tr ng-repeat="instance in $data" data-id="{{instance.id}}.{{instance.model.InstanceID}}">
-                <td data-title="'running_tbl_instance_id'|translate" sortable="'model.InstanceID'">{{instance.model.InstanceID}}</td>
-                <td data-title="'label_service_name'|translate" sortable="'name'">{{instance.name}}</td>
+                <td data-title="'running_tbl_instance_id'|translate" sortable="'instance.model.InstanceID'">{{instance.model.InstanceID}}</td>
                 <td data-title="'label_service_status'|translate" sortable="'status.status'" style="text-align:center;">
                     <health-icon data-status="instance.status"></health-icon>
                 </td>
@@ -206,7 +208,7 @@
                     <span ng-show="instance.resources.RAMCommitment!==0" ng-class="{'bad': !instance.resourcesGood()}" class="overcomText">{{instance.resources.RAMLast|toMB:true}} / {{instance.resources.RAMMax|toMB:true}} / {{instance.resources.RAMAverage|toMB:true}} MB</span>
                 </td>
                 <td data-title="'host'|translate" sortable="'getHostName(instance.model.HostID)'" ng-click="click_host(instance.model.HostID)" class="link">{{getHostName(instance.model.HostID)}}</td>
-                <td data-title="'running_tbl_docker_id'|translate" sortable="'model.DockerID'">{{instance.model.DockerID|cut:false:12:"..."}}</td>
+                <td data-title="'running_tbl_docker_id'|translate" sortable="'instance.model.ContainerID'">{{instance.model.ContainerID|cut:false:12:"..."}}</td>
                 <td data-title="'running_tbl_actions'|translate">
                     <button ng-click="viewLog(instance)" class="btn btn-link action">
                         <i class="glyphicon glyphicon-list-alt"></i>
@@ -216,7 +218,7 @@
                         <i class="glyphicon glyphicon-list-alt"></i>
                         <span translate>action_view_instance_log</span>
                     </a>
-                    <button ng-click="instance.stop()" class="btn btn-link action">
+                    <button ng-click="currentService.stopInstance(instance)" class="btn btn-link action">
                         <i class="glyphicon glyphicon-refresh"></i>
                         <span translate>action_restart</span>
                     </button>
@@ -228,4 +230,9 @@
     <br>
 
     <!-- Graphs -->
-    <graph-panel ng-if="services.current.model.MonitoringProfile.GraphConfigs.length > 0" data-service-id="services.current.model.ID" data-graph-configs="services.current.model.MonitoringProfile.GraphConfigs" class="infoWrapper graphPanel"></graph-panel>
+    <graph-panel 
+        ng-if="currentService.monitoringProfile.GraphConfigs.length > 0" 
+        data-service-id="currentService.id" 
+        data-graph-configs="currentService.monitoringProfile.GraphConfigs" 
+        class="infoWrapper graphPanel">
+    </graph-panel>

--- a/web/ui/src/common/resourcesFactory.js
+++ b/web/ui/src/common/resourcesFactory.js
@@ -312,6 +312,45 @@
             }
         };
 
+        var v2MethodConfigs = {
+            getService: {
+                method: GET,
+                url: id => `/api/v2/services/${id}`,
+            },
+            getServiceChildren: {
+                method: GET,
+                url: id => `/api/v2/services/${id}/services`,
+            },
+            getServiceConfigs: {
+                method: GET,
+                url: id => `/api/v2/services/${id}/serviceconfigs`,
+            },
+            getServiceContext: {
+                method: GET,
+                url: id => `/api/v2/services/${id}/context`,
+            },
+            getServiceInstances: {
+                method: GET,
+                url: id => `/api/v2/services/${id}/instances`,
+            },
+            getServiceIpAssignments: {
+                method: GET,
+                url: id => `/api/v2/services/${id}/ipassignments?includeChildren`,
+            },
+            getServicePublicEndpoints: {
+                method: GET,
+                url: id => `/api/v2/services/${id}/publicendpoints`,
+            },
+            getServices: {
+                method: GET,
+                url: since => `/api/v2/services${ since ? "?since="+ since : ""}`,
+            },
+            getServiceStatus: {
+                method: GET,
+                url: id => `/api/v2/statuses?serviceId=${id}`,
+            }
+        };
+
         // adds success and error functions
         // to regular promise ala $http
         function httpify(deferred){
@@ -457,6 +496,13 @@
         // to interface
         for(var name in methodConfigs){
             resourcesFactoryInterface[name] = generateMethod(methodConfigs[name]);
+        }
+
+        // generate Version 2 API methods and attach
+        // to interface
+        resourcesFactoryInterface.v2 = {};
+        for(var name in v2MethodConfigs){
+            resourcesFactoryInterface.v2[name] = generateMethod(v2MethodConfigs[name]);
         }
 
         return resourcesFactoryInterface;

--- a/web/ui/src/common/resourcesFactory.js
+++ b/web/ui/src/common/resourcesFactory.js
@@ -317,9 +317,32 @@
                 method: GET,
                 url: id => `/api/v2/services/${id}`,
             },
+            updateService: {
+                method: PUT,
+                url: id => `/api/v2/services/${id}`,
+                payload: (id, service) => service
+            },
+            getServiceAncestors: {
+                method: GET,
+                url: id => `/api/v2/services/${id}?ancestors`,
+            },
             getServiceChildren: {
                 method: GET,
                 url: id => `/api/v2/services/${id}/services`,
+            },
+            getServiceConfig: {
+                method: GET,
+                url: id => `/api/v2/serviceconfigs/${id}`,
+            },
+            updateServiceConfig: {
+                method: PUT,
+                url: (id) => `/api/v2/serviceconfigs/${id}`,
+                payload: (id, cfg) => {return JSON.stringify({
+                    'Filename':    cfg.Filename, 
+                    'Owner':       cfg.Owner, 
+                    'Permissions': cfg.Permissions, 
+                    'Content':     cfg.Content
+                });}
             },
             getServiceConfigs: {
                 method: GET,
@@ -329,6 +352,11 @@
                 method: GET,
                 url: id => `/api/v2/services/${id}/context`,
             },
+            updateServiceContext: {
+                method: PUT,
+                url: id => `/api/v2/services/${id}/context`,
+                payload: (id, ctx) => ctx
+            },
             getServiceInstances: {
                 method: GET,
                 url: id => `/api/v2/services/${id}/instances`,
@@ -337,9 +365,17 @@
                 method: GET,
                 url: id => `/api/v2/services/${id}/ipassignments?includeChildren`,
             },
+            getServiceMonitoringProfile: {
+                method: GET,
+                url: id => `/api/v2/services/${id}/monitoringprofile`,
+            },
             getServicePublicEndpoints: {
                 method: GET,
-                url: id => `/api/v2/services/${id}/publicendpoints`,
+                url: id => `/api/v2/services/${id}/publicendpoints?includeChildren`,
+            },
+            getServiceExportEndpoints: {
+                method: GET,
+                url: id => `/api/v2/services/${id}/exportendpoints?includeChildren`,
             },
             getServices: {
                 method: GET,
@@ -348,6 +384,10 @@
             getServiceStatus: {
                 method: GET,
                 url: id => `/api/v2/statuses?serviceId=${id}`,
+            },
+            getServiceStatuses: {
+                method: GET,
+                url: ids => `/api/v2/statuses?${ids.map(id => `serviceId=${id}`).join('&')}`,
             }
         };
 

--- a/web/ui/src/common/resourcesFactory.js
+++ b/web/ui/src/common/resourcesFactory.js
@@ -360,6 +360,7 @@
             getServiceInstances: {
                 method: GET,
                 url: id => `/api/v2/services/${id}/instances`,
+                ignorePending: true
             },
             getServiceIpAssignments: {
                 method: GET,
@@ -384,10 +385,12 @@
             getServiceStatus: {
                 method: GET,
                 url: id => `/api/v2/statuses?serviceId=${id}`,
+                ignorePending: true
             },
             getServiceStatuses: {
                 method: GET,
                 url: ids => `/api/v2/statuses?${ids.map(id => `serviceId=${id}`).join('&')}`,
+                ignorePending: true
             }
         };
 
@@ -473,7 +476,7 @@
                 });
 
                 // NOTE: only limits GET requests
-                if(method === GET){
+                if(method === GET && !config.ignorePending){
                     pendingGETRequests[resourceName] = deferred;
                 }
 

--- a/web/ui/static/css/main.css
+++ b/web/ui/static/css/main.css
@@ -1421,9 +1421,14 @@ input[type=file] {
     height: auto;
 }
 
+/* give tree-expansion cells more room for their expansion buttons */
+.jelly-treetable tbody tr > td:first-child {
+    padding: 0 0 0 8px;
+}
+
 .table-collapse {
     font-size: 8px;
-    padding: 0px 3px 3px 3px;
+    padding: 6px 13px 12px 0;
     vertical-align: middle;
     cursor: pointer;
 }
@@ -1590,6 +1595,18 @@ input[type=file] {
 
 .modal .big .CodeMirror {
     height: 500px;
+}
+
+.modal .CodeMirror {
+    background: transparent;
+}
+
+.modal-context {
+    margin-top: 2rem;
+}
+
+.modal-mckracken {
+  margin-bottom: -50%;
 }
 
 /* sticky service controls */

--- a/web/ui/test/Health/serviceHealthSpec.js
+++ b/web/ui/test/Health/serviceHealthSpec.js
@@ -30,7 +30,7 @@ describe('serviceHealth', function() {
             name: "mockservice" + id,
             desiredState: STOPPED,
             instances: [],
-            fetchInstances: () => {}
+            fetchInstances: function(){}
         };
     }
     function createMockInstance(serviceID){

--- a/web/ui/test/Health/serviceHealthSpec.js
+++ b/web/ui/test/Health/serviceHealthSpec.js
@@ -28,19 +28,18 @@ describe('serviceHealth', function() {
         return {
             id: id,
             name: "mockservice" + id,
-            model: {
-                DesiredState: STOPPED
-            },
+            desiredState: STOPPED,
             instances: [],
-            getServiceInstances: function(){return this.instances;}
+            fetchInstances: () => {}
         };
     }
     function createMockInstance(serviceID){
         return {
             id: Math.floor(Math.random() * 10000),
+            healthChecks: {},
+            status: {},
             model: {
                 ServiceID: serviceID,
-                HealthChecks: {}
             }
         };
     }
@@ -57,7 +56,7 @@ describe('serviceHealth', function() {
 
         // create service
         var mockService = createMockService(id);
-        mockService.model.DesiredState = desiredState;
+        mockService.desiredState = desiredState;
 
         // attach instance
         mockService.instances = [mockInstance];
@@ -82,7 +81,7 @@ describe('serviceHealth', function() {
     // should be running, but no healthchecks yet. Probably starting up
     it("marks a started service with no health check as unknown", function(){
         var mockService = createMockService();
-        mockService.model.DesiredState = STARTED;
+        mockService.desiredState = STARTED;
         var mockServiceList = {};
         mockServiceList[mockService.id] = mockService;
         var statuses = serviceHealth.update(mockServiceList);


### PR DESCRIPTION
This change does approximately one million things. Primarily it makes the CC UI not need the entire application state (all services, all hosts, all pools) to operate.  

This does introduce some regressions, but this code needs to start QA asap.