### PR TITLE
Make the call to /api/v2/pools less demanding

### DIFF
--- a/facade/facade.go
+++ b/facade/facade.go
@@ -53,6 +53,7 @@ func New() *Facade {
 		templateStore: servicetemplate.NewStore(),
 		userStore:     user.NewStore(),
 		serviceCache:  NewServiceCache(),
+		poolCache:     NewPoolCache(),
 		hostRegistry:  auth.NewHostExpirationRegistry(),
 		deployments:   NewPendingDeploymentMgr(),
 		zzk:           getZZK(),
@@ -75,6 +76,7 @@ type Facade struct {
 	hcache        *health.HealthStatusCache
 	metricsClient MetricsClient
 	serviceCache  *serviceCache
+	poolCache     *poolCache
 	hostRegistry  auth.HostExpirationRegistryInterface
 	deployments   *PendingDeploymentMgr
 

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -87,15 +87,24 @@ func (f *Facade) SetZZK(zzk ZZK) { f.zzk = zzk }
 
 func (f *Facade) SetDFS(dfs dfs.DFS) { f.dfs = dfs }
 
-func (f *Facade) SetHostStore(store host.Store) { f.hostStore = store }
+func (f *Facade) SetHostStore(store host.Store) {
+	f.hostStore = store
+	f.poolCache.SetDirty()
+}
 
 func (f *Facade) SetHostkeyStore(store hostkey.Store) { f.hostkeyStore = store }
 
 func (f *Facade) SetRegistryStore(store registry.ImageRegistryStore) { f.registryStore = store }
 
-func (f *Facade) SetPoolStore(store pool.Store) { f.poolStore = store }
+func (f *Facade) SetPoolStore(store pool.Store) {
+	f.poolStore = store
+	f.poolCache.SetDirty()
+}
 
-func (f *Facade) SetServiceStore(store service.Store) { f.serviceStore = store }
+func (f *Facade) SetServiceStore(store service.Store) {
+	f.serviceStore = store
+	f.poolCache.SetDirty()
+}
 
 func (f *Facade) SetConfigStore(store serviceconfigfile.Store) { f.configStore = store }
 

--- a/facade/host.go
+++ b/facade/host.go
@@ -105,7 +105,9 @@ func (f *Facade) addHost(ctx datastore.Context, entity *host.Host) ([]byte, erro
 	}
 	err = f.zzk.AddHost(entity)
 
-	return delegatePEMBlock, nil
+	f.poolCache.SetDirty()
+
+	return delegatePEMBlock, err
 }
 
 // Generate and store an RSA key for the host
@@ -184,6 +186,9 @@ func (f *Facade) UpdateHost(ctx datastore.Context, entity *host.Host) error {
 	}
 
 	err = f.zzk.UpdateHost(entity)
+
+	f.poolCache.SetDirty()
+
 	return err
 }
 
@@ -255,6 +260,8 @@ func (f *Facade) RemoveHost(ctx datastore.Context, hostID string) (err error) {
 	if err != nil {
 		glog.Warningf("Could not disable dfs for deleted host %s: %s", _host.ID, err)
 	}
+
+	f.poolCache.SetDirty()
 
 	return nil
 }

--- a/facade/pool.go
+++ b/facade/pool.go
@@ -536,8 +536,6 @@ func (f *Facade) GetReadPools(ctx datastore.Context) ([]pool.ReadPool, error) {
 	var getPoolsFunc GetPoolsFunc = func() ([]pool.ReadPool, error) {
 		pools, err := f.poolStore.GetResourcePools(ctx)
 
-		fmt.Printf("in GetPoolsFunc begin CreatedAt: %v\n", pools[0].CreatedAt)
-
 		if err != nil {
 			return nil, fmt.Errorf("Could not load pools: %v", err)
 		}
@@ -559,8 +557,6 @@ func (f *Facade) GetReadPools(ctx datastore.Context) ([]pool.ReadPool, error) {
 				ConnectionTimeout: pools[i].ConnectionTimeout,
 				Permissions:       pools[i].Permissions,
 			})
-			fmt.Printf("in GetPoolsFunc end CreatedAt: %v\n", pools[i].CreatedAt)
-			fmt.Printf("in GetPoolsFunc end MemoryCommitment: %v\n", pools[i].MemoryCommitment)
 		}
 		return readPools, nil
 	}

--- a/facade/pool.go
+++ b/facade/pool.go
@@ -88,6 +88,9 @@ func (f *Facade) addResourcePool(ctx datastore.Context, entity *pool.ResourcePoo
 		entity.VirtualIPs = vips
 		return f.UpdateResourcePool(ctx, entity)
 	}
+
+	f.poolCache.SetDirty()
+
 	return nil
 }
 
@@ -175,6 +178,8 @@ func (f *Facade) updateResourcePool(ctx datastore.Context, entity *pool.Resource
 			}
 		}
 	}
+
+	f.poolCache.SetDirty()
 
 	return nil
 }
@@ -374,6 +379,8 @@ func (f *Facade) RemoveResourcePool(ctx datastore.Context, id string) error {
 		return err
 	}
 
+	f.poolCache.SetDirty()
+
 	return f.zzk.RemoveResourcePool(id)
 }
 
