### PR TITLE
CC-3096: Stop running services when emergency shutdown triggered

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -1100,6 +1100,7 @@ func (d *daemon) initFacade() *facade.Facade {
 	dfs.SetTmp(os.Getenv("TMP"))
 	f.SetDFS(dfs)
 	f.SetIsvcsPath(options.IsvcsPath)
+	f.SetServiceRunLevelTimeout(time.Duration(options.ServiceRunLevelTimeout) * time.Second)
 	d.hcache = health.New()
 	d.hcache.SetPurgeFrequency(5 * time.Second)
 	f.SetHealthCache(d.hcache)

--- a/cli/api/options.go
+++ b/cli/api/options.go
@@ -179,6 +179,7 @@ func GetDefaultOptions(cfg utils.ConfigReader) config.Options {
 		ZKSessionTimeout:           cfg.IntVal("ZK_SESSION_TIMEOUT", 15),
 		TokenExpiration:            cfg.IntVal("AUTH_TOKEN_EXPIRATION", 60*60),
 		StorageReportInterval:      cfg.IntVal("STORAGE_REPORT_INTERVAL", 30),
+		ServiceRunLevelTimeout:     cfg.IntVal("RUN_LEVEL_TIMEOUT", 60),
 	}
 
 	options.Endpoint = cfg.StringVal("ENDPOINT", "")

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -130,6 +130,8 @@ func New(driver api.API, config utils.ConfigReader, logControl logging.LogContro
 		cli.IntFlag{"zk-session-timeout", defaultOps.ZKSessionTimeout, "zookeeper session timeout in seconds"},
 		cli.IntFlag{"auth-token-expiry", defaultOps.TokenExpiration, "authentication token expiration in seconds"},
 
+		cli.IntFlag{"service-run-level-timeout", defaultOps.ServiceRunLevelTimeout, "max time in seconds to wait for services to start/stop before moving on to services at the next run level"},
+
 		// Reimplementing GLOG flags :(
 		cli.BoolTFlag{"logtostderr", "log to standard error instead of files"},
 		cli.BoolFlag{"alsologtostderr", "log to standard error as well as files"},

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -281,6 +281,7 @@ func getRuntimeOptions(cfg utils.ConfigReader, ctx *cli.Context) config.Options 
 		StorageReportInterval:      ctx.GlobalInt("storage-report-interval"),
 		ZKSessionTimeout:           ctx.GlobalInt("zk-session-timeout"),
 		TokenExpiration:            ctx.GlobalInt("auth-token-expiry"),
+		ServiceRunLevelTimeout:     ctx.GlobalInt("service-run-level-timeout"),
 	}
 
 	// Long story, but due to the way codegantsta handles bools and the way we start system services vs

--- a/config/options.go
+++ b/config/options.go
@@ -110,6 +110,7 @@ type Options struct {
 	TokenExpiration            int               // The time in seconds before an authentication token expires
 	LogConfigFilename          string            // Path to the logri configuration
 	StorageReportInterval      int               // frequency in seconds to report storage stats to opentsdb
+	ServiceRunLevelTimeout     int               // The time in seconds serviced will wait for a batch of services to stop/start before moving to services with the next run level
 }
 
 // GetOptions returns a COPY of the global options struct

--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -130,7 +130,18 @@ type ByEmergencyShutdown struct{ Services }
 
 // Sort by EmergencyShutdownLevel - 1, to ensure level of 0 is last
 func (s ByEmergencyShutdown) Less(i, j int) bool {
-	return s.Services[i].EmergencyShutdownLevel-1 < s.Services[j].EmergencyShutdownLevel-1
+	if s.Services[i].EmergencyShutdownLevel == s.Services[j].EmergencyShutdownLevel {
+		// If emergency shutdown level is the same, order by reverse start level
+		return !ByStartLevel{s.Services}.Less(i, j)
+	} else {
+		return s.Services[i].EmergencyShutdownLevel-1 < s.Services[j].EmergencyShutdownLevel-1
+	}
+}
+
+type ByStartLevel struct{ Services }
+
+func (s ByStartLevel) Less(i, j int) bool {
+	return s.Services[i].StartLevel-1 < s.Services[j].StartLevel-1
 }
 
 //ServiceEndpoint endpoint exported or imported by a service

--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -114,7 +114,23 @@ type Service struct {
 	// are stopped after services with a defined EmergencyShutdownLevel, in the normal order
 	// dictated by their StartLevel.
 	EmergencyShutdownLevel uint
+	// EmergencyShutdown is a flag that indicates whether this service has been shutdown due
+	// to an emergency (low-storage) situation.  Services with this flag set can not be started
+	EmergencyShutdown bool
 	datastore.VersionedEntity
+}
+
+// Types for sorting
+type Services []*Service
+
+func (s Services) Len() int      { return len(s) }
+func (s Services) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+type ByEmergencyShutdown struct{ Services }
+
+// Sort by EmergencyShutdownLevel - 1, to ensure level of 0 is last
+func (s ByEmergencyShutdown) Less(i, j int) bool {
+	return s.Services[i].EmergencyShutdownLevel-1 < s.Services[j].EmergencyShutdownLevel-1
 }
 
 //ServiceEndpoint endpoint exported or imported by a service

--- a/facade/dfs.go
+++ b/facade/dfs.go
@@ -482,8 +482,8 @@ func (f *Facade) Rollback(ctx datastore.Context, snapshotID string, force bool) 
 	for i, svc := range svcs {
 		if svc.DesiredState != int(service.SVCStop) {
 			if force {
-				defer f.scheduleService(ctx, info.TenantID, svc.ID, false, true, service.DesiredState(svc.DesiredState), true)
-				if _, err := f.scheduleService(ctx, info.TenantID, svc.ID, false, true, service.SVCStop, true); err != nil {
+				defer f.scheduleService(ctx, info.TenantID, svc.ID, false, true, service.DesiredState(svc.DesiredState), true, false)
+				if _, err := f.scheduleService(ctx, info.TenantID, svc.ID, false, true, service.SVCStop, true, false); err != nil {
 					glog.Errorf("Could not %s service %s (%s): %s", service.SVCStop, svc.Name, svc.ID, err)
 					return err
 				}
@@ -537,8 +537,8 @@ func (f *Facade) Snapshot(ctx datastore.Context, serviceID, message string, tags
 	serviceids := make([]string, len(svcs))
 	for i, svc := range svcs {
 		if svc.DesiredState == int(service.SVCRun) {
-			defer f.scheduleService(ctx, tenantID, svc.ID, false, true, service.DesiredState(svc.DesiredState), true)
-			if _, err := f.scheduleService(ctx, tenantID, svc.ID, false, true, service.SVCPause, true); err != nil {
+			defer f.scheduleService(ctx, tenantID, svc.ID, false, true, service.DesiredState(svc.DesiredState), true, false)
+			if _, err := f.scheduleService(ctx, tenantID, svc.ID, false, true, service.SVCPause, true, false); err != nil {
 				glog.Errorf("Could not %s service %s (%s): %s", service.SVCPause, svc.Name, svc.ID, err)
 				return "", err
 			}

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -80,7 +80,8 @@ type Facade struct {
 	hostRegistry  auth.HostExpirationRegistryInterface
 	deployments   *PendingDeploymentMgr
 
-	isvcsPath string
+	isvcsPath              string
+	serviceRunLevelTimeout time.Duration
 }
 
 func (f *Facade) SetZZK(zzk ZZK) { f.zzk = zzk }
@@ -123,3 +124,5 @@ func (f *Facade) SetHostExpirationRegistry(hostRegistry auth.HostExpirationRegis
 }
 
 func (f *Facade) SetDeploymentMgr(mgr *PendingDeploymentMgr) { f.deployments = mgr }
+
+func (f *Facade) SetServiceRunLevelTimeout(t time.Duration) { f.serviceRunLevelTimeout = t }

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -194,4 +194,6 @@ type FacadeInterface interface {
 	CountDescendantStates(ctx datastore.Context, serviceID string) (map[string]map[int]int, error)
 
 	ReloadLogstashConfig(ctx datastore.Context) error
+
+	EmergencyStopService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error)
 }

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -1549,3 +1549,24 @@ func (_m *FacadeInterface) WaitService(ctx datastore.Context, dstate service.Des
 
 	return r0
 }
+
+// EmergencyStopService provides a mock function with given fields: ctx, request
+func (_m *FacadeInterface) EmergencyStopService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error) {
+	ret := _m.Called(ctx, request)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(datastore.Context, dao.ScheduleServiceRequest) int); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, dao.ScheduleServiceRequest) error); ok {
+		r1 = rf(ctx, request)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/facade/service.go
+++ b/facade/service.go
@@ -1275,8 +1275,8 @@ func (f *Facade) scheduleService(ctx datastore.Context, tenantID, serviceID stri
 					errToReturn = serr
 					levelLogger.WithError(serr).Error("Error scheduling services to stop")
 				} else {
-					// Wait at most 10 minutesfor services to stop before continuing
-					f.WaitService(ctx, desiredState, 10*time.Minute, false, nextBatchIDs...)
+					// Wait for services to change state before continuing
+					f.WaitService(ctx, desiredState, f.serviceRunLevelTimeout, false, nextBatchIDs...)
 				}
 				affected += a
 

--- a/facade/service.go
+++ b/facade/service.go
@@ -1247,8 +1247,8 @@ func (f *Facade) scheduleService(ctx datastore.Context, tenantID, serviceID stri
 							errToReturn = serr
 							levelLogger.WithError(serr).Error("Error scheduling services to stop")
 						} else {
-							// Wait at most 10 minutesfor services to stop before continuing
-							f.WaitService(ctx, desiredState, 10*time.Minute, false, nextBatchIDs...)
+							// Wait for services to change state before continuing
+							f.WaitService(ctx, desiredState, f.serviceRunLevelTimeout, false, nextBatchIDs...)
 						}
 						affected += a
 						nextBatch = []*service.Service{svc}

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/domain/serviceconfigfile"
 	"github.com/control-center/serviced/domain/servicedefinition"
+	zzkmocks "github.com/control-center/serviced/facade/mocks"
 	zks "github.com/control-center/serviced/zzk/service"
 
 	"github.com/stretchr/testify/mock"
@@ -1276,6 +1277,154 @@ func (ft *FacadeIntegrationTest) TestFacade_StoppingParentStopsChildren(c *C) {
 		if subService.DesiredState == int(service.SVCRun) && subService.ParentServiceID == "ParentServiceID" {
 			c.Errorf("Was expecting child services to be stopped %v", subService)
 		}
+	}
+}
+
+func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService(c *C) {
+	svc := service.Service{
+		ID:                     "ParentServiceID",
+		Name:                   "ParentService",
+		Startup:                "/usr/bin/ping -c localhost",
+		Description:            "Ping a remote host a fixed number of times",
+		Instances:              1,
+		InstanceLimits:         domain.MinMax{1, 1, 1},
+		ImageID:                "test/pinger",
+		PoolID:                 "default",
+		DeploymentID:           "deployment_id",
+		DesiredState:           int(service.SVCRun),
+		Launch:                 "auto",
+		Endpoints:              []service.ServiceEndpoint{},
+		CreatedAt:              time.Now(),
+		UpdatedAt:              time.Now(),
+		EmergencyShutdownLevel: 0,
+	}
+	childService1 := service.Service{
+		ID:                     "childService1",
+		Name:                   "childservice1",
+		Launch:                 "auto",
+		PoolID:                 "default",
+		DeploymentID:           "deployment_id",
+		Startup:                "/bin/sh -c \"while true; do echo hello world 10; sleep 3; done\"",
+		ParentServiceID:        "ParentServiceID",
+		EmergencyShutdownLevel: 1,
+	}
+	childService2 := service.Service{
+		ID:                     "childService2",
+		Name:                   "childservice2",
+		Launch:                 "auto",
+		PoolID:                 "default",
+		DeploymentID:           "deployment_id",
+		Startup:                "/bin/sh -c \"while true; do echo date 10; sleep 3; done\"",
+		ParentServiceID:        "ParentServiceID",
+		EmergencyShutdownLevel: 2,
+	}
+	// add a service with 2 subservices
+	var err error
+	if err = ft.Facade.AddService(ft.CTX, svc); err != nil {
+		c.Fatalf("Failed Loading Parent Service Service: %+v, %s", svc, err)
+	}
+
+	if err = ft.Facade.AddService(ft.CTX, childService1); err != nil {
+		c.Fatalf("Failed Loading Child Service 1: %+v, %s", childService1, err)
+	}
+	if err = ft.Facade.AddService(ft.CTX, childService2); err != nil {
+		c.Fatalf("Failed Loading Child Service 2: %+v, %s", childService2, err)
+	}
+
+	// start the service
+	if _, err = ft.Facade.StartService(ft.CTX, dao.ScheduleServiceRequest{"ParentServiceID", true, true}); err != nil {
+		c.Fatalf("Unable to stop parent service: %+v, %s", svc, err)
+	}
+
+	// Set up mocks to handle stopping services and waiting
+	// We have to reset the zzk mocks to replace what is in SetUpTest
+	ft.zzk = &zzkmocks.ZZK{}
+	ft.Facade.SetZZK(ft.zzk)
+	stoppedChannels := make(map[string]chan interface{})
+	stoppedChannels["ParentServiceID"] = make(chan interface{})
+	stoppedChannels["childService1"] = make(chan interface{})
+	stoppedChannels["childService2"] = make(chan interface{})
+	ft.zzk.On("UpdateService", mock.AnythingOfType("*datastore.context"), mock.AnythingOfType("string"), mock.AnythingOfType("*service.Service"), mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return(nil)
+	ft.zzk.On("UpdateServices", mock.AnythingOfType("*datastore.context"), mock.AnythingOfType("string"),
+		mock.AnythingOfType("[]*service.Service"), mock.AnythingOfType("bool"),
+		mock.AnythingOfType("bool")).Return(nil).Run(func(args mock.Arguments) {
+		svcs := args.Get(2).([]*service.Service)
+		for _, s := range svcs {
+			if s.DesiredState == int(service.SVCStop) {
+				if ch, ok := stoppedChannels[s.ID]; ok {
+					// Sleep 1 second and then close the channel
+					time.Sleep(time.Second)
+					close(ch)
+				}
+			}
+		}
+	})
+
+	ft.zzk.On("WaitService", mock.AnythingOfType("*service.Service"), service.SVCStop,
+		mock.AnythingOfType("<-chan interface {}")).Return(nil).Run(func(args mock.Arguments) {
+		s := args.Get(0).(*service.Service)
+		cancel := args.Get(2).(<-chan interface{})
+		if ch, ok := stoppedChannels[s.ID]; ok {
+			// Wait for the channel or cancel before returning
+			select {
+			case <-ch:
+			case <-cancel:
+			}
+		}
+	})
+
+	// watch the services to make sure they shutdown in the correct order
+	go func() {
+		// childService2 should be the second service stopped
+		timer := time.NewTimer(10 * time.Second)
+		select {
+		case <-stoppedChannels["childService2"]:
+		case <-timer.C:
+			c.Fatalf("Timeout waiting for childService2 to stop")
+		}
+
+		// If this is stopped, level 1 must also be stopped
+		select {
+		case <-stoppedChannels["childService2"]:
+		default:
+			c.Fatalf("Level 2 stopped before Level 1")
+		}
+	}()
+
+	go func() {
+		// svc should be the last service stopped
+		timer := time.NewTimer(10 * time.Second)
+		select {
+		case <-stoppedChannels["ParentServiceID"]:
+		case <-timer.C:
+			c.Fatalf("Timeout waiting for parent service to stop")
+		}
+
+		// If this is stopped, levels 1 and 2 must also be stopped
+		select {
+		case <-stoppedChannels["childService1"]:
+		default:
+			c.Fatalf("Level 0 stopped before Level 1")
+		}
+
+		select {
+		case <-stoppedChannels["childService2"]:
+		default:
+			c.Fatalf("Level 0 stopped before Level 2")
+		}
+	}()
+
+	// emergency stop the parent
+	if _, err = ft.Facade.EmergencyStopService(ft.CTX, dao.ScheduleServiceRequest{"ParentServiceID", true, true}); err != nil {
+		c.Fatalf("Unable to emergency stop parent service: %+v, %s", svc, err)
+	}
+
+	// verify all services have EmergencyShutDown set to true
+	var services []service.Service
+	var serviceRequest dao.ServiceRequest
+	services, err = ft.Facade.GetServices(ft.CTX, serviceRequest)
+	for _, s := range services {
+		c.Assert(s.EmergencyShutdown, Equals, true)
 	}
 }
 

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -1280,7 +1280,7 @@ func (ft *FacadeIntegrationTest) TestFacade_StoppingParentStopsChildren(c *C) {
 	}
 }
 
-func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService(c *C) {
+func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Synchronous(c *C) {
 	svc := service.Service{
 		ID:                     "ParentServiceID",
 		Name:                   "ParentService",
@@ -1391,7 +1391,10 @@ func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService(c *C) {
 		}
 	}()
 
+	// This channel is closed when the last service is stopped
+	allDone := make(chan interface{})
 	go func() {
+		defer close(allDone)
 		// svc should be the last service stopped
 		timer := time.NewTimer(10 * time.Second)
 		select {
@@ -1414,9 +1417,204 @@ func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService(c *C) {
 		}
 	}()
 
-	// emergency stop the parent
-	if _, err = ft.Facade.EmergencyStopService(ft.CTX, dao.ScheduleServiceRequest{"ParentServiceID", true, true}); err != nil {
-		c.Fatalf("Unable to emergency stop parent service: %+v, %s", svc, err)
+	// emergency stop the parent synchronously
+	methodReturned := make(chan interface{})
+	go func() {
+		defer close(methodReturned)
+		if _, err = ft.Facade.EmergencyStopService(ft.CTX, dao.ScheduleServiceRequest{ServiceID: "ParentServiceID", AutoLaunch: true, Synchronous: true}); err != nil {
+			c.Fatalf("Unable to emergency stop parent service: %+v, %s", svc, err)
+		}
+	}()
+
+	// Make sure the call was synchronous
+	timer := time.NewTimer(10 * time.Second)
+	select {
+	case <-methodReturned:
+		c.Fatalf("Method returned before services stopped on synchronous call")
+	case <-allDone:
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for method to return")
+	}
+
+	// Wait for method to return
+	timer.Reset(10 * time.Second)
+	select {
+	case <-methodReturned:
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for EmergencyStopService to return")
+	}
+
+	// verify all services have EmergencyShutDown set to true
+	var services []service.Service
+	var serviceRequest dao.ServiceRequest
+	services, err = ft.Facade.GetServices(ft.CTX, serviceRequest)
+	for _, s := range services {
+		c.Assert(s.EmergencyShutdown, Equals, true)
+	}
+}
+
+func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Asynchronous(c *C) {
+	svc := service.Service{
+		ID:                     "ParentServiceID",
+		Name:                   "ParentService",
+		Startup:                "/usr/bin/ping -c localhost",
+		Description:            "Ping a remote host a fixed number of times",
+		Instances:              1,
+		InstanceLimits:         domain.MinMax{1, 1, 1},
+		ImageID:                "test/pinger",
+		PoolID:                 "default",
+		DeploymentID:           "deployment_id",
+		DesiredState:           int(service.SVCRun),
+		Launch:                 "auto",
+		Endpoints:              []service.ServiceEndpoint{},
+		CreatedAt:              time.Now(),
+		UpdatedAt:              time.Now(),
+		EmergencyShutdownLevel: 0,
+	}
+	childService1 := service.Service{
+		ID:                     "childService1",
+		Name:                   "childservice1",
+		Launch:                 "auto",
+		PoolID:                 "default",
+		DeploymentID:           "deployment_id",
+		Startup:                "/bin/sh -c \"while true; do echo hello world 10; sleep 3; done\"",
+		ParentServiceID:        "ParentServiceID",
+		EmergencyShutdownLevel: 1,
+	}
+	childService2 := service.Service{
+		ID:                     "childService2",
+		Name:                   "childservice2",
+		Launch:                 "auto",
+		PoolID:                 "default",
+		DeploymentID:           "deployment_id",
+		Startup:                "/bin/sh -c \"while true; do echo date 10; sleep 3; done\"",
+		ParentServiceID:        "ParentServiceID",
+		EmergencyShutdownLevel: 2,
+	}
+	// add a service with 2 subservices
+	var err error
+	if err = ft.Facade.AddService(ft.CTX, svc); err != nil {
+		c.Fatalf("Failed Loading Parent Service Service: %+v, %s", svc, err)
+	}
+
+	if err = ft.Facade.AddService(ft.CTX, childService1); err != nil {
+		c.Fatalf("Failed Loading Child Service 1: %+v, %s", childService1, err)
+	}
+	if err = ft.Facade.AddService(ft.CTX, childService2); err != nil {
+		c.Fatalf("Failed Loading Child Service 2: %+v, %s", childService2, err)
+	}
+
+	// start the service
+	if _, err = ft.Facade.StartService(ft.CTX, dao.ScheduleServiceRequest{"ParentServiceID", true, true}); err != nil {
+		c.Fatalf("Unable to stop parent service: %+v, %s", svc, err)
+	}
+
+	// Set up mocks to handle stopping services and waiting
+	// We have to reset the zzk mocks to replace what is in SetUpTest
+	ft.zzk = &zzkmocks.ZZK{}
+	ft.Facade.SetZZK(ft.zzk)
+	stoppedChannels := make(map[string]chan interface{})
+	stoppedChannels["ParentServiceID"] = make(chan interface{})
+	stoppedChannels["childService1"] = make(chan interface{})
+	stoppedChannels["childService2"] = make(chan interface{})
+	ft.zzk.On("UpdateService", mock.AnythingOfType("*datastore.context"), mock.AnythingOfType("string"), mock.AnythingOfType("*service.Service"), mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return(nil)
+	ft.zzk.On("UpdateServices", mock.AnythingOfType("*datastore.context"), mock.AnythingOfType("string"),
+		mock.AnythingOfType("[]*service.Service"), mock.AnythingOfType("bool"),
+		mock.AnythingOfType("bool")).Return(nil).Run(func(args mock.Arguments) {
+		svcs := args.Get(2).([]*service.Service)
+		for _, s := range svcs {
+			if s.DesiredState == int(service.SVCStop) {
+				if ch, ok := stoppedChannels[s.ID]; ok {
+					// Sleep 1 second and then close the channel
+					time.Sleep(time.Second)
+					close(ch)
+				}
+			}
+		}
+	})
+
+	ft.zzk.On("WaitService", mock.AnythingOfType("*service.Service"), service.SVCStop,
+		mock.AnythingOfType("<-chan interface {}")).Return(nil).Run(func(args mock.Arguments) {
+		s := args.Get(0).(*service.Service)
+		cancel := args.Get(2).(<-chan interface{})
+		if ch, ok := stoppedChannels[s.ID]; ok {
+			// Wait for the channel or cancel before returning
+			select {
+			case <-ch:
+			case <-cancel:
+			}
+		}
+	})
+
+	// watch the services to make sure they shutdown in the correct order
+	go func() {
+		// childService2 should be the second service stopped
+		timer := time.NewTimer(10 * time.Second)
+		select {
+		case <-stoppedChannels["childService2"]:
+		case <-timer.C:
+			c.Fatalf("Timeout waiting for childService2 to stop")
+		}
+
+		// If this is stopped, level 1 must also be stopped
+		select {
+		case <-stoppedChannels["childService2"]:
+		default:
+			c.Fatalf("Level 2 stopped before Level 1")
+		}
+	}()
+
+	// This channel is closed when the last service is stopped
+	allDone := make(chan interface{})
+	go func() {
+		defer close(allDone)
+		// svc should be the last service stopped
+		timer := time.NewTimer(10 * time.Second)
+		select {
+		case <-stoppedChannels["ParentServiceID"]:
+		case <-timer.C:
+			c.Fatalf("Timeout waiting for parent service to stop")
+		}
+
+		// If this is stopped, levels 1 and 2 must also be stopped
+		select {
+		case <-stoppedChannels["childService1"]:
+		default:
+			c.Fatalf("Level 0 stopped before Level 1")
+		}
+
+		select {
+		case <-stoppedChannels["childService2"]:
+		default:
+			c.Fatalf("Level 0 stopped before Level 2")
+		}
+	}()
+
+	// emergency stop the parent asynchronously
+	methodReturned := make(chan interface{})
+	go func() {
+		defer close(methodReturned)
+		if _, err = ft.Facade.EmergencyStopService(ft.CTX, dao.ScheduleServiceRequest{ServiceID: "ParentServiceID", AutoLaunch: true, Synchronous: false}); err != nil {
+			c.Fatalf("Unable to emergency stop parent service: %+v, %s", svc, err)
+		}
+	}()
+
+	// Make sure the call was asynchronous
+	timer := time.NewTimer(10 * time.Second)
+	select {
+	case <-methodReturned:
+	case <-allDone:
+		c.Fatalf("Services stopped before method returned on asynchronous call")
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for method to return")
+	}
+
+	// Wait for services to stop
+	timer.Reset(10 * time.Second)
+	select {
+	case <-allDone:
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for all services to stop")
 	}
 
 	// verify all services have EmergencyShutDown set to true

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -1352,9 +1352,11 @@ func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Synchronous(c *
 		for _, s := range svcs {
 			if s.DesiredState == int(service.SVCStop) {
 				if ch, ok := stoppedChannels[s.ID]; ok {
-					// Sleep 1 second and then close the channel
-					time.Sleep(time.Second)
-					close(ch)
+					// Spawn a thread that will sleep 1 second and then close the channel
+					go func() {
+						time.Sleep(time.Second)
+						close(ch)
+					}()
 				}
 			}
 		}
@@ -1525,9 +1527,11 @@ func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Asynchronous(c 
 		for _, s := range svcs {
 			if s.DesiredState == int(service.SVCStop) {
 				if ch, ok := stoppedChannels[s.ID]; ok {
-					// Sleep 1 second and then close the channel
-					time.Sleep(time.Second)
-					close(ch)
+					// Spawn a thread that will sleep 1 second and then close the channel
+					go func() {
+						time.Sleep(time.Second)
+						close(ch)
+					}()
 				}
 			}
 		}

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -1281,6 +1281,7 @@ func (ft *FacadeIntegrationTest) TestFacade_StoppingParentStopsChildren(c *C) {
 }
 
 func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Synchronous(c *C) {
+	// add a service with 4 subservices
 	svc := service.Service{
 		ID:                     "ParentServiceID",
 		Name:                   "ParentService",
@@ -1297,6 +1298,7 @@ func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Synchronous(c *
 		CreatedAt:              time.Now(),
 		UpdatedAt:              time.Now(),
 		EmergencyShutdownLevel: 0,
+		StartLevel:             1,
 	}
 	childService1 := service.Service{
 		ID:                     "childService1",
@@ -1318,7 +1320,28 @@ func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Synchronous(c *
 		ParentServiceID:        "ParentServiceID",
 		EmergencyShutdownLevel: 2,
 	}
-	// add a service with 2 subservices
+	childService3 := service.Service{
+		ID:                     "childService3",
+		Name:                   "childservice3",
+		Launch:                 "auto",
+		PoolID:                 "default",
+		DeploymentID:           "deployment_id",
+		Startup:                "/bin/sh -c \"while true; do echo date 10; sleep 3; done\"",
+		ParentServiceID:        "ParentServiceID",
+		EmergencyShutdownLevel: 0,
+		StartLevel:             0,
+	}
+	childService4 := service.Service{
+		ID:                     "childService4",
+		Name:                   "childservice4",
+		Launch:                 "auto",
+		PoolID:                 "default",
+		DeploymentID:           "deployment_id",
+		Startup:                "/bin/sh -c \"while true; do echo date 10; sleep 3; done\"",
+		ParentServiceID:        "ParentServiceID",
+		EmergencyShutdownLevel: 0,
+		StartLevel:             0,
+	}
 	var err error
 	if err = ft.Facade.AddService(ft.CTX, svc); err != nil {
 		c.Fatalf("Failed Loading Parent Service Service: %+v, %s", svc, err)
@@ -1329,6 +1352,12 @@ func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Synchronous(c *
 	}
 	if err = ft.Facade.AddService(ft.CTX, childService2); err != nil {
 		c.Fatalf("Failed Loading Child Service 2: %+v, %s", childService2, err)
+	}
+	if err = ft.Facade.AddService(ft.CTX, childService3); err != nil {
+		c.Fatalf("Failed Loading Child Service 3: %+v, %s", childService3, err)
+	}
+	if err = ft.Facade.AddService(ft.CTX, childService4); err != nil {
+		c.Fatalf("Failed Loading Child Service 4: %+v, %s", childService4, err)
 	}
 
 	// start the service
@@ -1344,6 +1373,8 @@ func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Synchronous(c *
 	stoppedChannels["ParentServiceID"] = make(chan interface{})
 	stoppedChannels["childService1"] = make(chan interface{})
 	stoppedChannels["childService2"] = make(chan interface{})
+	stoppedChannels["childService3"] = make(chan interface{})
+	stoppedChannels["childService4"] = make(chan interface{})
 	ft.zzk.On("UpdateService", mock.AnythingOfType("*datastore.context"), mock.AnythingOfType("string"), mock.AnythingOfType("*service.Service"), mock.AnythingOfType("bool"), mock.AnythingOfType("bool")).Return(nil)
 	ft.zzk.On("UpdateServices", mock.AnythingOfType("*datastore.context"), mock.AnythingOfType("string"),
 		mock.AnythingOfType("[]*service.Service"), mock.AnythingOfType("bool"),
@@ -1376,6 +1407,11 @@ func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Synchronous(c *
 	})
 
 	// watch the services to make sure they shutdown in the correct order
+	// Emergency shutdown order should be:
+	//  (EL 1) childService1
+	//  (EL 2) childService2
+	//  (EL 0, SL 0) childService3, childService4
+	//  (EL 0, SL 1) svc
 	go func() {
 		// childService2 should be the second service stopped
 		timer := time.NewTimer(10 * time.Second)
@@ -1387,9 +1423,55 @@ func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Synchronous(c *
 
 		// If this is stopped, level 1 must also be stopped
 		select {
-		case <-stoppedChannels["childService2"]:
+		case <-stoppedChannels["childService1"]:
 		default:
 			c.Fatalf("Level 2 stopped before Level 1")
+		}
+	}()
+
+	go func() {
+		// childService3 should stop after childservice2 and childService1
+		timer := time.NewTimer(10 * time.Second)
+		select {
+		case <-stoppedChannels["childService3"]:
+		case <-timer.C:
+			c.Fatalf("Timeout waiting for childService3 to stop")
+		}
+
+		// If this is stopped, levels 1 and 2 must also be stopped
+		select {
+		case <-stoppedChannels["childService2"]:
+		default:
+			c.Fatalf("Level 0 stopped before Level 2")
+		}
+
+		select {
+		case <-stoppedChannels["childService1"]:
+		default:
+			c.Fatalf("Level 0 stopped before Level 1")
+		}
+	}()
+
+	go func() {
+		// childService4 should stop after childservice2 and childService1
+		timer := time.NewTimer(10 * time.Second)
+		select {
+		case <-stoppedChannels["childService4"]:
+		case <-timer.C:
+			c.Fatalf("Timeout waiting for childService3 to stop")
+		}
+
+		// If this is stopped, levels 1 and 2 must also be stopped
+		select {
+		case <-stoppedChannels["childService2"]:
+		default:
+			c.Fatalf("Level 0 stopped before Level 2")
+		}
+
+		select {
+		case <-stoppedChannels["childService1"]:
+		default:
+			c.Fatalf("Level 0 stopped before Level 1")
 		}
 	}()
 
@@ -1416,6 +1498,19 @@ func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Synchronous(c *
 		case <-stoppedChannels["childService2"]:
 		default:
 			c.Fatalf("Level 0 stopped before Level 2")
+		}
+
+		// Level 0 with StartLevel 0 must also be stopped
+		select {
+		case <-stoppedChannels["childService3"]:
+		default:
+			c.Fatalf("Level 0, StartLevel 1 stopped before Level 0, StartLevel 0")
+		}
+
+		select {
+		case <-stoppedChannels["childService4"]:
+		default:
+			c.Fatalf("Level 0, StartLevel 1 stopped before Level 0, StartLevel 0")
 		}
 	}()
 
@@ -1562,7 +1657,7 @@ func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Asynchronous(c 
 
 		// If this is stopped, level 1 must also be stopped
 		select {
-		case <-stoppedChannels["childService2"]:
+		case <-stoppedChannels["childService1"]:
 		default:
 			c.Fatalf("Level 2 stopped before Level 1")
 		}

--- a/facade/testutils.go
+++ b/facade/testutils.go
@@ -16,6 +16,8 @@
 package facade
 
 import (
+	"time"
+
 	"github.com/control-center/serviced/auth"
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/datastore/elastic"
@@ -66,6 +68,7 @@ func (ft *FacadeIntegrationTest) SetUpSuite(c *gocheck.C) {
 	ft.CTX = datastore.Get()
 
 	ft.Facade = New()
+	ft.Facade.SetServiceRunLevelTimeout(1 * time.Minute)
 	ft.dfs = &dfsmocks.DFS{}
 	ft.Facade.SetDFS(ft.dfs)
 	ft.setupMockDFS()

--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -248,3 +248,6 @@
 
 # The frequency in seconds to report storage stats to opentsdb
 # SERVICED_STORAGE_REPORT_INTERVAL=30
+
+# The max amount of time to wait for services to start/stop before starting/stopping services at the next run level
+# SERVICED_RUN_LEVEL_TIMEOUT=60

--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -249,5 +249,5 @@
 # The frequency in seconds to report storage stats to opentsdb
 # SERVICED_STORAGE_REPORT_INTERVAL=30
 
-# The max amount of time to wait for services to start/stop before starting/stopping services at the next run level
+# The max amount of time, in seconds, to wait for services to start/stop before starting/stopping services at the next run level
 # SERVICED_RUN_LEVEL_TIMEOUT=60


### PR DESCRIPTION
Added a facade method that will stop a service and all child services in the order specified by their EmergencyShutdownLevel.  It will also set EmergencyShutdown to true for all affected services.