### PR TITLE
CC-2763: update dfs client list when changing pool dfs permissions an…

### DIFF
--- a/coordinator/storage/client.go
+++ b/coordinator/storage/client.go
@@ -140,7 +140,7 @@ func (c *Client) loop() {
 
 	var doneC chan<- string
 	var leader client.Leader
-	nodePath := fmt.Sprintf("/storage/clients/%s", node.IPAddr)
+	nodePath := fmt.Sprintf("%s/%s", ZkStorageClientsPath, node.IPAddr)
 
 	doneW := make(chan struct{})
 	defer func(channel *chan struct{}) { close(*channel) }(&doneW)

--- a/coordinator/storage/server.go
+++ b/coordinator/storage/server.go
@@ -21,7 +21,12 @@ import (
 	"github.com/control-center/serviced/coordinator/client"
 	"github.com/control-center/serviced/coordinator/client/zookeeper"
 	"github.com/control-center/serviced/domain/host"
+	"github.com/control-center/serviced/zzk"
 	"github.com/zenoss/glog"
+)
+
+var (
+	zkStorageClientsPath = "/storage/clients"
 )
 
 // Server manages the exporting of a file system to clients.
@@ -71,10 +76,8 @@ func (s *Server) Run(shutdown <-chan interface{}, conn client.Connection) error 
 		conn.CreateDir("/storage/leader")
 	}
 
