### PR TITLE
Only show ID field when searching for pool name in pool acceptance test

### DIFF
--- a/acceptance/common/api/cli_pool.rb
+++ b/acceptance/common/api/cli_pool.rb
@@ -25,7 +25,7 @@ module CCApi
         end
 
         def check_pool_exists(poolName)
-            result = CC.CLI.execute("%{serviced} pool list")
+            result = CC.CLI.execute("%{serviced} pool list --show-fields ID")
             matchData = result.match /^#{poolName}$/
             return matchData != nil
         end


### PR DESCRIPTION
`serviced pool list` now also contains the `Permissions` field, so we must specify that we only want the pool ID for matching pool name.