### PR TITLE
Fix filesystem-used metric

### DIFF
--- a/volume/devicemapper/devicemapper.go
+++ b/volume/devicemapper/devicemapper.go
@@ -1400,7 +1400,7 @@ func (d *DeviceMapperDriver) GetTenantStorageStats() ([]volume.TenantStorageStat
 			return nil, err
 		}
 		devicename := fmt.Sprintf("/dev/mapper/%s-%s", d.DevicePrefix, dev)
-		total, free, err := getFilesystemStats(devicename)
+		total, used, free, err := getFilesystemStats(devicename)
 		if err != nil {
 			return nil, err
 		}
@@ -1410,7 +1410,7 @@ func (d *DeviceMapperDriver) GetTenantStorageStats() ([]volume.TenantStorageStat
 		}
 		tss.FilesystemTotal = total
 		tss.FilesystemAvailable = free
-		tss.FilesystemUsed = total - free
+		tss.FilesystemUsed = used
 		tss.DeviceTotalBlocks = volume.BytesToBlocks(size)
 		//tss.DeviceUnallocatedBlocks = tss.DeviceTotalBlocks - tss.DeviceAllocatedBlocks
 		/* CC-2417


### PR DESCRIPTION
Previously, the value stored in 'storage.filesystem.used.<TENANT_ID>' metric was calculated as the difference between the total bytes for the filesystem and the available bytes; however that is incorrect because it does not take into account blocks reserved for the super-user (by default 5%).

After this change the metric will contain the correct value as returned by 'df'.

This change is related to [CC-3106](https://jira.zenoss.com/browse/CC-3106)