### PR TITLE
Add Startup/Shutdown ordering fields to Service

### DIFF
--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -107,13 +107,13 @@ type Service struct {
 	// with StartLevel 0 (representing undefined) start after and stop before services
 	// with a defined StartLevel.
 	StartLevel uint
-	// ShutdownLevel represents the order in which services are stopped in an
-	// emergency low-storage situation.  All services of a given ShutdownLevel are
-	// stopped before any services of a higher ShutdownLevel.  In an emergency
-	// low-storage shutdown, services with ShutdownLevel 0 (representing undefined)
-	// are stopped after services with a defined ShutdownLevel, in the normal order
+	// EmergencyShutdownLevel represents the order in which services are stopped in an
+	// emergency low-storage situation.  All services of a given EmergencyShutdownLevel are
+	// stopped before any services of a higher EmergencyShutdownLevel.  In an emergency
+	// low-storage shutdown, services with EmergencyShutdownLevel 0 (representing undefined)
+	// are stopped after services with a defined EmergencyShutdownLevel, in the normal order
 	// dictated by their StartLevel.
-	ShutdownLevel uint
+	EmergencyShutdownLevel uint
 	datastore.VersionedEntity
 }
 
@@ -237,7 +237,7 @@ func BuildService(sd servicedefinition.ServiceDefinition, parentServiceID string
 	svc.Prereqs = sd.Prereqs
 	svc.PIDFile = sd.PIDFile
 	svc.StartLevel = sd.StartLevel
-	svc.ShutdownLevel = sd.ShutdownLevel
+	svc.EmergencyShutdownLevel = sd.EmergencyShutdownLevel
 
 	svc.Endpoints = make([]ServiceEndpoint, 0)
 	for _, ep := range sd.Endpoints {

--- a/domain/service/service_test.go
+++ b/domain/service/service_test.go
@@ -203,7 +203,7 @@ func (s *S) TestCloneService(t *C) {
 			},
 		},
 		StartLevel:    777,
-		ShutdownLevel: 999,
+		EmergencyShutdownLevel: 999,
 	}
 
 	suffix := "tester"
@@ -216,7 +216,7 @@ func (s *S) TestCloneService(t *C) {
 	t.Check(clonedSvc.UpdatedAt.Equal(svc.UpdatedAt), Equals, false)
 	t.Check(clonedSvc.Name, Equals, svc.Name+suffix)
 	t.Check(clonedSvc.StartLevel, Equals, svc.StartLevel)
-	t.Check(clonedSvc.ShutdownLevel, Equals, svc.ShutdownLevel)
+	t.Check(clonedSvc.EmergencyShutdownLevel, Equals, svc.EmergencyShutdownLevel)
 
 	actualEp0 := clonedSvc.Endpoints[0]
 	t.Check(actualEp0.Name, Equals, "eptester")

--- a/domain/service/service_test.go
+++ b/domain/service/service_test.go
@@ -202,6 +202,8 @@ func (s *S) TestCloneService(t *C) {
 				},
 			},
 		},
+		StartLevel:    777,
+		ShutdownLevel: 999,
 	}
 
 	suffix := "tester"