-	storageClientsPath := "/storage/clients"
-
-	if exists, _ := conn.Exists(storageClientsPath); !exists {
-		conn.CreateDir(storageClientsPath)
+	if exists, _ := conn.Exists(zkStorageClientsPath); !exists {
+		conn.CreateDir(zkStorageClientsPath)
 	}
 
 	leader, err := conn.NewLeader("/storage/leader")
@@ -95,7 +98,7 @@ func (s *Server) Run(shutdown <-chan interface{}, conn client.Connection) error 
 	done := make(chan struct{})
 	defer func(channel *chan struct{}) { close(*channel) }(&done)
 	for {
-		clients, clientW, err := conn.ChildrenW(storageClientsPath, done)
+		clients, clientW, err := conn.ChildrenW(zkStorageClientsPath, done)
 		if err != nil {
 			glog.Errorf("Could not set up watch for storage clients: %s", err)
 			return err
@@ -120,4 +123,57 @@ func (s *Server) Run(shutdown <-chan interface{}, conn client.Connection) error 
 		close(done)
 		done = make(chan struct{})
 	}
+}
+
+func updateDfsClientInTransaction(tx client.Transaction, client *host.Host, delete bool) {
+	if delete {
+		tx.Delete(client.IPAddr)
+	} else {
+		node := &Node{
+			Host:    *client,
+			version: nil,
+		}
+		tx.Create(client.IPAddr, node)
+	}
+}
+
+func updateDfsClients(clients []host.Host, delete bool) error {
+	// Get a connection to /storage/clients
+	conn, err := zzk.GetLocalConnection(zkStorageClientsPath)
+	if err != nil {
+		return err
+	}
+	// Get current dfs clients and put them in a map
+	currentClients, err := conn.Children("")
+	if err != nil {
+		return err
+	}
+	currentClientsMap := make(map[string]bool)
+	for _, c := range currentClients {
+		currentClientsMap[c] = true
+	}
+	// Create a transaction
+	tx := conn.NewTransaction()
+	// Update clients
+	for _, c := range clients {
+		_, exists := currentClientsMap[c.IPAddr]
+		if delete && exists {
+			updateDfsClientInTransaction(tx, &c, delete)
+		} else if !delete && !exists {
+			updateDfsClientInTransaction(tx, &c, delete)
+		}
+	}
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func UnregisterDfsClients(clients ...host.Host) error {
+	return updateDfsClients(clients, true)
+}
+
+func RegisterDfsClients(clients ...host.Host) error {
+	return updateDfsClients(clients, false)
 }

--- a/facade/host.go
+++ b/facade/host.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/control-center/serviced/auth"
-	"github.com/control-center/serviced/coordinator/storage"
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain/addressassignment"
 	"github.com/control-center/serviced/domain/host"
@@ -249,7 +248,7 @@ func (f *Facade) RemoveHost(ctx datastore.Context, hostID string) (err error) {
 	}
 
 	// unregister host as dfs client
-	err = storage.UnregisterDfsClients(*_host)
+	err = f.zzk.UnregisterDfsClients(*_host)
 	if err != nil {
 		glog.Warningf("Could not disable dfs for deleted host %s: %s", _host.ID, err)
 	}

--- a/facade/host.go
+++ b/facade/host.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/control-center/serviced/auth"
+	"github.com/control-center/serviced/coordinator/storage"
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain/addressassignment"
 	"github.com/control-center/serviced/domain/host"
@@ -245,6 +246,12 @@ func (f *Facade) RemoveHost(ctx datastore.Context, hostID string) (err error) {
 		if err = f.AssignIPs(ctx, request); err != nil {
 			glog.Warningf("Failed assigning another ip to service %s: %s", svc.ID, err)
 		}
+	}
+
+	// unregister host as dfs client
+	err = storage.UnregisterDfsClients(*_host)
+	if err != nil {
+		glog.Warningf("Could not disable dfs for deleted host %s: %s", _host.ID, err)
 	}
 
 	return nil

--- a/facade/host_unit_test.go
+++ b/facade/host_unit_test.go
@@ -167,6 +167,7 @@ func (ft *FacadeUnitTest) Test_RemoveHost_HappyPath(c *C) {
 			*args.Get(2).(*host.Host) = h
 		})
 	ft.zzk.On("RemoveHost", &h).Return(nil)
+	ft.zzk.On("UnregisterDfsClients", []host.Host{h}).Return(nil)
 	ft.hostkeyStore.On("Delete", ft.ctx, h.ID).Return(nil)
 	ft.hostStore.On("Delete", ft.ctx, host.HostKey(h.ID)).Return(nil)
 

--- a/facade/mocks/ZZK.go
+++ b/facade/mocks/ZZK.go
@@ -493,3 +493,27 @@ func (_m *ZZK) GetServiceNodes() ([]zkservice.ServiceNode, error) {
 
 	return r0, r1
 }
+func (_m *ZZK) RegisterDfsClients(clients ...host.Host) error {
+	ret := _m.Called(clients)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(...host.Host) error); ok {
+		r0 = rf(clients...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *ZZK) UnregisterDfsClients(clients ...host.Host) error {
+	ret := _m.Called(clients)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(...host.Host) error); ok {
+		r0 = rf(clients...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/facade/pool.go
+++ b/facade/pool.go
@@ -158,20 +158,21 @@ func (f *Facade) updateResourcePool(ctx datastore.Context, entity *pool.Resource
 	if entity.HasDfsAccess() != current.HasDfsAccess() {
 		dfsClients, err := f.FindHostsInPool(ctx, entity.ID)
 		if err != nil {
-			msg := "Error retrieving hosts belonging to pool"
+			msg := "Error retrieving pool's hosts"
 			plog.WithError(err).WithField("poolID", entity.ID).Warning(msg)
-		}
-		var clientsError error
-		if entity.HasDfsAccess() { // Enable dfs access
-			plog.WithField("poolID", entity.ID).Debug("DFS Access enabled for pool")
-			clientsError = f.zzk.RegisterDfsClients(dfsClients...)
-		} else { // Disable dfs access
-			plog.WithField("poolID", entity.ID).Debug("DFS Access disabled for pool")
-			clientsError = f.zzk.UnregisterDfsClients(dfsClients...)
-		}
-		if clientsError != nil {
-			msg := "Could not update dfs clients in zk after changing pool permissions"
-			plog.WithError(err).WithField("poolID", entity.ID).Warning(msg)
+		} else {
+			var clientsError error
+			if entity.HasDfsAccess() { // Enable dfs access
+				plog.WithField("poolID", entity.ID).Debug("DFS Access enabled for pool")
+				clientsError = f.zzk.RegisterDfsClients(dfsClients...)
+			} else { // Disable dfs access
+				plog.WithField("poolID", entity.ID).Debug("DFS Access disabled for pool")
+				clientsError = f.zzk.UnregisterDfsClients(dfsClients...)
+			}
+			if clientsError != nil {
+				msg := "Could not update dfs clients in zk after changing pool permissions"
+				plog.WithError(err).WithField("poolID", entity.ID).Warning(msg)
+			}
 		}
 	}
 

--- a/facade/pool.go
+++ b/facade/pool.go
@@ -14,7 +14,6 @@
 package facade
 
 import (
-	"github.com/control-center/serviced/coordinator/storage"
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain/addressassignment"
 	"github.com/control-center/serviced/domain/host"
@@ -165,10 +164,10 @@ func (f *Facade) updateResourcePool(ctx datastore.Context, entity *pool.Resource
 		var clientsError error
 		if entity.HasDfsAccess() { // Enable dfs access
 			plog.WithField("poolID", entity.ID).Debug("DFS Access enabled for pool")
-			clientsError = storage.RegisterDfsClients(dfsClients...)
+			clientsError = f.zzk.RegisterDfsClients(dfsClients...)
 		} else { // Disable dfs access
 			plog.WithField("poolID", entity.ID).Debug("DFS Access disabled for pool")
-			clientsError = storage.UnregisterDfsClients(dfsClients...)
+			clientsError = f.zzk.UnregisterDfsClients(dfsClients...)
 		}
 		if clientsError != nil {
 			msg := "Could not update dfs clients in zk after changing pool permissions"

--- a/facade/testutils.go
+++ b/facade/testutils.go
@@ -104,7 +104,7 @@ func (ft *FacadeIntegrationTest) setupMockZZK() {
 	ft.zzk.On("DeleteRegistryLibrary", mock.AnythingOfType("string")).Return(nil)
 	ft.zzk.On("LockServices", mock.AnythingOfType("[]service.Service")).Return(nil)
 	ft.zzk.On("UnlockServices", mock.AnythingOfType("[]service.Service")).Return(nil)
-
+	ft.zzk.On("UnregisterDfsClients", mock.AnythingOfType("[]host.Host")).Return(nil)
 }
 
 func (ft *FacadeIntegrationTest) setupMockDFS() {

--- a/facade/zkapi.go
+++ b/facade/zkapi.go
@@ -21,6 +21,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/control-center/serviced/coordinator/client"
+	"github.com/control-center/serviced/coordinator/storage"
 	"github.com/control-center/serviced/datastore"
 	zkimgregistry "github.com/control-center/serviced/dfs/registry"
 	"github.com/control-center/serviced/domain/host"
@@ -794,4 +795,56 @@ func (zk *zkf) buildServiceRegistryCache(conn client.Connection) error {
 	}
 	zk.svcRegistry.BuildCache(publicPorts, vhosts)
 	return nil
+}
+
+func updateDfsClientInTransaction(tx client.Transaction, client *host.Host, delete bool) {
+	if delete {
+		tx.Delete(client.IPAddr)
+	} else {
+		node := &storage.Node{
+			Host: *client,
+		}
+		tx.Create(client.IPAddr, node)
+	}
+}
+
+func updateDfsClients(clients []host.Host, delete bool) error {
+	// Get a connection to /storage/clients
+	conn, err := zzk.GetLocalConnection(storage.ZkStorageClientsPath)
+	if err != nil {
+		return err
+	}
+	// Get current dfs clients and put them in a map
+	currentClients, err := conn.Children("")
+	if err != nil {
+		return err
+	}
+	currentClientsMap := make(map[string]bool)
+	for _, c := range currentClients {
+		currentClientsMap[c] = true
+	}
+	// Create a transaction
+	tx := conn.NewTransaction()
+	// Update clients
+	for _, c := range clients {
+		_, exists := currentClientsMap[c.IPAddr]
+		if delete && exists {
+			updateDfsClientInTransaction(tx, &c, delete)
+		} else if !delete && !exists {
+			updateDfsClientInTransaction(tx, &c, delete)
+		}
+	}
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (zk *zkf) UnregisterDfsClients(clients ...host.Host) error {
+	return updateDfsClients(clients, true)
+}
+
+func (zk *zkf) RegisterDfsClients(clients ...host.Host) error {
+	return updateDfsClients(clients, false)
 }

--- a/facade/zzk.go
+++ b/facade/zzk.go
@@ -55,4 +55,6 @@ type ZZK interface {
 	SendDockerAction(poolID, serviceID string, instanceID int, command string, args []string) error
 	GetServiceStateIDs(poolID, serviceID string) ([]zkservice.StateRequest, error)
 	GetServiceNodes() ([]zkservice.ServiceNode, error)
+	RegisterDfsClients(clients ...host.Host) error
+	UnregisterDfsClients(clients ...host.Host) error
 }


### PR DESCRIPTION
…d when deleting a host

## Demo

[zenny@ip-10-111-23-175 ~]$ serviced host list --show-fields ID,Pool,Addr
ID            Pool         Addr
6f0aaf17      default      10.111.23.175
6f0a9117      nodfs        10.111.23.145
6f0a7917      nodfs        10.111.23.121

[zenny@ip-10-111-23-175 ~]$ serviced pool list nodfs | grep Permissions
   "Permissions": 1,

[zenny@ip-10-111-23-175 ~]$ cat /etc/hosts.allow | tail -2
rpcbind mountd nfsd statd lockd rquotad : 127.0.0.1 10.111.23.175

### add dfs permissions

[zenny@ip-10-111-23-175 ~]$ serviced pool set-permission --dfs nodfs

[zenny@ip-10-111-23-175 ~]$ serviced pool list nodfs | grep Permissions
   "Permissions": 3,

[zenny@ip-10-111-23-175 ~]$ cat /etc/hosts.allow | tail -2
rpcbind mountd nfsd statd lockd rquotad : 127.0.0.1 10.111.23.121 10.111.23.145 10.111.23.175

### remove dfs permissions

[zenny@ip-10-111-23-175 ~]$ serviced pool set-permission --dfs=false nodfs
[zenny@ip-10-111-23-175 ~]$ serviced pool list nodfs | grep Permissions
   "Permissions": 1,

[zenny@ip-10-111-23-175 ~]$ cat /etc/hosts.allow | tail -2
rpcbind mountd nfsd statd lockd rquotad : 127.0.0.1 10.111.23.175

### remove a host with dfs permissions

[zenny@ip-10-111-23-175 ~]$ serviced host rm 6f0aaf17
6f0aaf17

[zenny@ip-10-111-23-175 ~]$ cat /etc/hosts.allow | tail -2
rpcbind mountd nfsd statd lockd rquotad : 127.0.0.1