### PR TITLE
Use correct instance id for downloading logs

### DIFF
--- a/web/ui/src/Hosts/HostDetailsController.js
+++ b/web/ui/src/Hosts/HostDetailsController.js
@@ -178,7 +178,7 @@
                                 classes: "btn-primary",
                                 label: "download",
                                 action: function(){
-                                    utils.downloadFile('/services/' + instance.model.ServiceID + '/' + instance.model.ID + '/logs/download');
+                                    utils.downloadFile('/services/' + instance.model.ServiceID + '/' + instance.id + '/logs/download');
                                 },
                                 icon: "glyphicon-download"
                             }


### PR DESCRIPTION
Duplicate the logic for downloading logs which exists in [ServiceDetailsController.js](https://github.com/control-center/serviced/blob/e05104e63b61411b7a84c93916ec315fc1e3d175/web/ui/src/Services/ServiceDetailsController.js#L640).

Fixes [CC-2987](https://jira.zenoss.com/browse/CC-2987)