### PR TITLE
Fix the bug that shutdowns rpc clients after ReportHealthStatus and R…

### DIFF
--- a/rpc/master/health_client.go
+++ b/rpc/master/health_client.go
@@ -43,7 +43,7 @@ func (c *Client) ReportHealthStatus(key health.HealthStatusKey, value health.Hea
 		Value:   value,
 		Expires: expires,
 	}
-	return c.call("ReportHealthStatus", request, empty)
+	return c.call("ReportHealthStatus", request, nil)
 }
 
 // ReportInstanceDead removes stopped instances from the health check status cache.
@@ -52,5 +52,5 @@ func (c *Client) ReportInstanceDead(serviceID string, instanceID int) error {
 		ServiceID:  serviceID,
 		InstanceID: instanceID,
 	}
-	return c.call("ReportInstanceDead", request, empty)
+	return c.call("ReportInstanceDead", request, nil)
 }

--- a/rpc/master/health_server.go
+++ b/rpc/master/health_server.go
@@ -63,13 +63,13 @@ func (s *Server) GetServicesHealth(unused struct{}, results *map[string]map[int]
 }
 
 // ReportHealthStatus sends an update to the health check status cache.
-func (s *Server) ReportHealthStatus(request HealthStatusRequest, unused *string) error {
+func (s *Server) ReportHealthStatus(request HealthStatusRequest, _ *struct{}) error {
 	s.f.ReportHealthStatus(request.Key, request.Value, request.Expires)
 	return nil
 }
 
 // ReportInstanceDead removes stopped instances from the health check status cache.
-func (s *Server) ReportInstanceDead(request ReportDeadInstanceRequest, unused *string) error {
+func (s *Server) ReportInstanceDead(request ReportDeadInstanceRequest, _ *struct{}) error {
 	s.f.ReportInstanceDead(request.ServiceID, request.InstanceID)
 	return nil
 }


### PR DESCRIPTION
…eportInstanceDead calls

Passing a non-pointer struct{} to those functions causes a json unmarshaling error. Replaced it with a pointer to an empty string.