@@ -525,30 +532,34 @@ var defaultRealm = "default"
 // GetReadPools returns a list of simplified resource pools
 func (f *Facade) GetReadPools(ctx datastore.Context) ([]pool.ReadPool, error) {
 	defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.GetReadPools"))
-	pools, err := f.poolStore.GetResourcePools(ctx)
 
-	if err != nil {
-		return nil, fmt.Errorf("Could not load pools: %v", err)
+	var getPoolsFunc GetPoolsFunc = func() ([]pool.ReadPool, error) {
+		pools, err := f.poolStore.GetResourcePools(ctx)
+
+		if err != nil {
+			return nil, fmt.Errorf("Could not load pools: %v", err)
+		}
+
+		readPools := []pool.ReadPool{}
+
+		for i := range pools {
+			f.calcPoolCapacity(ctx, &pools[i])
+			f.calcPoolCommitment(ctx, &pools[i])
+
+			readPools = append(readPools, pool.ReadPool{
+				ID:                pools[i].ID,
+				Description:       pools[i].Description,
+				CreatedAt:         pools[i].CreatedAt,
+				UpdatedAt:         pools[i].UpdatedAt,
+				CoreCapacity:      pools[i].CoreCapacity,
+				MemoryCapacity:    pools[i].MemoryCapacity,
+				MemoryCommitment:  pools[i].MemoryCommitment,
+				ConnectionTimeout: pools[i].ConnectionTimeout,
+				Permissions:       pools[i].Permissions,
+			})
+		}
+		return readPools, nil
 	}
 
-	readPools := []pool.ReadPool{}
-
-	for i := range pools {
-		f.calcPoolCapacity(ctx, &pools[i])
-		f.calcPoolCommitment(ctx, &pools[i])
-
-		readPools = append(readPools, pool.ReadPool{
-			ID:                pools[i].ID,
-			Description:       pools[i].Description,
-			CreatedAt:         pools[i].CreatedAt,
-			UpdatedAt:         pools[i].UpdatedAt,
-			CoreCapacity:      pools[i].CoreCapacity,
-			MemoryCapacity:    pools[i].MemoryCapacity,
-			MemoryCommitment:  pools[i].MemoryCommitment,
-			ConnectionTimeout: pools[i].ConnectionTimeout,
-			Permissions:       pools[i].Permissions,
-		})
-	}
-
-	return readPools, err
+	return f.poolCache.GetPools(getPoolsFunc)
 }

--- a/facade/pool.go
+++ b/facade/pool.go
@@ -462,7 +462,7 @@ func (f *Facade) CreateDefaultPool(ctx datastore.Context, id string) error {
 func (f *Facade) calcPoolCapacity(ctx datastore.Context, pool *pool.ResourcePool) error {
 	hosts, err := f.hostStore.FindHostsWithPoolID(ctx, pool.ID)
 	if err != nil {
-		// FIXME: this error shouldn't be ignored. Either log it and/or have the caller fail and return the error
+		glog.Errorf("Unable to find hosts in %s: %v", pool.ID, err)
 		return err
 	}
 
@@ -482,7 +482,7 @@ func (f *Facade) calcPoolCapacity(ctx datastore.Context, pool *pool.ResourcePool
 func (f *Facade) calcPoolCommitment(ctx datastore.Context, pool *pool.ResourcePool) error {
 	services, err := f.serviceStore.GetServicesByPool(ctx, pool.ID)
 	if err != nil {
-		// FIXME: this error shouldn't be ignored. Either log it and/or have the caller fail and return the error
+		glog.Errorf("Unable to find services on %s: %v", pool.ID, err)
 		return err
 	}
 

--- a/facade/pool.go
+++ b/facade/pool.go
@@ -536,6 +536,8 @@ func (f *Facade) GetReadPools(ctx datastore.Context) ([]pool.ReadPool, error) {
 	var getPoolsFunc GetPoolsFunc = func() ([]pool.ReadPool, error) {
 		pools, err := f.poolStore.GetResourcePools(ctx)
 
+		fmt.Printf("in GetPoolsFunc begin CreatedAt: %v\n", pools[0].CreatedAt)
+
 		if err != nil {
 			return nil, fmt.Errorf("Could not load pools: %v", err)
 		}
@@ -557,6 +559,8 @@ func (f *Facade) GetReadPools(ctx datastore.Context) ([]pool.ReadPool, error) {
 				ConnectionTimeout: pools[i].ConnectionTimeout,
 				Permissions:       pools[i].Permissions,
 			})
+			fmt.Printf("in GetPoolsFunc end CreatedAt: %v\n", pools[i].CreatedAt)
+			fmt.Printf("in GetPoolsFunc end MemoryCommitment: %v\n", pools[i].MemoryCommitment)
 		}
 		return readPools, nil
 	}

--- a/facade/pool_cache.go
+++ b/facade/pool_cache.go
@@ -1,0 +1,54 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package facade
+
+import (
+	"sync"
+
+	"github.com/control-center/serviced/domain/pool"
+)
+
+type poolCache struct {
+	mutex sync.RWMutex
+	dirty bool
+	pools []pool.ReadPool
+}
+
+type GetPoolsFunc func() ([]pool.ReadPool, error)
+
+func NewPoolCache() *poolCache {
+	return &poolCache{
+		mutex: sync.RWMutex{},
+		dirty: true,
+		pools: make([]pool.ReadPool, 0),
+	}
+}
+
+func (pc *poolCache) GetPools(getPoolsFunc GetPoolsFunc) ([]pool.ReadPool, error) {
+	var err error
+	if pc.dirty {
+		pc.mutex.Lock()
+		defer pc.mutex.Unlock()
+		pc.pools, err = getPoolsFunc()
+		if err == nil {
+			pc.dirty = false
+		}
+	}
+	return pc.pools, err
+}
+
+func (pc *poolCache) SetDirty() {
+	pc.mutex.Lock()
+	defer pc.mutex.Unlock()
+	pc.dirty = true
+}

--- a/facade/pool_cache.go
+++ b/facade/pool_cache.go
@@ -41,11 +41,11 @@ func NewPoolCache() *poolCache {
 // GetPools caches the result of getPoolsFunc if the cache is dirty
 // then returns the cached ReadPools.
 func (pc *poolCache) GetPools(getPoolsFunc GetPoolsFunc) ([]pool.ReadPool, error) {
+	pc.mutex.Lock()
+	defer pc.mutex.Unlock()
 
 	var err error
 	if pc.dirty {
-		pc.mutex.Lock()
-		defer pc.mutex.Unlock()
 		pc.pools, err = getPoolsFunc()
 		if err == nil {
 			pc.dirty = false

--- a/facade/pool_cache.go
+++ b/facade/pool_cache.go
@@ -13,7 +13,6 @@
 package facade
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/control-center/serviced/domain/pool"
@@ -45,7 +44,6 @@ func (pc *poolCache) GetPools(getPoolsFunc GetPoolsFunc) ([]pool.ReadPool, error
 
 	var err error
 	if pc.dirty {
-		fmt.Printf("cache is dirty...\n")
 		pc.mutex.Lock()
 		defer pc.mutex.Unlock()
 		pc.pools, err = getPoolsFunc()
@@ -53,7 +51,6 @@ func (pc *poolCache) GetPools(getPoolsFunc GetPoolsFunc) ([]pool.ReadPool, error
 			pc.dirty = false
 		}
 	}
-	fmt.Printf("in cache GetPools CreatedAt: %v\n", pc.pools[0].CreatedAt)
 	return pc.pools, err
 }
 

--- a/facade/pool_cache.go
+++ b/facade/pool_cache.go
@@ -18,14 +18,18 @@ import (
 	"github.com/control-center/serviced/domain/pool"
 )
 
+// poolCache is a simple in-memory cache for storing ReadPools.
+// The dirty flag should be set when changes are made that affect a ReadPool.
 type poolCache struct {
 	mutex sync.RWMutex
 	dirty bool
 	pools []pool.ReadPool
 }
 
+// GetPoolsFunc should return an up-to-date slice of ReadPools.
 type GetPoolsFunc func() ([]pool.ReadPool, error)
 
+// NewPoolCache creates a new poolCache, which is dirty and empty by default
 func NewPoolCache() *poolCache {
 	return &poolCache{
 		mutex: sync.RWMutex{},
@@ -34,6 +38,8 @@ func NewPoolCache() *poolCache {
 	}
 }
 
+// GetPools caches the result of getPoolsFunc if the cache is dirty
+// then returns the cached ReadPools.
 func (pc *poolCache) GetPools(getPoolsFunc GetPoolsFunc) ([]pool.ReadPool, error) {
 	var err error
 	if pc.dirty {
@@ -47,6 +53,8 @@ func (pc *poolCache) GetPools(getPoolsFunc GetPoolsFunc) ([]pool.ReadPool, error
 	return pc.pools, err
 }
 
+// SetDirty sets poolCache.dirty to true, meaning it will call a GetPoolsFunc
+// next time GetPools is called.
 func (pc *poolCache) SetDirty() {
 	pc.mutex.Lock()
 	defer pc.mutex.Unlock()

--- a/facade/pool_cache.go
+++ b/facade/pool_cache.go
@@ -13,6 +13,7 @@
 package facade
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/control-center/serviced/domain/pool"
@@ -41,8 +42,10 @@ func NewPoolCache() *poolCache {
 // GetPools caches the result of getPoolsFunc if the cache is dirty
 // then returns the cached ReadPools.
 func (pc *poolCache) GetPools(getPoolsFunc GetPoolsFunc) ([]pool.ReadPool, error) {
+
 	var err error
 	if pc.dirty {
+		fmt.Printf("cache is dirty...\n")
 		pc.mutex.Lock()
 		defer pc.mutex.Unlock()
 		pc.pools, err = getPoolsFunc()
@@ -50,6 +53,7 @@ func (pc *poolCache) GetPools(getPoolsFunc GetPoolsFunc) ([]pool.ReadPool, error
 			pc.dirty = false
 		}
 	}
+	fmt.Printf("in cache GetPools CreatedAt: %v\n", pc.pools[0].CreatedAt)
 	return pc.pools, err
 }
 

--- a/facade/pool_cache_test.go
+++ b/facade/pool_cache_test.go
@@ -242,8 +242,8 @@ func (ft *FacadeUnitTest) Test_PoolCacheHostChange(c *C) {
 	p = pools[0]
 	c.Assert(p.ID, Equals, resourcePool.ID)
 	c.Assert(p.CoreCapacity, Equals, 6)
-	c.Assert(p.MemoryCapacity, Equals, uint64(22000))
-	c.Assert(p.MemoryCommitment, Equals, uint64(4000))
+	c.Assert(p.MemoryCapacity, Equals, uint64(12000))
+	c.Assert(p.MemoryCommitment, Equals, uint64(3000))
 	c.Assert(p.ConnectionTimeout, Equals, 10)
 	c.Assert(p.CreatedAt, TimeEqual, resourcePool.CreatedAt)
 	c.Assert(p.UpdatedAt, TimeEqual, resourcePool.UpdatedAt)

--- a/facade/pool_cache_test.go
+++ b/facade/pool_cache_test.go
@@ -18,6 +18,7 @@ package facade_test
 import (
 	"time"
 
+	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain/host"
 	"github.com/control-center/serviced/domain/pool"
 	"github.com/control-center/serviced/domain/service"
@@ -27,64 +28,78 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (ft *FacadeUnitTest) Test_PoolCacheServiceChange(c *C) {
+type poolCacheEnv struct {
+	resourcePool  pool.ResourcePool
+	firstHost     host.Host
+	secondHost    host.Host
+	firstService  service.Service
+	secondService service.Service
+}
+
+func SetupPoolCacheEnv() *poolCacheEnv {
+	return &poolCacheEnv{
+		resourcePool: pool.ResourcePool{
+			ID:                "firstPool",
+			Description:       "The first pool",
+			MemoryCapacity:    0,
+			MemoryCommitment:  0,
+			CoreCapacity:      0,
+			ConnectionTimeout: 10,
+			CreatedAt:         time.Now(),
+			UpdatedAt:         time.Now(),
+			Permissions:       pool.DFSAccess,
+		},
+		firstHost: host.Host{
+			ID:     "firstHost",
+			PoolID: "firstPool",
+			Cores:  6,
+			Memory: 12000,
+		},
+		secondHost: host.Host{
+			ID:     "secondHost",
+			PoolID: "firstPool",
+			Cores:  8,
+			Memory: 10000,
+		},
+		firstService: service.Service{
+			ID: "firstService",
+			RAMCommitment: utils.EngNotation{
+				Value: uint64(1000),
+			},
+		},
+		secondService: service.Service{
+			ID: "secondService",
+			RAMCommitment: utils.EngNotation{
+				Value: uint64(2000),
+			},
+		},
+	}
+}
+
+// Test_PoolCacheEditService tests that the cache is invalidated when a
+// service's ram commitment changes, and is subsequently updated on the next get
+func (ft *FacadeUnitTest) Test_PoolCacheEditService(c *C) {
 	ft.setupMockDFSLocking()
 
-	resourcePool := pool.ResourcePool{
-		ID:                "firstPool",
-		Description:       "The first pool",
-		MemoryCapacity:    0,
-		MemoryCommitment:  0,
-		CoreCapacity:      0,
-		ConnectionTimeout: 10,
-		CreatedAt:         time.Now(),
-		UpdatedAt:         time.Now(),
-		Permissions:       pool.DFSAccess,
-	}
+	pc := SetupPoolCacheEnv()
 
-	firstHost := host.Host{
-		ID:     "firstHost",
-		Cores:  6,
-		Memory: 12000,
-	}
-
-	secondHost := host.Host{
-		ID:     "secondHost",
-		Cores:  8,
-		Memory: 10000,
-	}
-
-	firstService := service.Service{
-		ID: "firstService",
-		RAMCommitment: utils.EngNotation{
-			Value: uint64(1000),
-		},
-	}
-
-	secondService := service.Service{
-		ID: "secondService",
-		RAMCommitment: utils.EngNotation{
-			Value: uint64(2000),
-		},
-	}
-
-	ft.hostStore.On("FindHostsWithPoolID", ft.ctx, resourcePool.ID).
-		Return([]host.Host{firstHost, secondHost}, nil)
+	ft.hostStore.On("FindHostsWithPoolID", ft.ctx, pc.resourcePool.ID).
+		Return([]host.Host{pc.firstHost, pc.secondHost}, nil)
 
 	ft.poolStore.On("GetResourcePools", ft.ctx).
-		Return([]pool.ResourcePool{resourcePool}, nil)
+		Return([]pool.ResourcePool{pc.resourcePool}, nil)
 
-	ft.serviceStore.On("GetServicesByPool", ft.ctx, resourcePool.ID).
-		Return([]service.Service{firstService, secondService}, nil).Once()
+	ft.serviceStore.On("GetServicesByPool", ft.ctx, pc.resourcePool.ID).
+		Return([]service.Service{pc.firstService, pc.secondService}, nil).Once()
 
-	ft.serviceStore.On("GetServiceDetails", ft.ctx, firstService.ID).
+	ft.serviceStore.On("GetServiceDetails", ft.ctx, pc.firstService.ID).
 		Return(&service.ServiceDetails{
-			ID:            firstService.ID,
-			RAMCommitment: firstService.RAMCommitment,
+			ID:            pc.firstService.ID,
+			RAMCommitment: pc.firstService.RAMCommitment,
 		}, nil)
 
-	ft.serviceStore.On("Get", ft.ctx, firstService.ID).
-		Return(&firstService, nil)
+	ft.serviceStore.On("Get", ft.ctx, pc.firstService.ID).
+		Return(&pc.firstService, nil)
 
 	ft.serviceStore.On("Put", ft.ctx, mock.AnythingOfType("*service.Service")).
 		Return(nil)
@@ -102,98 +117,67 @@ func (ft *FacadeUnitTest) Test_PoolCacheServiceChange(c *C) {
 
 	p := pools[0]
 
-	c.Assert(p.ID, Equals, resourcePool.ID)
+	c.Assert(p.ID, Equals, pc.resourcePool.ID)
 	c.Assert(p.CoreCapacity, Equals, 14)
 	c.Assert(p.MemoryCapacity, Equals, uint64(22000))
 	c.Assert(p.MemoryCommitment, Equals, uint64(3000))
 	c.Assert(p.ConnectionTimeout, Equals, 10)
-	c.Assert(p.CreatedAt, TimeEqual, resourcePool.CreatedAt)
-	c.Assert(p.UpdatedAt, TimeEqual, resourcePool.UpdatedAt)
-	c.Assert(p.Permissions, Equals, resourcePool.Permissions)
+	c.Assert(p.CreatedAt, TimeEqual, pc.resourcePool.CreatedAt)
+	c.Assert(p.UpdatedAt, TimeEqual, pc.resourcePool.UpdatedAt)
+	c.Assert(p.Permissions, Equals, pc.resourcePool.Permissions)
 
-	firstService.RAMCommitment = utils.EngNotation{
+	pc.firstService.RAMCommitment = utils.EngNotation{
 		Value: uint64(2000),
 	}
 
-	ft.Facade.UpdateService(ft.ctx, firstService)
+	err = ft.Facade.UpdateService(ft.ctx, pc.firstService)
+	c.Assert(err, IsNil)
 
-	ft.serviceStore.On("GetServicesByPool", ft.ctx, resourcePool.ID).
-		Return([]service.Service{firstService, secondService}, nil).Once()
+	// Make sure that we return the new secondService with the updated RAMCommitment
+	ft.serviceStore.On("GetServicesByPool", ft.ctx, pc.resourcePool.ID).
+		Return([]service.Service{pc.firstService, pc.secondService}, nil).Once()
 
+	// GetReadPools should see that the cache is dirty, and update itself
 	pools, err = ft.Facade.GetReadPools(ft.ctx)
 	c.Assert(err, IsNil)
 	c.Assert(pools, Not(IsNil))
 	c.Assert(len(pools), Equals, 1)
 
 	p = pools[0]
-	c.Assert(p.ID, Equals, resourcePool.ID)
+	c.Assert(p.ID, Equals, pc.resourcePool.ID)
 	c.Assert(p.CoreCapacity, Equals, 14)
 	c.Assert(p.MemoryCapacity, Equals, uint64(22000))
 	c.Assert(p.MemoryCommitment, Equals, uint64(4000))
 	c.Assert(p.ConnectionTimeout, Equals, 10)
-	c.Assert(p.CreatedAt, TimeEqual, resourcePool.CreatedAt)
-	c.Assert(p.UpdatedAt, TimeEqual, resourcePool.UpdatedAt)
-	c.Assert(p.Permissions, Equals, resourcePool.Permissions)
+	c.Assert(p.CreatedAt, TimeEqual, pc.resourcePool.CreatedAt)
+	c.Assert(p.UpdatedAt, TimeEqual, pc.resourcePool.UpdatedAt)
+	c.Assert(p.Permissions, Equals, pc.resourcePool.Permissions)
 }
 
-func (ft *FacadeUnitTest) Test_PoolCacheHostChange(c *C) {
+// Test_PoolCacheRemoveHost tests that cache is invalidated when a host is
+// removed from a pool, and is subsequently updated on the next get
+func (ft *FacadeUnitTest) Test_PoolCacheRemoveHost(c *C) {
 	ft.setupMockDFSLocking()
 
-	resourcePool := pool.ResourcePool{
-		ID:                "firstPool",
-		Description:       "The first pool",
-		MemoryCapacity:    0,
-		MemoryCommitment:  0,
-		CoreCapacity:      0,
-		ConnectionTimeout: 10,
-		CreatedAt:         time.Now(),
-		UpdatedAt:         time.Now(),
-		Permissions:       pool.DFSAccess,
-	}
+	pc := SetupPoolCacheEnv()
 
-	firstHost := host.Host{
-		ID:     "firstHost",
-		Cores:  6,
-		Memory: 12000,
-	}
-
-	secondHost := host.Host{
-		ID:     "secondHost",
-		Cores:  8,
-		Memory: 10000,
-	}
-
-	firstService := service.Service{
-		ID: "firstService",
-		RAMCommitment: utils.EngNotation{
-			Value: uint64(1000),
-		},
-	}
-
-	secondService := service.Service{
-		ID: "secondService",
-		RAMCommitment: utils.EngNotation{
-			Value: uint64(2000),
-		},
-	}
-
-	ft.hostStore.On("FindHostsWithPoolID", ft.ctx, resourcePool.ID).
-		Return([]host.Host{firstHost, secondHost}, nil).Once()
+	ft.hostStore.On("FindHostsWithPoolID", ft.ctx, pc.resourcePool.ID).
+		Return([]host.Host{pc.firstHost, pc.secondHost}, nil).Once()
 
 	ft.poolStore.On("GetResourcePools", ft.ctx).
-		Return([]pool.ResourcePool{resourcePool}, nil)
+		Return([]pool.ResourcePool{pc.resourcePool}, nil)
 
-	ft.serviceStore.On("GetServicesByPool", ft.ctx, resourcePool.ID).
-		Return([]service.Service{firstService, secondService}, nil)
+	ft.serviceStore.On("GetServicesByPool", ft.ctx, pc.resourcePool.ID).
+		Return([]service.Service{pc.firstService, pc.secondService}, nil)
 
-	ft.serviceStore.On("GetServiceDetails", ft.ctx, firstService.ID).
+	ft.serviceStore.On("GetServiceDetails", ft.ctx, pc.firstService.ID).
 		Return(&service.ServiceDetails{
-			ID:            firstService.ID,
-			RAMCommitment: firstService.RAMCommitment,
+			ID:            pc.firstService.ID,
+			RAMCommitment: pc.firstService.RAMCommitment,
 		}, nil)
 
-	ft.serviceStore.On("Get", ft.ctx, firstService.ID).
-		Return(&firstService, nil)
+	ft.serviceStore.On("Get", ft.ctx, pc.firstService.ID).
+		Return(&pc.firstService, nil)
 
 	ft.serviceStore.On("Put", ft.ctx, mock.AnythingOfType("*service.Service")).
 		Return(nil)
@@ -201,17 +185,17 @@ func (ft *FacadeUnitTest) Test_PoolCacheHostChange(c *C) {
 	ft.configStore.On("GetConfigFiles", ft.ctx, mock.AnythingOfType("string"), mock.AnythingOfType("string")).
 		Return([]*serviceconfigfile.SvcConfigFile{}, nil)
 
-	ft.hostStore.On("Get", ft.ctx, host.HostKey(secondHost.ID), mock.AnythingOfType("*host.Host")).
+	ft.hostStore.On("Get", ft.ctx, host.HostKey(pc.secondHost.ID), mock.AnythingOfType("*host.Host")).
 		Return(nil).
 		Run(func(args mock.Arguments) {
-			*args.Get(2).(*host.Host) = secondHost
+			*args.Get(2).(*host.Host) = pc.secondHost
 		})
 
-	ft.zzk.On("RemoveHost", &secondHost).Return(nil)
-	ft.zzk.On("UnregisterDfsClients", []host.Host{secondHost}).Return(nil)
+	ft.zzk.On("RemoveHost", &pc.secondHost).Return(nil)
+	ft.zzk.On("UnregisterDfsClients", []host.Host{pc.secondHost}).Return(nil)
 
-	ft.hostkeyStore.On("Delete", ft.ctx, secondHost.ID).Return(nil)
-	ft.hostStore.On("Delete", ft.ctx, host.HostKey(secondHost.ID)).Return(nil)
+	ft.hostkeyStore.On("Delete", ft.ctx, pc.secondHost.ID).Return(nil)
+	ft.hostStore.On("Delete", ft.ctx, host.HostKey(pc.secondHost.ID)).Return(nil)
 
 	pools, err := ft.Facade.GetReadPools(ft.ctx)
 	c.Assert(err, IsNil)
@@ -220,19 +204,20 @@ func (ft *FacadeUnitTest) Test_PoolCacheHostChange(c *C) {
 
 	p := pools[0]
 
-	c.Assert(p.ID, Equals, resourcePool.ID)
+	c.Assert(p.ID, Equals, pc.resourcePool.ID)
 	c.Assert(p.CoreCapacity, Equals, 14)
 	c.Assert(p.MemoryCapacity, Equals, uint64(22000))
 	c.Assert(p.MemoryCommitment, Equals, uint64(3000))
 	c.Assert(p.ConnectionTimeout, Equals, 10)
-	c.Assert(p.CreatedAt, TimeEqual, resourcePool.CreatedAt)
-	c.Assert(p.UpdatedAt, TimeEqual, resourcePool.UpdatedAt)
-	c.Assert(p.Permissions, Equals, resourcePool.Permissions)
+	c.Assert(p.CreatedAt, TimeEqual, pc.resourcePool.CreatedAt)
+	c.Assert(p.UpdatedAt, TimeEqual, pc.resourcePool.UpdatedAt)
+	c.Assert(p.Permissions, Equals, pc.resourcePool.Permissions)
 
-	ft.Facade.RemoveHost(ft.ctx, secondHost.ID)
+	err = ft.Facade.RemoveHost(ft.ctx, pc.secondHost.ID)
+	c.Assert(err, IsNil)
 
-	ft.hostStore.On("FindHostsWithPoolID", ft.ctx, resourcePool.ID).
-		Return([]host.Host{firstHost}, nil).Once()
+	ft.hostStore.On("FindHostsWithPoolID", ft.ctx, pc.resourcePool.ID).
+		Return([]host.Host{pc.firstHost}, nil).Once()
 
 	pools, err = ft.Facade.GetReadPools(ft.ctx)
 	c.Assert(err, IsNil)
@@ -240,12 +225,99 @@ func (ft *FacadeUnitTest) Test_PoolCacheHostChange(c *C) {
 	c.Assert(len(pools), Equals, 1)
 
 	p = pools[0]
-	c.Assert(p.ID, Equals, resourcePool.ID)
+	c.Assert(p.ID, Equals, pc.resourcePool.ID)
 	c.Assert(p.CoreCapacity, Equals, 6)
 	c.Assert(p.MemoryCapacity, Equals, uint64(12000))
 	c.Assert(p.MemoryCommitment, Equals, uint64(3000))
 	c.Assert(p.ConnectionTimeout, Equals, 10)
-	c.Assert(p.CreatedAt, TimeEqual, resourcePool.CreatedAt)
-	c.Assert(p.UpdatedAt, TimeEqual, resourcePool.UpdatedAt)
-	c.Assert(p.Permissions, Equals, resourcePool.Permissions)
+	c.Assert(p.CreatedAt, TimeEqual, pc.resourcePool.CreatedAt)
+	c.Assert(p.UpdatedAt, TimeEqual, pc.resourcePool.UpdatedAt)
+	c.Assert(p.Permissions, Equals, pc.resourcePool.Permissions)
+}
+
+// Test_PoolCacheAddHost tests that cache is invalidated when a host is
+// added to a pool, and is subsequently updated on the next get
+func (ft *FacadeUnitTest) Test_PoolCacheAddHost(c *C) {
+	ft.setupMockDFSLocking()
+
+	pc := SetupPoolCacheEnv()
+
+	ft.hostStore.On("FindHostsWithPoolID", ft.ctx, pc.resourcePool.ID).
+		Return([]host.Host{pc.firstHost}, nil).Once()
+
+	ft.poolStore.On("GetResourcePools", ft.ctx).
+		Return([]pool.ResourcePool{pc.resourcePool}, nil)
+
+	ft.serviceStore.On("GetServicesByPool", ft.ctx, pc.resourcePool.ID).
+		Return([]service.Service{pc.firstService, pc.secondService}, nil)
+
+	ft.serviceStore.On("GetServiceDetails", ft.ctx, pc.firstService.ID).
+		Return(&service.ServiceDetails{
+			ID:            pc.firstService.ID,
+			RAMCommitment: pc.firstService.RAMCommitment,
+		}, nil)
+
+	ft.serviceStore.On("Get", ft.ctx, pc.firstService.ID).
+		Return(&pc.firstService, nil)
+
+	ft.serviceStore.On("Put", ft.ctx, mock.AnythingOfType("*service.Service")).
+		Return(nil)
+
+	ft.configStore.On("GetConfigFiles", ft.ctx, mock.AnythingOfType("string"), mock.AnythingOfType("string")).
+		Return([]*serviceconfigfile.SvcConfigFile{}, nil)
+
+	ft.hostStore.On("Get", ft.ctx, host.HostKey(pc.secondHost.ID), mock.AnythingOfType("*host.Host")).
+		Return(datastore.ErrNoSuchEntity{}).
+		Once()
+
+	pools, err := ft.Facade.GetReadPools(ft.ctx)
+	c.Assert(err, IsNil)
+	c.Assert(pools, Not(IsNil))
+	c.Assert(len(pools), Equals, 1)
+
+	p := pools[0]
+
+	c.Assert(p.ID, Equals, pc.resourcePool.ID)
+	c.Assert(p.CoreCapacity, Equals, 6)
+	c.Assert(p.MemoryCapacity, Equals, uint64(12000))
+	c.Assert(p.MemoryCommitment, Equals, uint64(3000))
+	c.Assert(p.ConnectionTimeout, Equals, 10)
+	c.Assert(p.CreatedAt, TimeEqual, pc.resourcePool.CreatedAt)
+	c.Assert(p.UpdatedAt, TimeEqual, pc.resourcePool.UpdatedAt)
+	c.Assert(p.Permissions, Equals, pc.resourcePool.Permissions)
+
+	ft.poolStore.On("Get", ft.ctx, pool.Key(pc.resourcePool.ID), mock.AnythingOfType("*pool.ResourcePool")).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			*args.Get(2).(*pool.ResourcePool) = pc.resourcePool
+		})
+
+	ft.hostStore.On("FindHostsWithPoolID", ft.ctx, pc.resourcePool.ID).
+		Return([]host.Host{pc.firstHost, pc.secondHost}, nil)
+
+	ft.hostkeyStore.On("Put", ft.ctx, pc.secondHost.ID, mock.AnythingOfType("*hostkey.HostKey")).
+		Return(nil)
+
+	ft.hostStore.On("Put", ft.ctx, host.HostKey(pc.secondHost.ID), &pc.secondHost).
+		Return(nil)
+
+	ft.zzk.On("AddHost", &pc.secondHost).Return(nil)
+
+	_, err = ft.Facade.AddHost(ft.ctx, &pc.secondHost)
+	c.Assert(err, IsNil)
+
+	pools, err = ft.Facade.GetReadPools(ft.ctx)
+	c.Assert(err, IsNil)
+	c.Assert(pools, Not(IsNil))
+	c.Assert(len(pools), Equals, 1)
+
+	p = pools[0]
+	c.Assert(p.ID, Equals, pc.resourcePool.ID)
+	c.Assert(p.CoreCapacity, Equals, 14)
+	c.Assert(p.MemoryCapacity, Equals, uint64(22000))
+	c.Assert(p.MemoryCommitment, Equals, uint64(3000))
+	c.Assert(p.ConnectionTimeout, Equals, 10)
+	c.Assert(p.CreatedAt, TimeEqual, pc.resourcePool.CreatedAt)
+	c.Assert(p.UpdatedAt, TimeEqual, pc.resourcePool.UpdatedAt)
+	c.Assert(p.Permissions, Equals, pc.resourcePool.Permissions)
 }

--- a/facade/pool_cache_test.go
+++ b/facade/pool_cache_test.go
@@ -1,0 +1,132 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package facade_test
+
+import (
+	"time"
+
+	"github.com/control-center/serviced/domain/host"
+	"github.com/control-center/serviced/domain/pool"
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/domain/serviceconfigfile"
+	"github.com/control-center/serviced/utils"
+	"github.com/stretchr/testify/mock"
+	. "gopkg.in/check.v1"
+)
+
+func (ft *FacadeUnitTest) Test_PoolCache(c *C) {
+	ft.setupMockDFSLocking()
+
+	resourcePool := pool.ResourcePool{
+		ID:                "firstPool",
+		Description:       "The first pool",
+		MemoryCapacity:    0,
+		MemoryCommitment:  0,
+		CoreCapacity:      0,
+		ConnectionTimeout: 10,
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+		Permissions:       pool.DFSAccess,
+	}
+
+	firstHost := host.Host{
+		ID:     "firstHost",
+		Cores:  6,
+		Memory: 12000,
+	}
+
+	secondHost := host.Host{
+		ID:     "secondHost",
+		Cores:  8,
+		Memory: 10000,
+	}
+
+	firstService := service.Service{
+		ID: "firstService",
+		RAMCommitment: utils.EngNotation{
+			Value: uint64(1000),
+		},
+	}
+
+	secondService := service.Service{
+		ID: "secondService",
+		RAMCommitment: utils.EngNotation{
+			Value: uint64(2000),
+		},
+	}
+
+	ft.hostStore.On("FindHostsWithPoolID", ft.ctx, resourcePool.ID).
+		Return([]host.Host{firstHost, secondHost}, nil)
+
+	ft.poolStore.On("GetResourcePools", ft.ctx).
+		Return([]pool.ResourcePool{resourcePool}, nil)
+
+	ft.serviceStore.On("GetServicesByPool", ft.ctx, resourcePool.ID).
+		Return([]service.Service{firstService, secondService}, nil)
+
+	ft.serviceStore.On("GetServiceDetails", ft.ctx, firstService.ID).
+		Return(&service.ServiceDetails{
+			ID:            firstService.ID,
+			RAMCommitment: firstService.RAMCommitment,
+		}, nil)
+
+	ft.serviceStore.On("Get", ft.ctx, firstService.ID).
+		Return(&firstService, nil)
+
+	ft.serviceStore.On("Put", ft.ctx, mock.AnythingOfType("*service.Service")).
+		Return(nil)
+
+	ft.configStore.On("GetConfigFiles", ft.ctx, mock.AnythingOfType("string"), mock.AnythingOfType("string")).
+		Return([]*serviceconfigfile.SvcConfigFile{}, nil)
+
+	ft.zzk.On("UpdateService", ft.ctx, mock.AnythingOfType("string"), mock.AnythingOfType("*service.Service"),
+		false, false).Return(nil)
+
+	pools, err := ft.Facade.GetReadPools(ft.ctx)
+	c.Assert(err, IsNil)
+	c.Assert(pools, Not(IsNil))
+	c.Assert(len(pools), Equals, 1)
+
+	p := pools[0]
+	c.Assert(p.ID, Equals, resourcePool.ID)
+	c.Assert(p.CoreCapacity, Equals, 14)
+	c.Assert(p.MemoryCapacity, Equals, uint64(22000))
+	c.Assert(p.MemoryCommitment, Equals, uint64(3000))
+	c.Assert(p.ConnectionTimeout, Equals, 10)
+	c.Assert(p.CreatedAt, TimeEqual, resourcePool.CreatedAt)
+	c.Assert(p.UpdatedAt, TimeEqual, resourcePool.UpdatedAt)
+	c.Assert(p.Permissions, Equals, resourcePool.Permissions)
+
+	firstService.RAMCommitment = utils.EngNotation{
+		Value: uint64(2000),
+	}
+	ft.Facade.UpdateService(ft.ctx, firstService)
+
+	pools, err = ft.Facade.GetReadPools(ft.ctx)
+	c.Assert(err, IsNil)
+	c.Assert(pools, Not(IsNil))
+	c.Assert(len(pools), Equals, 1)
+
+	p = pools[0]
+	c.Assert(p.ID, Equals, resourcePool.ID)
+	c.Assert(p.CoreCapacity, Equals, 14)
+	c.Assert(p.MemoryCapacity, Equals, uint64(22000))
+	c.Assert(p.MemoryCommitment, Equals, uint64(4000))
+	c.Assert(p.ConnectionTimeout, Equals, 10)
+	c.Assert(p.CreatedAt, TimeEqual, resourcePool.CreatedAt)
+	c.Assert(p.UpdatedAt, TimeEqual, resourcePool.UpdatedAt)
+	c.Assert(p.Permissions, Equals, resourcePool.Permissions)
+}

--- a/facade/service.go
+++ b/facade/service.go
@@ -215,6 +215,7 @@ func (f *Facade) UpdateService(ctx datastore.Context, svc service.Service) error
 	mutex := getTenantLock(tenantID)
 	mutex.RLock()
 	defer mutex.RUnlock()
+	fmt.Printf("updating service, ram commitment is %v\n", svc.RAMCommitment)
 	return f.updateService(ctx, tenantID, svc, false, false)
 }
 
@@ -284,6 +285,8 @@ func (f *Facade) updateService(ctx datastore.Context, tenantID string, svc servi
 		}
 	}
 
+	fmt.Printf("updating service2, ram commitment is %v\n", svc.RAMCommitment)
+	fmt.Printf("setting pool cache to dirty\n")
 	f.poolCache.SetDirty()
 
 	// sync the service with the coordinator

--- a/facade/service.go
+++ b/facade/service.go
@@ -215,7 +215,6 @@ func (f *Facade) UpdateService(ctx datastore.Context, svc service.Service) error
 	mutex := getTenantLock(tenantID)
 	mutex.RLock()
 	defer mutex.RUnlock()
-	fmt.Printf("updating service, ram commitment is %v\n", svc.RAMCommitment)
 	return f.updateService(ctx, tenantID, svc, false, false)
 }
 
@@ -285,8 +284,6 @@ func (f *Facade) updateService(ctx datastore.Context, tenantID string, svc servi
 		}
 	}
 
-	fmt.Printf("updating service2, ram commitment is %v\n", svc.RAMCommitment)
-	fmt.Printf("setting pool cache to dirty\n")
 	f.poolCache.SetDirty()
 
 	// sync the service with the coordinator

--- a/facade/service.go
+++ b/facade/service.go
@@ -284,6 +284,8 @@ func (f *Facade) updateService(ctx datastore.Context, tenantID string, svc servi
 		}
 	}
 
+	f.poolCache.SetDirty()
+
 	// sync the service with the coordinator
 	if err := f.syncService(ctx, tenantID, svc.ID, setLockOnUpdate, setLockOnUpdate); err != nil {
 		glog.Errorf("Could not sync service %s (%s): %s", svc.Name, svc.ID, err)
@@ -743,6 +745,8 @@ func (f *Facade) removeService(ctx datastore.Context, id string) error {
 			glog.Errorf("Error while removing service %s (%s): %s", svc.Name, svc.ID, err)
 			return err
 		}
+
+		f.poolCache.SetDirty()
 
 		f.serviceCache.RemoveIfParentChanged(svc.ID, svc.ParentServiceID)
 		return nil


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3025

This PR fixes CC-3025 by creating a pool cache to be used for ReadPools.

Due to the multiple ways poolCache can be invalidated and the cost of updating a stale poolCache, the best way I could think to manage this cache was by having a simple dirty flag that's set when the cache will be stale, and have a func to refresh the cache as a parameter to GetPools from cache, which is called when GetPools is called if the cache is dirty.

Unit tests were setup to verify that the cache is getting correctly invalidated and subsequently updated.