### PR TITLE
Refactor "pipe" to take a function with no args

### DIFF
--- a/cli/cmd/cmd_logging_test.go
+++ b/cli/cmd/cmd_logging_test.go
@@ -89,10 +89,8 @@ func (s *CmdLoggingSuite) Test_LoadsConfigFile_Error(c *C) {
 			watch <- struct{}{}
 		})
 	s.api.On("GetHosts").Return([]host.Host{}, nil)
-	f := func(args ...string) { s.Run(env, args...) }
-	g := func(args ...string) { pipeStderr(f, args...) }
-	output := string(pipe(g, "serviced", "host", "list"))
-	output = strings.Split(output, "\n")[0]
+	output := captureStderr(func() { s.Run(env, "serviced", "host", "list") })
+	firstLine := strings.Split(string(output), "\n")[0]
 	timeout := time.After(time.Second)
 	select {
 	case <-watch:
@@ -101,7 +99,7 @@ func (s *CmdLoggingSuite) Test_LoadsConfigFile_Error(c *C) {
 	}
 	s.log.AssertExpectations(c)
 	s.api.AssertExpectations(c)
-	c.Assert(output, Matches, ".*"+err)
+	c.Assert(firstLine, Matches, ".*"+err)
 }
 
 func (s *CmdLoggingSuite) Test_LoadsSpecifiedConfigFile(c *C) {

--- a/cli/cmd/docker_test.go
+++ b/cli/cmd/docker_test.go
@@ -68,7 +68,7 @@ func ExampleServicedCLI_CmdDockerOverride_usage() {
 }
 
 func ExampleServicedCli_cmdDockerOverride_fail() {
-	pipeStderr(InitDockerAPITest, "serviced", "docker", "override", "anything", OverrideFail)
+	pipeStderr(func() { InitDockerAPITest("serviced", "docker", "override", "anything", OverrideFail) })
 
 	// Output:
 	// override failed

--- a/cli/cmd/healthcheck_test.go
+++ b/cli/cmd/healthcheck_test.go
@@ -143,7 +143,7 @@ func ExampleServicedCLI_CmdHealthCheck_twoServices() {
 }
 
 func ExampleServicedCLI_CmdHealthCheck_undefinedService() {
-	pipeStderr(InitHealthCheckAPITest, "serviced", "healthcheck", "undefined-iservice")
+	pipeStderr(func() { InitHealthCheckAPITest("serviced", "healthcheck", "undefined-iservice") })
 
 	// Output:
 	// could not find isvc "undefined-iservice"
@@ -151,7 +151,7 @@ func ExampleServicedCLI_CmdHealthCheck_undefinedService() {
 }
 
 func ExampleServicedCLI_CmdHealthCheck_failedStatus() {
-	pipeStderr(InitHealthCheckAPITest, "serviced", "healthcheck", "test-iservice-failed")
+	pipeStderr(func() { InitHealthCheckAPITest("serviced", "healthcheck", "test-iservice-failed") })
 
 	// Output:
 	// Service Name          Container Name    Container ID  Health Check  Status
@@ -160,7 +160,7 @@ func ExampleServicedCLI_CmdHealthCheck_failedStatus() {
 }
 
 func ExampleServicedCLI_CmdHealthCheck_stoppedStatus() {
-	pipeStderr(InitHealthCheckAPITest, "serviced", "healthcheck", "test-iservice-stopped")
+	pipeStderr(func() { InitHealthCheckAPITest("serviced", "healthcheck", "test-iservice-stopped") })
 
 	// Output:
 	// Service Name           Container Name     Container ID  Health Check  Status
@@ -169,7 +169,7 @@ func ExampleServicedCLI_CmdHealthCheck_stoppedStatus() {
 }
 
 func ExampleServicedCLI_CmdHealthCheck_unknownStatus() {
-	pipeStderr(InitHealthCheckAPITest, "serviced", "healthcheck", "test-iservice-unknown")
+	pipeStderr(func() { InitHealthCheckAPITest("serviced", "healthcheck", "test-iservice-unknown") })
 
 	// Output:
 	// Service Name           Container Name     Container ID  Health Check  Status

--- a/cli/cmd/host_test.go
+++ b/cli/cmd/host_test.go
@@ -152,7 +152,7 @@ func TestServicedCLI_CmdHostList_one(t *testing.T) {
 	}
 
 	var actual host.Host
-	output := pipe(InitHostAPITest, "serviced", "host", "list", "test-host-id-1")
+	output := captureStdout(func() { InitHostAPITest("serviced", "host", "list", "test-host-id-1") })
 	if err := json.Unmarshal(output, &actual); err != nil {
 		t.Fatalf("error unmarshaling resource: %s", err)
 	}
@@ -170,7 +170,7 @@ func TestServicedCLI_CmdHostList_all(t *testing.T) {
 	}
 
 	var actual []host.Host
-	output := pipe(InitHostAPITest, "serviced", "host", "list", "--verbose")
+	output := captureStdout(func() { InitHostAPITest("serviced", "host", "list", "--verbose") })
 	if err := json.Unmarshal(output, &actual); err != nil {
 		t.Fatalf("error unmarshaling resource: %s", err)
 	}
@@ -195,9 +195,9 @@ func ExampleServicedCLI_CmdHostList_fail() {
 	DefaultHostAPITest.fail = true
 	defer func() { DefaultHostAPITest.fail = false }()
 	// Error retrieving host
-	pipeStderr(InitHostAPITest, "serviced", "host", "list", "test-host-id-1")
+	pipeStderr(func() { InitHostAPITest("serviced", "host", "list", "test-host-id-1") })
 	// Error retrieving all hosts
-	pipeStderr(InitHostAPITest, "serviced", "host", "list")
+	pipeStderr(func() { InitHostAPITest("serviced", "host", "list") })
 
 	// Output:
 	// invalid host
@@ -208,9 +208,9 @@ func ExampleServicedCLI_CmdHostList_err() {
 	DefaultHostAPITest.hosts = make([]host.Host, 0)
 	defer func() { DefaultHostAPITest.hosts = DefaultTestHosts }()
 	// Host not found
-	pipeStderr(InitHostAPITest, "serviced", "host", "list", "test-host-id-0")
+	pipeStderr(func() { InitHostAPITest("serviced", "host", "list", "test-host-id-0") })
 	// No hosts found
-	pipeStderr(InitHostAPITest, "serviced", "host", "list")
+	pipeStderr(func() { InitHostAPITest("serviced", "host", "list") })
 
 	// Output:
 	// host not found
@@ -257,7 +257,7 @@ func ExampleServicedCLI_CmdHostAdd_registerfail() {
 	// Register host failed.  Write key file
 	DefaultHostAPITest.registerFail = true
 	defer func() { DefaultHostAPITest.registerFail = false }()
-	pipeStderr(InitHostAPITest, "serviced", "host", "add", "--register", "127.0.0.1:8080", "default")
+	pipeStderr(func(){InitHostAPITest( "serviced", "host", "add", "--register", "127.0.0.1:8080", "default")})
 
 	// Output:
 	// Wrote delegate key file to IP-127-0-0-1.delegate.key
@@ -270,7 +270,7 @@ func ExampleServicedCLI_CmdHostAdd_registerfail() {
 
 func ExampleServicedCLI_CmdHostAdd_keyfile() {
 	// Specify location of key file.
-	pipeStderr(InitHostAPITest, "serviced", "host", "add", "--key-file", "foobar", "127.0.0.1:8080", "default")
+	pipeStderr(func(){InitHostAPITest( "serviced", "host", "add", "--key-file", "foobar", "127.0.0.1:8080", "default")})
 
 	// Output:
 	// Wrote delegate key file to foobar
@@ -284,7 +284,7 @@ func ExampleServicedCLI_CmdHostAdd_keyfilefail() {
 	// Failure writing keyfile
 	DefaultHostAPITest.writeFail = true
 	defer func() { DefaultHostAPITest.writeFail = false }()
-	pipeStderr(InitHostAPITest, "serviced", "host", "add", "127.0.0.1:8080", "default")
+	pipeStderr(func(){InitHostAPITest( "serviced", "host", "add", "127.0.0.1:8080", "default")})
 
 	// Output:
 	// 127.0.0.1-default
@@ -297,7 +297,7 @@ func ExampleServicedCLI_CmdHostAdd_keyfilefail() {
 func ExampleServicedCLI_CmdHostAdd_keyfileRegister() {
 	// Specify location of key file and register host.
 	// Write the key file even though we registered.
-	pipeStderr(InitHostAPITest, "serviced", "host", "add", "--register", "--key-file", "foobar", "127.0.0.3:8080", "default")
+	pipeStderr(func(){InitHostAPITest( "serviced", "host", "add", "--register", "--key-file", "foobar", "127.0.0.3:8080", "default")})
 
 	// Output:
 	// Registered host at 127.0.0.3
@@ -317,14 +317,14 @@ func ExampleServicedCLI_CmdHostAdd_badurl() {
 func ExampleServicedCLI_CmdHostAdd_fail() {
 	DefaultHostAPITest.fail = true
 	defer func() { DefaultHostAPITest.fail = false }()
-	pipeStderr(InitHostAPITest, "serviced", "host", "add", "127.0.0.1:8080", "default")
+	pipeStderr(func() { InitHostAPITest("serviced", "host", "add", "127.0.0.1:8080", "default") })
 
 	// Output:
 	// invalid host
 }
 
 func ExampleServicedCLI_CmdHostAdd_err() {
-	pipeStderr(InitHostAPITest, "serviced", "host", "add", "127.0.0.1:8080", NilPool)
+	pipeStderr(func() { InitHostAPITest("serviced", "host", "add", "127.0.0.1:8080", NilPool) })
 
 	// Output:
 	// received nil host
@@ -369,7 +369,7 @@ func ExampleServicedCLI_CmdHostRemove_usage() {
 }
 
 func ExampleServicedCLI_CmdHostRemove_err() {
-	pipeStderr(InitHostAPITest, "serviced", "host", "remove", "test-host-id-0")
+	pipeStderr(func() { InitHostAPITest("serviced", "host", "remove", "test-host-id-0") })
 
 	// Output:
 	// test-host-id-0: no host found

--- a/cli/cmd/pool_test.go
+++ b/cli/cmd/pool_test.go
@@ -181,7 +181,7 @@ func TestServicedCLI_CmdPoolList_one(t *testing.T) {
 	}
 
 	var actual pool.ResourcePool
-	output := pipeAPI(RunCmd, test, "serviced", "pool", "list", poolID)
+	output := captureStdout(func() { RunCmd(test, "serviced", "pool", "list", poolID) })
 	if err := json.Unmarshal(output, &actual); err != nil {
 		t.Fatalf("error unmarshalling resource: %s", err)
 	}
@@ -200,7 +200,7 @@ func TestServicedCLI_CmdPoolList_all(t *testing.T) {
 	}
 
 	var actual []*pool.ResourcePool
-	output := pipeAPI(RunCmd, test, "serviced", "pool", "list", "--verbose")
+	output := captureStdout(func() { RunCmd(test, "serviced", "pool", "list", "--verbose") })
 	if err := json.Unmarshal(output, &actual); err != nil {
 		t.Fatalf("error unmarshalling resource: %s", err)
 	}
@@ -225,9 +225,9 @@ func ExampleServicedCLI_CmdPoolList_fail() {
 	test := DefaultPoolAPI()
 	test.fail = true
 	// Error retrieving pool
-	pipeAPIStderr(RunCmd, test, "serviced", "pool", "list", "test-pool-id-1")
+	pipeStderr(func() { RunCmd(test, "serviced", "pool", "list", "test-pool-id-1") })
 	// Error retrieving all pools
-	pipeAPIStderr(RunCmd, test, "serviced", "pool", "list")
+	pipeStderr(func() { RunCmd(test, "serviced", "pool", "list") })
 
 	// Output:
 	// invalid pool
@@ -239,9 +239,9 @@ func ExampleServicedCLI_CmdPoolList_err() {
 	*test.pools = make([]pool.ResourcePool, 0)
 
 	// Pool not found
-	pipeAPIStderr(RunCmd, test, "serviced", "pool", "list", "test-pool-id-0")
+	pipeStderr(func() { RunCmd(test, "serviced", "pool", "list", "test-pool-id-0") })
 	// No pools found
-	pipeAPIStderr(RunCmd, test, "serviced", "pool", "list")
+	pipeStderr(func() { RunCmd(test, "serviced", "pool", "list") })
 
 	// Output:
 	// pool not found
@@ -270,7 +270,7 @@ func ExampleServicedCLI_CmdPoolAdd() {
 }
 
 func ExampleServicedCLI_CmdPoolAdd_err() {
-	pipeAPIStderr(RunCmd, DefaultPoolAPI(), "serviced", "pool", "add", NilPool, "4", "1024", "3")
+	pipeStderr(func() { RunCmd(DefaultPoolAPI(), "serviced", "pool", "add", NilPool, "4", "1024", "3") })
 
 	// Output:
 	// received nil resource pool
@@ -306,7 +306,7 @@ func TestServicedCLI_CmdPoolAdd_perm(t *testing.T) {
 }
 
 func ExampleServicedCLI_CmdPoolRemove() {
-	pipeAPIStderr(RunCmd, DefaultPoolAPI(), "serviced", "pool", "remove", "test-pool-id-1")
+	pipeStderr(func() { RunCmd(DefaultPoolAPI(), "serviced", "pool", "remove", "test-pool-id-1") })
 
 	// Output:
 	// test-pool-id-1
@@ -331,7 +331,7 @@ func ExampleServicedCLI_CmdPoolRemove_usage() {
 }
 
 func ExampleServicedCLI_CmdPoolRemove_err() {
-	pipeAPIStderr(RunCmd, DefaultPoolAPI(), "serviced", "pool", "remove", "test-pool-id-0")
+	pipeStderr(func() { RunCmd(DefaultPoolAPI(), "serviced", "pool", "remove", "test-pool-id-0") })
 
 	// Output:
 	// test-pool-id-0: pool not found
@@ -364,7 +364,7 @@ func TestExampleServicedCLI_CmdPoolListIPs(t *testing.T) {
 	}
 
 	var actual []host.HostIPResource
-	output := pipeAPI(RunCmd, test, "serviced", "pool", "list-ips", poolID, "--verbose")
+	output := captureStdout(func() { RunCmd(test, "serviced", "pool", "list-ips", poolID, "--verbose") })
 	if err := json.Unmarshal(output, &actual); err != nil {
 		t.Fatalf("error unmarshalling resource: %s", err)
 	}
@@ -400,7 +400,7 @@ func ExampleServicedCLI_CmdPoolListIPs_usage() {
 }
 
 func ExampleServicedCLI_CmdPoolListIPs_fail() {
-	pipeAPIStderr(RunCmd, DefaultPoolAPI(), "serviced", "pool", "list-ips", "test-pool-id-0")
+	pipeStderr(func() { RunCmd(DefaultPoolAPI(), "serviced", "pool", "list-ips", "test-pool-id-0") })
 
 	// Output:
 	// no pool found
@@ -409,7 +409,7 @@ func ExampleServicedCLI_CmdPoolListIPs_fail() {
 func ExampleServicedCLI_CmdPoolListIPs_err() {
 	test := DefaultPoolAPI()
 	test.hostIPs = nil
-	pipeAPIStderr(RunCmd, test, "serviced", "pool", "list-ips", "test-pool-id-1")
+	pipeStderr(func() { RunCmd(test, "serviced", "pool", "list-ips", "test-pool-id-1") })
 
 	// Output:
 	// no resource pool IPs found

--- a/cli/cmd/publicendpoint_test.go
+++ b/cli/cmd/publicendpoint_test.go
@@ -87,7 +87,7 @@ func InitPublicEndpointPortTest(args ...string) {
 }
 
 func ExampleServicedCLI_CmdPublicEndpointsList_usage(t *testing.T) {
-	output := pipe(InitSnapshotAPITest, "serviced", "service", "public-endpoints", "list", "-h")
+	output := captureStdout(func() { InitSnapshotAPITest("serviced", "service", "public-endpoints", "list", "-h") })
 	expected :=
 		"NAME:\n" +
 			"   list - Lists public endpoints for a service\n" +
@@ -114,7 +114,9 @@ func ExampleServicedCLI_CmdPublicEndpointsList_usage(t *testing.T) {
 }
 
 func ExampleServicedCLI_CmdPublicEndpointsList_InvalidService() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "list", "invalidservice")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "list", "invalidservice")
+	})
 
 	// Output:
 	// service not found
@@ -176,21 +178,27 @@ func ExampleServicedCLI_CmdPublicEndpointsList_endpointTypePort() {
 }
 
 func ExampleServicedCLI_CmdPublicEndpointsList_endpointTypeVHost() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "list", "Zenoss", "zproxy", "--vhosts")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "list", "Zenoss", "zproxy", "--vhosts")
+	})
 
 	// Output:
 	// No public endpoints found
 }
 
 func ExampleServicedCLI_CmdPublicEndpointsList_endpointNoneFound() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "list", "Zenoss", "zope")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "list", "Zenoss", "zope")
+	})
 
 	// Output:
 	// No public endpoints found
 }
 
 func ExampleServicedCLI_CmdPublicEndpointsList_endpointInvalid() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "list", "Zenoss", "invalid")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "list", "Zenoss", "invalid")
+	})
 
 	// Output:
 	// Endpoint 'invalid' not found
@@ -259,14 +267,18 @@ func ExampleServicedCLI_CmdPublicEndpointsPortAdd() {
 }
 
 func ExampleServicedCLI_CmdPublicEndpointsPortAdd_InvalidEnable() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "port", "add", "Zenoss", "zproxy", ":22222", "http", "invalid")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "port", "add", "Zenoss", "zproxy", ":22222", "http", "invalid")
+	})
 
 	// Output:
 	// The enabled flag must be true or false
 }
 
 func ExampleServicedCLI_CmdPublicEndpointsPortAdd_InvalidProtocol() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "port", "add", "Zenoss", "zproxy", ":22222", "invalid", "true")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "port", "add", "Zenoss", "zproxy", ":22222", "invalid", "true")
+	})
 
 	// Output:
 	// The protocol must be one of: https, http, other-tls, other
