### PR TITLE
Remove race condition from simple_lru_test

### DIFF
--- a/utils/cache/interface.go
+++ b/utils/cache/interface.go
@@ -27,4 +27,3 @@ type LRUCache interface {
 	// Returns the maximum size of the cache.
 	GetMaxSize() int
 }
-

--- a/utils/cache/simple_lru.go
+++ b/utils/cache/simple_lru.go
@@ -13,17 +13,17 @@
 package cache
 
 import (
-	"time"
 	lru "github.com/hashicorp/golang-lru"
+	"time"
 )
 
 type SimpleLRUCache struct {
-	maxItems         int
-	expiration       time.Duration
-	cleanupInterval  time.Duration
+	maxItems        int
+	expiration      time.Duration
+	cleanupInterval time.Duration
 
 	// Keep the cache implementation private
-	lruCache         *lru.Cache
+	lruCache *lru.Cache
 }
 
 // assert the LRUCache interface is implemented by SimpleLRUCache
@@ -31,9 +31,9 @@ var _ LRUCache = &SimpleLRUCache{}
 
 // An internal struct to track the expiration time for each item in the cache
 type cacheItem struct {
-	key        string
-	value      interface{}
-	expires    time.Time
+	key     string
+	value   interface{}
+	expires time.Time
 }
 
 //
