### PR TITLE
CC-2960: Handle services with mixed case names

### DIFF
--- a/facade/service.go
+++ b/facade/service.go
@@ -2149,7 +2149,7 @@ func (f *Facade) ResolveServicePath(ctx datastore.Context, svcPath string) ([]se
 	var (
 		parent  string
 		current string
-		result  []service.ServiceDetails
+		result  = []service.ServiceDetails{}
 	)
 	plog := plog.WithFields(log.Fields{
 		"svcpath": svcPath,


### PR DESCRIPTION
Also deals with a case where we were returning a nil array instead of an empty array, which led to Go's RPC client library treating the response as an error with a value of nil.