### PR TITLE
CC services endpoint returns MonitoringProfile data for top level ser…

### DIFF
--- a/web/resources.go
+++ b/web/resources.go
@@ -157,9 +157,11 @@ func restGetAllServices(w *rest.ResponseWriter, r *rest.Request, ctx *requestCon
 			return
 		}
 
-		for ii, _ := range result {
-			result[ii].MonitoringProfile.MetricConfigs = append(result[ii].MonitoringProfile.MetricConfigs, *config)
-			result[ii].MonitoringProfile.GraphConfigs = append(result[ii].MonitoringProfile.GraphConfigs, getInternalGraphConfigs(result[ii].ID)...)
+		for ii, svc := range result {
+			if len(svc.Startup) > 2 {
+				result[ii].MonitoringProfile.MetricConfigs = append(result[ii].MonitoringProfile.MetricConfigs, *config)
+				result[ii].MonitoringProfile.GraphConfigs = append(result[ii].MonitoringProfile.GraphConfigs, getInternalGraphConfigs(result[ii].ID)...)
+			}
 		}
 		w.WriteJson(&result)
 		return
@@ -172,9 +174,11 @@ func restGetAllServices(w *rest.ResponseWriter, r *rest.Request, ctx *requestCon
 			return
 		}
 
-		for ii, _ := range result {
-			result[ii].MonitoringProfile.MetricConfigs = append(result[ii].MonitoringProfile.MetricConfigs, *config)
-			result[ii].MonitoringProfile.GraphConfigs = append(result[ii].MonitoringProfile.GraphConfigs, getInternalGraphConfigs(result[ii].ID)...)
+		for ii, svc := range result {
+			if len(svc.Startup) > 2 {
+				result[ii].MonitoringProfile.MetricConfigs = append(result[ii].MonitoringProfile.MetricConfigs, *config)
+				result[ii].MonitoringProfile.GraphConfigs = append(result[ii].MonitoringProfile.GraphConfigs, getInternalGraphConfigs(result[ii].ID)...)
+			}
 		}
 		w.WriteJson(&result)
 		return
@@ -211,12 +215,14 @@ func restGetAllServices(w *rest.ResponseWriter, r *rest.Request, ctx *requestCon
 		}
 	}
 
-	for ii, _ := range result {
+	for ii, svc := range result {
 		if strings.HasPrefix(result[ii].ID, "isvc-") {
 			continue
 		}
-		result[ii].MonitoringProfile.MetricConfigs = append(result[ii].MonitoringProfile.MetricConfigs, *config)
-		result[ii].MonitoringProfile.GraphConfigs = append(result[ii].MonitoringProfile.GraphConfigs, getInternalGraphConfigs(result[ii].ID)...)
+		if len(svc.Startup) > 2 {
+			result[ii].MonitoringProfile.MetricConfigs = append(result[ii].MonitoringProfile.MetricConfigs, *config)
+			result[ii].MonitoringProfile.GraphConfigs = append(result[ii].MonitoringProfile.GraphConfigs, getInternalGraphConfigs(result[ii].ID)...)
+		}
 	}
 	w.WriteJson(&result)
 }


### PR DESCRIPTION
…vices
Put back the check we had in 1.1.x : https://github.com/control-center/serviced/blob/support/1.1.x/web/service_internal_metrics.go#L51
Dont return monitoring profile for services without a command