@@ -293,7 +305,9 @@ func ExampleServicedCLI_CmdPublicEndpointsPortRemove() {
 }
 
 func ExampleServicedCLI_CmdPublicEndpointsPortEnable_InvalidArgCount() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "port", "enable", "Zenoss", "zproxy", ":22222", "true", "invalid")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "port", "enable", "Zenoss", "zproxy", ":22222", "true", "invalid")
+	})
 
 	// Output:
 	// NAME:
@@ -309,14 +323,18 @@ func ExampleServicedCLI_CmdPublicEndpointsPortEnable_InvalidArgCount() {
 }
 
 func ExampleServicedCLI_CmdPublicEndpointsPortEnable_InvalidService() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "port", "enable", "invalid", "zproxy", ":22222", "true")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "port", "enable", "invalid", "zproxy", ":22222", "true")
+	})
 
 	// Output:
 	// service not found
 }
 
 func ExampleServicedCLI_CmdPublicEndpointsPortEnable_InvalidEnableFlag() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "port", "enable", "Zenoss", "zproxy", ":22222", "invalid")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "port", "enable", "Zenoss", "zproxy", ":22222", "invalid")
+	})
 
 	// Output:
 	// The enabled flag must be true or false
@@ -355,14 +373,18 @@ func ExampleServicedCLI_cmdPublicEndpointsVHostAdd_InvalidArgCount() {
 }
 
 func ExampleServicedCLI_cmdPublicEndpointsVHostAdd_InvalidService() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "vhost", "add", "invalid", "zproxy", "zproxy2", "true")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "vhost", "add", "invalid", "zproxy", "zproxy2", "true")
