### PR TITLE
CC-2832: Pass through the correct flag for whether to dial remote endpoints using TLS

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -20,6 +20,8 @@
 package config
 
 import (
+	"strconv"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/control-center/serviced/logging"
 	"github.com/control-center/serviced/volume"
@@ -46,7 +48,7 @@ type Options struct {
 	DockerDNS                  []string
 	Agent                      bool
 	MuxPort                    int
-	MuxDisableTLS              string            //  Disable TLS for MUX connections, string val of bool
+	MuxDisableTLS              string //  Disable TLS for MUX connections, string val of bool
 	KeyPEMFile                 string
 	CertPEMFile                string
 	VolumesPath                string
@@ -125,4 +127,9 @@ func LoadOptions(ops Options) {
 		}).Debug("Overriding Elastic startup timeout")
 		options.ESStartupTimeout = minTimeout
 	}
+}
+
+func MuxTLSIsEnabled() bool {
+	disabled, _ := strconv.ParseBool(options.MuxDisableTLS)
+	return !disabled && options.MuxPort > 0
 }

--- a/dao/testsvc/s2/service.json
+++ b/dao/testsvc/s2/service.json
@@ -16,7 +16,27 @@
               "PortList": [
                 {
                   "PortAddr": ":1234",
-                  "Enabled": true
+                  "Enabled": true,
+                  "UseTLS": true,
+                  "Protocol": "https"
+                },
+                {
+                  "PortAddr": ":1235",
+                  "Enabled": true,
+                  "UseTLS": false,
+                  "Protocol": "http"
+                },
+                {
+                  "PortAddr": ":1236",
+                  "Enabled": true,
+                  "UseTLS": true,
+                  "Protocol": "tcp"
+                },
+                {
+                  "PortAddr": ":1237",
+                  "Enabled": true,
+                  "UseTLS": false,
+                  "Protocol": "tcp"
                 }
               ]
             }

--- a/smoke.sh
+++ b/smoke.sh
@@ -62,13 +62,20 @@ test_vhost() {
     return 0
 }
 
-test_service_port() {
+test_service_port_http() {
+    wget --no-check-certificate --content-on-error -O- http://${HOSTNAME}:1235 || return 1
+}
 
-    # make sure it is accessible
-    wget --content-on-error -O- http://${HOSTNAME}:1234 || return 1
+test_service_port_tcp() {
+    wget --no-check-certificate --content-on-error -O- http://${HOSTNAME}:1237 || return 1
+}
 
-    # make sure it is accessible via ipv6
-    # wget --no-check-certificate -qO- http://[${IP6}]:1234 || return 1
+test_service_port_https() {
+    wget --no-check-certificate --content-on-error -O- https://${HOSTNAME}:1234 || return 1
+}
+
+test_service_port_tcp_tls() {
+    wget --no-check-certificate --content-on-error -O- https://${HOSTNAME}:1236 || return 1
 }
 
 test_assigned_ip() {
@@ -228,7 +235,7 @@ echo "Pre-test cleanup complete"
 
 # Setup
 install_prereqs
-add_to_etc_hosts 
+add_to_etc_hosts
 
 # Run all the tests
 start_serviced             && succeed "Serviced has started within timeout"      || fail "serviced failed to start within $START_TIMEOUT seconds."
@@ -251,6 +258,11 @@ retry 10 test_port_mapped  && succeed "Attached and hit imported port correctly"
 test_snapshot              && succeed "Created snapshot"                           || fail "Unable to create snapshot"
 test_snapshot_errs         && succeed "Snapshot errs returned expected err code"   || fail "Snapshot errs did not return expected err code"
 test_service_shell         && succeed "Service shell ran successfully"             || fail "Unable to run service shell"
-test_service_port          && succeed "Accessing public endpoint via port success" || fail "Unable to access public endpoint via port"
+
+test_service_port_http     && succeed "Accessing public endpoint via HTTP port success"    || fail "Unable to access public endpoint via HTTP port"
+test_service_port_https    && succeed "Accessing public endpoint via HTTPS port success"   || fail "Unable to access public endpoint via HTTPS port"
+test_service_port_tcp      && succeed "Accessing public endpoint via TCP port success"     || fail "Unable to access public endpoint via TCP port"
+test_service_port_tcp_tls  && succeed "Accessing public endpoint via TCP/TLS port success" || fail "Unable to access public endpoint via TCP/TLS port"
+
 stop_service               && succeed "Stopped service"                            || fail "Unable to stop service"
 # "trap cleanup EXIT", above, will handle cleanup

--- a/web/serve.go
+++ b/web/serve.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/control-center/serviced/config"
 	"github.com/control-center/serviced/proxy"
 )
 
@@ -61,7 +62,7 @@ func ServeTCP(cancel <-chan struct{}, listener net.Listener, tlsConfig *tls.Conf
 			})
 
 			// setup remote connection
-			remote, err := GetRemoteConnection(tlsConfig != nil, export)
+			remote, err := GetRemoteConnection(config.MuxTLSIsEnabled(), export)
 			if err != nil {
 				logger.WithError(err).Error("Could not get remote connection for endpoint")
 				continue
@@ -126,7 +127,7 @@ func ServeHTTP(cancel <-chan struct{}, address, protocol string, listener net.Li
 			return
 		}
 
-		rp := GetReverseProxy(tlsConfig != nil, export)
+		rp := GetReverseProxy(config.MuxTLSIsEnabled(), export)
 
 		logger.WithFields(log.Fields{
 			"application": export.Application,

--- a/web/utils.go
+++ b/web/utils.go
@@ -104,7 +104,7 @@ func newTlsDialer(config *tls.Config) dialerInterface {
 // GetRemoteConnection returns a connection to a remote address
 func GetRemoteConnection(useTLS bool, export *registry.ExportDetails) (remote net.Conn, err error) {
 	var dialer dialerInterface
-	if useTLS {
+	if useTLS && !IsLocalAddress(export.HostIP) {
 		config := tls.Config{InsecureSkipVerify: true}
 		dialer = newTlsDialer(&config)
 	} else {


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-2832

This also updates the smoke test to be more comprehensive w/r/t public ports, and fixes a bug discovered where TCP public ports simply don't work on a single-host system.