### PR TITLE
Pass more config options to serviced-controller

### DIFF
--- a/auth/token.go
+++ b/auth/token.go
@@ -198,7 +198,7 @@ func LoadTokenFile(tokenfile string) error {
 	// No need to handle expires or save file, because we're loading from the file rather
 	// than re-requesting authentication tokens
 	updateToken(string(data), zerotime, "")
-	log.Infof("Updated authentication token from disk")
+	log.Debug("Updated authentication token from disk")
 	return nil
 }
 

--- a/auth/token.go
+++ b/auth/token.go
@@ -164,14 +164,12 @@ func WatchTokenFile(tokenfile string, done <-chan interface{}) error {
 	})
 
 	loadToken := func() {
-		data, err := ioutil.ReadFile(tokenfile)
+		err := LoadTokenFile(tokenfile)
 		if err != nil {
 			log.WithError(err).Warn("Unable to load authentication token from file. Continuing to watch for changes")
+		} else {
+			log.Infof("Updated authentication token from disk")
 		}
-		// No need to handle expires or save file, because we're loading from the file rather
-		// than re-requesting authentication tokens
-		updateToken(string(data), zerotime, "")
-		log.Infof("Updated authentication token from disk")
 	}
 
 	// An initial token load without any file changes
@@ -185,6 +183,22 @@ func WatchTokenFile(tokenfile string, done <-chan interface{}) error {
 	for _ = range filechangechan {
 		loadToken()
 	}
+	return nil
+}
+
+func LoadTokenFile(tokenfile string) error {
+	log := log.WithFields(logrus.Fields{
+		"tokenfile": tokenfile,
+	})
+
+	data, err := ioutil.ReadFile(tokenfile)
+	if err != nil {
+		log.WithError(err).Warn("Unable to load authentication token from file.")
+	}
+	// No need to handle expires or save file, because we're loading from the file rather
+	// than re-requesting authentication tokens
+	updateToken(string(data), zerotime, "")
+	log.Infof("Updated authentication token from disk")
 	return nil
 }
 

