### PR TITLE
More scheduling optimization

### DIFF
--- a/domain/service/servicehealth.go
+++ b/domain/service/servicehealth.go
@@ -54,7 +54,6 @@ func BuildServiceHealth(svc Service) *ServiceHealth {
 		HealthChecks: make(map[string]health.HealthCheck),
 	}
 
-	sh.HealthChecks = make(map[string]health.HealthCheck)
 	for key, value := range svc.HealthChecks {
 		sh.HealthChecks[key] = value
 	}

--- a/domain/service/servicehealth.go
+++ b/domain/service/servicehealth.go
@@ -54,6 +54,7 @@ func BuildServiceHealth(svc Service) *ServiceHealth {
 		HealthChecks: make(map[string]health.HealthCheck),
 	}
 
+	sh.HealthChecks = make(map[string]health.HealthCheck)
 	for key, value := range svc.HealthChecks {
 		sh.HealthChecks[key] = value
 	}

--- a/facade/instance_test.go
+++ b/facade/instance_test.go
@@ -368,14 +368,10 @@ func (ft *FacadeUnitTest) TestGetHostInstances_Success(c *C) {
 }
 
 func (ft *FacadeUnitTest) TestGetHostStrategyInstances(c *C) {
-	hst1 := &host.Host{
+	hst1 := host.Host{
 		ID:     "testhost1",
 		PoolID: "default",
 	}
-	ft.hostStore.On("Get", ft.ctx, host.HostKey("testhost1"), mock.AnythingOfType("*host.Host")).Return(nil).Run(func(args mock.Arguments) {
-		arg := args.Get(2).(*host.Host)
-		*arg = *hst1
-	})
 	states1 := []zkservice.State{
 		{
 			HostID:     "testhost1",
@@ -395,14 +391,10 @@ func (ft *FacadeUnitTest) TestGetHostStrategyInstances(c *C) {
 	}
 	ft.zzk.On("GetHostStates", ft.ctx, "default", "testhost1").Return(states1, nil)
 
-	hst2 := &host.Host{
+	hst2 := host.Host{
 		ID:     "testhost2",
 		PoolID: "default",
 	}
-	ft.hostStore.On("Get", ft.ctx, host.HostKey("testhost2"), mock.AnythingOfType("*host.Host")).Return(nil).Run(func(args mock.Arguments) {
-		arg := args.Get(2).(*host.Host)
-		*arg = *hst2
-	})
 	states2 := []zkservice.State{
 		{
 			HostID:     "testhost2",
@@ -434,8 +426,7 @@ func (ft *FacadeUnitTest) TestGetHostStrategyInstances(c *C) {
 	}
 	ft.serviceStore.On("Get", ft.ctx, "testservice").Return(svc, nil)
 
-	expected := []service.StrategyInstance{
-		{
+	expected := []*service.StrategyInstance{
 			HostID:        hst1.ID,
 			ServiceID:     svc.ID,
 			CPUCommitment: int(svc.CPUCommitment),
@@ -449,7 +440,7 @@ func (ft *FacadeUnitTest) TestGetHostStrategyInstances(c *C) {
 			HostPolicy:    svc.HostPolicy,
 		},
 	}
-	actual, err := ft.Facade.GetHostStrategyInstances(ft.ctx, "testhost1", "testhost2")
+	actual, err := ft.Facade.GetHostStrategyInstances(ft.ctx, []host.Host{hst1, hst2})
 	c.Assert(err, IsNil)
 	c.Assert(actual, DeepEquals, expected)
 }

--- a/facade/instance_test.go
+++ b/facade/instance_test.go
@@ -426,13 +426,15 @@ func (ft *FacadeUnitTest) TestGetHostStrategyInstances(c *C) {
 	}
 	ft.serviceStore.On("Get", ft.ctx, "testservice").Return(svc, nil)
 
-	expected := []*service.StrategyInstance{
+	expectedMap := map[string]service.StrategyInstance{
+		hst1.ID: {
 			HostID:        hst1.ID,
 			ServiceID:     svc.ID,
 			CPUCommitment: int(svc.CPUCommitment),
 			RAMCommitment: svc.RAMCommitment.Value,
 			HostPolicy:    svc.HostPolicy,
-		}, {
+		},
+		hst2.ID: {
 			HostID:        hst2.ID,
 			ServiceID:     svc.ID,
 			CPUCommitment: int(svc.CPUCommitment),
@@ -442,5 +444,10 @@ func (ft *FacadeUnitTest) TestGetHostStrategyInstances(c *C) {
 	}
 	actual, err := ft.Facade.GetHostStrategyInstances(ft.ctx, []host.Host{hst1, hst2})
 	c.Assert(err, IsNil)
-	c.Assert(actual, DeepEquals, expected)
+	c.Assert(len(actual), Equals, len(expectedMap))
+	for _, result := range(actual) {
+		expected, ok := expectedMap[(*result).HostID]
+		c.Assert(ok, Equals, true)
+		c.Assert(*result, Equals, expected)
+	}
 }

--- a/facade/mocks/ZZK.go
+++ b/facade/mocks/ZZK.go
@@ -25,6 +25,18 @@ func (_m *ZZK) UpdateService(ctx datastore.Context, tenantID string, svc *servic
 
 	return r0
 }
+func (_m *ZZK) UpdateServices(ctx datastore.Context, tenantID string, svcs []*service.Service, setLockOnCreate bool, setLockOnUpdate bool) error {
+        ret := _m.Called(ctx, tenantID, svcs, setLockOnCreate, setLockOnUpdate)
+
+        var r0 error
+        if rf, ok := ret.Get(0).(func(datastore.Context, string, []*service.Service, bool, bool) error); ok {
+                r0 = rf(ctx, tenantID, svcs, setLockOnCreate, setLockOnUpdate)
+        } else {
+                r0 = ret.Error(0)
+        }
+
+        return r0
+}
 func (_m *ZZK) SyncServiceRegistry(ctx datastore.Context, tenantID string, svc *service.Service) error {
 	ret := _m.Called(ctx, tenantID, svc)
 

--- a/facade/testutils.go
+++ b/facade/testutils.go
@@ -96,6 +96,7 @@ func (ft *FacadeIntegrationTest) setupMockZZK() {
 	ft.zzk.On("UpdateHost", mock.AnythingOfType("*host.Host")).Return(nil)
 	ft.zzk.On("RemoveHost", mock.AnythingOfType("*host.Host")).Return(nil)
 	ft.zzk.On("UpdateService", mock.AnythingOfType("*datastore.context"), mock.AnythingOfType("string"), mock.AnythingOfType("*service.Service"), mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return(nil)
+	ft.zzk.On("UpdateServices", mock.AnythingOfType("*datastore.context"), mock.AnythingOfType("string"), mock.AnythingOfType("[]*service.Service"), mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return(nil)
 	ft.zzk.On("RemoveService", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil)
 	ft.zzk.On("RemoveServiceEndpoints", mock.AnythingOfType("string")).Return(nil)
 	ft.zzk.On("RemoveTenantExports", mock.AnythingOfType("string")).Return(nil)

--- a/facade/zzk.go
+++ b/facade/zzk.go
@@ -24,6 +24,7 @@ import (
 
 type ZZK interface {
 	UpdateService(ctx datastore.Context, tenantID string, svc *service.Service, setLockOnCreate, setLockOnUpdate bool) error
+	UpdateServices(ctx datastore.Context, tenantID string, svc []*service.Service, setLockOnCreate, setLockOnUpdate bool) error
 	SyncServiceRegistry(ctx datastore.Context, tenantID string, svc *service.Service) error
 	RemoveService(poolID, serviceID string) error
 	RemoveServiceEndpoints(serviceID string) error

--- a/scheduler/strategy.go
+++ b/scheduler/strategy.go
@@ -60,14 +60,14 @@ func StrategySelectHost(sn *zkservice.ServiceNode, hosts []host.Host, strat stra
 
 	// Look up all running services for the hosts
 	glog.V(2).Infof("Looking up instances for hosts: %+v", hostids)
-	svcs, err := facade.GetHostStrategyInstances(datastore.Get(), hostids...)
+	svcs, err := facade.GetHostStrategyInstances(datastore.Get(), hosts)
 	if err != nil {
 		return "", err
 	}
 	// Assign the services to the StrategyHosts
 	for _, s := range svcs {
 		if h, ok := hostmap[s.HostID]; ok {
-			h.services = append(h.services, &StrategyRunningService{s})
+			h.services = append(h.services, &StrategyRunningService{*s})
 		}
 	}
 	shosts := []strategy.Host{}


### PR DESCRIPTION
More optimizations in support of CC-2509. The two main themes (primarily in c0d78ea)

* do not pass arrays of Service objs; pass arrays of pointers to Service objs
* When updating ZK for manual scheduling, group the updates by pool, so we only have to check the ZK path "/pool/<poolName>/services" once for a given pool instead of once for each service (e.g. replaces 2000 of those checks with 100 checks in the 100-pools scenario). 