+	})
 
 	// Output:
 	// service not found
 }
 
 func ExampleServicedCLI_cmdPublicEndpointsVHostAdd_InvalidEnableFlag() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "vhost", "add", "Zenoss", "invalid", "zproxy2", "invalid")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "vhost", "add", "Zenoss", "invalid", "zproxy2", "invalid")
+	})
 
 	// Output:
 	// The enabled flag must be true or false
@@ -376,7 +398,9 @@ func ExampleServicedCLI_CmdPublicEndpointsVHostRemove() {
 }
 
 func ExampleServicedCLI_CmdPublicEndpointsVHostEnable_InvalidArgCount() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "vhost", "enable", "Zenoss", "zproxy", "zproxy", "true", "invalid")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "vhost", "enable", "Zenoss", "zproxy", "zproxy", "true", "invalid")
+	})
 
 	// Output:
 	// NAME:
@@ -392,14 +416,18 @@ func ExampleServicedCLI_CmdPublicEndpointsVHostEnable_InvalidArgCount() {
 }
 
 func ExampleServicedCLI_CmdPublicEndpointsVHostEnable_InvalidService() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "vhost", "enable", "invalid", "zproxy", "zproxy", "true")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "vhost", "enable", "invalid", "zproxy", "zproxy", "true")
+	})
 
 	// Output:
 	// service not found
 }
 
 func ExampleServicedCLI_CmdPublicEndpointsVHostEnable_InvalidEnableFlag() {
-	pipeStderr(InitPublicEndpointPortTest, "serviced", "service", "public-endpoints", "vhost", "enable", "Zenoss", "zproxy", "zproxy", "invalid")
+	pipeStderr(func() {
+		InitPublicEndpointPortTest("serviced", "service", "public-endpoints", "vhost", "enable", "Zenoss", "zproxy", "zproxy", "invalid")
+	})
 
 	// Output:
 	// The enabled flag must be true or false

--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -379,7 +379,7 @@ func TestServicedCLI_CmdServiceList_one(t *testing.T) {
 	}
 
 	var actual service.Service
-	output := pipe(InitServiceAPITest, "serviced", "service", "list", serviceID)
+	output := captureStdout(func() { InitServiceAPITest("serviced", "service", "list", serviceID) })
 	if err := json.Unmarshal(output, &actual); err != nil {
 		t.Fatalf("error unmarshaling resource: %s", err)
 	}
@@ -397,7 +397,7 @@ func TestServicedCLI_CmdServiceList_all(t *testing.T) {
 	}
 
 	var actual []*service.Service
-	output := pipe(InitServiceAPITest, "serviced", "service", "list", "--verbose")
+	output := captureStdout(func() { InitServiceAPITest("serviced", "service", "list", "--verbose") })
 	if err := json.Unmarshal(output, &actual); err != nil {
 		t.Fatalf("error unmarshaling resource: %s", err)
 	}
@@ -422,9 +422,9 @@ func ExampleServicedCLI_CmdServiceList_fail() {
 	DefaultServiceAPITest.errs["GetServices"] = ErrInvalidService
 	defer func() { DefaultServiceAPITest.errs["GetServices"] = nil }()
 	// Error retrieving service
-	pipeStderr(InitServiceAPITest, "serviced", "service", "list", "test-service-0")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "list", "test-service-0") })
 	// Error retrieving all services
