### PR TITLE
Validate endpoints for migration more efficiently

### DIFF
--- a/domain/service/validation.go
+++ b/domain/service/validation.go
@@ -20,25 +20,6 @@ import (
 	"github.com/control-center/serviced/validation"
 )
 
-// ServiceEndpointValidator looks for duplicate service endpoints
-type ServiceEndpointValidator map[string]string
-
-func NewServiceEndpointValidator() ServiceEndpointValidator {
-	return ServiceEndpointValidator(make(map[string]string))
-}
-
-func (v ServiceEndpointValidator) IsValid(vErr *validation.ValidationError, svc *Service) {
-	for _, ep := range svc.Endpoints {
-		if ep.Purpose == "export" {
-			if serviceID, ok := v[ep.Application]; ok {
-				vErr.AddViolation(fmt.Sprintf("found duplicate endpoint name %s amongst services %s and %s", ep.Application, svc.ID, serviceID))
-			} else {
-				v[ep.Application] = svc.ID
-			}
-		}
-	}
-}
-
 //ValidEntity validate that Service has all required fields
 func (s *Service) ValidEntity() error {
 

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -243,65 +243,6 @@ func (ft *FacadeIntegrationTest) TestFacade_validateService_badServiceID(t *C) {
 	t.Assert(err, ErrorMatches, "No such entity {kind:service, id:badID}")
 }
 
-func (ft *FacadeIntegrationTest) TestFacade_validateServiceEndpoints_noDupsInOneService(t *C) {
-	svc := service.Service{
-		ID:           "svc1",
-		Name:         "TestFacade_validateServiceEndpoints",
-		DeploymentID: "deployment_id",
-		PoolID:       "pool_id",
-		Launch:       "auto",
-		DesiredState: int(service.SVCStop),
-		Endpoints: []service.ServiceEndpoint{
-			service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{Name: "test_ep_1", Application: "test_ep_1", Purpose: "export"}),
-			service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{Name: "test_ep_2", Application: "test_ep_2", Purpose: "export"}),
-		},
-	}
-
-	err := ft.Facade.validateServiceEndpoints(ft.CTX, &svc)
-	t.Assert(err, IsNil)
-}
-
-func (ft *FacadeIntegrationTest) TestFacade_validateServiceEndpoints_noDupsInAllServices(t *C) {
-	svc := service.Service{
-		ID:           "svc1",
-		Name:         "TestFacade_validateServiceEndpoints",
-		DeploymentID: "deployment_id",
-		PoolID:       "pool_id",
-		Launch:       "auto",
-		DesiredState: int(service.SVCStop),
-		Endpoints: []service.ServiceEndpoint{
-			service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{Name: "test_ep_1", Application: "test_ep_1", Purpose: "export"}),
-			service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{Name: "test_ep_2", Application: "test_ep_2", Purpose: "export"}),
-		},
-	}
-
-	if err := ft.Facade.AddService(ft.CTX, svc); err != nil {
-		t.Fatalf("Setup failed; could not add svc %s: %s", svc.ID, err)
-		return
-	}
-
-	childSvc := service.Service{
-		ID:              "svc2",
-		ParentServiceID: svc.ID,
-		Name:            "TestFacade_validateServiceEndpoints_child",
-		DeploymentID:    "deployment_id",
-		PoolID:          "pool_id",
-		Launch:          "auto",
-		DesiredState:    int(service.SVCStop),
-		Endpoints: []service.ServiceEndpoint{
-			service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{Name: "test_ep_3", Application: "test_ep_3", Purpose: "export"}),
-			service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{Name: "test_ep_4", Application: "test_ep_4", Purpose: "export"}),
-		},
-	}
-	if err := ft.Facade.AddService(ft.CTX, childSvc); err != nil {
-		t.Fatalf("Setup failed; could not add svc %s: %s", childSvc.ID, err)
-		return
-	}
-
-	err := ft.Facade.validateServiceEndpoints(ft.CTX, &svc)
-	t.Assert(err, IsNil)
-}
-
 func (ft *FacadeIntegrationTest) TestFacade_validateServiceAdd_EnableDuplicatePublicEndpoint(t *C) {
 	svc := service.Service{
 		ID:           "svc1",
@@ -350,67 +291,6 @@ func (ft *FacadeIntegrationTest) TestFacade_validateServiceAdd_EnableDuplicatePu
 	svc.Endpoints[0].VHostList[0].Enabled = true
 
 	t.Assert(ft.Facade.UpdateService(ft.CTX, svc), NotNil)
-}
-
-func (ft *FacadeIntegrationTest) TestFacade_validateServiceEndpoints_dupsInOneService(t *C) {
-	svc := service.Service{
-		ID:           "svc1",
-		Name:         "TestFacade_validateServiceEndpoints",
-		DeploymentID: "deployment_id",
-		PoolID:       "pool_id",
-		Launch:       "auto",
-		DesiredState: int(service.SVCStop),
-		Endpoints: []service.ServiceEndpoint{
-			service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{Name: "test_ep_1", Application: "test_ep_1", Purpose: "export"}),
-			service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{Name: "test_ep_1", Application: "test_ep_1", Purpose: "export"}),
-		},
-	}
-
-	err := ft.Facade.validateServiceEndpoints(ft.CTX, &svc)
-	t.Check(err, NotNil)
-	t.Check(strings.Contains(err.Error(), "found duplicate endpoint name"), Equals, true)
-}
-
-func (ft *FacadeIntegrationTest) TestFacade_validateServiceEndpoints_dupsBtwnServices(t *C) {
-	svc := service.Service{
-		ID:           "svc1",
-		Name:         "TestFacade_validateServiceEndpoints",
-		DeploymentID: "deployment_id",
-		PoolID:       "pool_id",
-		Launch:       "auto",
-		DesiredState: int(service.SVCStop),
-		Endpoints: []service.ServiceEndpoint{
-			service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{Name: "test_ep_1", Application: "test_ep_1", Purpose: "export"}),
-			service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{Name: "test_ep_2", Application: "test_ep_2", Purpose: "export"}),
-		},
-	}
-
-	if err := ft.Facade.AddService(ft.CTX, svc); err != nil {
-		t.Fatalf("Setup failed; could not add svc %s: %s", svc.ID, err)
-		return
-	}
-
-	childSvc := service.Service{
-		ID:              "svc2",
-		ParentServiceID: svc.ID,
-		Name:            "TestFacade_validateServiceEndpoints_child",
-		DeploymentID:    "deployment_id",
-		PoolID:          "pool_id",
-		Launch:          "auto",
-		DesiredState:    int(service.SVCStop),
-		Endpoints: []service.ServiceEndpoint{
-			service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{Name: "test_ep_1", Application: "test_ep_1", Purpose: "export"}),
-			service.BuildServiceEndpoint(servicedefinition.EndpointDefinition{Name: "test_ep_2", Application: "test_ep_2", Purpose: "export"}),
-		},
-	}
-	if err := ft.Facade.AddService(ft.CTX, childSvc); err != nil {
-		t.Fatalf("Setup failed; could not add svc %s: %s", childSvc.ID, err)
-		return
-	}
-
-	err := ft.Facade.validateServiceEndpoints(ft.CTX, &svc)
-	t.Check(err, NotNil)
-	t.Check(strings.Contains(err.Error(), "found duplicate endpoint name"), Equals, true)
 }
 
 func (ft *FacadeIntegrationTest) TestFacade_migrateServiceConfigs_noConfigs(t *C) {


### PR DESCRIPTION
We now call the now-more-efficient GetServiceExportedEndpoints and then make one pass through that, checking for conflicts in the list of migrated services.