### PR TITLE
Fix pending deployment status reporting

### DIFF
--- a/facade/facade.go
+++ b/facade/facade.go
@@ -54,6 +54,7 @@ func New() *Facade {
 		userStore:     user.NewStore(),
 		serviceCache:  NewServiceCache(),
 		hostRegistry:  auth.NewHostExpirationRegistry(),
+		deployments:   NewPendingDeploymentMgr(),
 		zzk:           getZZK(),
 	}
 }
@@ -75,6 +76,7 @@ type Facade struct {
 	metricsClient MetricsClient
 	serviceCache  *serviceCache
 	hostRegistry  auth.HostExpirationRegistryInterface
+	deployments   *PendingDeploymentMgr
 
 	isvcsPath string
 }
@@ -108,3 +110,5 @@ func (f *Facade) SetIsvcsPath(path string) { f.isvcsPath = path }
 func (f *Facade) SetHostExpirationRegistry(hostRegistry auth.HostExpirationRegistryInterface) {
 	f.hostRegistry = hostRegistry
 }
+
+func (f *Facade) SetDeploymentMgr(mgr *PendingDeploymentMgr) { f.deployments = mgr }

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -71,7 +71,7 @@ type FacadeInterface interface {
 
 	DeployTemplateActive() (active []map[string]string, err error)
 
-	DeployTemplateStatus(deploymentID string) (status string, err error)
+	DeployTemplateStatus(deploymentID string, lastStatus string, timeout time.Duration) (status string, err error)
 
 	AddHost(ctx datastore.Context, entity *host.Host) ([]byte, error)
 

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -264,19 +264,19 @@ func (_m *FacadeInterface) DeployTemplateActive() ([]map[string]string, error) {
 }
 
 // DeployTemplateStatus provides a mock function with given fields: deploymentID
-func (_m *FacadeInterface) DeployTemplateStatus(deploymentID string) (string, error) {
-	ret := _m.Called(deploymentID)
+func (_m *FacadeInterface) DeployTemplateStatus(deploymentID string, lastStatus string, timeout time.Duration) (string, error) {
+	ret := _m.Called(deploymentID, lastStatus, timeout)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(string) string); ok {
-		r0 = rf(deploymentID)
+	if rf, ok := ret.Get(0).(func(string, string, time.Duration) string); ok {
+		r0 = rf(deploymentID, lastStatus, timeout)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(deploymentID)
+	if rf, ok := ret.Get(1).(func(string, string, time.Duration) error); ok {
+		r1 = rf(deploymentID, lastStatus, timeout)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/facade/pendingdeployment.go
+++ b/facade/pendingdeployment.go
@@ -1,0 +1,122 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package facade
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/control-center/serviced/utils"
+)
+
+var (
+	ErrPendingDeploymentConflict = errors.New("template deployment id conflict")
+)
+
+// PendingDeployment represents a template deployment which is has been initiated
+// but has not yet completed.  It is synchronized, allowing access from multiple
+// goroutines.  In particular clients can register for asynchronous notification of
+// changes to its "status".
+type PendingDeployment struct {
+	status       utils.ValueChangePublisher
+	templateID   string
+	poolID       string
+	deploymentID string
+	templateName string
+	mutex        sync.RWMutex
+}
+
+// NewPendingDeployment returns a new PendingDeployment object.
+func NewPendingDeployment(deploymentID, templateID, poolID string) PendingDeployment {
+	return PendingDeployment{
+		status:       utils.NewValueChangePublisher("Starting"),
+		templateID:   templateID,
+		deploymentID: deploymentID,
+		poolID:       poolID,
+		mutex:        sync.RWMutex{},
+	}
+}
+
+// UpdateStatus updates the status of a PendingDeployment.
+func (d *PendingDeployment) UpdateStatus(status string) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.status.Set(status)
+}
+
+// SetTemplateName sets the template name of a PendingDeployment.
+func (d *PendingDeployment) SetTemplateName(name string) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.templateName = name
+}
+
+// GetStatus returns the current status of a PendingDeployment and a
+// channel which will be closewhen the status changes.
+func (d *PendingDeployment) GetStatus() (string, <-chan struct{}) {
+	// mutex lock not necessary; d.status.Get is protected
+	status, notify := d.status.Get()
+	return status.(string), notify
+}
+
+// GetInfo returns all information about a pending deployment in the
+// form of a map, appropriate for json serialization.
+func (d *PendingDeployment) GetInfo() map[string]string {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	status, _ := d.status.Get()
+	return map[string]string{
+		"TemplateID":   d.templateID,
+		"templateName": d.templateName,
+		"PoolID":       d.poolID,
+		"DeploymentID": d.deploymentID,
+		"status":       status.(string),
+	}
+}
+
+// PendingDeploymentMGr maintains a map from deployment ID to PendingDeployment
+// objects.
+type PendingDeploymentMgr struct {
+	deployments map[string]*PendingDeployment
+	mutex       sync.RWMutex
+}
+
+// NewPendingDeployment allocates a new PendingDeployment with the given attributes
+// and associates it with the PendingDeploymentMgr
+func (dm *PendingDeploymentMgr) NewPendingDeployment(deploymentID, templateID, poolID string) (*PendingDeployment, error) {
+	dm.mutex.Lock()
+	defer dm.mutex.Unlock()
+	if _, ok := dm.deployments[deploymentID]; ok {
+		return nil, ErrPendingDeploymentConflict
+	}
+	deployment := NewPendingDeployment(deploymentID, templateID, poolID)
+	dm.deployments[deploymentID] = &deployment
+	return &deployment, nil
+}
+
+// GetPendingDeployment returns the PendingDeployment associated with the
+// given deploymentID if one exists; nil otherwise.
+func (dm *PendingDeploymentMgr) GetPendingDeployment(deploymentID string) *PendingDeployment {
+	dm.mutex.RLock()
+	defer dm.mutex.RUnlock()
+	return dm.deployments[deploymentID]
+}
+
+// DeletePendingDeployment removes the PendingDeployment associated with the
+// given deploymentID from the PendingDeploymentMgr.
+func (dm *PendingDeploymentMgr) DeletePendingDeployment(deploymentID string) {
+	dm.mutex.Lock()
+	delete(dm.deployments, deploymentID)
+	dm.mutex.Unlock()
+}

--- a/facade/pendingdeployment.go
+++ b/facade/pendingdeployment.go
@@ -92,6 +92,14 @@ type PendingDeploymentMgr struct {
 	mutex       sync.RWMutex
 }
 
+// NewPendingDeploymentMgr returns a new PendingDeploymentMgr
+func NewPendingDeploymentMgr() *PendingDeploymentMgr {
+	return &PendingDeploymentMgr{
+		deployments: make(map[string]*PendingDeployment),
+		mutex:       sync.RWMutex{},
+	}
+}
+
 // NewPendingDeployment allocates a new PendingDeployment with the given attributes
 // and associates it with the PendingDeploymentMgr
 func (dm *PendingDeploymentMgr) NewPendingDeployment(deploymentID, templateID, poolID string) (*PendingDeployment, error) {

--- a/facade/pendingdeployment_test.go
+++ b/facade/pendingdeployment_test.go
@@ -1,0 +1,91 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package facade_test
+
+import (
+	"github.com/control-center/serviced/facade"
+	. "gopkg.in/check.v1"
+	"time"
+)
+
+func (ft *FacadeUnitTest) Test_NewPendingDeployment(c *C) {
+	deploymentID, templateID, poolID := "a", "b", "c"
+	pd := facade.NewPendingDeployment(deploymentID, templateID, poolID)
+	info := pd.GetInfo()
+	c.Assert(info["TemplateID"], Equals, templateID)
+	c.Assert(info["PoolID"], Equals, poolID)
+	c.Assert(info["DeploymentID"], Equals, deploymentID)
+	c.Assert(info["status"], Equals, "Starting")
+	c.Assert(info["templateName"], Equals, "")
+}
+
+func (ft *FacadeUnitTest) Test_PendingDeployment_GetStatus(c *C) {
+	deploymentID, templateID, poolID := "a", "b", "c"
+	pd := facade.NewPendingDeployment(deploymentID, templateID, poolID)
+	status, notify := pd.GetStatus()
+	c.Assert(status, Equals, "Starting")
+
+	newStatus := "I am Henry The Eighth I am"
+	pd.UpdateStatus(newStatus)
+	status, _ = pd.GetStatus()
+	c.Assert(status, Equals, newStatus)
+
+	select {
+	case _, ok := <-notify:
+		// channel was closed
+		c.Assert(ok, Equals, false)
+	case <-time.After(time.Second):
+		c.Fail()
+	}
+}
+
+func (ft *FacadeUnitTest) Test_PendingDeployment_SetTemplateName(c *C) {
+	deploymentID, templateID, poolID := "a", "b", "c"
+	templateName := "foobar"
+	pd := facade.NewPendingDeployment(deploymentID, templateID, poolID)
+	pd.SetTemplateName(templateName)
+	info := pd.GetInfo()
+	c.Assert(info["templateName"], Equals, templateName)
+}
+
+func (ft *FacadeUnitTest) Test_PendingDeploymentMgr_New(c *C) {
+	pdm := facade.NewPendingDeploymentMgr()
+	deploymentID, templateID, poolID := "a", "b", "c"
+	pd, _ := pdm.NewPendingDeployment(deploymentID, templateID, poolID)
+	info := pd.GetInfo()
+	c.Assert(info["TemplateID"], Equals, templateID)
+	c.Assert(info["PoolID"], Equals, poolID)
+	c.Assert(info["DeploymentID"], Equals, deploymentID)
+}
+
+func (ft *FacadeUnitTest) Test_PendingDeploymentMgr_Conflict(c *C) {
+	pdm := facade.NewPendingDeploymentMgr()
+	deploymentID, templateID, poolID := "a", "b", "c"
+	pd, err := pdm.NewPendingDeployment(deploymentID, templateID, poolID)
+	c.Assert(pd, NotNil)
+	c.Assert(err, IsNil)
+	pd, err = pdm.NewPendingDeployment(deploymentID, templateID, poolID)
+	c.Assert(pd, IsNil)
+	c.Assert(err, Equals, facade.ErrPendingDeploymentConflict)
+}
+
+func (ft *FacadeUnitTest) Test_PendingDeploymentMgr_Get(c *C) {
+	pdm := facade.NewPendingDeploymentMgr()
+	deploymentID, templateID, poolID := "a", "b", "c"
+	pd, _ := pdm.NewPendingDeployment(deploymentID, templateID, poolID)
+	pd1 := pdm.GetPendingDeployment(deploymentID)
+	c.Assert(pd, Equals, pd1)
+}

--- a/utils/valuechangepublisher.go
+++ b/utils/valuechangepublisher.go
@@ -1,0 +1,51 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "sync"
+
+// ValueChangePublisher allows for subscribers to be notified upon change of
+// a value.
+type ValueChangePublisher struct {
+	value  interface{}
+	mutex  sync.RWMutex
+	notify chan struct{}
+}
+
+// Returns a new ValueChangePublisher
+func NewValueChangePublisher(initialValue interface{}) ValueChangePublisher {
+	return ValueChangePublisher{
+		value:  initialValue,
+		mutex:  sync.RWMutex{},
+		notify: make(chan struct{}),
+	}
+}
+
+// Set closes the current channel notifying current subscribers of a change
+// and stores the value.
+func (v *ValueChangePublisher) Set(value interface{}) {
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+	v.value = value
+	close(v.notify)
+	v.notify = make(chan struct{})
+}
+
+// Get returns the current value of the publisher and a channel that will
+// be closed when the value changes.
+func (v *ValueChangePublisher) Get() (interface{}, <-chan struct{}) {
+	v.mutex.RLock()
+	defer v.mutex.RUnlock()
+	return v.value, v.notify
+}

--- a/utils/valuechangepublisher_test.go
+++ b/utils/valuechangepublisher_test.go
@@ -1,0 +1,80 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package utils_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/control-center/serviced/utils"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type valueChangePublisherSuite struct {
+}
+
+var _ = Suite(&valueChangePublisherSuite{})
+
+func (s *valueChangePublisherSuite) Test_Synchronous(c *C) {
+	initial := "foo"
+	p := utils.NewValueChangePublisher(initial)
+	value, _ := p.Get()
+	c.Assert(value, Equals, initial)
+
+	expected := "bar"
+	p.Set(expected)
+	value, _ = p.Get()
+	c.Assert(value, Equals, expected)
+}
+
+func (s *valueChangePublisherSuite) Test_Notify(c *C) {
+	initial := "foo"
+	p := utils.NewValueChangePublisher(initial)
+	value, notify := p.Get()
+
+	expected := "bar"
+	ready, ok := make(chan struct{}), make(chan struct{})
+	go func() {
+		select {
+		case <-ready:
+			close(ok)
+		case <-notify:
+			v, _ := p.Get()
+			c.Assert(v, Equals, expected)
+		case <-time.After(time.Second):
+			c.Fail()
+		}
+	}()
+
+	close(ready)
+	<-ok
+	c.Assert(value, Equals, initial)
+	p.Set(expected)
+
+	// notify does not block; the value was already changed
+	select {
+	case <-notify:
+		value, _ = p.Get()
+		c.Assert(value, Equals, expected)
+	case <-time.After(time.Second):
+		c.Fail()
+	}
+}

--- a/web/ui/src/DeployWiz/DeployWizard.js
+++ b/web/ui/src/DeployWiz/DeployWizard.js
@@ -330,14 +330,20 @@
                 });
 
             //now that we have started deploying our app, we poll for status
