### PR TITLE
Correct previous fix for CC-2973

### DIFF
--- a/domain/service/api.go
+++ b/domain/service/api.go
@@ -34,18 +34,26 @@ type PublicEndpoint struct {
 	Enabled     bool
 }
 
+// BaseIPAssignment is a minimal service object that describes a service endpoint
+// which may or may not have an address assignment.
+type BaseIPAssignment struct {
+	ServiceID       string
+	ParentServiceID string
+	ServiceName     string
+	PoolID          string
+	Port            uint16
+	Application     string
+	EndpointName    string
+}
+
 // IPAssignment is a minimal service object that describes an address assignment
 // for a service.
 type IPAssignment struct {
-	ServiceID   string
-	ServiceName string
-	PoolID      string
+	BaseIPAssignment
 	HostID      string
 	HostName    string
 	Type        string
 	IPAddress   string
-	Port        uint16
-	Application string
 }
 
 // ExportedEndpoint is a minimal service object that describes exported

--- a/domain/service/mocks/Store.go
+++ b/domain/service/mocks/Store.go
@@ -129,6 +129,29 @@ func (_m *Store) GetAllPublicEndpoints(ctx datastore.Context) ([]service.PublicE
 	return r0, r1
 }
 
+// GetAllIPAssignments returns all IP assignments in the system, including those that may not have address assignments
+func (_m *Store) GetAllIPAssignments(ctx datastore.Context) ([]service.BaseIPAssignment, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []service.BaseIPAssignment
+	if rf, ok := ret.Get(0).(func(datastore.Context) []service.BaseIPAssignment); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]service.BaseIPAssignment)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetAllServiceDetails provides a mock function with given fields: ctx, since
 func (_m *Store) GetAllServiceDetails(ctx datastore.Context, since time.Duration) ([]service.ServiceDetails, error) {
 	ret := _m.Called(ctx, since)

--- a/domain/service/servicestore.go
+++ b/domain/service/servicestore.go
@@ -94,6 +94,9 @@ type Store interface {
 	// GetAllPublicEndpoints returns all public endpoints in the system
 	GetAllPublicEndpoints(ctx datastore.Context) ([]PublicEndpoint, error)
 
+	// GetAllIPAssignments returns all IP assignments in the system, including those that may not have address assignments
+	GetAllIPAssignments(ctx datastore.Context) ([]BaseIPAssignment, error)
+
 	// GetServiceDetailsByIDOrName returns the service details for any services
 	// whose serviceID matches the query exactly or whose names contain the
 	// query as a substring

--- a/facade/addressassignment_test.go
+++ b/facade/addressassignment_test.go
@@ -61,6 +61,7 @@ func (ft *FacadeIntegrationTest) TestGetServiceAddressAssignmentDetails(c *C) {
 				Name:        "ep1",
 				Application: "ep1",
 				Purpose:     "export",
+				Protocol:    "tcp",
 				AddressConfig: servicedefinition.AddressResourceConfig{
 					Port:     1234,
 					Protocol: "tcp",
@@ -84,6 +85,7 @@ func (ft *FacadeIntegrationTest) TestGetServiceAddressAssignmentDetails(c *C) {
 				Name:        "ep2a",
 				Application: "ep2a",
 				Purpose:     "export",
+				Protocol:    "tcp",
 				AddressConfig: servicedefinition.AddressResourceConfig{
 					Port:     2123,
 					Protocol: "tcp",
@@ -93,6 +95,7 @@ func (ft *FacadeIntegrationTest) TestGetServiceAddressAssignmentDetails(c *C) {
 				Name:        "ep2b",
 				Application: "ep2b",
 				Purpose:     "export",
+				Protocol:    "tcp",
 				AddressConfig: servicedefinition.AddressResourceConfig{
 					Port:     2124,
 					Protocol: "tcp",
@@ -126,15 +129,19 @@ func (ft *FacadeIntegrationTest) TestGetServiceAddressAssignmentDetails(c *C) {
 	c.Assert(addrs, HasLen, 1)
 	expected := []service.IPAssignment{
 		{
-			ServiceID:   "serviceid1",
-			ServiceName: "svcA",
-			PoolID:      "poolid",
+			BaseIPAssignment: service.BaseIPAssignment{
+				ServiceID:       "serviceid1",
+				ParentServiceID: "",
+				ServiceName:     "svcA",
+				PoolID:          "poolid",
+				Port:            1234,
+				Application:     "ep1",
+				EndpointName:    "ep1",
+			},
 			Type:        "static",
 			HostID:      "deadb11f",
 			HostName:    "h1",
 			IPAddress:   "12.27.36.45",
-			Port:        1234,
-			Application: "ep1",
 		},
 	}
 	c.Assert(addrs, DeepEquals, expected)
@@ -143,30 +150,38 @@ func (ft *FacadeIntegrationTest) TestGetServiceAddressAssignmentDetails(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(addrs, HasLen, 3)
 	expected = append(expected, service.IPAssignment{
-		ServiceID:   "serviceid2",
-		ServiceName: "svcB",
-		PoolID:      "poolid",
+		BaseIPAssignment: service.BaseIPAssignment{
+			ServiceID:       "serviceid2",
+			ParentServiceID: "serviceid1",
+			ServiceName:     "svcB",
+			PoolID:          "poolid",
+			Port:            2123,
+			Application:     "ep2a",
+			EndpointName:    "ep2a",
+		},
 		Type:        "static",
 		HostID:      "deadb11f",
 		HostName:    "h1",
 		IPAddress:   "12.27.36.45",
-		Port:        2123,
-		Application: "ep2a",
 	})
 	expected = append(expected, service.IPAssignment{
-		ServiceID:   "serviceid2",
-		ServiceName: "svcB",
-		PoolID:      "poolid",
+		BaseIPAssignment: service.BaseIPAssignment{
+			ServiceID:       "serviceid2",
+			ParentServiceID: "serviceid1",
+			ServiceName:     "svcB",
+			PoolID:          "poolid",
+			Port:            2124,
+			Application:     "ep2b",
+			EndpointName:    "ep2b",
+		},
 		Type:        "static",
 		HostID:      "deadb11f",
 		HostName:    "h1",
 		IPAddress:   "12.27.36.45",
-		Port:        2124,
-		Application: "ep2b",
 	})
-	for _, assign := range(addrs) {
+	for _, assign := range (addrs) {
 		verified := false
-		for _, exp := range(expected) {
+		for _, exp := range (expected) {
 			if assign.ServiceID == exp.ServiceID && assign.Application == exp.Application {
 				verified = true
 				c.Assert(assign, Equals, exp)
@@ -186,4 +201,33 @@ func (ft *FacadeIntegrationTest) TestGetServiceAddressAssignmentDetails(c *C) {
 	addrs, err = ft.Facade.GetServiceAddressAssignmentDetails(ft.CTX, "serviceid3", true)
 	c.Assert(err, IsNil)
 	c.Assert(addrs, HasLen, 0)
+
+	// Remove one of the address assignments and verify that the expected number for the
+	// service hasn't changed
+	var assign *addressassignment.AddressAssignment
+	assign, err = ft.Facade.FindAssignmentByServiceEndpoint(ft.CTX, "serviceid2", "ep2a")
+	c.Assert(err, IsNil)
+	err = ft.Facade.RemoveAddressAssignment(ft.CTX, assign.ID)
+	c.Assert(err, IsNil)
+
+	addrs, err = ft.Facade.GetServiceAddressAssignmentDetails(ft.CTX, "serviceid2", true)
+	c.Assert(err, IsNil)
+	c.Assert(addrs, HasLen, 2)
+
+	verified := false
+	for _, addr := range(addrs) {
+		if addr.EndpointName == "ep2a" {
+			verified = true
+			c.Assert(addr.Type, Equals, "")
+			c.Assert(addr.HostID, Equals, "")
+			c.Assert(addr.HostName, Equals, "")
+			c.Assert(addr.IPAddress, Equals, "")
+		} else {
+			c.Assert(addr, DeepEquals, expected[2])
+		}
+	}
+	if !verified {
+		c.Errorf("Results did not have empty assignment for serviceid2-ep2b ")
+	}
 }
+


### PR DESCRIPTION
The first attempt to fix CC-2973 introduced a bug - if an IP assignment was removed from the assignment store, then the first round of CC-2973 would NOT return the corresponding endpoint.

This refactor changes the logic to include ip assignments for endpoints that are missing assignments