### PR TITLE
CC UI Resource Pools page generates too many requests and causes serviced cpu usage to go up

### DIFF
--- a/facade/facade.go
+++ b/facade/facade.go
@@ -53,6 +53,7 @@ func New() *Facade {
 		templateStore: servicetemplate.NewStore(),
 		userStore:     user.NewStore(),
 		serviceCache:  NewServiceCache(),
+		poolCache:     NewPoolCache(),
 		hostRegistry:  auth.NewHostExpirationRegistry(),
 		deployments:   NewPendingDeploymentMgr(),
 		zzk:           getZZK(),
@@ -75,6 +76,7 @@ type Facade struct {
 	hcache        *health.HealthStatusCache
 	metricsClient MetricsClient
 	serviceCache  *serviceCache
+	poolCache     *poolCache
 	hostRegistry  auth.HostExpirationRegistryInterface
 	deployments   *PendingDeploymentMgr
 

--- a/facade/host.go
+++ b/facade/host.go
@@ -105,7 +105,9 @@ func (f *Facade) addHost(ctx datastore.Context, entity *host.Host) ([]byte, erro
 	}
 	err = f.zzk.AddHost(entity)
 
-	return delegatePEMBlock, nil
+	f.poolCache.SetDirty()
+
+	return delegatePEMBlock, err
 }
 
 // Generate and store an RSA key for the host
@@ -184,6 +186,9 @@ func (f *Facade) UpdateHost(ctx datastore.Context, entity *host.Host) error {
 	}
 
 	err = f.zzk.UpdateHost(entity)
+
+	f.poolCache.SetDirty()
+
 	return err
 }
 
@@ -255,6 +260,8 @@ func (f *Facade) RemoveHost(ctx datastore.Context, hostID string) (err error) {
 	if err != nil {
 		glog.Warningf("Could not disable dfs for deleted host %s: %s", _host.ID, err)
 	}
+
+	f.poolCache.SetDirty()
 
 	return nil
 }

--- a/facade/pool.go
+++ b/facade/pool.go
@@ -88,6 +88,9 @@ func (f *Facade) addResourcePool(ctx datastore.Context, entity *pool.ResourcePoo
 		entity.VirtualIPs = vips
 		return f.UpdateResourcePool(ctx, entity)
 	}
+
+	f.poolCache.SetDirty()
+
 	return nil
 }
 
@@ -175,6 +178,8 @@ func (f *Facade) updateResourcePool(ctx datastore.Context, entity *pool.Resource
 			}
 		}
 	}
+
+	f.poolCache.SetDirty()
 
 	return nil
 }
@@ -374,6 +379,8 @@ func (f *Facade) RemoveResourcePool(ctx datastore.Context, id string) error {
 		return err
 	}
 
+	f.poolCache.SetDirty()
+
 	return f.zzk.RemoveResourcePool(id)
 }
 
