### PR TITLE
CC-2850 Instance not restarted if container dies during wan outtage

### DIFF
--- a/node/agent.go
+++ b/node/agent.go
@@ -79,8 +79,8 @@ type HostAgent struct {
 	mount                []string             // each element is in the form: dockerImage,hostPath,containerPath
 	currentServices      map[string]*exec.Cmd // the current running services
 	mux                  *proxy.TCPMux
-	muxport              string               // the mux port to serviced (default is 22250)
-	useTLS               bool                 // true if TLS should be enabled for MUX
+	muxport              string // the mux port to serviced (default is 22250)
+	useTLS               bool   // true if TLS should be enabled for MUX
 	proxyRegistry        proxy.ProxyRegistry
 	zkClient             *coordclient.Client
 	maxContainerAge      time.Duration   // maximum age for a stopped container before it is removed
@@ -114,7 +114,7 @@ type AgentOptions struct {
 	Master               string
 	UIPort               string
 	RPCPort              string
-	RPCDisableTLS        bool                 // true if TLS should be disabled for RPC
+	RPCDisableTLS        bool // true if TLS should be disabled for RPC
 	DockerDNS            []string
 	VolumesPath          string
 	Mount                []string
@@ -407,8 +407,8 @@ func (a *HostAgent) Start(shutdown <-chan interface{}) {
 		case <-startExit:
 			glog.Infof("Host Agent restarting")
 			close(unregister)
-			unregister = make(chan interface{})
 			rwg.Wait()
+			unregister = make(chan interface{})
 		case <-shutdown:
 			glog.Infof("Host Agent shutting down")
 

--- a/node/agent.go
+++ b/node/agent.go
@@ -408,7 +408,11 @@ func (a *HostAgent) Start(shutdown <-chan interface{}) {
 			glog.Infof("Host Agent restarting")
 			close(unregister)
 			rwg.Wait()
+
+			// The unregister var is used directly in the goroutine that calls
+			// RegisterHost above. Always wait for rwg before re-assigning it.
 			unregister = make(chan interface{})
+
 		case <-shutdown:
 			glog.Infof("Host Agent shutting down")
 


### PR DESCRIPTION
Fixed a race that prevented the zk listener from restarting when a WAN outtage ends.  Now, if a container dies during a WAN outtage, it will be restarted when the WAN comes back.
