### PR TITLE
Do not authenticate the host unless we need to make an RPC call

### DIFF
--- a/api_acceptance.sh
+++ b/api_acceptance.sh
@@ -30,18 +30,18 @@ add_to_etc_hosts
 
 start_serviced             && succeed "Serviced started within timeout"    || fail "serviced failed to start within $START_TIMEOUT seconds."
 
+# add the local host as a CC host so there will be available IP assignments.
+${SERVICED} host add --register "${HOSTNAME}:4979" "default" --memory "100%" -k /dev/null
+if [ $? -ne 0 ]; then
+    echo "Failed to add CC host for api acceptance test, exiting";
+    exit 1;
+fi
+
 # build/start mock agents
 cd ${DIR}
 make mockAgent
 cd ${DIR}/acceptance
 sudo GOPATH=${GOPATH} PATH=${PATH} ./startMockAgents.sh --no-wait
-
-# add the local host as a CC host so there will be available IP assignments.
-../serviced host add --register "${HOSTNAME}:4979" "default" --memory "100%" -k /dev/null
-if [ $? -ne 0 ]; then
-    echo "Failed to add CC host for api acceptance test, exiting";
-    exit 1;
-fi
 
 # launch cucumber/capybara with colorized output disabled for better readability in Jenkins
 CUCUMBER_OPTS=--no-color ./runAPIacceptance.sh -a https://${HOSTNAME} $*

--- a/cli/api/api.go
+++ b/cli/api/api.go
@@ -140,9 +140,7 @@ func (a *api) connectMaster() (master.ClientInterface, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not create a client to the master: %s", err)
 		}
-		if err := a.authenticateHost(); err != nil {
-			return nil, err
-		}
+		a.authenticateHost()
 	}
 	return a.master, nil
 }
@@ -155,9 +153,7 @@ func (a *api) connectAgent(address string) (*agent.Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not create a client to the agent: %s", err)
 		}
-		if err := a.authenticateHost(); err != nil {
-			return nil, err
-		}
+		a.authenticateHost()
 	}
 	return a.agent, nil
 }
@@ -182,9 +178,7 @@ func (a *api) connectDAO() (dao.ControlPlane, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not create a client to the agent: %s", err)
 		}
-		if err := a.authenticateHost(); err != nil {
-			return nil, err
-		}
+		a.authenticateHost()
 	}
 	return a.dao, nil
 }

--- a/cli/api/api_test.go
+++ b/cli/api/api_test.go
@@ -48,6 +48,7 @@ type TestAPISuite struct {
 }
 
 func (s *TestAPISuite) SetUpTest(c *C) {
+	hostAuthenticated = true   // by-pass any attempt to read/validate authentication tokens
 	s.mockControlPlane = &daomocks.ControlPlane{}
 	s.mockMasterClient = &mocks.ClientInterface{}
 

--- a/smoke.sh
+++ b/smoke.sh
@@ -39,14 +39,14 @@ deploy_service() {
 start_service() {
     SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service start ${SERVICE_ID}
     sleep 5
-    [[ "1" == $(serviced service list ${SERVICE_ID} | python -c "import json, sys; print json.load(sys.stdin)['DesiredState']") ]] || return 1
+    [[ "1" == $(SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} list ${SERVICE_ID} | python -c "import json, sys; print json.load(sys.stdin)['DesiredState']") ]] || return 1
     return 0
 }
 
 stop_service() {
     SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service stop ${SERVICE_ID}
     sleep 10
-    [[ "0" == $(serviced service list ${SERVICE_ID} | python -c "import json, sys; print json.load(sys.stdin)['DesiredState']") ]] || return 1
+    [[ "0" == $(SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} list ${SERVICE_ID} | python -c "import json, sys; print json.load(sys.stdin)['DesiredState']") ]] || return 1
     return 0
 }
 
@@ -228,10 +228,13 @@ echo "Pre-test cleanup complete"
 
 # Setup
 install_prereqs
-add_to_etc_hosts 
+add_to_etc_hosts
 
 # Run all the tests
 start_serviced             && succeed "Serviced has started within timeout"      || fail "serviced failed to start within $START_TIMEOUT seconds."
+
+echo "SERVICED=${SERVICED}"
+
 retry 20 add_host          && succeed "Added host successfully"                  || fail "Unable to add host"
 add_template               && succeed "Added template successfully"              || fail "Unable to add template"
 deploy_service             && succeed "Deployed service successfully"            || fail "Unable to deploy service"

--- a/smoke.sh
+++ b/smoke.sh
@@ -13,40 +13,40 @@ TEST_VAR_PATH=/tmp/serviced-smoke/var
 
 # Add a host
 add_host() {
-    HOST_ID=$(sudo SERVICED_ISVCS_PATH=${SERVICED_ISVCS_PATH} SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} host add "${IP}:4979" default --register | tail -n 1)
+    HOST_ID=$(sudo ${SERVICED} host add "${IP}:4979" default --register | tail -n 1)
     sleep 1
