### PR TITLE
Fix query syntax for GetServiceDetailsByIDOrName

### DIFF
--- a/domain/service/servicestore_test.go
+++ b/domain/service/servicestore_test.go
@@ -376,6 +376,14 @@ func (s *S) Test_GetServiceDetailsByIDOrName(c *C) {
 		ParentServiceID: "svc_b",
 		DeploymentID:    "deployment_id",
 	}
+	svce := &Service{
+		ID:              "svceid",
+		PoolID:          "testPool",
+		Name:            "svc-e",
+		Launch:          "auto",
+		ParentServiceID: "svc_b",
+		DeploymentID:    "deployment_id",
+	}
 	svcdontmatch := &Service{
 		ID:              "svc_a",
 		PoolID:          "testPool",
@@ -389,6 +397,7 @@ func (s *S) Test_GetServiceDetailsByIDOrName(c *C) {
 	c.Assert(s.store.Put(s.ctx, svcc), IsNil)
 	c.Assert(s.store.Put(s.ctx, svcd), IsNil)
 	c.Assert(s.store.Put(s.ctx, svcd2), IsNil)
+	c.Assert(s.store.Put(s.ctx, svce), IsNil)
 	c.Assert(s.store.Put(s.ctx, svcdontmatch), IsNil)
 
 	// Get by exact ID should succeed
@@ -396,6 +405,11 @@ func (s *S) Test_GetServiceDetailsByIDOrName(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(details, HasLen, 1)
 	c.Assert(details[0].ID, Equals, "svcaid")
+
+	details, err = s.store.GetServiceDetailsByIDOrName(s.ctx, "svc-e", false)
+	c.Assert(err, IsNil)
+	c.Assert(details, HasLen, 1)
+	c.Assert(details[0].ID, Equals, "svceid")
 
 	// Get where substring of query matches a svc ID should fail
 	details, err = s.store.GetServiceDetailsByIDOrName(s.ctx, "svcaidnope", false)

--- a/facade/service.go
+++ b/facade/service.go
@@ -2178,7 +2178,12 @@ func (f *Facade) ResolveServicePath(ctx datastore.Context, svcPath string) ([]se
 	if err != nil {
 		return nil, err
 	}
-	plog.WithField("matches", len(details)).Debug("Found possible service matches")
+	plog.WithFields(log.Fields{
+		"svcPath": svcPath,
+		"current": current,
+		"prefix":  prefix,
+		"matches": len(details),
+	}).Debug("Found possible service matches")
 
 	// Populate the ancestry for all of the found services, so we can check
 	// their parents


### PR DESCRIPTION
The bug was due to the fact that the previous logic created a regex query where the dash, `-`,  in `mariadb-model` was mapped to `[--]` in the query string.  I changed the query construct to only use `[xX]` notation for letters, and to escape any of the characters which are reserved in the ES regex syntax, and to treat all other characters as simple character matches.