-	pipeStderr(InitServiceAPITest, "serviced", "service", "list")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "list") })
 
 	// Output:
 	// invalid service
@@ -435,9 +435,9 @@ func ExampleServicedCLI_CmdServiceList_err() {
 	DefaultServiceAPITest.services = nil
 	defer func() { DefaultServiceAPITest.services = DefaultTestServices }()
 	// Service not found
-	pipeStderr(InitServiceAPITest, "serviced", "service", "list", "test-service-0")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "list", "test-service-0") })
 	// No Services found
-	pipeStderr(InitServiceAPITest, "serviced", "service", "list")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "list") })
 
 	// Output:
 	// service not found
@@ -488,21 +488,27 @@ func ExampleServicedCLI_CmdServiceAdd_usage() {
 func ExampleServicedCLI_CmdServiceAdd_fail() {
 	DefaultServiceAPITest.errs["AddService"] = ErrStub
 	defer func() { DefaultServiceAPITest.errs["AddService"] = nil }()
-	pipeStderr(InitServiceAPITest, "serviced", "service", "add", "--parent-id", "test-service-1", "test-service", "test-image", "bash -c lsof")
+	pipeStderr(func() {
+		InitServiceAPITest("serviced", "service", "add", "--parent-id", "test-service-1", "test-service", "test-image", "bash -c lsof")
+	})
 
 	// Output:
 	// stub for facade failed
 }
 
 func ExampleServicedCLI_CmdServiceAdd_missingParentArg() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "add", "test-service", "test-pool", "test-image", "bash -c lsof")
+	pipeStderr(func() {
+		InitServiceAPITest("serviced", "service", "add", "test-service", "test-pool", "test-image", "bash -c lsof")
+	})
 
 	// Output:
 	// Must specify a parent service ID
 }
 
 func ExampleServicedCLI_CmdServiceAdd_parentNotFound() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "add", "--parent-id", "test-parent", NilService, "test-image", "bash -c lsof")
+	pipeStderr(func() {
+		InitServiceAPITest("serviced", "service", "add", "--parent-id", "test-parent", NilService, "test-image", "bash -c lsof")
+	})
 
 	// Output:
 	// Error searching for parent service: service not found
