### PR TITLE
Remove last v1 api thingies from ServiceDetailsController

### DIFF
--- a/domain/host/host.go
+++ b/domain/host/host.go
@@ -96,6 +96,7 @@ type ReadServiced struct {
 
 type HostStatus struct {
 	HostID        string
+	HostName      string
 	MemoryUsage   service.Usage
 	Active        bool
 	Authenticated bool

--- a/facade/host.go
+++ b/facade/host.go
@@ -401,7 +401,7 @@ func (f *Facade) GetHostStatuses(ctx datastore.Context, hostIDs []string, since 
 			continue
 		}
 
-		status := host.HostStatus{HostID: id, MemoryUsage: service.Usage{}}
+		status := host.HostStatus{HostID: id, HostName: h.Name, MemoryUsage: service.Usage{}}
 		active, err := f.zzk.IsHostActive(h.PoolID, h.ID)
 		if err != nil {
 			continue

--- a/web/ui/src/Hosts/HostsController.js
+++ b/web/ui/src/Hosts/HostsController.js
@@ -174,7 +174,7 @@
                         utils.validatePortNumber(modalScope.newHost.port, $translate) ||
                         utils.validateRAMLimit(modalScope.newHost.RAMLimit);
                     if(err){
-                        $notification.create("Error", err).error();
+                        this.createNotification("Error", err).error();
                         return false;
                     }
                     return true;

--- a/web/ui/src/Nav/NavbarController.js
+++ b/web/ui/src/Nav/NavbarController.js
@@ -33,7 +33,6 @@
             { url: '#/apps', label: 'nav_apps', sublinks: [ '#/services/'] },
             { url: '#/pools', label: 'nav_pools', sublinks: [ '#/pools/' ] },
             { url: '#/hosts', label: 'nav_hosts', sublinks: [ '#/hosts/' ] },
-            { url: '#/status', label: 'nav_status', sublinks: [ '#/status/' ] },
             { url: logSearchLink, label: 'nav_logs', sublinks: [], target: "_blank" },
             { url: '#/backuprestore', label: 'nav_backuprestore', sublinks: [] }
         ];

--- a/web/ui/src/Pools/Pool.js
+++ b/web/ui/src/Pools/Pool.js
@@ -42,9 +42,7 @@
             if (this.hosts && !force) {
                 deferred.resolve();
             }
-            // TODO - this is actually a v2 endpoint
-            // and should be on resourcesFactory.v2
-            resourcesFactory.getPoolHosts(this.id)
+            resourcesFactory.v2.getPoolHosts(this.id)
                 .then(data => {
                     this.hosts = data.map(h => new Host(h));
                     this.touch();

--- a/web/ui/src/Pools/PoolDetailsController.js
+++ b/web/ui/src/Pools/PoolDetailsController.js
@@ -171,7 +171,6 @@
 
         // update/refresh current pools data
         function update(){
-            // TODO - use v2 endpoint once its in
             return resourcesFactory.getPool($scope.params.poolID)
                 .success(pool => setCurrentPool(pool));
         }

--- a/web/ui/src/Services/ServiceDetailsController.js
+++ b/web/ui/src/Services/ServiceDetailsController.js
@@ -775,9 +775,9 @@
                         });
                 };
 
-
+                $scope.hostNames = {};
                 $scope.getHostName = function (id) {
-                    return "I DONT KNOW";
+                    return $scope.hostNames[id];
                 };
 
                 // expand/collapse state of service tree nodes
@@ -1103,6 +1103,22 @@
                     };
 
                     $scope.ips = {};
+
+                    // get host status to create a map of
+                    // host id to name
+                    (function getHostNames(){
+                        resourcesFactory.v2.getHostStatuses()
+                            .then(result => {
+                                $scope.hostNames = result.reduce((acc,s) => {
+                                    acc[s.HostID] = s.HostName;
+                                    return acc;
+                                }, {});
+                            })
+                            .catch(err => {
+                                console.warn("Could not fetch host names, retrying in 1s", err);
+                                $timeout(getHostNames, 1000);
+                            });
+                    })();
 
                     // if the current service changes, update
                     // various service controller thingies

--- a/web/ui/src/Services/edit-service.html
+++ b/web/ui/src/Services/edit-service.html
@@ -2,35 +2,35 @@
   <label for="new_service_name">
       <span translate>label_service_name</span>:
   </label>