@@ -213,6 +215,8 @@ func (s *S) TestCloneService(t *C) {
 	t.Check(clonedSvc.CreatedAt.Equal(svc.CreatedAt), Equals, false)
 	t.Check(clonedSvc.UpdatedAt.Equal(svc.UpdatedAt), Equals, false)
 	t.Check(clonedSvc.Name, Equals, svc.Name+suffix)
+	t.Check(clonedSvc.StartLevel, Equals, svc.StartLevel)
+	t.Check(clonedSvc.ShutdownLevel, Equals, svc.ShutdownLevel)
 
 	actualEp0 := clonedSvc.Endpoints[0]
 	t.Check(actualEp0.Name, Equals, "eptester")

--- a/domain/service/service_unit_test.go
+++ b/domain/service/service_unit_test.go
@@ -82,7 +82,7 @@ func (s *ServiceDomainUnitTestSuite) TestBuildServiceSimple(t *C) {
 		CPUShares:     cpuShares,
 		PIDFile:       pidFile,
 		StartLevel:    startLevel,
-		ShutdownLevel: shutdownLevel,
+		EmergencyShutdownLevel: shutdownLevel,
 	}
 	actual, err := service.BuildService(sd, "", "", 0, "")
 
@@ -108,5 +108,5 @@ func (s *ServiceDomainUnitTestSuite) TestBuildServiceSimple(t *C) {
 	t.Check(actual.CPUShares, Equals, cpuShares)
 	t.Check(actual.PIDFile, Equals, pidFile)
 	t.Check(actual.StartLevel, Equals, startLevel)
-	t.Check(actual.ShutdownLevel, Equals, shutdownLevel)
+	t.Check(actual.EmergencyShutdownLevel, Equals, shutdownLevel)
 }

--- a/domain/service/service_unit_test.go
+++ b/domain/service/service_unit_test.go
@@ -1,0 +1,112 @@
+// Copyright 2016 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package service_test
+
+import (
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/domain/servicedefinition"
+	"github.com/control-center/serviced/utils"
+	. "gopkg.in/check.v1"
+)
+
+// Test that simple fields are correctly copied from ServiceDefinition
+func (s *ServiceDomainUnitTestSuite) TestBuildServiceSimple(t *C) {
+	name := "Name"
+	title := "title"
+	version := "version"
+	command := "command"
+	description := "description"
+	environment := []string{"enviroment:foobar", "a:b", "c:d"}
+	tags := []string{"tags", "foo", "bar"}
+	imageID := "imageid"
+	changeOptions := []string{"changeoptions", "boo"}
+	launch := "launch"
+	hostname := "hostname"
+	privileged := true
+	context := map[string]interface{}{"context": 1, "foo": "bar"}
+	ramCommitment := utils.NewEngNotation(1024)
+	cpuCommitment := uint64(112233)
+	disableShell := true
+	runs := map[string]string{"runs": "foo"}
+	actions := map[string]string{"action": "reaction", "foo": "barr"}
+	memoryLimit := 123.456
+	cpuShares := int64(123456)
+	pidFile := "pidfile"
+	startLevel := uint(1234)
+	shutdownLevel := uint(4567)
+
+	sd := servicedefinition.ServiceDefinition{
+		Name:        name,
+		Title:       title,
+		Version:     version,
+		Command:     command,
+		Description: description,
+		Environment: environment,
+		Tags:        tags,
+		ImageID:     imageID,
+		// Instances: instances,
+		ChangeOptions: changeOptions,
+		Launch:        launch,
+		Hostname:      hostname,
+		Privileged:    privileged,
+		// ConfigFiles: configfiles,
+		Context: context,
+		// Endpoints: endpoints,
+		// Services: services,
+		// Volumes: volumes,
+		// LogConfigs: logconfigs,
+		// SnapShot: snapshot,
+		RAMCommitment: ramCommitment,
+		CPUCommitment: cpuCommitment,
+		DisableShell:  disableShell,
+		Runs:          runs,
+		// Commands: commands,
+		Actions: actions,
+		// HealthChecks: healthchecks,
+		// Prereqs: prereqs,
+		// MonitoringProfile: monitoringprofile,
+		MemoryLimit:   memoryLimit,
+		CPUShares:     cpuShares,
+		PIDFile:       pidFile,
+		StartLevel:    startLevel,
+		ShutdownLevel: shutdownLevel,
+	}
+	actual, err := service.BuildService(sd, "", "", 0, "")
+
+	t.Assert(err, IsNil)
+	t.Check(actual.Name, Equals, name)
+	t.Check(actual.Title, Equals, title)
+	t.Check(actual.Startup, Equals, command)
+	t.Check(actual.Description, Equals, description)
+	t.Check(actual.Environment, DeepEquals, environment)
+	t.Check(actual.Tags, DeepEquals, tags)
+	t.Check(actual.ImageID, Equals, imageID)
+	t.Check(actual.ChangeOptions, DeepEquals, changeOptions)
+	t.Check(actual.Launch, Equals, launch)
+	t.Check(actual.Hostname, Equals, hostname)
+	t.Check(actual.Privileged, Equals, privileged)
+	t.Check(actual.Context, DeepEquals, context)
+	t.Check(actual.RAMCommitment, Equals, ramCommitment)
+	t.Check(actual.CPUCommitment, Equals, cpuCommitment)
+	t.Check(actual.DisableShell, Equals, disableShell)
+	t.Check(actual.Runs, DeepEquals, runs)
+	t.Check(actual.Actions, DeepEquals, actions)
+	t.Check(actual.MemoryLimit, Equals, memoryLimit)
+	t.Check(actual.CPUShares, Equals, cpuShares)
+	t.Check(actual.PIDFile, Equals, pidFile)
+	t.Check(actual.StartLevel, Equals, startLevel)
+	t.Check(actual.ShutdownLevel, Equals, shutdownLevel)
+}

--- a/domain/servicedefinition/servicedefinition.go
+++ b/domain/servicedefinition/servicedefinition.go
@@ -65,7 +65,7 @@ type ServiceDefinition struct {
 	CPUShares         int64
 	PIDFile           string // An optional path or command to generate a path for a PID file to which signals are relayed.
 	StartLevel        uint   // Services start in the order implied by this field (low to high) and stopped in reverse order
-	ShutdownLevel     uint   // In case of low storage, Services stopped in the order implied by this field (low to high)
+	EmergencyShutdownLevel     uint   // In case of low storage, Services stopped in the order implied by this field (low to high)
 }
 
 // SnapshotCommands commands to be called during and after a snapshot

--- a/domain/servicedefinition/servicedefinition.go
+++ b/domain/servicedefinition/servicedefinition.go
@@ -64,6 +64,8 @@ type ServiceDefinition struct {
 	MemoryLimit       float64
 	CPUShares         int64
 	PIDFile           string // An optional path or command to generate a path for a PID file to which signals are relayed.
+	StartLevel        uint   // Services start in the order implied by this field (low to high) and stopped in reverse order
+	ShutdownLevel     uint   // In case of low storage, Services stopped in the order implied by this field (low to high)
 }
 
 // SnapshotCommands commands to be called during and after a snapshot
@@ -228,7 +230,7 @@ func (e *EndpointDefinition) UnmarshalJSON(b []byte) error {
 		}
 		plog.WithFields(log.Fields{
 			"vhostlist": e.VHostList,
-			"vhosts": e.VHosts,
+			"vhosts":    e.VHosts,
 		}).Debug("VHostList created from VHosts")
 		e.VHosts = nil
 	}

