### PR TITLE
Backport fix from PR 3209

### DIFF
--- a/acceptance/ui/features/api/cli_pool.rb
+++ b/acceptance/ui/features/api/cli_pool.rb
@@ -24,7 +24,7 @@ module CCApi
         end
 
         def check_pool_exists(poolName)
-            result = CC.CLI.execute("%{serviced} pool list")
+            result = CC.CLI.execute("%{serviced} pool list --show-fields ID")
             matchData = result.match /^#{poolName}$/
             return matchData != nil
         end


### PR DESCRIPTION
A recent change in the output format of `serviced pool list` confused the CLI-based setup portion of the UI acceptance tests into thinking that pool creation failed. This PR applies the same change from #3209 for the API acceptance tests to the UI acceptance tests.