@@ -537,7 +543,7 @@ func ExampleServicedCLI_CmdServiceRemove_usage() {
 }
 
 func ExampleServicedCLI_CmdServiceRemove_err() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "remove", "test-service-0")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "remove", "test-service-0") })
 
 	// Output:
 	// service not found
@@ -547,7 +553,7 @@ func ExampleServicedCLI_CmdServiceRemove_failed() {
 	DefaultServiceAPITest.errs["RemoveService"] = ErrStub
 	defer func() { DefaultServiceAPITest.errs["RemoveService"] = nil }()
 
-	pipeStderr(InitServiceAPITest, "serviced", "service", "remove", "test-service-1")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "remove", "test-service-1") })
 
 	// Output:
 	// test-service-1: stub for facade failed
@@ -599,7 +605,7 @@ func ExampleServicedCLI_CmdServiceEdit_fail() {
 	DefaultServiceAPITest.errs["GetServices"] = ErrInvalidService
 	defer func() { DefaultServiceAPITest.errs["GetServices"] = nil }()
 	// Failed to get service
-	pipeStderr(InitServiceAPITest, "serviced", "service", "edit", "test-service-0")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "edit", "test-service-0") })
 	// TODO: Failed to update service
 
 	// Output:
@@ -608,7 +614,7 @@ func ExampleServicedCLI_CmdServiceEdit_fail() {
 
 func ExampleServicedCLI_CmdServiceEdit_err() {
 	// Service not found
-	pipeStderr(InitServiceAPITest, "serviced", "service", "edit", "test-service-0")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "edit", "test-service-0") })
 	// TODO: Nil Service after update
 
 	// Output:
@@ -646,14 +652,14 @@ func ExampleServicedCLI_CmdServiceAssignIPs_usage() {
 func ExampleServicedCLI_CmdServiceAssignIPs_fail() {
 	DefaultServiceAPITest.errs["AssignIP"] = ErrInvalidService
 	defer func() { DefaultServiceAPITest.errs["AssignIP"] = nil }()
-	pipeStderr(InitServiceAPITest, "serviced", "service", "assign-ip", "test-service-3")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "assign-ip", "test-service-3") })
 
 	// Output:
 	// invalid service
 }
 
 func ExampleServicedCLI_CmdServiceAssignIPs_err() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "assign-ip", "test-service-0", "100.99.88.1")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "assign-ip", "test-service-0", "100.99.88.1") })
 
 	// Output:
 	// service not found
@@ -682,14 +688,14 @@ func ExampleServicedCLI_CmdServiceStart_usage() {
 func ExampleServicedCLI_CmdServiceStart_fail() {
 	DefaultServiceAPITest.errs["StartService"] = ErrStub
 	defer func() { DefaultServiceAPITest.errs["StartService"] = nil }()
-	pipeStderr(InitServiceAPITest, "serviced", "service", "start", "test-service-1")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "start", "test-service-1") })
 
 	// Output:
 	// stub for facade failed
 }
 
 func ExampleServicedCLI_CmdServiceStart_err() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "start", "test-service-0")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "start", "test-service-0") })
 
 	// Output:
 	// service not found
@@ -725,17 +731,17 @@ func ExampleServicedCLI_CmdServiceRestart_usage() {
 func ExampleServicedCLI_CmdServiceRestart_fail() {
 	DefaultServiceAPITest.errs["RestartService"] = ErrStub
 	defer func() { DefaultServiceAPITest.errs["RestartService"] = nil }()
-	pipeStderr(InitServiceAPITest, "serviced", "service", "restart", "test-service-1")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "restart", "test-service-1") })
 
 	// Output:
 	// stub for facade failed
 }
 
 func ExampleServicedCLI_CmdServiceRestart_err() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "restart", "test-service-0")    // Non-existant service
-	pipeStderr(InitServiceAPITest, "serviced", "service", "restart", "test-service-3/4")  // Non-existant instance
-	pipeStderr(InitServiceAPITest, "serviced", "service", "restart", "test-service-3/a")  // Non-numeric instance number
-	pipeStderr(InitServiceAPITest, "serviced", "service", "restart", "test-service-3/0b") // Non-numeric instance number
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "restart", "test-service-0") })    // Non-existant service
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "restart", "test-service-3/4") })  // Non-existant instance
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "restart", "test-service-3/a") })  // Non-numeric instance number
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "restart", "test-service-3/0b") }) // Non-numeric instance number
 
 	// Output:
 	// service not found
@@ -774,7 +780,7 @@ func ExampleServicedCLI_CmdServiceStop_usage() {
 }
 
 func ExampleServicedCLI_CmdServiceStop_err() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "stop", "test-service-0")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "stop", "test-service-0") })
 
 	// Output:
 	// service not found
@@ -849,7 +855,7 @@ func ExampleServicedCLI_CmdServiceShell_usage() {
 */
 
 func ExampleServicedCLI_CmdServiceShell_err() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "shell", "test-service-0", "some", "command")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "shell", "test-service-0", "some", "command") })
 
 	// Output:
 	// service not found
@@ -857,7 +863,7 @@ func ExampleServicedCLI_CmdServiceShell_err() {
 }
 
 /*func ExampleServicedCLI_CmdServiceRun_list() {
-	output := pipe(InitServiceAPITest, "serviced", "service", "run", "test-service-1")
+	output := captureStdout(func(){InitServiceAPITest( "serviced", "service", "run", "test-service-1")})
 	actual := strings.Split(string(output[:]), "\n")
 	sort.Strings(actual)
 
@@ -921,7 +927,7 @@ func ExampleServicedCLI_CmdServiceRun_usage() {
 */
 
 func ExampleServicedCLI_CmdServiceRun_err() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "run", "test-service-0", "goodbye")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "run", "test-service-0", "goodbye") })
 
 	// Output:
 	// service not found