-    [ -z "$(SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} host list ${HOST_ID} 2>/dev/null)" ] && return 1
+    [ -z "$(${SERVICED} host list ${HOST_ID} 2>/dev/null)" ] && return 1
     return 0
 }
 
 add_template() {
-    TEMPLATE_ID=$(SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} template compile ${DIR}/dao/testsvc | SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} template add)
+    TEMPLATE_ID=$(${SERVICED} template compile ${DIR}/dao/testsvc | ${SERVICED} template add)
     sleep 1
-    [ -z "$(SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} template list ${TEMPLATE_ID})" ] && return 1
+    [ -z "$(${SERVICED} template list ${TEMPLATE_ID})" ] && return 1
     return 0
 }
 
 deploy_service() {
     echo "Deploying template id '${TEMPLATE_ID}'"
-    echo SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} template deploy ${TEMPLATE_ID} default testsvc
-    SERVICE_ID=$(SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} template deploy ${TEMPLATE_ID} default testsvc)
+    echo ${SERVICED} template deploy ${TEMPLATE_ID} default testsvc
+    SERVICE_ID=$(${SERVICED} template deploy ${TEMPLATE_ID} default testsvc)
     echo " deployed template id '${TEMPLATE_ID}' - SERVICE_ID='${SERVICE_ID}'"
     sleep 2
-    [ -z "$(SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service list ${SERVICE_ID})" ] && return 1
+    [ -z "$(${SERVICED} service list ${SERVICE_ID})" ] && return 1
     return 0
 }
 
 start_service() {
-    SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service start ${SERVICE_ID}
+    ${SERVICED} service start --sync ${SERVICE_ID}
     sleep 5
-    [[ "1" == $(SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} list ${SERVICE_ID} | python -c "import json, sys; print json.load(sys.stdin)['DesiredState']") ]] || return 1
+    [[ "1" == $(${SERVICED} service list ${SERVICE_ID} | python -c "import json, sys; print json.load(sys.stdin)['DesiredState']") ]] || return 1
     return 0
 }
 
 stop_service() {
-    SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service stop ${SERVICE_ID}
+    ${SERVICED} service stop --sync ${SERVICE_ID}
     sleep 10
-    [[ "0" == $(SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} list ${SERVICE_ID} | python -c "import json, sys; print json.load(sys.stdin)['DesiredState']") ]] || return 1
+    [[ "0" == $(${SERVICED} service list ${SERVICE_ID} | python -c "import json, sys; print json.load(sys.stdin)['DesiredState']") ]] || return 1
     return 0
 }
 
@@ -89,7 +89,7 @@ test_dir_config() {
 }
 
 test_attached() {
-    varx=$(SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service attach s1 whoami | tr -d '\r')
+    varx=$(${SERVICED} service attach s1 whoami | tr -d '\r')
     if [[ "$varx" == "root" ]]; then
         return 0
     fi
@@ -97,8 +97,8 @@ test_attached() {
 }
 
 test_port_mapped() {
-    echo "SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service attach s1 wget -qO- http://localhost:9090/etc/bar.txt"
-    varx=`SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service attach s1 wget -qO- http://localhost:9090/etc/bar.txt 2>/dev/null | tr -d '\r'| grep -v "^$" | tail -1`
+    echo "${SERVICED} service attach s1 wget -qO- http://localhost:9090/etc/bar.txt"
+    varx=`${SERVICED} service attach s1 wget -qO- http://localhost:9090/etc/bar.txt 2>/dev/null | tr -d '\r'| grep -v "^$" | tail -1`
     if [[ "$varx" == "baz" ]]; then
         return 0
     fi
@@ -106,26 +106,26 @@ test_port_mapped() {
 }
 
 test_snapshot() {
-    SNAPSHOT_ID=$(SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service snapshot testsvc)
-    SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} snapshot list | grep -q ${SNAPSHOT_ID}
+    SNAPSHOT_ID=$(${SERVICED} service snapshot testsvc)
+    ${SERVICED} snapshot list | grep -q ${SNAPSHOT_ID}
     return $?
 }
 
 test_snapshot_errs() {
     # make sure snapshot add returns non-zero code on error
-    SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} snapshot add invalid-id &>/dev/null
+    ${SERVICED} snapshot add invalid-id &>/dev/null
     if [[ "$?" == 0 ]]; then
         return 1
     fi
 
     # make sure service snapshot returns non-zero code on error
-    SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service snapshot invalid-id &>/dev/null
+    ${SERVICED} service snapshot invalid-id &>/dev/null
     if [[ "$?" == 0 ]]; then
         return 1
     fi
 
     # make sure snapshot rollback returns non-zero code on error
-    SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} snapshot rollback invalid-id &>/dev/null
+    ${SERVICED} snapshot rollback invalid-id &>/dev/null
     if [[ "$?" == 0 ]]; then
         return 1
     fi
