### PR TITLE
CC-2745 Allow attaching to instances running in non-admin pools

### DIFF
--- a/cli/api/instance.go
+++ b/cli/api/instance.go
@@ -85,7 +85,7 @@ func (a *api) AttachServiceInstance(serviceID string, instanceID int, command st
 			"/usr/bin/ssh",
 			"-t", targetIP, "--",
 			"serviced", "--endpoint", GetOptionsRPCEndpoint(),
-			"service", "attach", fmt.Sprintf("%s/%d", serviceID, instanceID),
+			"service", "attach", fmt.Sprintf("%s", targetContainer),
 		}
 		cmd = append(cmd, command)
 		cmd = append(cmd, args...)

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/control-center/serviced/cli/api"
+	"github.com/control-center/serviced/commons/docker"
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/utils"
 )
@@ -683,9 +684,9 @@ func cmdSetTreeCharset(ctx *cli.Context, config utils.ConfigReader) {
 	}
 }
 
-// parseServiceInstance gets the service id and instance id from a provided
+// parseServiceInstance gets the service or docker id and instance id from a provided
 // service string, being either a deploymentPath/servicepath/instanceid or
-// serviceid/instanceid
+// serviceid/instanceid or dockerid
 func (c *ServicedCli) parseServiceInstance(keyword string) (string, int, error) {
 	servicepath, name := path.Split(keyword)
 	instanceID := -1
@@ -701,6 +702,13 @@ func (c *ServicedCli) parseServiceInstance(keyword string) (string, int, error) 
 		} else {
 			servicepath = strings.TrimRight(servicepath, "/")
 			instanceID = num
+		}
+	}
+
+	// is the servicepath a dockerid?
+	if instanceID < 0 {
+		if _, err := docker.FindContainer(servicepath); err == nil {
+			return servicepath, instanceID, nil
 		}
 	}
 


### PR DESCRIPTION
# DEMO
## Setup
```
$ serviced host list | grep 10.111.3.9
6f0a0903      collector      ip-10-111-3-9.zenoss.loc        10.111.3.9        4979         8          59.6G      277.8M / 403.2M / 247.4M      172.17.0.0/255.255.255.0      1.2.0-0.0.3127.unstable
$ serviced pool list collector | grep Permissions
   "Permissions": 0,
$ serviced service status | grep 10.111.3.9
            zenjmx               5hub328585lx8v66a0wfh2ak5   running   X         3m45s    1G     277.9M / 403.2M / 254.1M   ip-10-111-3-9.zenoss.loc     Y        875f2430b6f3

```
## Attach from master succeeds
```
$ serviced service attach zenjmx
The authenticity of host '10.111.3.9 (10.111.3.9)' can't be established.
ECDSA key fingerprint is e7:f4:55:89:ca:de:63:27:69:d5:5f:da:35:f2:1a:e6.
Are you sure you want to continue connecting (yes/no)? yes
Password:
[root@875f2430b6f3 /]# exit
exit
Connection to 10.111.3.9 closed.
```
## Attach from non-admin delegate fails
```
$ ssh zenny@10.111.3.9
The authenticity of host '10.111.3.9 (10.111.3.9)' can't be established.
ECDSA key fingerprint is e7:f4:55:89:ca:de:63:27:69:d5:5f:da:35:f2:1a:e6.
Are you sure you want to continue connecting (yes/no)? yes
Password:
Last login: Fri Oct 14 20:55:46 2016 from 10.111.3.165
[zenny@ip-10-111-3-9 ~]$ serviced service attach zenjmx
Delegate does not have admin access
Delegate does not have admin access
```
## Unless we use the docker ID:
```
[zenny@ip-10-111-3-9 ~]$ docker ps
CONTAINER ID        IMAGE                                                           COMMAND                  CREATED             STATUS              PORTS               NAMES
875f2430b6f3        10.111.3.165:5000/9g2zrjvwzg69s31co6vicl80x/resmgr_5.2:latest   "/serviced/serviced-c"   55 minutes ago      Up 55 minutes                           5hub328585lx8v66a0wfh2ak5-0
[zenny@ip-10-111-3-9 ~]$ serviced service attach 875f2430b6f3
[root@875f2430b6f3 /]#
```