### PR TITLE
CLI serviced host list should indicate whether the host is authenticated

### DIFF
--- a/cli/api/apimocks/API.go
+++ b/cli/api/apimocks/API.go
@@ -1278,3 +1278,45 @@ func (_m *API) SendDockerAction(serviceID string, instanceID int, action string,
 
 	return r0
 }
+func (_m *API) GetHostWithAuthInfo(_a0 string) (*api.AuthHost, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *api.AuthHost
+	if rf, ok := ret.Get(0).(func(string) *api.AuthHost); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.AuthHost)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *API) GetHostsWithAuthInfo() ([]api.AuthHost, error) {
+	ret := _m.Called()
+
+	var r0 []api.AuthHost
+	if rf, ok := ret.Get(0).(func() []api.AuthHost); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]api.AuthHost)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -50,6 +50,8 @@ type API interface {
 	WriteDelegateKey(string, []byte) error
 	AuthenticateHost(string) (string, int64, error)
 	ResetHostKey(string) ([]byte, error)
+	GetHostWithAuthInfo(string) (*AuthHost, error)
+	GetHostsWithAuthInfo() ([]AuthHost, error)
 
 	// Pools
 	GetResourcePools() ([]pool.ResourcePool, error)

--- a/cli/cmd/cmd_logging_test.go
+++ b/cli/cmd/cmd_logging_test.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/control-center/serviced/cli/api"
 	mockapi "github.com/control-center/serviced/cli/api/apimocks"
-	"github.com/control-center/serviced/domain/host"
 	mocklog "github.com/control-center/serviced/logging/mocks"
 	"github.com/control-center/serviced/utils"
 	"github.com/stretchr/testify/mock"
@@ -53,7 +53,7 @@ func (s *CmdLoggingSuite) Test_LoadsCliDefaultConfigFile(c *C) {
 	expected := "/opt/serviced/etc/logconfig-cli.yaml"
 	s.log.On("ApplyConfigFromFile", expected).Return(nil)
 	s.log.On("WatchConfigFile", expected).Return(nil)
-	s.api.On("GetHosts").Return([]host.Host{}, nil)
+	s.api.On("GetHostsWithAuthInfo").Return([]api.AuthHost{}, nil)
 	s.Run(env, "serviced", "host", "list")
 }
 
@@ -72,7 +72,7 @@ func (s *CmdLoggingSuite) Test_LoadsDefaultConfigFileFromHome(c *C) {
 	expected := home + "/etc/logconfig-cli.yaml"
 	s.log.On("ApplyConfigFromFile", expected).Return(nil)
 	s.log.On("WatchConfigFile", expected).Return(nil)
-	s.api.On("GetHosts").Return([]host.Host{}, nil)
+	s.api.On("GetHostsWithAuthInfo").Return([]api.AuthHost{}, nil)
 	s.Run(env, "serviced", "host", "list")
 }
 
@@ -88,7 +88,7 @@ func (s *CmdLoggingSuite) Test_LoadsConfigFile_Error(c *C) {
 		func(args mock.Arguments) {
 			watch <- struct{}{}
 		})
-	s.api.On("GetHosts").Return([]host.Host{}, nil)
+	s.api.On("GetHostsWithAuthInfo").Return([]api.AuthHost{}, nil)
 	output := captureStderr(func() { s.Run(env, "serviced", "host", "list") })
 	firstLine := strings.Split(string(output), "\n")[0]
 	timeout := time.After(time.Second)
@@ -107,7 +107,7 @@ func (s *CmdLoggingSuite) Test_LoadsSpecifiedConfigFile(c *C) {
 	env := map[string]string{"LOG_CONFIG": expected}
 	s.log.On("ApplyConfigFromFile", expected).Return(nil)
 	s.log.On("WatchConfigFile", expected).Return(nil)
-	s.api.On("GetHosts").Return([]host.Host{}, nil)
+	s.api.On("GetHostsWithAuthInfo").Return([]api.AuthHost{}, nil)
 	s.Run(env, "serviced", "host", "list")
 }
 
@@ -116,7 +116,7 @@ func (s *CmdLoggingSuite) Test_VerbosityFlag(c *C) {
 	expected := "/opt/serviced/etc/logconfig-cli.yaml"
 	s.log.On("ApplyConfigFromFile", expected).Return(nil)
 	s.log.On("WatchConfigFile", expected).Return(nil)
-	s.api.On("GetHosts").Return([]host.Host{}, nil)
+	s.api.On("GetHostsWithAuthInfo").Return([]api.AuthHost{}, nil)
 	tests := map[int]logrus.Level{
 		0:  logrus.DebugLevel,
 		1:  logrus.InfoLevel,
@@ -137,7 +137,7 @@ func (s *CmdLoggingSuite) Test_GlogOptions(c *C) {
 	expected := "/opt/serviced/etc/logconfig-cli.yaml"
 	s.log.On("ApplyConfigFromFile", expected).Return(nil)
 	s.log.On("WatchConfigFile", expected).Return(nil)
-	s.api.On("GetHosts").Return([]host.Host{}, nil)
+	s.api.On("GetHostsWithAuthInfo").Return([]api.AuthHost{}, nil)
 
 	s.log.On("SetAlsoToStderr", true).Return().Once()
 	s.Run(env, "serviced", "--alsologtostderr", "host", "list")

--- a/cli/cmd/host.go
+++ b/cli/cmd/host.go
@@ -47,7 +47,7 @@ func (c *ServicedCli) initHost() {
 					},
 					cli.StringFlag{
 						Name:  "show-fields",
-						Value: "ID,Pool,Name,Addr,RPCPort,Cores,RAM,Cur/Max/Avg,Network,Release",
+						Value: "ID,Auth,Pool,Name,Addr,RPCPort,Cores,RAM,Cur/Max/Avg,Network,Release",
 						Usage: "Comma-delimited list describing which fields to display",
 					},
 				},
@@ -154,7 +154,7 @@ func (c *ServicedCli) printHostAdd(ctx *cli.Context) {
 func (c *ServicedCli) cmdHostList(ctx *cli.Context) {
 	if len(ctx.Args()) > 0 {
 		hostID := ctx.Args()[0]
-		if host, err := c.driver.GetHost(hostID); err != nil {
+		if host, err := c.driver.GetHostWithAuthInfo(hostID); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 		} else if host == nil {
 			fmt.Fprintln(os.Stderr, "host not found")
@@ -166,7 +166,7 @@ func (c *ServicedCli) cmdHostList(ctx *cli.Context) {
 		return
 	}
 
-	hosts, err := c.driver.GetHosts()
+	hosts, err := c.driver.GetHostsWithAuthInfo()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
@@ -192,6 +192,7 @@ func (c *ServicedCli) cmdHostList(ctx *cli.Context) {
 			}
 			t.AddRow(map[string]interface{}{
 				"ID":          h.ID,
+				"Auth":        h.Authenticated,
 				"Pool":        h.PoolID,
 				"Name":        h.Name,
 				"Addr":        h.IPAddr,

--- a/cli/cmd/host_test.go
+++ b/cli/cmd/host_test.go
@@ -143,6 +143,31 @@ func (t HostAPITest) WriteDelegateKey(filename string, data []byte) error {
 	return nil
 }
 
+func (t HostAPITest) GetHostWithAuthInfo(id string) (*api.AuthHost, error) {
+	if t.fail {
+		return nil, ErrInvalidHost
+	}
+
+	for _, h := range t.hosts {
+		if h.ID == id {
+			return &api.AuthHost{h, true}, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (t HostAPITest) GetHostsWithAuthInfo() ([]api.AuthHost, error) {
+	if t.fail {
+		return nil, ErrInvalidHost
+	}
+	authHosts := []api.AuthHost{}
+	for _, h := range t.hosts {
+		authHosts = append(authHosts, api.AuthHost{h, true})
+	}
+	return authHosts, nil
+}
+
 func TestServicedCLI_CmdHostList_one(t *testing.T) {
 	hostID := "test-host-id-1"
 

--- a/rpc/master/hosts_client.go
+++ b/rpc/master/hosts_client.go
@@ -104,3 +104,9 @@ func (c *Client) ResetHostKey(hostID string) ([]byte, error) {
 	err := c.call("ResetHostKey", hostID, &response)
 	return response, err
 }
+
+func (c *Client) HostsAuthenticated(hostIDs []string) (map[string]bool, error) {
+	response := make(map[string]bool)
+	err := c.call("HostsAuthenticated", hostIDs, &response)
+	return response, err
+}

--- a/rpc/master/hosts_server.go
+++ b/rpc/master/hosts_server.go
@@ -170,3 +170,18 @@ func (s *Server) ResetHostKey(hostID string, key *[]byte) error {
 	*key = publicKey
 	return err
 }
+
+// Given a list of hostsID return if they are authenticated
+func (s *Server) HostsAuthenticated(hostIDs []string, res *map[string]bool) error {
+	authenticatedHosts := make(map[string]bool)
+	if hostIDs == nil || len(hostIDs) == 0 {
+		*res = authenticatedHosts
+		return nil
+	}
+	for _, hid := range hostIDs {
+		isAuth, _ := s.f.HostIsAuthenticated(s.context(), hid)
+		authenticatedHosts[hid] = isAuth
+	}
+	*res = authenticatedHosts
+	return nil
+}

--- a/rpc/master/interface.go
+++ b/rpc/master/interface.go
@@ -68,6 +68,9 @@ type ClientInterface interface {
 	// Reset hostID's private key
 	ResetHostKey(hostID string) ([]byte, error)
 
+	// HostsAuthenticated returns if the hosts passed are authenticated or not
+	HostsAuthenticated(hostIDs []string) (map[string]bool, error)
+
 	//--------------------------------------------------------------------------
 	// Pool Management Functions
 

--- a/rpc/master/mocks/ClientInterface.go
+++ b/rpc/master/mocks/ClientInterface.go
@@ -227,6 +227,27 @@ func (_m *ClientInterface) ResetHostKey(hostID string) ([]byte, error) {
 
 	return r0, r1
 }
+func (_m *ClientInterface) HostsAuthenticated(hostIDs []string) (map[string]bool, error) {
+	ret := _m.Called(hostIDs)
+
+	var r0 map[string]bool
+	if rf, ok := ret.Get(0).(func([]string) map[string]bool); ok {
+		r0 = rf(hostIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]bool)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = rf(hostIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
 func (_m *ClientInterface) GetResourcePool(poolID string) (*pool.ResourcePool, error) {
 	ret := _m.Called(poolID)
 
@@ -402,8 +423,6 @@ func (_m *ClientInterface) GetServiceInstances(serviceID string) ([]service.Inst
 
 	return r0, r1
 }
-
-// GetEvaluatedService provides a mock function with given fields: serviceID, instanceID
 func (_m *ClientInterface) GetEvaluatedService(serviceID string, instanceID int) (*service.Service, string, error) {
 	ret := _m.Called(serviceID, instanceID)
 
@@ -420,9 +439,7 @@ func (_m *ClientInterface) GetEvaluatedService(serviceID string, instanceID int)
 	if rf, ok := ret.Get(1).(func(string, int) string); ok {
 		r1 = rf(serviceID, instanceID)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(string)
-		}
+		r1 = ret.Get(1).(string)
 	}
 
 	var r2 error


### PR DESCRIPTION
Example:
[zenny@ip-10-111-23-121 ~]$ serviced host list --show-fields ID,Auth,Pool,Name
ID            Auth      Pool         Name
6f0aaf17      true      default      ip-10-111-23-175.zenoss.loc
6f0a7917      true      default      ip-10-111-23-121.zenoss.loc
6f0a9117      true      default      ip-10-111-23-145.zenoss.loc