### PR TITLE
CC-2983 export endpoints in service definitions for collector services cause "duplicate endpoint found" if more than one collector is defined at install time

### DIFF
--- a/facade/service.go
+++ b/facade/service.go
@@ -623,7 +623,6 @@ func (f *Facade) validateServiceDeployment(ctx datastore.Context, parentID strin
 		}
 		// Evaluate templated endpoints
 		if err = f.evaluateEndpointTemplates(ctx, svc); err != nil {
-			glog.Errorf("Could not evaluate endpoint templates for service %s with parent %s: %s", svc.Name, svc.ParentServiceID, err)
 			return nil, err
 		}
 

--- a/facade/service.go
+++ b/facade/service.go
@@ -621,6 +621,12 @@ func (f *Facade) validateServiceDeployment(ctx datastore.Context, parentID strin
 			glog.Errorf("Could not create service %s: %s", sd.Name, err)
 			return nil, err
 		}
+		// Evaluate templated endpoints
+		if err = f.evaluateEndpointTemplates(ctx, svc); err != nil {
+			glog.Errorf("Could not evaluate endpoint templates for service %s with parent %s: %s", svc.Name, svc.ParentServiceID, err)
+			return nil, err
+		}
+
 		svcs = append(svcs, *svc)
 		for _, sdSvc := range sd.Services {
 			childsvcs, err := deployServices(svc, &sdSvc)

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -980,6 +980,88 @@ func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_FailDupeEndpointsAcr
 	t.Assert(err, Equals, ErrServiceDuplicateEndpoint)
 }
 
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_Deploy_FailDupeEndpointsWithTemplate(t *C) {
+	err := ft.setupMigrationTestWithoutEndpoints(t)
+	t.Assert(err, IsNil)
+
+	// Try to deploy 2 services with the same parent and same templated endpoint
+	deployRequest := ft.createServiceDeploymentRequest(t)
+	deployRequest.ParentID = "original_service_id_child_1"
+	deployRequest.Service.Endpoints = []servicedefinition.EndpointDefinition{
+		servicedefinition.EndpointDefinition{
+			Name:        "original_service_endpoint_name_child_1",
+			Application: "{{(parent .).Name}}_original_service_endpoint_application_child_1",
+			Purpose:     "export",
+		},
+	}
+
+	deployRequest2 := ft.createServiceDeploymentRequest(t)
+	deployRequest2.ParentID = "original_service_id_child_1"
+	deployRequest2.Service.Name = "added-service-2"
+	deployRequest2.Service.Endpoints = []servicedefinition.EndpointDefinition{
+		servicedefinition.EndpointDefinition{
+			Name:        "original_service_endpoint_name_child_1",
+			Application: "{{(parent .).Name}}_original_service_endpoint_application_child_1",
+			Purpose:     "export",
+		},
+	}
+
+	request := dao.ServiceMigrationRequest{
+		ServiceID: "original_service_id_tenant",
+		Deploy:    []*dao.ServiceDeploymentRequest{deployRequest, deployRequest2},
+	}
+
+	ft.dfs.On("Download",
+		deployRequest.Service.ImageID,
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("bool"),
+	).Return("mockImageId", nil)
+
+	err = ft.Facade.MigrateServices(ft.CTX, request)
+	t.Assert(err, Equals, ErrServiceDuplicateEndpoint)
+}
+
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_Deploy_EndpointsWithTemplate(t *C) {
+	err := ft.setupMigrationTestWithoutEndpoints(t)
+	t.Assert(err, IsNil)
+
+	// Deploy 2 services with the same templated endpoint but different parents
+	deployRequest := ft.createServiceDeploymentRequest(t)
+	deployRequest.ParentID = "original_service_id_child_1"
+	deployRequest.Service.Endpoints = []servicedefinition.EndpointDefinition{
+		servicedefinition.EndpointDefinition{
+			Name:        "original_service_endpoint_name_child_1",
+			Application: "{{(parent .).Name}}_original_service_endpoint_application_child_1",
+			Purpose:     "export",
+		},
+	}
+
+	deployRequest2 := ft.createServiceDeploymentRequest(t)
+	deployRequest2.ParentID = "original_service_id_child_0"
+	deployRequest2.Service.Name = "added-service-2"
+	deployRequest2.Service.Endpoints = []servicedefinition.EndpointDefinition{
+		servicedefinition.EndpointDefinition{
+			Name:        "original_service_endpoint_name_child_1",
+			Application: "{{(parent .).Name}}_original_service_endpoint_application_child_1",
+			Purpose:     "export",
+		},
+	}
+
+	request := dao.ServiceMigrationRequest{
+		ServiceID: "original_service_id_tenant",
+		Deploy:    []*dao.ServiceDeploymentRequest{deployRequest, deployRequest2},
+	}
+
+	ft.dfs.On("Download",
+		deployRequest.Service.ImageID,
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("bool"),
+	).Return("mockImageId", nil)
+
+	err = ft.Facade.MigrateServices(ft.CTX, request)
+	t.Assert(err, IsNil)
+}
+
 func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_FailDupeExistingEndpoint(t *C) {
 	err := ft.setupMigrationTestWithEndpoints(t)
 	t.Assert(err, IsNil)

--- a/facade/servicetemplate.go
+++ b/facade/servicetemplate.go
@@ -369,25 +369,12 @@ func (f *Facade) deployService(ctx datastore.Context, tenantID string, parentSer
 	}
 
 	updateDeployTemplateStatus(deploymentID, "deploy_loading_service|"+newsvc.Name)
-	//for each endpoint, evaluate its Application
-	getService := func(serviceID string) (service.Service, error) {
-		s, err := f.GetService(ctx, serviceID)
-		if err != nil {
-			return service.Service{}, err
-		}
-		return *s, err
-	}
-	findChildService := func(parentID, serviceName string) (service.Service, error) {
-		s, err := f.FindChildService(ctx, parentID, serviceName)
-		if err != nil {
-			return service.Service{}, err
-		}
-		return *s, err
-	}
-	if err = newsvc.EvaluateEndpointTemplates(getService, findChildService, 0); err != nil {
+
+	if err = f.evaluateEndpointTemplates(ctx, newsvc); err != nil {
 		glog.Errorf("Could not evaluate endpoint templates for service %s with parent %s: %s", newsvc.Name, newsvc.ParentServiceID, err)
 		return "", err
 	}
+
 	if tenantID == "" {
 		tenantID = newsvc.ID
 	}
@@ -433,4 +420,24 @@ func (f *Facade) deployService(ctx datastore.Context, tenantID string, parentSer
 		}
 	}
 	return newsvc.ID, nil
+}
+
+func (f *Facade) evaluateEndpointTemplates(ctx datastore.Context, newsvc *service.Service) error {
+	//for each endpoint, evaluate its Application
+	getService := func(serviceID string) (service.Service, error) {
+		s, err := f.GetService(ctx, serviceID)
+		if err != nil {
+			return service.Service{}, err
+		}
+		return *s, err
+	}
+	findChildService := func(parentID, serviceName string) (service.Service, error) {
+		s, err := f.FindChildService(ctx, parentID, serviceName)
+		if err != nil {
+			return service.Service{}, err
+		}
+		return *s, err
+	}
+
+	return newsvc.EvaluateEndpointTemplates(getService, findChildService, 0)
 }


### PR DESCRIPTION
Evaluate templates before validating endpoints

Fixes [CC-2983](https://jira.zenoss.com/browse/CC-2983)