### PR TITLE
Feature/cc 2959

### DIFF
--- a/metrics/cache_test.go
+++ b/metrics/cache_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestCache(t *testing.T) {
 
-	clock := utils.NewTestClock()
+	clock := utils.NewBufferedTestClock()
 
 	cache := MemoryUsageCache{
 		Usages: make(map[string]*MemoryUsageItem),
@@ -83,15 +83,7 @@ func TestCache(t *testing.T) {
 		t.Errorf("Cache did not return the correct item")
 	}
 
-	// Force expiration
-	// I know this seems crazy, but go clock.Fire() may not trigger before
-	// cache.Get is called.
-	done := make(chan struct{})
-	go func() {
-		close(done)
-		clock.Fire()
-	}()
-	<-done
+	clock.Fire()
 
 	// Cache should no longer have a value for key, try with different getter
 	x, err = cache.Get("first", getter2)

--- a/utils/clock.go
+++ b/utils/clock.go
@@ -51,3 +51,9 @@ func NewTestClock() TestClock {
 		AfterChan: make(chan time.Time),
 	}
 }
+
+func NewBufferedTestClock() TestClock {
+	return TestClock{
+		AfterChan: make(chan time.Time, 1),
+	}
+}


### PR DESCRIPTION
Test was failing because of a race condition calling the fake clock's Fire() method. Modifying the channel to have a buffer of 1 allows the call to block until the event is queued, and return once the event is ready to send. 

Fix verified by running test in a loop in 2 terminals for ~2 hours. Before fix, an error would usually occur in the first few hundred runs. After fix, I had >2200 runs (x2 terminals) with no failures.