### PR TITLE
Feature/CC-2934 Make serviced pool list -v more user-friendly

### DIFF
--- a/cli/cmd/pool.go
+++ b/cli/cmd/pool.go
@@ -196,10 +196,8 @@ func (c *ServicedCli) cmdPoolList(ctx *cli.Context) {
 	}
 
 	if ctx.Bool("verbose") {
-		if jsonPool, err := json.MarshalIndent(pools, " ", "  "); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to marshal resource pool list: %s", err)
-		} else {
-			fmt.Println(string(jsonPool))
+		for _, p := range pools {
+			fmt.Print(strings.Replace(p.ToString(), "\n", "\n  ", -1))
 		}
 	} else {
 		t := NewTable(ctx.String("show-fields"))

--- a/cli/cmd/pool.go
+++ b/cli/cmd/pool.go
@@ -197,7 +197,40 @@ func (c *ServicedCli) cmdPoolList(ctx *cli.Context) {
 
 	if ctx.Bool("verbose") {
 		for _, p := range pools {
-			fmt.Print(strings.Replace(p.ToString(), "\n", "\n  ", -1))
+			permissionStr := ""
+			switch p.Permissions {
+			case 0:
+				permissionStr = "No Permissions"
+			case 1:
+				permissionStr = "Admin Permissions Only"
+			case 2:
+				permissionStr = "DFS Permissions Only"
+			case 3:
+				permissionStr = "DFS and Admin Permissions"
+			}
+			fmt.Printf("%s\n", p.ID)
+			fmt.Printf("  %-20s%s\n", "Realm:", p.Realm)
+			fmt.Printf("  %-20s%s\n", "Description:", p.Description)
+			fmt.Printf("  %-20s", "Virtual IPs:")
+			if len(p.VirtualIPs) > 0 {
+				fmt.Printf("\n")
+				for _, vIP := range p.VirtualIPs {
+					fmt.Printf("    %-20s%s\n", "Bind Interface:", vIP.BindInterface)
+					fmt.Printf("    %-20s%s\n", "IP:", vIP.IP)
+					fmt.Printf("    %-20s%s\n", "Netmask:", vIP.Netmask)
+				}
+			} else {
+				fmt.Printf("None\n")
+			}
+			fmt.Printf("  %-20s%d\n", "Core Limit:", p.CoreLimit)
+			fmt.Printf("  %-20s%d\n", "Memory Limit:", p.MemoryLimit)
+			fmt.Printf("  %-20s%d\n", "Core Capacity:", p.CoreCapacity)
+			fmt.Printf("  %-20s%d\n", "Memory Capacity:", p.MemoryCapacity)
+			fmt.Printf("  %-20s%d\n", "Memory Commitment:", p.MemoryCommitment)
+			fmt.Printf("  %-20s%d\n", "Connection Timout:", p.ConnectionTimeout)
+			fmt.Printf("  %-20s%s\n", "Created At:", p.CreatedAt)
+			fmt.Printf("  %-20s%s\n", "Updated At:", p.UpdatedAt)
+			fmt.Printf("  %-20s%s\n", "Permissions:", permissionStr)
 		}
 	} else {
 		t := NewTable(ctx.String("show-fields"))

--- a/domain/pool/pool.go
+++ b/domain/pool/pool.go
@@ -18,7 +18,6 @@ import (
 	"github.com/control-center/serviced/domain"
 	"github.com/control-center/serviced/domain/host"
 
-	"fmt"
 	"reflect"
 	"sort"
 	"time"
@@ -55,45 +54,6 @@ type ResourcePool struct {
 	MonitoringProfile domain.MonitorProfile
 	Permissions       Permission
 	datastore.VersionedEntity
-}
-
-func (p ResourcePool) ToString() string {
-	permissionStr := ""
-	switch p.Permissions {
-	case 0:
-		permissionStr = "No Permissions"
-	case 1:
-		permissionStr = "DFS Permissions Only"
-	case 2:
-		permissionStr = "Admin Permissions Only"
-	case 3:
-		permissionStr = "DFS and Admin Permissions"
-	}
-	pStr := ""
-	pStr += fmt.Sprintf("%s\n", p.ID)
-	pStr += fmt.Sprintf("%-20s%s\n", "Realm:", p.Realm)
-	pStr += fmt.Sprintf("%-20s%s\n", "Description:", p.Description)
-	pStr += fmt.Sprintf("%-20s", "Virtual IPs:")
-	if len(p.VirtualIPs) > 0 {
-		pStr += fmt.Sprintf("\n")
-		for _, vIP := range p.VirtualIPs {
-			pStr += fmt.Sprintf("  %-20s%s\n", "Bind Interface:", vIP.BindInterface)
-			pStr += fmt.Sprintf("  %-20s%s\n", "IP:", vIP.IP)
-			pStr += fmt.Sprintf("  %-20s%s\n", "Netmask:", vIP.Netmask)
-		}
-	} else {
-		pStr += fmt.Sprintf("None\n")
-	}
-	pStr += fmt.Sprintf("%-20s%d\n", "Core Limit:", p.CoreLimit)
-	pStr += fmt.Sprintf("%-20s%d\n", "Memory Limit:", p.MemoryLimit)
-	pStr += fmt.Sprintf("%-20s%d\n", "Core Capacity:", p.CoreCapacity)
-	pStr += fmt.Sprintf("%-20s%d\n", "Memory Capacity:", p.MemoryCapacity)
-	pStr += fmt.Sprintf("%-20s%d\n", "Memory Commitment:", p.MemoryCommitment)
-	pStr += fmt.Sprintf("%-20s%d\n", "Connection Timout:", p.ConnectionTimeout)
-	pStr += fmt.Sprintf("%-20s%s\n", "Created At:", p.CreatedAt)
-	pStr += fmt.Sprintf("%-20s%s\n", "Updated At:", p.UpdatedAt)
-	pStr += fmt.Sprintf("%-20s%s\n", "Permissions:", permissionStr)
-	return pStr
 }
 
 func (p ResourcePool) GetConnectionTimeout() time.Duration {

--- a/domain/pool/pool.go
+++ b/domain/pool/pool.go
@@ -18,6 +18,7 @@ import (
 	"github.com/control-center/serviced/domain"
 	"github.com/control-center/serviced/domain/host"
 
+	"fmt"
 	"reflect"
 	"sort"
 	"time"
@@ -54,6 +55,45 @@ type ResourcePool struct {
 	MonitoringProfile domain.MonitorProfile
 	Permissions       Permission
 	datastore.VersionedEntity
+}
+
+func (p ResourcePool) ToString() string {
+	permissionStr := ""
+	switch p.Permissions {
+	case 0:
+		permissionStr = "No Permissions"
+	case 1:
+		permissionStr = "DFS Permissions Only"
+	case 2:
+		permissionStr = "Admin Permissions Only"
+	case 3:
+		permissionStr = "DFS and Admin Permissions"
+	}
+	pStr := ""
+	pStr += fmt.Sprintf("%s\n", p.ID)
+	pStr += fmt.Sprintf("%-20s%s\n", "Realm:", p.Realm)
+	pStr += fmt.Sprintf("%-20s%s\n", "Description:", p.Description)
+	pStr += fmt.Sprintf("%-20s", "Virtual IPs:")
+	if len(p.VirtualIPs) > 0 {
+		pStr += fmt.Sprintf("\n")
+		for _, vIP := range p.VirtualIPs {
+			pStr += fmt.Sprintf("  %-20s%s\n", "Bind Interface:", vIP.BindInterface)
+			pStr += fmt.Sprintf("  %-20s%s\n", "IP:", vIP.IP)
+			pStr += fmt.Sprintf("  %-20s%s\n", "Netmask:", vIP.Netmask)
+		}
+	} else {
+		pStr += fmt.Sprintf("None\n")
+	}
+	pStr += fmt.Sprintf("%-20s%d\n", "Core Limit:", p.CoreLimit)
+	pStr += fmt.Sprintf("%-20s%d\n", "Memory Limit:", p.MemoryLimit)
+	pStr += fmt.Sprintf("%-20s%d\n", "Core Capacity:", p.CoreCapacity)
+	pStr += fmt.Sprintf("%-20s%d\n", "Memory Capacity:", p.MemoryCapacity)
+	pStr += fmt.Sprintf("%-20s%d\n", "Memory Commitment:", p.MemoryCommitment)
+	pStr += fmt.Sprintf("%-20s%d\n", "Connection Timout:", p.ConnectionTimeout)
+	pStr += fmt.Sprintf("%-20s%s\n", "Created At:", p.CreatedAt)
+	pStr += fmt.Sprintf("%-20s%s\n", "Updated At:", p.UpdatedAt)
+	pStr += fmt.Sprintf("%-20s%s\n", "Permissions:", permissionStr)
+	return pStr
 }
 
 func (p ResourcePool) GetConnectionTimeout() time.Duration {


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-2934

`serviced pool list -v` was printing a json dump of the pools slice, which is not user-friendly and does not describe permissions in a decipherable way.

The changes in this PR print the pool information in a more user-friendly way.

Note that the MonitoringProfile and VersionedEntity properties are not being printed.  (Should they be?)