### PR TITLE
Add Master.UpdateHost to the non-admin RPC list

### DIFF
--- a/rpc/rpcutils/authcodec.go
+++ b/rpc/rpcutils/authcodec.go
@@ -37,6 +37,7 @@ var (
 		"Master.GetSystemUser":                   struct{}{},
 		"Master.ReportHealthStatus":              struct{}{},
 		"Master.ReportInstanceDead":              struct{}{},
+		"Master.UpdateHost":                      struct{}{},
 		"ControlCenter.GetServices":              struct{}{},
 		"ControlCenterAgent.GetEvaluatedService": struct{}{},
 		"ControlCenterAgent.GetHostID":           struct{}{},


### PR DESCRIPTION
When delegates check in with the master, they call Master.UpdateHost to
update their properties (e.g., RAM, serviced version, etc.)  Previously,
hosts in a non-admin pool were no able to do so.

Note that this opens a potential security hole which will need to be
addressed in the future.

Fixes [CC-2873](https://jira.zenoss.com/browse/CC-2873)