-  <input class="form-control" focusme id="new_service_name" type="text" placeholder="{{'placeholder_service_name'|translate}}" ng-model="editableService.Name">
+  <input class="form-control" focusme id="new_service_name" type="text" placeholder="{{'placeholder_service_name'|translate}}" ng-model="model.Name">
 </div>
 
 <div class="form-group">
     <label for="new_service_description">
         <span translate>label_service_description</span>:
     </label>
-    <textarea class="form-control" id="new_service_description" placeholder="{{'placeholder_service_description'|translate}}" rows="3" ng-model="editableService.Description"></textarea>
+    <textarea class="form-control" id="new_service_description" placeholder="{{'placeholder_service_description'|translate}}" rows="3" ng-model="model.Description"></textarea>
 </div>
 
 <div class="form-group">
     <label for="edit_instances">
         <span translate>label_service_instances</span>:
     </label>
-    <input class="form-control" id="edit_instances" type="number" min="{{editableService.InstanceLimits.Min ? editableService.InstanceLimits.Min : 0}}" max="{{editableService.InstanceLimits.Max ? editableService.InstanceLimits.Max : undefined}}" style="width: 75px;" ng-model="editableService.Instances">
+    <input class="form-control" id="edit_instances" type="number" min="{{model.InstanceLimits.Min ? model.InstanceLimits.Min : 0}}" max="{{model.InstanceLimits.Max ? model.InstanceLimits.Max : undefined}}" style="width: 75px;" ng-model="model.Instances">
 </div>
 
 <div class="form-group">
   <label for="new_service_ram_commitment">
       <span translate>ram_commitment</span> (eg 256M): <span class="warningMessage">*</span>
   </label>
-  <input class="form-control" id="new_service_ram_commitment" type="text" placeholder="256M" ng-model="editableService.RAMCommitment">
+  <input class="form-control" id="new_service_ram_commitment" type="text" placeholder="256M" ng-model="model.RAMCommitment">
 </div>
 
 <div class="form-group">
     <label for="edit_service_pool">
         <span translate>label_service_pool</span>: <span class="warningMessage">*</span>
     </label>
-    <select class="form-control" name="edit_service_pool" id="new_host_parent" ng-model="editableService.PoolID"
+    <select class="form-control" name="edit_service_pool" id="new_host_parent" ng-model="model.PoolID"
         ng-options="pool.id as pool.id for pool in pools">
     </select>
 </div>
@@ -39,7 +39,7 @@
   <label for="new_service_startup">
       <span translate>label_service_startup</span>: <span class="warningMessage">*</span>
   </label>
-  <input class="form-control" id="new_service_startup" type="text" placeholder="{{'placeholder_service_startup'|translate}}" ng-model="editableService.Startup">
+  <input class="form-control" id="new_service_startup" type="text" placeholder="{{'placeholder_service_startup'|translate}}" ng-model="model.Startup">
 </div>
 
 <br>

--- a/web/ui/src/common/resourcesFactory.js
+++ b/web/ui/src/common/resourcesFactory.js
@@ -55,26 +55,9 @@
                 method: GET,
                 url: id => `/pools/${id}`
             },
-            getV2Pools: {
-                method: GET,
-                url: "/api/v2/pools",
-            },
             getPoolIPs: {
                 method: GET,
                 url: id => `/pools/${id}/ips`
-            },
-            // TODO - MOVE THIS WHEN THE V2 API
-            // OBJECT IS IN!
-            getPoolHosts: {
-                method: GET,
-                url: id => `/api/v2/pools/${id}/hosts`
-            },
-            // TODO - MOVE THIS WHEN THE V2 API
-            // OBJECT IS IN!
-            getHostStatuses: {
-                method: GET,
-                url: id => `/api/v2/hoststatuses`,
-                ignorePending: true
             },
             addVHost: {
                 method: PUT,
@@ -321,6 +304,10 @@
             getPools: {
                 method: GET,
                 url: () => `/api/v2/pools`,
+            },
+            getPoolHosts: {
+                method: GET,
+                url: id => `/api/v2/pools/${id}/hosts`
             },
             getHosts: {
                 method: GET,


### PR DESCRIPTION
There were a few little bits of thingies that used the super expensive v1 endpoints in the ServiceDetailsController that needed to be removed:

* pools are now loaded when "edit service" is clicked instead of on page load
* host names are looked up from the (small/fast) host status object and cached
* a few TODOs were resolved for moving v1/v2 calls around