@@ -958,7 +964,7 @@ func ExampleServicedCLI_CmdServiceListSnapshots() {
 }
 
 func TestServicedCLI_CmdServiceListSnapshots_ShowTagsShort(t *testing.T) {
-	output := pipe(InitServiceAPITest, "serviced", "service", "list-snapshots", "test-service-1", "-t")
+	output := captureStdout(func() { InitServiceAPITest("serviced", "service", "list-snapshots", "test-service-1", "-t") })
 	expected :=
 		"Snapshot                                 Description        Tags" +
 			"\ntest-service-1-snapshot-1                description 1      tag-1" +
@@ -974,7 +980,7 @@ func TestServicedCLI_CmdServiceListSnapshots_ShowTagsShort(t *testing.T) {
 }
 
 func TestServicedCLI_CmdServiceListSnapshots_ShowTagsLong(t *testing.T) {
-	output := pipe(InitServiceAPITest, "serviced", "service", "list-snapshots", "test-service-1", "--show-tags")
+	output := captureStdout(func() { InitServiceAPITest("serviced", "service", "list-snapshots", "test-service-1", "--show-tags") })
 	expected :=
 		"Snapshot                                 Description        Tags" +
 			"\ntest-service-1-snapshot-1                description 1      tag-1" +
@@ -1011,14 +1017,14 @@ func ExampleServicedCLI_CmdServiceListSnapshots_usage() {
 func ExampleServicedCLI_CmdServiceListSnapshots_fail() {
 	DefaultServiceAPITest.errs["GetSnapshotsByServiceID"] = ErrStub
 	defer func() { DefaultServiceAPITest.errs["GetSnapshotsByServiceID"] = nil }()
-	pipeStderr(InitServiceAPITest, "serviced", "service", "list-snapshots", "test-service-1")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "list-snapshots", "test-service-1") })
 
 	// Output:
 	// stub for facade failed
 }
 
 func ExampleServicedCLI_CmdServiceListSnapshots_err() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "list-snapshots", "test-service-3")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "list-snapshots", "test-service-3") })
 
 	// Output:
 	// no snapshots found
@@ -1069,14 +1075,14 @@ func ExampleServicedCLI_CmdServiceSnapshot_usage() {
 func ExampleServicedCLI_CmdServiceSnapshot_fail() {
 	DefaultServiceAPITest.errs["AddSnapshot"] = ErrStub
 	defer func() { DefaultServiceAPITest.errs["AddSnapshot"] = nil }()
-	pipeStderr(InitServiceAPITest, "serviced", "service", "snapshot", "test-service-1")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "snapshot", "test-service-1") })
 
 	// Output:
 	// stub for facade failed
 }
 
 func ExampleServicedCLI_CmdServiceSnapshot_err() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "snapshot", "test-service-0")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "snapshot", "test-service-0") })
 
 	// Output:
 	// service not found
@@ -1105,21 +1111,21 @@ func ExampleServicedCLI_CmdServiceEndpoints_usage() {
 }
 
 func ExampleServicedCLI_CmdServiceEndpoints_err() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "endpoints", "test-service-0")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "endpoints", "test-service-0") })
 
 	// Output:
 	// service not found
 }
 
 func ExampleServicedCLI_CmdServiceEndpoints_worksNoEndpoints() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "endpoints", "test-service-1")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "endpoints", "test-service-1") })
 
 	// Output:
 	// Zenoss - no endpoints defined
 }
 
 func ExampleServicedCLI_CmdServiceEndpoints_works() {
-	pipeStderr(InitServiceAPITest, "serviced", "service", "endpoints", "test-service-2")
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "endpoints", "test-service-2") })
 
 	// Output:
 	// Name    ServiceID         Endpoint         Purpose    Host       HostIP     HostPort    ContainerID     ContainerIP     ContainerPort

--- a/cli/cmd/snapshot_test.go
+++ b/cli/cmd/snapshot_test.go
@@ -193,7 +193,7 @@ func ExampleServicedCLI_CmdSnapshotList() {
 }
 
 func TestServicedCLI_CmdSnapshotList_ShowTagsShort(t *testing.T) {
-	output := pipe(InitSnapshotAPITest, "serviced", "snapshot", "list", "-t")
+	output := captureStdout(func() { InitSnapshotAPITest("serviced", "snapshot", "list", "-t") })
 	expected :=
 		"Snapshot                                 Description        Tags" +
 			"\ntest-service-1-snapshot-1                description 1      tag-1" +
@@ -211,7 +211,7 @@ func TestServicedCLI_CmdSnapshotList_ShowTagsShort(t *testing.T) {
 }
 
 func TestServicedCLI_CmdSnapshotList_ShowTagsLong(t *testing.T) {
-	output := pipe(InitSnapshotAPITest, "serviced", "snapshot", "list", "--show-tags")
+	output := captureStdout(func() { InitSnapshotAPITest("serviced", "snapshot", "list", "--show-tags") })
 	expected :=
 		"Snapshot                                 Description        Tags" +
 			"\ntest-service-1-snapshot-1                description 1      tag-1" +
@@ -238,7 +238,7 @@ func ExampleServicedCLI_CmdSnapshotList_byServiceID() {
 }
 
 func TestServicedCLI_CmdSnapshotList_byServiceID_ShowTagsShort(t *testing.T) {
-	output := pipe(InitSnapshotAPITest, "serviced", "snapshot", "list", "test-service-1", "-t")
+	output := captureStdout(func() { InitSnapshotAPITest("serviced", "snapshot", "list", "test-service-1", "-t") })
 	expected :=
 		"Snapshot                                 Description        Tags" +
 			"\ntest-service-1-snapshot-1                description 1      tag-1" +
@@ -255,7 +255,7 @@ func TestServicedCLI_CmdSnapshotList_byServiceID_ShowTagsShort(t *testing.T) {
 }
 
 func TestervicedCLI_CmdSnapshotList_byServiceID_ShowTagsLong(t *testing.T) {
-	output := pipe(InitSnapshotAPITest, "serviced", "snapshot", "list", "test-service-1", "--show-tags")
+	output := captureStdout(func() { InitSnapshotAPITest("serviced", "snapshot", "list", "test-service-1", "--show-tags") })
 	expected :=
 		"Snapshot                                 Description        Tags" +
 			"\ntest-service-1-snapshot-1                description 1      tag-1" +
@@ -274,13 +274,13 @@ func ExampleServicedCLI_CmdSnapshotList_fail() {
 	DefaultSnapshotAPITest.fail = true
 	defer func() { DefaultSnapshotAPITest.fail = false }()
 	// failed to retrieve all snapshots
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "list")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "list") })
 	// failed to retrieve all snapshots by service id
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "list", "test-service-1")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "list", "test-service-1") })
 	// failed to retrieve all snapshots with tags
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "list", "-t")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "list", "-t") })
 	// failed to retrieve all snapshots with tags by service id
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "list", "test-service-1", "-t")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "list", "test-service-1", "-t") })
 
 	// Output:
 	// invalid snapshot
