### PR TITLE
CC-2968: Update commands for serviced service (logs|attach)

### DIFF
--- a/cli/api/instance.go
+++ b/cli/api/instance.go
@@ -84,8 +84,7 @@ func (a *api) AttachServiceInstance(serviceID string, instanceID int, command st
 		cmd := []string{
 			"/usr/bin/ssh",
 			"-t", targetIP, "--",
-			"serviced", "--endpoint", GetOptionsRPCEndpoint(),
-			"service", "attach", fmt.Sprintf("%s", targetContainer),
+			"docker", "exec", "-it", fmt.Sprintf("%s", targetContainer),
 		}
 		cmd = append(cmd, command)
 		cmd = append(cmd, args...)


### PR DESCRIPTION
The strategy for attaching/getting logs from a remote Docker container was to run "ssh HOST serviced service attach DOCKERID". We just removed support for "attach DOCKERID". We could put it back, but the problem remains that it wouldn't work on pools without delegate access. This PR updates those commands to run the docker commands directly, rather than going through serviced RPC calls to get the same thing.