@@ -525,30 +532,34 @@ var defaultRealm = "default"
 // GetReadPools returns a list of simplified resource pools
 func (f *Facade) GetReadPools(ctx datastore.Context) ([]pool.ReadPool, error) {
 	defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.GetReadPools"))
-	pools, err := f.poolStore.GetResourcePools(ctx)
 
-	if err != nil {
-		return nil, fmt.Errorf("Could not load pools: %v", err)
+	var getPoolsFunc GetPoolsFunc = func() ([]pool.ReadPool, error) {
+		pools, err := f.poolStore.GetResourcePools(ctx)
+
+		if err != nil {
+			return nil, fmt.Errorf("Could not load pools: %v", err)
+		}
+
+		readPools := []pool.ReadPool{}
+
+		for i := range pools {
+			f.calcPoolCapacity(ctx, &pools[i])
+			f.calcPoolCommitment(ctx, &pools[i])
+
+			readPools = append(readPools, pool.ReadPool{
+				ID:                pools[i].ID,
+				Description:       pools[i].Description,
+				CreatedAt:         pools[i].CreatedAt,
+				UpdatedAt:         pools[i].UpdatedAt,
+				CoreCapacity:      pools[i].CoreCapacity,
+				MemoryCapacity:    pools[i].MemoryCapacity,
+				MemoryCommitment:  pools[i].MemoryCommitment,
+				ConnectionTimeout: pools[i].ConnectionTimeout,
+				Permissions:       pools[i].Permissions,
+			})
+		}
+		return readPools, nil
 	}
 
-	readPools := []pool.ReadPool{}
-
-	for i := range pools {
-		f.calcPoolCapacity(ctx, &pools[i])
-		f.calcPoolCommitment(ctx, &pools[i])
-
-		readPools = append(readPools, pool.ReadPool{
-			ID:                pools[i].ID,
-			Description:       pools[i].Description,
-			CreatedAt:         pools[i].CreatedAt,
-			UpdatedAt:         pools[i].UpdatedAt,
-			CoreCapacity:      pools[i].CoreCapacity,
-			MemoryCapacity:    pools[i].MemoryCapacity,
-			MemoryCommitment:  pools[i].MemoryCommitment,
-			ConnectionTimeout: pools[i].ConnectionTimeout,
-			Permissions:       pools[i].Permissions,
-		})
-	}
-
-	return readPools, err
+	return f.poolCache.GetPools(getPoolsFunc)
 }

--- a/facade/pool.go
+++ b/facade/pool.go
@@ -462,7 +462,7 @@ func (f *Facade) CreateDefaultPool(ctx datastore.Context, id string) error {
 func (f *Facade) calcPoolCapacity(ctx datastore.Context, pool *pool.ResourcePool) error {
 	hosts, err := f.hostStore.FindHostsWithPoolID(ctx, pool.ID)
 	if err != nil {
-		// FIXME: this error shouldn't be ignored. Either log it and/or have the caller fail and return the error
+		glog.Errorf("Unable to find hosts in %s: %v", pool.ID, err)
 		return err
 	}
 
@@ -482,7 +482,7 @@ func (f *Facade) calcPoolCapacity(ctx datastore.Context, pool *pool.ResourcePool
 func (f *Facade) calcPoolCommitment(ctx datastore.Context, pool *pool.ResourcePool) error {
 	services, err := f.serviceStore.GetServicesByPool(ctx, pool.ID)
 	if err != nil {
-		// FIXME: this error shouldn't be ignored. Either log it and/or have the caller fail and return the error
+		glog.Errorf("Unable to find services on %s: %v", pool.ID, err)
 		return err
 	}
 

--- a/facade/pool_cache.go
+++ b/facade/pool_cache.go
@@ -1,0 +1,54 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package facade
+
+import (
+	"sync"
+
+	"github.com/control-center/serviced/domain/pool"
+)
+
+type poolCache struct {
+	mutex sync.RWMutex
+	dirty bool
+	pools []pool.ReadPool
+}
+
+type GetPoolsFunc func() ([]pool.ReadPool, error)
+
+func NewPoolCache() *poolCache {
+	return &poolCache{
+		mutex: sync.RWMutex{},
+		dirty: true,
+		pools: make([]pool.ReadPool, 0),
+	}
+}
+
+func (pc *poolCache) GetPools(getPoolsFunc GetPoolsFunc) ([]pool.ReadPool, error) {
+	var err error
+	if pc.dirty {
+		pc.mutex.Lock()
+		defer pc.mutex.Unlock()
+		pc.pools, err = getPoolsFunc()
+		if err == nil {
+			pc.dirty = false
+		}
+	}
+	return pc.pools, err
+}
+
+func (pc *poolCache) SetDirty() {
+	pc.mutex.Lock()
+	defer pc.mutex.Unlock()
+	pc.dirty = true
+}

--- a/facade/pool_cache.go
+++ b/facade/pool_cache.go
@@ -18,14 +18,18 @@ import (
 	"github.com/control-center/serviced/domain/pool"
 )
 
+// poolCache is a simple in-memory cache for storing ReadPools.
+// The dirty flag should be set when changes are made that affect a ReadPool.
 type poolCache struct {
 	mutex sync.RWMutex
 	dirty bool
 	pools []pool.ReadPool
 }
 
+// GetPoolsFunc should return an up-to-date slice of ReadPools.
 type GetPoolsFunc func() ([]pool.ReadPool, error)
 
+// NewPoolCache creates a new poolCache, which is dirty and empty by default
 func NewPoolCache() *poolCache {
 	return &poolCache{
 		mutex: sync.RWMutex{},
@@ -34,6 +38,8 @@ func NewPoolCache() *poolCache {
 	}
 }
 
+// GetPools caches the result of getPoolsFunc if the cache is dirty
+// then returns the cached ReadPools.
 func (pc *poolCache) GetPools(getPoolsFunc GetPoolsFunc) ([]pool.ReadPool, error) {
 	var err error
 	if pc.dirty {
@@ -47,6 +53,8 @@ func (pc *poolCache) GetPools(getPoolsFunc GetPoolsFunc) ([]pool.ReadPool, error
 	return pc.pools, err
 }
 
+// SetDirty sets poolCache.dirty to true, meaning it will call a GetPoolsFunc
+// next time GetPools is called.
 func (pc *poolCache) SetDirty() {
 	pc.mutex.Lock()
 	defer pc.mutex.Unlock()

--- a/facade/service.go
+++ b/facade/service.go
@@ -284,6 +284,8 @@ func (f *Facade) updateService(ctx datastore.Context, tenantID string, svc servi
 		}
 	}
 
+	f.poolCache.SetDirty()
+
 	// sync the service with the coordinator
 	if err := f.syncService(ctx, tenantID, svc.ID, setLockOnUpdate, setLockOnUpdate); err != nil {
 		glog.Errorf("Could not sync service %s (%s): %s", svc.Name, svc.ID, err)
@@ -743,6 +745,8 @@ func (f *Facade) removeService(ctx datastore.Context, id string) error {
 			glog.Errorf("Error while removing service %s (%s): %s", svc.Name, svc.ID, err)
 			return err
 		}
+
+		f.poolCache.SetDirty()
 
 		f.serviceCache.RemoveIfParentChanged(svc.ID, svc.ParentServiceID)
 		return nil


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3025

The commits in this PR fix CC-3025 by creating/maintaining a cache to get the pools from instead of querying elastic.