+            var deployStatusRequest = {
+                DeploymentID: $scope.install.deploymentID,
+                LastStatus: "initial status that won't match anything",
+                Timeout: 3000
+            };
             var getStatus = function(){
                 if(checkStatus){
                     var $status = $("#deployStatusText");
-                    resourcesFactory.getDeployStatus(deploymentDefinition)
+                    resourcesFactory.getDeployStatus(deployStatusRequest)
                         .success(function(data){
-                            if(data.Detail === "timeout"){
+                            if(data.Detail === deployStatusRequest.lastStatus){
                                 $("#deployStatus .dialogIcon").fadeOut(200, function(){$("#deployStatus .dialogIcon").fadeIn(200);});
                             }else{
+                                deployStatusRequest.LastStatus = data.Detail;
                                 var parts = data.Detail.split("|");
                                 if(parts[1]){
                                     $status.html('<strong>' + $translate.instant(parts[0]) + ":</strong> " + parts[1]);


### PR DESCRIPTION
This change addresses some code debt in the existing _pending deployment status reporting_ approach.
There were several problems that were addressed:
1) The use of ad-hoc mutexes made the code brittle and difficult to reason about.
2) The storing of "lastStatus" in the per-deployment map meant that querying from multiple clients would have incorrect results.  This was not critical in the current application, but having an efficient pattern for this is desirable for other domains (e.g., backup status)
3) Storing the per-deployment data in a global variable was not amenable to unit testing.
4) The busy-wait loop checking for changed status is inefficient and inelegant, given the robust synchronization techniques in go.

The new approach is for the status query to take two parameters - a timeout, and the last status reported.  If the current status is the same as the last status, the server will wait for the status to change up to the timeout. 

Fixes [CC-3076](https://jira.zenoss.com/browse/CC-3076)