@@ -293,13 +293,13 @@ func ExampleServicedCLI_CmdSnapshotList_err() {
 	DefaultSnapshotAPITest.snapshots = nil
 	defer func() { DefaultSnapshotAPITest.snapshots = DefaultTestSnapshots }()
 	// no snapshots found
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "list")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "list") })
 	// no snapshots found for service id
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "list", "test-service-1")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "list", "test-service-1") })
 	// no snapshots found with tags
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "list", "-t")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "list", "-t") })
 	// no snapshots found with tags for service id
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "list", "test-service-1", "-t")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "list", "test-service-1", "-t") })
 
 	// Output:
 	// no snapshots found
@@ -355,7 +355,7 @@ this command exits 1 which fails the test runner
 func ExampleServicedCLI_CmdSnapshotAdd_fail() {
 	DefaultSnapshotAPITest.fail = true
 	defer func() { DefaultSnapshotAPITest.fail = false }()
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "add", "test-service-2")
+	pipeStderr(func(){InitSnapshotAPITest( "serviced", "snapshot", "add", "test-service-2")})
 
 	// Output:
 	// invalid snapshot
@@ -365,7 +365,7 @@ func ExampleServicedCLI_CmdSnapshotAdd_fail() {
 /*
 this command exits 1 which fails the test runner
 func ExampleServicedCLI_CmdSnapshotAdd_err() {
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "add", NilSnapshot)
+	pipeStderr(func(){InitSnapshotAPITest( "serviced", "snapshot", "add", NilSnapshot)})
 
 	// Output:
 	// received nil snapshot
@@ -429,7 +429,7 @@ func ExampleServicedCLI_CmdSnapshotRemove_usage() {
 }
 
 func ExampleServicedCLI_CmdSnapshotRemove_BadID() {
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "remove", "test-service-0-snapshot")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "remove", "test-service-0-snapshot") })
 
 	// Output:
 	// no snapshot found
@@ -445,7 +445,7 @@ func ExampleServicedCLI_CmdSnapshotRemove_nomatch_Tag() {
 func ExampleServicedCLI_CmdSnapshotRemove_error() {
 	DefaultSnapshotAPITest.fail = true
 	defer func() { DefaultSnapshotAPITest.fail = false }()
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "remove", "test-service-1-snapshot-1")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "remove", "test-service-1-snapshot-1") })
 
 	// Output:
 	// invalid snapshot
@@ -454,7 +454,7 @@ func ExampleServicedCLI_CmdSnapshotRemove_error() {
 func ExampleServicedCLI_CmdSnapshotRemove_errorGetByTag() {
 	DefaultSnapshotAPITest.getByTagFail = true
 	defer func() { DefaultSnapshotAPITest.getByTagFail = false }()
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "remove", "test-service-1", "tag-1")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "remove", "test-service-1", "tag-1") })
 
 	// Output:
 	// unable to retrieve snapshot by tag name
@@ -488,14 +488,14 @@ func ExampleServicedCLI_CmdSnapshotCommit_usage() {
 func ExampleServicedCLI_CmdSnapshotCommit_fail() {
 	DefaultSnapshotAPITest.fail = true
 	defer func() { DefaultSnapshotAPITest.fail = false }()
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "commit", "ABC123")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "commit", "ABC123") })
 
 	// Output:
 	// invalid snapshot
 }
 
 func ExampleServicedCLI_CmdSnapshotCommit_err() {
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "commit", NilSnapshot)
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "commit", NilSnapshot) })
 
 	// Output:
 	// received nil snapshot
@@ -530,7 +530,7 @@ func ExampleServicedCLI_CmdSnapshotRollback_usage() {
 /*
 this command exits 1 which fails the test runner
 func ExampleServicedCLI_CmdSnapshotRollback_err() {
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "rollback", "test-service-0-snapshot")
+	pipeStderr(func(){InitSnapshotAPITest( "serviced", "snapshot", "rollback", "test-service-0-snapshot")})
 
 	// Output:
 	// no snapshot found
@@ -564,7 +564,7 @@ func ExampleServicedCLI_CmdSnapshotTag() {
 }
 
 func ExampleServicedCLI_CmdSnapshotTag_err() {
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "tag", "test-service-0-snapshot", "tag-A")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "tag", "test-service-0-snapshot", "tag-A") })
 
 	// Output:
 	// no snapshot found
@@ -573,7 +573,7 @@ func ExampleServicedCLI_CmdSnapshotTag_err() {
 func ExampleServicedCLI_CmdSnapshotTag_fail() {
 	DefaultSnapshotAPITest.fail = true
 	defer func() { DefaultSnapshotAPITest.fail = false }()
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "tag", "test-service-1-snapshot-1", "tag-A")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "tag", "test-service-1-snapshot-1", "tag-A") })
 
 	// Output:
 	// invalid snapshot
@@ -582,7 +582,7 @@ func ExampleServicedCLI_CmdSnapshotTag_fail() {
 func ExampleServicedCLI_CmdSnapshotTag_btrfsFail() {
 	DefaultSnapshotAPITest.btrfsFail = true
 	defer func() { DefaultSnapshotAPITest.btrfsFail = false }()
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "tag", "test-service-1-snapshot-1", "tag-A")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "tag", "test-service-1-snapshot-1", "tag-A") })
 
 	// Output:
 	// operation not supported on btrfs driver
@@ -596,7 +596,7 @@ func ExampleServicedCLI_CmdSnapshotUntag() {
 }
 
 func ExampleServicedCLI_CmdSnapshotUntag_err() {
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "untag", "test-service-0", "tag-A")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "untag", "test-service-0", "tag-A") })
 
 	// Output:
 	// no snapshot found
@@ -605,7 +605,7 @@ func ExampleServicedCLI_CmdSnapshotUntag_err() {
 func ExampleServicedCLI_CmdSnapshotUntag_fail() {
 	DefaultSnapshotAPITest.fail = true
 	defer func() { DefaultSnapshotAPITest.fail = false }()
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "untag", "test-service-1", "tag-2")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "untag", "test-service-1", "tag-2") })
 
 	// Output:
 	// invalid snapshot
@@ -614,7 +614,7 @@ func ExampleServicedCLI_CmdSnapshotUntag_fail() {
 func ExampleServicedCLI_CmdSnapshotUntag_btrfsFail() {
 	DefaultSnapshotAPITest.btrfsFail = true
 	defer func() { DefaultSnapshotAPITest.btrfsFail = false }()
-	pipeStderr(InitSnapshotAPITest, "serviced", "snapshot", "untag", "test-service-1", "tag-A")
+	pipeStderr(func() { InitSnapshotAPITest("serviced", "snapshot", "untag", "test-service-1", "tag-A") })
 
 	// Output:
 	// operation not supported on btrfs driver

--- a/cli/cmd/template_test.go
+++ b/cli/cmd/template_test.go
@@ -141,7 +141,7 @@ func TestServicedCLI_CmdTemplateList_one(t *testing.T) {
 	}
 
 	var actual template.ServiceTemplate
-	output := pipe(InitTemplateAPITest, "serviced", "template", "list", templateID)
+	output := captureStdout(func() { InitTemplateAPITest("serviced", "template", "list", templateID) })
 
 	if err := json.Unmarshal(output, &actual); err != nil {
 		t.Fatalf("error unmarshaling resource: %s", err)
@@ -160,7 +160,7 @@ func TestServicedCLI_CmdTemplateList_all(t *testing.T) {
 	}
 
 	var actual []*template.ServiceTemplate
-	output := pipe(InitTemplateAPITest, "serviced", "template", "list", "--verbose")
+	output := captureStdout(func() { InitTemplateAPITest("serviced", "template", "list", "--verbose") })
 	if err := json.Unmarshal(output, &actual); err != nil {
 		t.Fatalf("error unmarshaling resource: %s", err)
 	}
@@ -185,9 +185,9 @@ func ExampleServicedCLI_CmdTemplateList_fail() {
 	DefaultTemplateAPITest.fail = true
 	defer func() { DefaultTemplateAPITest.fail = false }()
 	// Error retrieving template
-	pipeStderr(InitTemplateAPITest, "serviced", "template", "list", "test-template-1")
+	pipeStderr(func() { InitTemplateAPITest("serviced", "template", "list", "test-template-1") })
 	// Error retrieving all templates
-	pipeStderr(InitTemplateAPITest, "serviced", "template", "list")
+	pipeStderr(func() { InitTemplateAPITest("serviced", "template", "list") })
 
 	// Output:
 	// invalid template
@@ -198,9 +198,9 @@ func ExampleServicedCLI_CmdTemplateList_err() {
 	DefaultTemplateAPITest.templates = nil
 	defer func() { DefaultTemplateAPITest.templates = DefaultTestTemplates }()
 	// template not found
-	pipeStderr(InitTemplateAPITest, "serviced", "template", "list", "test-template-0")
+	pipeStderr(func() { InitTemplateAPITest("serviced", "template", "list", "test-template-0") })
 	// no templates found
-	pipeStderr(InitTemplateAPITest, "serviced", "template", "list")
+	pipeStderr(func() { InitTemplateAPITest("serviced", "template", "list") })
 
 	// Output:
 	// template not found
@@ -245,7 +245,7 @@ func ExampleServicedCLI_CmdTemplateRemove_usage() {
 }
 
 func ExampleServicedCLI_CmdTemplateRemove_err() {
-	pipeStderr(InitTemplateAPITest, "serviced", "template", "remove", "test-template-0")
+	pipeStderr(func() { InitTemplateAPITest("serviced", "template", "remove", "test-template-0") })
 
 	// Output:
 	// test-template-0: no templates found
@@ -280,7 +280,9 @@ func ExampleServicedCLI_CmdTemplateDeploy_usage() {
 func ExampleServicedCLI_CmdTemplateDeploy_fail() {
 	DefaultTemplateAPITest.fail = true
 	defer func() { DefaultTemplateAPITest.fail = false }()
-	pipeStderr(InitTemplateAPITest, "serviced", "template", "deploy", "test-template-1", "test-pool", "deployment-id")
+	pipeStderr(func() {
+		InitTemplateAPITest("serviced", "template", "deploy", "test-template-1", "test-pool", "deployment-id")
+	})
 
 	// Output:
 	// Deploying template - please wait...
@@ -288,7 +290,9 @@ func ExampleServicedCLI_CmdTemplateDeploy_fail() {
 }
 
 func ExampleServicedCLI_CmdTemplateDeploy_err() {
-	pipeStderr(InitTemplateAPITest, "serviced", "template", "deploy", NilTemplate, "test-pool", "deployment-id")
+	pipeStderr(func() {
+		InitTemplateAPITest("serviced", "template", "deploy", NilTemplate, "test-pool", "deployment-id")
+	})
 
 	// Output:
 	// Deploying template - please wait...
@@ -304,7 +308,7 @@ func TestServicedCLI_CmdTemplateCompile(t *testing.T) {
 	}
 
 	var actual template.ServiceTemplate
-	output := pipe(InitTemplateAPITest, "serviced", "template", "compile", dir)
+	output := captureStdout(func() { InitTemplateAPITest("serviced", "template", "compile", dir) })
 	if err := json.Unmarshal(output, &actual); err != nil {
 		t.Fatalf("error unmarshaling resource: %s", err)
 	}
@@ -337,14 +341,14 @@ func ExampleServicedCLI_CmdTemplateCompile_usage() {
 func ExampleServicedCLI_CmdTemplateCompile_fail() {
 	DefaultTemplateAPITest.fail = true
 	defer func() { DefaultTemplateAPITest.fail = false }()
-	pipeStderr(InitTemplateAPITest, "serviced", "template", "compile", "/path/to/template")
+	pipeStderr(func() { InitTemplateAPITest("serviced", "template", "compile", "/path/to/template") })
 
 	// Output:
 	// invalid template
 }
 
 func ExampleServicedCLI_CmdTemplateCompile_err() {
-	pipeStderr(InitTemplateAPITest, "serviced", "template", "compile", NilTemplate)
+	pipeStderr(func() { InitTemplateAPITest("serviced", "template", "compile", NilTemplate) })
 
 	// Output:
 	// received nil template


### PR DESCRIPTION
Previously, cmd.pipe() took as arguments a function with a variadic string parameter, and a variadic string parameter.  The function was called with the strings.

After this change, the pipe function (which has been renamed to captureStdout) takes a single parameterless function instead.  This prevents the proliferation of pipe functions, each taking different
arguments (e.g., pipeAPI).  To pass parameters to the function, a closure can be formed from an anonymous function.

Also created a captureStderr which operates in a parallel fashion, and refactored pipeStderr to take a single parameterless function and use captureStderr.

This design makes it easy to capture the output streams from an arbitrary function.