### PR TITLE
Fix incorrect error message

### DIFF
--- a/utils/nfs.go
+++ b/utils/nfs.go
@@ -11,7 +11,7 @@ func IsNFSMountStale(mountpoint string) bool {
 	// See http://stackoverflow.com/questions/17612004/linux-shell-script-how-to-detect-nfs-mount-point-or-the-server-is-dead
 	// for explanation of the following command.
 	if err := exec.Command("/bin/bash", "-c", fmt.Sprintf("read -t1 < <(stat -t '%s' 2>&-)", mountpoint)).Run(); err != nil {
-		if err.Error() == "wait: no child processes" {
+		if err.Error() == "waitid: no child processes" {
 			glog.V(2).Infof("Distributed storage check hit probably spurious ECHILD. Ignoring.")
 			return false
 		}


### PR DESCRIPTION
To check a NFS mountpoint is stale, a bash command is executed, and the error message is checked if there's any. A string against which the error message is checked was incorrect. 