--- a/domain/servicedefinition/template_test.go
+++ b/domain/servicedefinition/template_test.go
@@ -124,7 +124,7 @@ done
 					},
 				},
 				StartLevel:    0,
-				ShutdownLevel: 0,
+				EmergencyShutdownLevel: 0,
 			},
 			ServiceDefinition{
 				Name:    "s2",
@@ -159,7 +159,7 @@ done
 					Resume: "echo resume",
 				},
 				StartLevel:    123,
-				ShutdownLevel: 321,
+				EmergencyShutdownLevel: 321,
 			},
 		},
 	}
@@ -198,8 +198,8 @@ func (a *ServiceDefinition) equals(b *ServiceDefinition) (identical bool, msg st
 	if a.StartLevel != b.StartLevel {
 		return false, fmt.Sprintf("StartLevel differs: %d != %d", a.StartLevel, b.StartLevel)
 	}
-	if a.ShutdownLevel != b.ShutdownLevel {
-		return false, fmt.Sprintf("ShutdownLevel differs: %d != %d", a.ShutdownLevel, b.ShutdownLevel)
+	if a.EmergencyShutdownLevel != b.EmergencyShutdownLevel {
+		return false, fmt.Sprintf("EmergencyShutdownLevel differs: %d != %d", a.EmergencyShutdownLevel, b.EmergencyShutdownLevel)
 	}
 
 	sort.Sort(ServiceDefinitionByName(a.Services))

--- a/domain/servicedefinition/template_test.go
+++ b/domain/servicedefinition/template_test.go
@@ -123,6 +123,8 @@ done
 						Type:              "",
 					},
 				},
+				StartLevel:    0,
+				ShutdownLevel: 0,
 			},
 			ServiceDefinition{
 				Name:    "s2",
@@ -156,6 +158,8 @@ done
 					Pause:  "echo pause",
 					Resume: "echo resume",
 				},
+				StartLevel:    123,
+				ShutdownLevel: 321,
 			},
 		},
 	}
@@ -190,6 +194,12 @@ func (a *ServiceDefinition) equals(b *ServiceDefinition) (identical bool, msg st
 	if len(a.Volumes) != len(b.Volumes) {
 		return false, fmt.Sprintf("Number of volumes differ between %s [%d] and %s [%d]",
 			a.Name, len(a.Volumes), b.Name, len(b.Volumes))
+	}
+	if a.StartLevel != b.StartLevel {
+		return false, fmt.Sprintf("StartLevel differs: %d != %d", a.StartLevel, b.StartLevel)
+	}
+	if a.ShutdownLevel != b.ShutdownLevel {
+		return false, fmt.Sprintf("ShutdownLevel differs: %d != %d", a.ShutdownLevel, b.ShutdownLevel)
 	}
 
 	sort.Sort(ServiceDefinitionByName(a.Services))

--- a/domain/servicedefinition/testsvc/s1/service.json
+++ b/domain/servicedefinition/testsvc/s1/service.json
@@ -46,5 +46,7 @@
             "ResourcePath": "test2",
             "ContainerPath": "/test2",
             "Type": ""
-          }]
+          }],
+		  "#StartLevel": "StartLevel ommitted to test default value",
+		  "#ShutdownLevel": "ShutdownLevel ommitted to test default value"
 }

--- a/domain/servicedefinition/testsvc/s1/service.json
+++ b/domain/servicedefinition/testsvc/s1/service.json
@@ -48,5 +48,5 @@
             "Type": ""
           }],
 		  "#StartLevel": "StartLevel ommitted to test default value",
-		  "#ShutdownLevel": "ShutdownLevel ommitted to test default value"
+		  "#EmergencyShutdownLevel": "EmergencyShutdownLevel ommitted to test default value"
 }

--- a/domain/servicedefinition/testsvc/s2/service.json
+++ b/domain/servicedefinition/testsvc/s2/service.json
@@ -29,5 +29,5 @@
             "Resume": "echo resume"
           },
 		  "StartLevel": 123,
-		  "ShutdownLevel": 321
+		  "EmergencyShutdownLevel": 321
 }

--- a/domain/servicedefinition/testsvc/s2/service.json
+++ b/domain/servicedefinition/testsvc/s2/service.json
@@ -27,5 +27,7 @@
           "Snapshot": {
             "Pause": "echo pause",
             "Resume": "echo resume"
-          }
+          },
+		  "StartLevel": 123,
+		  "ShutdownLevel": 321
 }


### PR DESCRIPTION
+ Add StartLevel and ShutdownLevel to Service and ServiceDefinition structures.
+ Add relevant unit tests

Fixes [CC-2382](https://jira.zenoss.com/browse/CC-2382)