### PR TITLE
Fix one of the acceptance tests failures

### DIFF
--- a/acceptance/ui/features/api/cli_service.rb
+++ b/acceptance/ui/features/api/cli_service.rb
@@ -15,7 +15,7 @@ module CCApi
             # Make sure one of the lines matches each of the values
             result = CC.CLI.execute("%{serviced} service public-endpoints port list")
             result.each_line do |line|
-                return true if (result =~ /#{service}/) && (result =~ /#{endpoint}/) && (result =~ /#{portAddr}/) && (result =~ /#{protocol}/) && (result =~ /#{enabled}/)
+                return true if (line =~ /#{service}/i) && (line =~ /#{endpoint}/i) && (line =~ /#{portAddr}/i) && (line =~ /#{protocol}/i) && (line =~ /#{enabled}/i)
             end
 
             fail(ArgumentError.new("port #{name} doesn't exist"))
@@ -31,7 +31,7 @@ module CCApi
             # Make sure one of the lines matches each of the values
             result = CC.CLI.execute("%{serviced} service public-endpoints vhost list")
             result.each_line do |line|
-                return true if (result =~ /#{service}/) && (result =~ /#{endpoint}/) && (result =~ /#{vhost}/) && (result =~ /#{enabled}/)
+                return true if (line =~ /#{service}/i) && (line =~ /#{endpoint}/i) && (line =~ /#{vhost}/i) && (line =~ /#{enabled}/i)
             end
 
             fail(ArgumentError.new("vhost #{name} doesn't exist"))
@@ -225,7 +225,7 @@ module CCApi
         def remove_publicendpoint_port(service, endpoint, portAddr)
             CC.CLI.execute("%{serviced} service public-endpoints port rm #{service} #{endpoint} #{portAddr}")
         end
-        
+
         def remove_publicendpoint_vhost(service, endpoint, vhost)
             CC.CLI.execute("%{serviced} service public-endpoints vhost rm #{service} #{endpoint} #{vhost}")
         end


### PR DESCRIPTION
A recent change produced slightly different CLI output for list-public-endpoints. The new output had capitalized "Other" for non-http port addresses.  This resulted in failures for the scenario `List the port public endpoints`  The failures looked like:
```
port "port0" doesn't exist (ArgumentError)
./features/api/cli_service.rb:21:in `verify_publicendpoint_port_list_matches'
./features/steps/cli_steps.rb:31:in `/^I should see the (port|vhost) public endpoint (.*) in the list output$/'
features/cli.feature:16:in `Then I should see the port public endpoint "port0" in the list output'
```

This change makes the string comparison in the underlying step method use case-insensitive comparison.