### PR TITLE
Fix logsash conf to avoid errors caused by deprecated mapping

### DIFF
--- a/isvcs/resources/logstash/logstash.conf.in
+++ b/isvcs/resources/logstash/logstash.conf.in
@@ -23,5 +23,6 @@ filter {
 output {
 	elasticsearch {
 		hosts => "elasticsearch:9100"
+		template_overwrite => true
 	}
 }

--- a/isvcs/resources/logstash/logstash.conf.template
+++ b/isvcs/resources/logstash/logstash.conf.template
@@ -19,5 +19,6 @@ input {
 output {
 	elasticsearch {
 		hosts => "elasticsearch:9100"
+		template_overwrite => true
 	}
 }


### PR DESCRIPTION
Followed the recommendation given here: https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/310