@@ -136,7 +136,7 @@ test_snapshot_errs() {
 test_service_shell() {
     sentinel=smoke_test_service_shell_sentinel_$$
     container=smoke_test_service_shell_$$
-    SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service shell -s=$container s1 echo $sentinel
+    ${SERVICED} service shell -s=$container s1 echo $sentinel
     docker logs $container | grep -q $sentinel
     return $?
 }
@@ -145,31 +145,31 @@ test_service_run() {
     set -x
 
     # Make sure we start with no snapshots, othewise the checks below may pass for the wrong reason
-    SNAPSHOT_COUNT=`SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service list-snapshots s2 | wc -l`
+    SNAPSHOT_COUNT=`${SERVICED} service list-snapshots s2 | wc -l`
     [ "${SNAPSHOT_COUNT}" == "0" ] || return 1
 
     local rc=""
-    SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service run s2 exit0; rc="$?"
+    ${SERVICED} service run s2 exit0; rc="$?"
     [ "$rc" -eq 0 ] || return "$rc"
 
     # Verify that the commit moved the 'latest' tag to the same layer ID as the snapshot
-    TENANT_ID=`SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service status testsvc --show-fields ServiceID | grep -v ServiceID `
+    TENANT_ID=`${SERVICED} service status testsvc --show-fields ServiceID | grep -v ServiceID `
     LATEST_IMAGE_ID=`docker images | grep ${TENANT_ID} | grep latest | awk '{print $3}' `
-    SNAPSHOT_LABEL=`SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service list-snapshots s2 | cut -d_ -f2 `
+    SNAPSHOT_LABEL=`${SERVICED} service list-snapshots s2 | cut -d_ -f2 `
     SNAPSHOT_IMAGE_ID=`docker images | grep ${SNAPSHOT_LABEL} | awk '{print $3}' `
     [ "${SNAPSHOT_IMAGE_ID}" == "${LATEST_IMAGE_ID}" ] || return 1
 
-    SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service run s2 exit1; rc="$?"
+    ${SERVICED} service run s2 exit1; rc="$?"
     [ "$rc" -eq 42 ] || return "255"
 
     # Verify that the no additional snapshots were created
-    SNAPSHOT_COUNT=`SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service list-snapshots s2 | wc -l`
+    SNAPSHOT_COUNT=`${SERVICED} service list-snapshots s2 | wc -l`
     [ "${SNAPSHOT_COUNT}" == "1" ] || return 1
 
     # make sure kills to 'runs' are working OK
     for signal in INT TERM; do
         local sleepyPid=""
-        SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service run s2 sleepy60 &
+        ${SERVICED} service run s2 sleepy60 &
         sleepyPid="$!"
         sleep 10
         kill -"$signal" "$sleepyPid"
@@ -182,18 +182,18 @@ test_service_run() {
 test_service_run_command() {
     set -x
     local rc=""
-    SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service run s1 commands-exit0; rc="$?"
+    ${SERVICED} service run s1 commands-exit0; rc="$?"
     [ "$rc" -eq 0 ] || return "$rc"
-    SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service run s1 commands-exit1; rc="$?"
+    ${SERVICED} service run s1 commands-exit1; rc="$?"
     [ "$rc" -eq 42 ] || return "255"
-    SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service run s1 commands-exit0-nc; rc="$?"
+    ${SERVICED} service run s1 commands-exit0-nc; rc="$?"
     [ "$rc" -eq 0 ] || return "$rc"
-    SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service run s1 commands-exit1-nc; rc="$?"
+    ${SERVICED} service run s1 commands-exit1-nc; rc="$?"
     [ "$rc" -eq 42 ] || return "255"
     # make sure kills to 'commands' are working OK
     for signal in INT TERM; do
         local sleepyPid=""
-        SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service run s1 commands-sleepy60 &
+        ${SERVICED} service run s1 commands-sleepy60 &
         sleepyPid="$!"
         sleep 10
         kill -"$signal" "$sleepyPid"
@@ -202,7 +202,7 @@ test_service_run_command() {
     done
     for signal in INT TERM; do
         local sleepyPid=""
-        SERVICED_ETC_PATH=${SERVICED_ETC_PATH} ${SERVICED} service run s1 commands-sleepy60-nc &
+        ${SERVICED} service run s1 commands-sleepy60-nc &
         sleepyPid="$!"
         sleep 10
         kill -"$signal" "$sleepyPid"
@@ -256,4 +256,7 @@ test_snapshot_errs         && succeed "Snapshot errs returned expected err code"
 test_service_shell         && succeed "Service shell ran successfully"             || fail "Unable to run service shell"
 test_service_port          && succeed "Accessing public endpoint via port success" || fail "Unable to access public endpoint via port"
 stop_service               && succeed "Stopped service"                            || fail "Unable to stop service"
+
+echo "ALL TESTS PASSED"
+
 # "trap cleanup EXIT", above, will handle cleanup


### PR DESCRIPTION
Fixes CC-2844

The HA resource agent was timing out when trying to check some CC config with `serviced config` in cases where the CC master had already been stopped. This was because the CLI always issued an RPC to get a valid auth token, even for calls like `serviced config` and `serviced version` which perform no actual network I/O in and of themselves. This change moves the authenticateHost call so it only occurs for CLI calls that trigger an RPC.