--- a/cli/api/api_test.go
+++ b/cli/api/api_test.go
@@ -48,6 +48,7 @@ type TestAPISuite struct {
 }
 
 func (s *TestAPISuite) SetUpTest(c *C) {
+	hostAuthenticated = true   // by-pass any attempt to read/validate authentication tokens
 	s.mockControlPlane = &daomocks.ControlPlane{}
 	s.mockMasterClient = &mocks.ClientInterface{}
 

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -908,6 +908,7 @@ func (d *daemon) startAgent() error {
 			Master:               options.Endpoint,
 			UIPort:               options.UIPort,
 			RPCPort:              options.RPCPort,
+			RPCDisableTLS:        rpcutils.RPCDisableTLS,
 			DockerDNS:            options.DockerDNS,
 			VolumesPath:          options.VolumesPath,
 			Mount:                options.Mount,

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -643,13 +643,14 @@ func createMuxListener() net.Listener {
 		err      error
 	)
 
+	muxDisableTLS, _ := strconv.ParseBool(options.MuxDisableTLS)
 	log := log.WithFields(logrus.Fields{
-		"tls":  !options.MuxDisableTLS,
+		"tls":  !muxDisableTLS,
 		"port": options.MuxPort,
 	})
 	log.Debug("Starting traffic multiplexer")
 
-	if !options.MuxDisableTLS {
+	if !muxDisableTLS {
 		tlsConfig, err := getTLSConfig("mux")
 		if err != nil {
 			log.WithError(err).Fatal("Invalid TLS configuration")
@@ -902,6 +903,7 @@ func (d *daemon) startAgent() error {
 			}
 		}
 
+		muxDisableTLS, _ := strconv.ParseBool(options.MuxDisableTLS)
 		agentOptions := node.AgentOptions{
 			IPAddress:            agentIP,
 			PoolID:               thisHost.PoolID,
@@ -915,7 +917,8 @@ func (d *daemon) startAgent() error {
 			FSType:               options.FSType,
 			Zookeepers:           options.Zookeepers,
 			Mux:                  mux,
-			UseTLS:               !options.MuxDisableTLS,
+			MuxPort:              fmt.Sprintf("%d", options.MuxPort),
+			UseTLS:               !muxDisableTLS,
 			DockerRegistry:       options.DockerRegistry,
 			MaxContainerAge:      time.Duration(int(time.Second) * options.MaxContainerAge),
 			VirtualAddressSubnet: options.VirtualAddressSubnet,
@@ -1125,12 +1128,13 @@ func (d *daemon) initWeb() {
 		"master": options.Endpoint,
 	})
 	log.Debug("Starting Control Center UI server")
+	muxDisableTLS, _ := strconv.ParseBool(options.MuxDisableTLS)
 	cpserver := web.NewServiceConfig(
 		options.UIPort,
 		options.Endpoint,
 		options.ReportStats,
 		options.HostAliases,
-		!options.MuxDisableTLS,
+		!muxDisableTLS,
 		options.MuxPort,
 		options.AdminGroup,
 		options.CertPEMFile,

--- a/cli/api/options.go
+++ b/cli/api/options.go
@@ -133,7 +133,7 @@ func GetDefaultOptions(cfg utils.ConfigReader) config.Options {
 		Master:                     cfg.BoolVal("MASTER", false),
 		Agent:                      cfg.BoolVal("AGENT", false),
 		MuxPort:                    cfg.IntVal("MUX_PORT", 22250),
-		MuxDisableTLS:              cfg.BoolVal("MUX_DISABLE_TLS", false),
+		MuxDisableTLS:              strconv.FormatBool(cfg.BoolVal("MUX_DISABLE_TLS", false)),
 		KeyPEMFile:                 cfg.StringVal("KEY_FILE", ""),
 		CertPEMFile:                cfg.StringVal("CERT_FILE", ""),
 		Zookeepers:                 cfg.StringSlice("ZK", []string{}),

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -80,7 +80,7 @@ func New(driver api.API, config utils.ConfigReader, logControl logging.LogContro
 		cli.BoolFlag{"master", "run in master mode, i.e., the control center service"},
 		cli.BoolFlag{"agent", "run in agent mode, i.e., a host in a resource pool"},
 		cli.IntFlag{"mux", defaultOps.MuxPort, "multiplexing port"},
-		cli.BoolFlag{"mux-disable-tls", "disable TLS for mux connections"},
+		cli.StringFlag{"mux-disable-tls", defaultOps.MuxDisableTLS, "disable TLS for mux connections"},
 		cli.StringSliceFlag{"mux-tls-ciphers", convertToStringSlice(defaultOps.MUXTLSCiphers), "list of supported TLS ciphers for MUX"},
 		cli.StringFlag{"mux-tls-min-version", string(defaultOps.MUXTLSMinVersion), "mininum TLS version for MUX"},
 		cli.StringFlag{"volumes-path", defaultOps.VolumesPath, "path where application data is stored"},
@@ -267,7 +267,7 @@ func getRuntimeOptions(cfg utils.ConfigReader, ctx *cli.Context) config.Options 
 		Master:                     ctx.GlobalBool("master"),
 		Agent:                      ctx.GlobalBool("agent"),
 		MuxPort:                    ctx.GlobalInt("mux"),
-		MuxDisableTLS:              ctx.GlobalBool("mux-disable-tls"),
+		MuxDisableTLS:              ctx.GlobalString("mux-disable-tls"),
 		MUXTLSCiphers:              ctx.GlobalStringSlice("mux-tls-ciphers"),
 		MUXTLSMinVersion:           ctx.GlobalString("mux-tls-min-version"),
 		VolumesPath:                ctx.GlobalString("volumes-path"),
@@ -343,10 +343,6 @@ func getRuntimeOptions(cfg utils.ConfigReader, ctx *cli.Context) config.Options 
 	}
 
 	options.Endpoint = getEndpoint(options)
-
-	if cfg.StringVal("MUX_DISABLE_TLS", "") == "1" {
-		options.MuxDisableTLS = true
-	}
 
 	// Set the logging configuration filename.
 	// This is handled in a non-standard way for two reasons:

--- a/config/options.go
+++ b/config/options.go
@@ -46,7 +46,7 @@ type Options struct {
 	DockerDNS                  []string
 	Agent                      bool
 	MuxPort                    int
-	MuxDisableTLS              bool // Whether TLS should be disabled for the mux
+	MuxDisableTLS              string            //  Disable TLS for MUX connections, string val of bool
 	KeyPEMFile                 string
 	CertPEMFile                string
 	VolumesPath                string

--- a/container/controller.go
+++ b/container/controller.go
@@ -89,7 +89,7 @@ type ControllerOptions struct {
 	Mux struct { // TCPMUX configuration: RFC 1078
 		Enabled     bool   // True if muxing is used
 		Port        int    // the TCP port to use
-		TLS         bool   // True if TLS is used
+		DisableTLS  bool   // True if TLS is disabled
 		KeyPEMFile  string // Path to the key file when TLS is used
 		CertPEMFile string // Path to the cert file when TLS is used
 	}
@@ -431,7 +431,7 @@ func NewController(options ControllerOptions) (*Controller, error) {
 		InstanceID:           instanceID,
 		IsShell:              os.Getenv("SERVICED_IS_SERVICE_SHELL") == "true",
 		TCPMuxPort:           uint16(options.Mux.Port),
-		UseTLS:               options.Mux.TLS,
+		UseTLS:               !options.Mux.DisableTLS,
 		VirtualAddressSubnet: options.VirtualAddressSubnet,
 	}
 	c.endpoints, err = NewContainerEndpoints(service, opts)

--- a/node/agent.go
+++ b/node/agent.go
@@ -79,7 +79,8 @@ type HostAgent struct {
 	mount                []string             // each element is in the form: dockerImage,hostPath,containerPath
 	currentServices      map[string]*exec.Cmd // the current running services
 	mux                  *proxy.TCPMux
-	useTLS               bool                 // true if MUX should use TLS
+	muxport              string               // the mux port to serviced (default is 22250)
+	useTLS               bool                 // true if TLS should be enabled for MUX
 	proxyRegistry        proxy.ProxyRegistry
 	zkClient             *coordclient.Client
 	maxContainerAge      time.Duration   // maximum age for a stopped container before it is removed
@@ -120,6 +121,7 @@ type AgentOptions struct {
 	FSType               volume.DriverType
 	Zookeepers           []string
 	Mux                  *proxy.TCPMux
+	MuxPort              string
 	UseTLS               bool
 	DockerRegistry       string
 	MaxContainerAge      time.Duration // Maximum container age for a stopped container before being removed
@@ -146,6 +148,7 @@ func NewHostAgent(options AgentOptions, reg registry.Registry) (*HostAgent, erro
 	agent.dockerDNS = options.DockerDNS
 	agent.mount = options.Mount
 	agent.mux = options.Mux
+	agent.muxport = options.MuxPort
 	agent.useTLS = options.UseTLS
 	agent.maxContainerAge = options.MaxContainerAge
 	agent.virtualAddressSubnet = options.VirtualAddressSubnet

--- a/node/agent.go
+++ b/node/agent.go
@@ -71,6 +71,7 @@ type HostAgent struct {
 	master               string               // the connection string to the master agent
 	uiport               string               // the port to the ui (legacy was port 8787, now default 443)
 	rpcport              string               // the rpc port to serviced (default is 4979)
+	rpcDisableTLS        bool                 // true of TLS should be disabled for RPC
 	hostID               string               // the hostID of the current host
 	dockerDNS            []string             // docker dns addresses
 	storage              volume.Driver        // driver supporting the application data
@@ -78,7 +79,7 @@ type HostAgent struct {
 	mount                []string             // each element is in the form: dockerImage,hostPath,containerPath
 	currentServices      map[string]*exec.Cmd // the current running services
 	mux                  *proxy.TCPMux
-	useTLS               bool // Whether the mux uses TLS
+	useTLS               bool                 // true if MUX should use TLS
 	proxyRegistry        proxy.ProxyRegistry
 	zkClient             *coordclient.Client
 	maxContainerAge      time.Duration   // maximum age for a stopped container before it is removed
@@ -112,6 +113,7 @@ type AgentOptions struct {
 	Master               string
 	UIPort               string
 	RPCPort              string
+	RPCDisableTLS        bool                 // true if TLS should be disabled for RPC
 	DockerDNS            []string
 	VolumesPath          string
 	Mount                []string
@@ -140,6 +142,7 @@ func NewHostAgent(options AgentOptions, reg registry.Registry) (*HostAgent, erro
 	agent.master = options.Master
 	agent.uiport = options.UIPort
 	agent.rpcport = options.RPCPort
+	agent.rpcDisableTLS = options.RPCDisableTLS
 	agent.dockerDNS = options.DockerDNS
 	agent.mount = options.Mount
 	agent.mux = options.Mux

--- a/node/container.go
+++ b/node/container.go
@@ -669,12 +669,16 @@ func (a *HostAgent) createContainerConfig(tenantID string, svc *service.Service,
 	if !a.useTLS {
 		cmd = append(cmd, "--mux-disable-tls")
 	}
-
+	if a.rpcDisableTLS {
+		cmd = append(cmd, "--rpc-disable-tls")
+	}
 	cfg.Cmd = append(cmd,
 		svc.ID,
 		strconv.Itoa(instanceID),
 		svc.Startup)
 
+	logger.WithField("Cmd", cfg.Cmd).Debug("Container start string")
+	logger.WithField("Env", cfg.Env).Debug("Container env vars")
 	if svc.Privileged {
 		hcfg.Privileged = true
 	}

--- a/node/container.go
+++ b/node/container.go
@@ -639,6 +639,7 @@ func (a *HostAgent) createContainerConfig(tenantID string, svc *service.Service,
 		fmt.Sprintf("SERVICED_NOREGISTRY=%s", os.Getenv("SERVICED_NOREGISTRY")),
 		fmt.Sprintf("SERVICED_SERVICE_IMAGE=%s", svc.ImageID),
 		fmt.Sprintf("SERVICED_MAX_RPC_CLIENTS=1"),
+		fmt.Sprintf("SERVICED_MUX_PORT=%s", a.muxport),
 		fmt.Sprintf("SERVICED_RPC_PORT=%s", a.rpcport),
 		fmt.Sprintf("SERVICED_LOG_ADDRESS=%s", a.logstashURL),
 		//The SERVICED_UI_PORT environment variable is deprecated and services should always use port 443 to contact serviced from inside a container

--- a/serviced-controller/daemon.go
+++ b/serviced-controller/daemon.go
@@ -25,6 +25,7 @@ import (
 
 func main() {
 	defaultRPCPort := 4979
+	defaultMuxPort := 22250
 	defaultMetricsForwarderPort := ":22350"
 	if cpConsumerUrl, err := url.Parse(os.Getenv("CONTROLPLANE_CONSUMER_URL")); err == nil {
 		hostParts := strings.Split(cpConsumerUrl.Host, ":")
@@ -39,7 +40,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{"forwarder-binary", "/usr/local/serviced/resources/logstash/filebeat", "path to the filebeat binary"},
 		cli.StringFlag{"forwarder-config", "/etc/filebeat.conf", "path to the filebeat config file"},
-		cli.IntFlag{"muxport", 22250, "multiplexing port to use"},
+		cli.IntFlag{"muxport", defaultMuxPort, "multiplexing port to use"},
 		cli.StringFlag{"keyfile", "", "path to private key file (defaults to compiled in private keys"},
 		cli.StringFlag{"certfile", "", "path to public certificate file (defaults to compiled in public cert)"},
 		cli.IntFlag{"rpcport", defaultRPCPort, "port to use for RPC requests"},

--- a/serviced-controller/daemon.go
+++ b/serviced-controller/daemon.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/control-center/serviced/servicedversion"
-	"github.com/control-center/serviced/utils"
 )
 
 func main() {
@@ -43,7 +42,7 @@ func main() {
 		cli.IntFlag{"muxport", 22250, "multiplexing port to use"},
 		cli.StringFlag{"keyfile", "", "path to private key file (defaults to compiled in private keys"},
 		cli.StringFlag{"certfile", "", "path to public certificate file (defaults to compiled in public cert)"},
-		cli.StringFlag{"endpoint", utils.GetGateway(defaultRPCPort), "serviced endpoint address"},
+		cli.IntFlag{"rpcport", defaultRPCPort, "port to use for RPC requests"},
 		cli.BoolTFlag{"autorestart", "restart process automatically when it finishes"},
 		cli.BoolFlag{"mux-disable-tls", "disable contacting the mux via TLS"},
 		cli.BoolFlag{"disable-metric-forwarding", "disable forwarding of metrics for this container"},

--- a/serviced-controller/daemon.go
+++ b/serviced-controller/daemon.go
@@ -43,6 +43,7 @@ func main() {
 		cli.StringFlag{"keyfile", "", "path to private key file (defaults to compiled in private keys"},
 		cli.StringFlag{"certfile", "", "path to public certificate file (defaults to compiled in public cert)"},
 		cli.IntFlag{"rpcport", defaultRPCPort, "port to use for RPC requests"},
+		cli.BoolFlag{"rpc-disable-tls", "disable TLS for RPC requests"},
 		cli.BoolTFlag{"autorestart", "restart process automatically when it finishes"},
 		cli.BoolFlag{"mux-disable-tls", "disable contacting the mux via TLS"},
 		cli.BoolFlag{"disable-metric-forwarding", "disable forwarding of metrics for this container"},

--- a/serviced-controller/options.go
+++ b/serviced-controller/options.go
@@ -31,6 +31,7 @@ type ControllerOptions struct {
 	CertPEMFile             string   // path to the CertPEMfile
 	ServicedEndpoint        string
 	RPCPort                 int      // the TCP port for the RPC to the agent
+	RPCDisableTLS           bool     // True if TLS should be used on RPC connections
 	Autorestart             bool
 	MetricForwarderPort     string // port to which container processes send performance data to
 	Logstash                bool
@@ -45,6 +46,7 @@ type ControllerOptions struct {
 
 func (c ControllerOptions) toContainerControllerOptions() (options container.ControllerOptions, err error) {
 	options.ServicedEndpoint = c.ServicedEndpoint
+	options.RPCDisableTLS = c.RPCDisableTLS
 	options.Service.Autorestart = c.Autorestart
 	options.Service.InstanceID = c.InstanceID
 	options.Service.ID = c.ServiceID

--- a/serviced-controller/options.go
+++ b/serviced-controller/options.go
@@ -30,6 +30,7 @@ type ControllerOptions struct {
 	KeyPEMFile              string   // path to the KeyPEMfile
 	CertPEMFile             string   // path to the CertPEMfile
 	ServicedEndpoint        string
+	RPCPort                 int      // the TCP port for the RPC to the agent
 	Autorestart             bool
 	MetricForwarderPort     string // port to which container processes send performance data to
 	Logstash                bool

--- a/serviced-controller/options.go
+++ b/serviced-controller/options.go
@@ -26,12 +26,12 @@ type ControllerOptions struct {
 	Command                 []string // The command to launch
 	MuxPort                 int      // the TCP port for the remote mux
 	Mux                     bool     // True if a remote mux is used
-	TLS                     bool     // True if TLS should be used on the mux
+	MUXDisableTLS           bool     // True if TLS should be disabled on the mux
 	KeyPEMFile              string   // path to the KeyPEMfile
 	CertPEMFile             string   // path to the CertPEMfile
 	ServicedEndpoint        string
 	RPCPort                 int      // the TCP port for the RPC to the agent
-	RPCDisableTLS           bool     // True if TLS should be used on RPC connections
+	RPCDisableTLS           bool     // True if TLS should be disabled on RPC connections
 	Autorestart             bool
 	MetricForwarderPort     string // port to which container processes send performance data to
 	Logstash                bool
@@ -53,7 +53,7 @@ func (c ControllerOptions) toContainerControllerOptions() (options container.Con
 	options.Service.Command = c.Command
 	options.Mux.Port = c.MuxPort
 	options.Mux.Enabled = c.Mux
-	options.Mux.TLS = c.TLS
+	options.Mux.DisableTLS = c.MUXDisableTLS
 	options.Mux.KeyPEMFile = c.KeyPEMFile
 	options.Mux.CertPEMFile = c.CertPEMFile
 	options.Logforwarder.Enabled = c.Logstash

--- a/serviced-controller/proxy.go
+++ b/serviced-controller/proxy.go
@@ -37,6 +37,7 @@ func CmdServiceProxy(ctx *cli.Context) {
 		KeyPEMFile:              ctx.GlobalString("keyfile"),
 		CertPEMFile:             ctx.GlobalString("certfile"),
 		RPCPort:                 ctx.GlobalInt("rpcport"),
+		RPCDisableTLS:           ctx.GlobalBool("rpc-disable-tls"),
 		Autorestart:             ctx.GlobalBool("autorestart"),
 		MetricForwarderPort:     ctx.GlobalString("metric-forwarder-port"),
 		Logstash:                ctx.GlobalBool("logstash"),
@@ -52,10 +53,10 @@ func CmdServiceProxy(ctx *cli.Context) {
 		MetricForwardingEnabled: !ctx.GlobalBool("disable-metric-forwarding"),
 	}
 
-	options.MuxPort = cfg.IntVal("MUX_PORT", options.MuxPort)
+	options.MuxPort = cfg.IntVal("MUX_PORT", options.MuxPort)			// TODO: Is this set in container.go?
 	options.RPCPort = cfg.IntVal("RPC_PORT", options.RPCPort)
-	options.KeyPEMFile = cfg.StringVal("KEY_FILE", options.KeyPEMFile)
-	options.CertPEMFile = cfg.StringVal("CERT_FILE", options.CertPEMFile)
+	options.KeyPEMFile = cfg.StringVal("KEY_FILE", options.KeyPEMFile)		// TODO: Is this set in container.go?
+	options.CertPEMFile = cfg.StringVal("CERT_FILE", options.CertPEMFile)		// TODO: Is this set in container.go?
 	options.LogstashURL = cfg.StringVal("LOG_ADDRESS", options.LogstashURL)
 	options.VirtualAddressSubnet = cfg.StringVal("VIRTUAL_ADDRESS_SUBNET", options.VirtualAddressSubnet)
 	options.ServicedEndpoint = utils.GetGateway(options.RPCPort)
@@ -65,8 +66,11 @@ func CmdServiceProxy(ctx *cli.Context) {
 	}
 
 	rpcutils.RPC_CLIENT_SIZE = 2
+	rpcutils.RPCDisableTLS = options.RPCDisableTLS
 	if err := StartProxy(options); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		// exit with an error if we can't start the proxy so that the delegate can record the container logs
+		os.Exit(1)
 	}
 }
 

--- a/serviced-controller/proxy.go
+++ b/serviced-controller/proxy.go
@@ -36,7 +36,7 @@ func CmdServiceProxy(ctx *cli.Context) {
 		TLS:                     !ctx.GlobalBool("mux-disable-tls"),
 		KeyPEMFile:              ctx.GlobalString("keyfile"),
 		CertPEMFile:             ctx.GlobalString("certfile"),
-		ServicedEndpoint:        ctx.GlobalString("endpoint"),
+		RPCPort:                 ctx.GlobalInt("rpcport"),
 		Autorestart:             ctx.GlobalBool("autorestart"),
 		MetricForwarderPort:     ctx.GlobalString("metric-forwarder-port"),
 		Logstash:                ctx.GlobalBool("logstash"),
@@ -53,17 +53,18 @@ func CmdServiceProxy(ctx *cli.Context) {
 	}
 
 	options.MuxPort = cfg.IntVal("MUX_PORT", options.MuxPort)
+	options.RPCPort = cfg.IntVal("RPC_PORT", options.RPCPort)
 	options.KeyPEMFile = cfg.StringVal("KEY_FILE", options.KeyPEMFile)
 	options.CertPEMFile = cfg.StringVal("CERT_FILE", options.CertPEMFile)
 	options.LogstashURL = cfg.StringVal("LOG_ADDRESS", options.LogstashURL)
 	options.VirtualAddressSubnet = cfg.StringVal("VIRTUAL_ADDRESS_SUBNET", options.VirtualAddressSubnet)
+	options.ServicedEndpoint = utils.GetGateway(options.RPCPort)
 
 	if ctx.IsSet("logtostderr") {
 		glog.SetToStderr(ctx.GlobalBool("logtostderr"))
 	}
 
 	rpcutils.RPC_CLIENT_SIZE = 2
-
 	if err := StartProxy(options); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}


### PR DESCRIPTION
Fixes CC-2816

Includes changes to pass the following to serviced container controller:
* MUX port
* flag for mux-disable-tls
* RPC port
* flag for rpc-disable-tls