### PR TITLE
CC-2778, add Application property to getServiceAddressAssignmentDetails

### DIFF
--- a/domain/service/api.go
+++ b/domain/service/api.go
@@ -45,6 +45,7 @@ type IPAssignment struct {
 	Type        string
 	IPAddress   string
 	Port        uint16
+	Application string
 }
 
 // ExportedEndpoint is a minimal service object that describes exported

--- a/facade/addressassignment.go
+++ b/facade/addressassignment.go
@@ -96,6 +96,7 @@ func (f *Facade) getServiceAddressAssignmentDetails(ctx datastore.Context, svc s
 
 			// Append a new record for the port
 			addr.Port = ep.AddressConfig.Port
+			addr.Application = ep.Application
 			addrs = append(addrs, addr)
 			logger.WithField("port", ep.AddressConfig.Port).Debug("Added port")
 		}

--- a/facade/addressassignment_test.go
+++ b/facade/addressassignment_test.go
@@ -125,6 +125,7 @@ func (ft *FacadeIntegrationTest) TestGetServiceAddressAssignmentDetails(c *C) {
 			HostName:    "h1",
 			IPAddress:   "12.27.36.45",
 			Port:        1234,
+			Application: "ep1",
 		},
 	}
 	c.Assert(addrs, DeepEquals, expected)
@@ -141,6 +142,7 @@ func (ft *FacadeIntegrationTest) TestGetServiceAddressAssignmentDetails(c *C) {
 		HostName:    "h1",
 		IPAddress:   "12.27.36.45",
 		Port:        2123,
+		Application: "ep2",
 	})
 	c.Assert(addrs, DeepEquals, expected)
 

--- a/web/ui/src/Services/ServiceDetailsController.js
+++ b/web/ui/src/Services/ServiceDetailsController.js
@@ -219,8 +219,7 @@
                                     IPAddr = data.HostIPs[i].IPAddress;
                                     value = 'Host: ' + IPAddr + ' - ' + data.HostIPs[i].InterfaceName;
                                     options.push({ 'Value': value, 'IPAddr': IPAddr });
-                                    // TODO: look up associated endpoint name
-                                    //modalScope.assignments.ip.EndpointName = "Boogity";
+                                    modalScope.assignments.ip.Application = ip.Application;
 
                                     // set the default value to the currently assigned value
                                     if (modalScope.assignments.ip.IPAddress === IPAddr) {

--- a/web/ui/src/Services/assign-ip.html
+++ b/web/ui/src/Services/assign-ip.html
@@ -4,7 +4,7 @@
 </div>
 <div class="form-group">
     <label for="assign_ip" translate>label_endpoint</label>
-    <input class="form-control"  value="{{assignments.ip.EndpointName}}" disabled>
+    <input class="form-control"  value="{{assignments.ip.Application}}" disabled>
 </div>
 <div class="form-group">
     <label for="assign_ip" translate>label_port</label>


### PR DESCRIPTION
CC-2778, add Application property to getServiceAddressAssignmentDetails v2 API
so the UI can show the endpoints's application name.