@@ -82,8 +82,8 @@ func (c *SimpleLRUCache) Get(key string) (interface{}, bool) {
 	if data != nil && ok {
 		var item cacheItem
 		item, _ = data.(cacheItem)
-		item.expires = time.Now().Add(c.expiration)	// update the expiration
-                c.lruCache.Add(key, item)
+		item.expires = time.Now().Add(c.expiration) // update the expiration
+		c.lruCache.Add(key, item)
 		return item.value, true
 	}
 	return nil, false
@@ -93,8 +93,8 @@ func (c *SimpleLRUCache) Get(key string) (interface{}, bool) {
 // If the key already exists in the cache, it's value will be replaced.
 func (c *SimpleLRUCache) Set(key string, value interface{}) {
 	item := cacheItem{
-		key:   key,
-		value: value,
+		key:     key,
+		value:   value,
 		expires: time.Now().Add(c.expiration),
 	}
 
@@ -124,9 +124,9 @@ func (c *SimpleLRUCache) startCleaner(shutdown chan struct{}) {
 	go (func() {
 		for {
 			select {
-			case <- timer:
+			case <-timer:
 				c.cleanup()
-			case <- shutdown:
+			case <-shutdown:
 				return
 			}
 		}

--- a/utils/cache/simple_lru.go
+++ b/utils/cache/simple_lru.go
@@ -29,6 +29,23 @@ type SimpleLRUCache struct {
 // assert the LRUCache interface is implemented by SimpleLRUCache
 var _ LRUCache = &SimpleLRUCache{}
 
+var timeFunc func() time.Time = time.Now
+
+// At sets a fake time, executes the provided
+// function, then restores the default time getter,
+// making it possible to test time-sensitive stuff
+func At(t time.Time, f func()) {
+	defer func() {
+		timeFunc = time.Now
+	}()
+
+	timeFunc = func() time.Time {
+		return t
+	}
+
+	f()
+}
+
 // An internal struct to track the expiration time for each item in the cache
 type cacheItem struct {
 	key     string
@@ -82,7 +99,7 @@ func (c *SimpleLRUCache) Get(key string) (interface{}, bool) {
 	if data != nil && ok {
 		var item cacheItem
 		item, _ = data.(cacheItem)
-		item.expires = time.Now().Add(c.expiration) // update the expiration
+		item.expires = timeFunc().Add(c.expiration) // update the expiration
 		c.lruCache.Add(key, item)
 		return item.value, true
 	}
@@ -95,7 +112,7 @@ func (c *SimpleLRUCache) Set(key string, value interface{}) {
 	item := cacheItem{
 		key:     key,
 		value:   value,
-		expires: time.Now().Add(c.expiration),
+		expires: timeFunc().Add(c.expiration),
 	}
 
 	c.lruCache.Add(key, item)
@@ -120,13 +137,14 @@ func (c *SimpleLRUCache) GetCleanupInterval() time.Duration {
 }
 
 func (c *SimpleLRUCache) startCleaner(shutdown chan struct{}) {
-	timer := time.Tick(c.cleanupInterval)
+	timer := time.NewTicker(c.cleanupInterval)
 	go (func() {
 		for {
 			select {
-			case <-timer:
+			case <-timer.C:
 				c.cleanup()
 			case <-shutdown:
+				timer.Stop()
 				return
 			}
 		}
@@ -134,7 +152,7 @@ func (c *SimpleLRUCache) startCleaner(shutdown chan struct{}) {
 }
 
 func (c *SimpleLRUCache) cleanup() {
-	now := time.Now()
+	now := timeFunc()
 	for _, key := range c.lruCache.Keys() {
 		data, ok := c.lruCache.Get(key)
 		if data != nil && ok {

--- a/utils/cache/simple_lru_test.go
+++ b/utils/cache/simple_lru_test.go
@@ -29,36 +29,35 @@ import (
 )
 
 var (
-	maxCacheSize = 4
-	itemTimeToLive = time.Minute * 2
+	maxCacheSize    = 4
+	itemTimeToLive  = time.Minute * 2
 	cleanupInterval = time.Second * 30
 )
 
 func TestSimpleLRU(t *testing.T) { TestingT(t) }
 
-type  TestSimpleLRUSuite struct{
-	cache *SimpleLRUCache
+type TestSimpleLRUSuite struct {
+	cache    *SimpleLRUCache
 	shutdown chan struct{}
 }
 
 var _ = Suite(&TestSimpleLRUSuite{})
 
-
 type testItem struct {
-	Name  string
-	ID    int
+	Name string
+	ID   int
 }
 
-func (s * TestSimpleLRUSuite) SetUpTest(c *C) {
+func (s *TestSimpleLRUSuite) SetUpTest(c *C) {
 	s.shutdown = make(chan struct{})
 	s.cache, _ = NewSimpleLRUCache(maxCacheSize, itemTimeToLive, cleanupInterval, s.shutdown)
 }
 
-func (s * TestSimpleLRUSuite) TearDownTest(c *C) {
+func (s *TestSimpleLRUSuite) TearDownTest(c *C) {
 	close(s.shutdown)
 }
 
-func (s * TestSimpleLRUSuite) TestConstructor(c *C) {
+func (s *TestSimpleLRUSuite) TestConstructor(c *C) {
 	shutdown := make(chan struct{})
 	defer close(shutdown)
 	cache, err := NewSimpleLRUCache(maxCacheSize, itemTimeToLive, cleanupInterval, shutdown)
@@ -71,8 +70,7 @@ func (s * TestSimpleLRUSuite) TestConstructor(c *C) {
 	c.Assert(cache.GetCurrentSize(), Equals, 0)
 }
 
-
-func (s * TestSimpleLRUSuite) TestConstructorFails(c *C) {
+func (s *TestSimpleLRUSuite) TestConstructorFails(c *C) {
 	shutdown := make(chan struct{})
 	defer close(shutdown)
 	cache, err := NewSimpleLRUCache(0, itemTimeToLive, cleanupInterval, shutdown)
@@ -84,14 +82,14 @@ func (s * TestSimpleLRUSuite) TestConstructorFails(c *C) {
 	c.Assert(cache, IsNil)
 }
 
-func (s * TestSimpleLRUSuite) TestGetOnEmptyCache(c *C) {
+func (s *TestSimpleLRUSuite) TestGetOnEmptyCache(c *C) {
 	result, isFound := s.cache.Get("somekey")
 
 	c.Assert(isFound, Equals, false)
 	c.Assert(result, IsNil)
 }
 
-func (s * TestSimpleLRUSuite) TestSimpleSetAndGet(c *C) {
+func (s *TestSimpleLRUSuite) TestSimpleSetAndGet(c *C) {
 	item := testItem{
 		Name: "something",
 		ID:   21,
@@ -109,7 +107,7 @@ func (s * TestSimpleLRUSuite) TestSimpleSetAndGet(c *C) {
 	c.Assert(result, IsNil)
 }
 
-func (s * TestSimpleLRUSuite) TestMaxItems(c *C) {
+func (s *TestSimpleLRUSuite) TestMaxItems(c *C) {
 	// Fill the cache with exactly the max number of items
 	for i := 1; i <= maxCacheSize; i++ {
 		item := testItem{
@@ -184,7 +182,7 @@ func (s * TestSimpleLRUSuite) TestMaxItems(c *C) {
 	c.Assert(result, IsNil)
 }
 
-func (s * TestSimpleLRUSuite) TestCacheEmptyAfterTTLExpires(c *C) {
+func (s *TestSimpleLRUSuite) TestCacheEmptyAfterTTLExpires(c *C) {
 	// Use a shorter values than the test suite defaults so we don't hold up the entire test suite waiting
 	// for the cache to clear
 	shutdown := make(chan struct{})
@@ -206,7 +204,7 @@ func (s * TestSimpleLRUSuite) TestCacheEmptyAfterTTLExpires(c *C) {
 	c.Assert(cache.GetCurrentSize(), Equals, 0)
 }
 
-func (s * TestSimpleLRUSuite) TestUsedItemsRemainInCache(c *C) {
+func (s *TestSimpleLRUSuite) TestUsedItemsRemainInCache(c *C) {
 	// Use a shorter values than the test suite defaults so we don't hold up the entire test suite waiting
 	// for the cache to clear
 	shutdown := make(chan struct{})
@@ -222,7 +220,7 @@ func (s * TestSimpleLRUSuite) TestUsedItemsRemainInCache(c *C) {
 		cache.Set(item.Name, item)
 	}
 
-	time.Sleep(time.Second*5)
+	time.Sleep(time.Second * 5)
 	for i := 1; i <= 2; i++ {
 		_, ok := cache.Get(fmt.Sprintf("key %d", i))
 		c.Assert(ok, Equals, true)

--- a/utils/cache/simple_lru_test.go
+++ b/utils/cache/simple_lru_test.go
@@ -31,7 +31,7 @@ import (
 var (
 	maxCacheSize    = 4
 	itemTimeToLive  = time.Minute * 2
-	cleanupInterval = time.Second * 30
+	cleanupInterval = time.Duration(-1) // Duration < 0 signifies no automatic cleanup
 )
 
 func TestSimpleLRU(t *testing.T) { TestingT(t) }
@@ -182,52 +182,53 @@ func (s *TestSimpleLRUSuite) TestMaxItems(c *C) {
 	c.Assert(result, IsNil)
 }
 
-func (s *TestSimpleLRUSuite) TestCacheEmptyAfterTTLExpires(c *C) {
-	// Use a shorter values than the test suite defaults so we don't hold up the entire test suite waiting
-	// for the cache to clear
+func (s *TestSimpleLRUSuite) TestCleanupRemovesExpiredItems(c *C) {
 	shutdown := make(chan struct{})
 	defer close(shutdown)
-	cache, _ := NewSimpleLRUCache(maxCacheSize, time.Second*10, time.Second*2, shutdown)
+	now := time.Now()
+	cache, _ := NewSimpleLRUCache(maxCacheSize, itemTimeToLive, cleanupInterval, shutdown)
 
-	// Fill the cache with exactly the max number of items
-	for i := 1; i <= maxCacheSize; i++ {
-		item := testItem{
-			Name: fmt.Sprintf("key %d", i),
-			ID:   i,
-		}
-		cache.Set(item.Name, item)
-	}
+	// Add an item
+	At(now, func() { cache.Set("foo", "bar") })
 
-	// Sleep long enough for the cache cleanup to run
-	time.Sleep(cache.GetExpiration() + cache.GetCleanupInterval())
+	// Cleanup called before expiration does not clean up the item
+	At(now.Add(itemTimeToLive-time.Nanosecond), func() { cache.cleanup() })
+	c.Assert(cache.GetCurrentSize(), Equals, 1)
 
+	// Cleanup called after expiration cleans up the item
+	At(now.Add(itemTimeToLive+time.Nanosecond), func() { cache.cleanup() })
 	c.Assert(cache.GetCurrentSize(), Equals, 0)
 }
 
 func (s *TestSimpleLRUSuite) TestUsedItemsRemainInCache(c *C) {
-	// Use a shorter values than the test suite defaults so we don't hold up the entire test suite waiting
-	// for the cache to clear
 	shutdown := make(chan struct{})
 	defer close(shutdown)
-	cache, _ := NewSimpleLRUCache(maxCacheSize, time.Second*10, time.Second*2, shutdown)
+	now := time.Now()
+	cache, _ := NewSimpleLRUCache(maxCacheSize, itemTimeToLive, cleanupInterval, shutdown)
 
-	// Fill the cache with exactly the max number of items
-	for i := 1; i <= maxCacheSize; i++ {
-		item := testItem{
-			Name: fmt.Sprintf("key %d", i),
-			ID:   i,
-		}
-		cache.Set(item.Name, item)
+	// Add two items to the cache
+	items := []testItem{
+		{"A", 0},
+		{"B", 1},
+	}
+	for _, item := range items {
+		At(now, func() { cache.Set(item.Name, item) })
 	}
 
-	time.Sleep(time.Second * 5)
-	for i := 1; i <= 2; i++ {
-		_, ok := cache.Get(fmt.Sprintf("key %d", i))
+	// Touch the second item
+	At(now.Add(itemTimeToLive/2), func() {
+		_, ok := cache.Get(items[1].Name)
 		c.Assert(ok, Equals, true)
-	}
+	})
 
-	// Sleep long enough for the cache cleanup to run
-	time.Sleep(time.Second*5 + cache.GetCleanupInterval())
+	// Cleanup called after expiration cleans up the first item, but not the second
+	At(now.Add(itemTimeToLive+time.Nanosecond), func() { cache.cleanup() })
+	c.Assert(cache.GetCurrentSize(), Equals, 1)
 
-	c.Assert(cache.GetCurrentSize(), Equals, 2)
+	item, ok := cache.Get(items[0].Name)
+	c.Assert(ok, Equals, false)
+
+	item, ok = cache.Get(items[1].Name)
+	c.Assert(ok, Equals, true)
+	c.Assert(item, Equals, items[1])
 }


### PR DESCRIPTION
Explicitly call routines "at" the desired time in order to test
functionality, rather than starting the interval-based cleanup routine
and using sleep to try to get the proper ordering.  Previously, rare
failures were occurring in these tests.  As a side effect, by removing
the calls to sleep, this change speeds up the test execution by 24
seconds.

Fixes [CC-2823](https://jira.zenoss.com/browse/CC-2823)