### PR TITLE
CC-3107 Need to indicate "all-clear" for emergency shutdown

### DIFF
--- a/cli/api/apimocks/API.go
+++ b/cli/api/apimocks/API.go
@@ -1555,5 +1555,25 @@ func (_m *API) WriteDelegateKey(_a0 string, _a1 []byte) error {
 	return r0
 }
 
-var _ api.API = (*API)(nil)
+// ClearEmergency provides a mock function with given fields: _a0
+func (_m *API) ClearEmergency(_a0 string) (int, error) {
+	ret := _m.Called(_a0)
 
+	var r0 int
+	if rf, ok := ret.Get(0).(func(string) int); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+var _ api.API = (*API)(nil)

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -78,6 +78,7 @@ type API interface {
 	AssignIP(IPConfig) error
 	GetEndpoints(serviceID string, reportImports, reportExports, validate bool) ([]applicationendpoint.EndpointReport, error)
 	ResolveServicePath(path string) ([]service.ServiceDetails, error)
+	ClearEmergency(serviceID string) (int, error)
 
 	// Shell
 	StartShell(ShellConfig) error

--- a/cli/api/service.go
+++ b/cli/api/service.go
@@ -410,3 +410,12 @@ func (a *api) ResolveServicePath(path string) ([]service.ServiceDetails, error) 
 	}
 	return client.ResolveServicePath(path)
 }
+
+func (a *api) ClearEmergency(serviceID string) (int, error) {
+	client, err := a.connectMaster()
+	if err != nil {
+		return 0, err
+	}
+
+	return client.ClearEmergency(serviceID)
+}

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -461,6 +461,13 @@ func (c *ServicedCli) initService() {
 					},
 				},
 			},
+			{
+				Name:         "clear-emergency",
+				Usage:        "Clears the 'emergency shutdown' state for a service and all child services",
+				Description:  "serviced service clear-emergency { SERVICEID | SERVICENAME | DEPLOYMENTID/...PARENTNAME.../SERVICENAME }",
+				BashComplete: c.printServicesFirst,
+				Action:       c.cmdServiceClearEmergency,
+			},
 		},
 	})
 }
@@ -1542,4 +1549,29 @@ func (c *ServicedCli) cmdServiceEndpoints(ctx *cli.Context) {
 		}
 		t.Print()
 	}
+}
+
+// serviced service clear-emergency { SERVICEID | SERVICENAME | DEPLOYMENTID/...PARENTNAME.../SERVICENAME }
+func (c *ServicedCli) cmdServiceClearEmergency(ctx *cli.Context) {
+	// verify args
+	args := ctx.Args()
+	if len(args) < 1 {
+		fmt.Printf("Incorrect Usage.\n\n")
+		cli.ShowCommandHelp(ctx, "clear-emergency")
+		return
+	}
+
+	svc, _, err := c.searchForService(ctx.Args().First())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+
+	count, err := c.driver.ClearEmergency(svc.ID)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+
+	fmt.Printf("Cleared emergency status for %d services\n", count)
 }

--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -429,6 +429,13 @@ func (t ServiceAPITest) AddSnapshot(config api.SnapshotConfig) (string, error) {
 	return fmt.Sprintf("%s-snapshot description=%q tags=%q", config.ServiceID, config.Message, config.Tag), nil
 }
 
+func (t ServiceAPITest) ClearEmergency(serviceID string) (int, error) {
+	if t.errs["ClearEmergency"] != nil {
+		return 0, t.errs["ClearEmergency"]
+	}
+	return 1, nil
+}
+
 func TestServicedCLI_CmdServiceList_one(t *testing.T) {
 	serviceID := "test-service-1"
 
@@ -1194,4 +1201,46 @@ func ExampleServicedCLI_CmdServiceEndpoints_works() {
 	// Name    ServiceID         Endpoint         Purpose    Host       HostIP     HostPort    ContainerID     ContainerIP     ContainerPort
 	// Zope    test-service-2    endpointName1    export     hostID1    hostIP1    10          containerID1    containerIP1    100
 	// Zope    test-service-2    endpointName2    import     hostID2    hostIP2    20          containerID2    containerIP2    200
+}
+
+func ExampleServicedCLI_CmdServiceClearEmergency_works() {
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "clear-emergency", "test-service-1") })
+
+	// Output:
+	// Cleared emergency status for 1 services
+}
+
+func ExampleServicedCLI_CmdServiceClearEmergency_errNoService() {
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "clear-emergency", "test-service-0") })
+
+	// Output:
+	// service not found
+}
+
+func ExampleServicedCLI_CmdServiceClearEmergency_err() {
+	DefaultServiceAPITest.errs["ClearEmergency"] = ErrStub
+	defer func() { DefaultServiceAPITest.errs["ClearEmergency"] = nil }()
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "clear-emergency", "test-service-1") })
+
+	// Output:
+	// stub for facade failed
+}
+
+func ExampleServicedCLI_CmdServiceClearEmergency_usage() {
+	pipeStderr(func() { InitServiceAPITest("serviced", "service", "clear-emergency") })
+
+	// Output:
+	// Incorrect Usage.
+	//
+	// NAME:
+	//    clear-emergency - Clears the 'emergency shutdown' state for a service and all child services
+	//
+	// USAGE:
+	//    command clear-emergency [command options] [arguments...]
+	//
+	// DESCRIPTION:
+	//    serviced service clear-emergency { SERVICEID | SERVICENAME | DEPLOYMENTID/...PARENTNAME.../SERVICENAME }
+	//
+	// OPTIONS:
+	//
 }

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -196,4 +196,6 @@ type FacadeInterface interface {
 	ReloadLogstashConfig(ctx datastore.Context) error
 
 	EmergencyStopService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error)
+
+	ClearEmergencyStopFlag(ctx datastore.Context, serviceID string) (int, error)
 }

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -1570,3 +1570,24 @@ func (_m *FacadeInterface) EmergencyStopService(ctx datastore.Context, request d
 
 	return r0, r1
 }
+
+// EmergencyStopService provides a mock function with given fields: ctx, serviceID
+func (_m *FacadeInterface) ClearEmergencyStopFlag(ctx datastore.Context, serviceID string) (int, error) {
+	ret := _m.Called(ctx, serviceID)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) int); ok {
+		r0 = rf(ctx, serviceID)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, serviceID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/facade/service.go
+++ b/facade/service.go
@@ -1179,6 +1179,34 @@ func (f *Facade) ScheduleService(ctx datastore.Context, serviceID string, autoLa
 	return f.scheduleService(ctx, tenantID, serviceID, autoLaunch, synchronous, desiredState, false, false)
 }
 
+func (f *Facade) clearEmergencyStopFlag(ctx datastore.Context, tenantID, serviceID string) (int, error) {
+	defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.clearEmergencyStopFlag"))
+	svcs := []*service.Service{}
+	visitor := func(svc *service.Service) error {
+		if svc.EmergencyShutdown {
+			svcs = append(svcs, svc)
+		}
+		return nil
+	}
+	err := f.walkServices(ctx, serviceID, true, visitor, "clearEmergencyStopFlag")
+	if err != nil {
+		plog.WithError(err).Errorf("Could not retrieve service(s) to clear emergency stop flag")
+		return 0, err
+	}
+
+	cleared := 0
+	for _, svc := range svcs {
+		svc.EmergencyShutdown = false
+		err = f.updateService(ctx, tenantID, *svc, false, false)
+		if err != nil {
+			plog.WithField("service", svc.ID).WithError(err).Error("Failed to update database with EmergencyShutdown")
+		} else {
+			cleared++
+		}
+	}
+	return cleared, nil
+}
+
 func (f *Facade) scheduleService(ctx datastore.Context, tenantID, serviceID string, autoLaunch bool, synchronous bool, desiredState service.DesiredState, locked bool, emergency bool) (int, error) {
 	defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.scheduleService"))
 	logger := plog.WithFields(log.Fields{
@@ -1481,6 +1509,19 @@ func (f *Facade) EmergencyStopService(ctx datastore.Context, request dao.Schedul
 	mutex.RLock()
 	defer mutex.RUnlock()
 	return f.scheduleService(ctx, tenantID, request.ServiceID, request.AutoLaunch, request.Synchronous, service.SVCStop, false, true)
+}
+
+// ClearEmergencyStopFlag sets EmergencyStop to false for all services on the tenant that have it set to true
+func (f *Facade) ClearEmergencyStopFlag(ctx datastore.Context, serviceID string) (int, error) {
+	defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.ClearEmergencyStopFlag"))
+	tenantID, err := f.GetTenantID(ctx, serviceID)
+	if err != nil {
+		return 0, err
+	}
+	mutex := getTenantLock(tenantID)
+	mutex.RLock()
+	defer mutex.RUnlock()
+	return f.clearEmergencyStopFlag(ctx, tenantID, serviceID)
 }
 
 type ipinfo struct {

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -1732,6 +1732,100 @@ func (ft *FacadeIntegrationTest) TestFacade_EmergencyStopService_Asynchronous(c 
 	waitServiceWG.Wait()
 }
 
+func (ft *FacadeIntegrationTest) TestFacade_ClearEmergencyStopFlag(c *C) {
+	// add a service with 2 subservices and set EmergencyShutdown to true for all 3
+	svc := service.Service{
+		ID:                "ParentServiceID",
+		Name:              "ParentService",
+		Startup:           "/usr/bin/ping -c localhost",
+		Description:       "Ping a remote host a fixed number of times",
+		Instances:         1,
+		InstanceLimits:    domain.MinMax{1, 1, 1},
+		ImageID:           "test/pinger",
+		PoolID:            "default",
+		DeploymentID:      "deployment_id",
+		DesiredState:      int(service.SVCRun),
+		Launch:            "auto",
+		Endpoints:         []service.ServiceEndpoint{},
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+		EmergencyShutdown: true,
+	}
+	childService1 := service.Service{
+		ID:                "childService1",
+		Name:              "childservice1",
+		Launch:            "auto",
+		PoolID:            "default",
+		DeploymentID:      "deployment_id",
+		Startup:           "/bin/sh -c \"while true; do echo hello world 10; sleep 3; done\"",
+		ParentServiceID:   "ParentServiceID",
+		EmergencyShutdown: true,
+	}
+	childService2 := service.Service{
+		ID:                "childService2",
+		Name:              "childservice2",
+		Launch:            "auto",
+		PoolID:            "default",
+		DeploymentID:      "deployment_id",
+		Startup:           "/bin/sh -c \"while true; do echo date 10; sleep 3; done\"",
+		ParentServiceID:   "ParentServiceID",
+		EmergencyShutdown: true,
+	}
+	var err error
+	if err = ft.Facade.AddService(ft.CTX, svc); err != nil {
+		c.Fatalf("Failed Loading Parent Service Service: %+v, %s", svc, err)
+	}
+
+	if err = ft.Facade.AddService(ft.CTX, childService1); err != nil {
+		c.Fatalf("Failed Loading Child Service 1: %+v, %s", childService1, err)
+	}
+	if err = ft.Facade.AddService(ft.CTX, childService2); err != nil {
+		c.Fatalf("Failed Loading Child Service 2: %+v, %s", childService2, err)
+	}
+
+	// Clear emergency stop on one child
+	count, err := ft.Facade.ClearEmergencyStopFlag(ft.CTX, "childService1")
+	c.Assert(err, IsNil)
+	c.Assert(count, Equals, 1)
+
+	// Make sure emergency stop is cleared for only that one service
+	var services []service.Service
+	var serviceRequest dao.ServiceRequest
+	services, err = ft.Facade.GetServices(ft.CTX, serviceRequest)
+	c.Assert(err, IsNil)
+	for _, s := range services {
+		if s.ID == "childService1" {
+			c.Assert(s.EmergencyShutdown, Equals, false)
+		} else {
+			c.Assert(s.EmergencyShutdown, Equals, true)
+		}
+	}
+
+	// clear emergency stop on the parent service
+	count, err = ft.Facade.ClearEmergencyStopFlag(ft.CTX, "ParentServiceID")
+	c.Assert(err, IsNil)
+	c.Assert(count, Equals, 2)
+
+	// Make sure emergency stop is cleared on all services
+	services, err = ft.Facade.GetServices(ft.CTX, serviceRequest)
+	c.Assert(err, IsNil)
+	for _, s := range services {
+		c.Assert(s.EmergencyShutdown, Equals, false)
+	}
+
+	// Clear emergency stop on a service that is already cleared
+	count, err = ft.Facade.ClearEmergencyStopFlag(ft.CTX, "ParentServiceID")
+	c.Assert(err, IsNil)
+	c.Assert(count, Equals, 0)
+
+	// Make sure emergency stop is still cleared on all services
+	services, err = ft.Facade.GetServices(ft.CTX, serviceRequest)
+	c.Assert(err, IsNil)
+	for _, s := range services {
+		c.Assert(s.EmergencyShutdown, Equals, false)
+	}
+}
+
 func (ft *FacadeIntegrationTest) setupMigrationTestWithoutEndpoints(t *C) error {
 	return ft.setupMigrationTest(t, false)
 }

--- a/rpc/master/interface.go
+++ b/rpc/master/interface.go
@@ -119,6 +119,9 @@ type ClientInterface interface {
 	// ResolveServicePath will return ServiceDetails that match the given path
 	ResolveServicePath(path string) ([]service.ServiceDetails, error)
 
+	// ClearEmergency will set EmergencyShutdown to false on the service and all child services
+	ClearEmergency(serviceID string) (int, error)
+
 	//--------------------------------------------------------------------------
 	// Service Instance Management Functions
 

--- a/rpc/master/mocks/ClientInterface.go
+++ b/rpc/master/mocks/ClientInterface.go
@@ -1,16 +1,3 @@
-// Copyright 2016 The Serviced Authors.
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package mocks
 
 import applicationendpoint "github.com/control-center/serviced/domain/applicationendpoint"
@@ -176,6 +163,27 @@ func (_m *ClientInterface) AuthenticateHost(hostID string) (string, int64, error
 	}
 
 	return r0, r1, r2
+}
+
+// ClearEmergency provides a mock function with given fields: serviceID
+func (_m *ClientInterface) ClearEmergency(serviceID string) (int, error) {
+	ret := _m.Called(serviceID)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(string) int); ok {
+		r0 = rf(serviceID)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(serviceID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Close provides a mock function with given fields:

--- a/rpc/master/service_client.go
+++ b/rpc/master/service_client.go
@@ -101,3 +101,11 @@ func (c *Client) ResolveServicePath(path string) ([]service.ServiceDetails, erro
 	err := c.call("ResolveServicePath", path, &svcs)
 	return svcs, err
 }
+
+// ClearEmergency clears the EmergencyShutdown flag on a service and all child services
+// it returns the number of affected services
+func (c *Client) ClearEmergency(serviceID string) (int, error) {
+	affected := 0
+	err := c.call("ClearEmergency", serviceID, &affected)
+	return affected, err
+}

--- a/rpc/master/service_server.go
+++ b/rpc/master/service_server.go
@@ -139,3 +139,14 @@ func (s *Server) ResolveServicePath(path string, response *[]service.ServiceDeta
 	*response = svcs
 	return nil
 }
+
+// ClearEmergency clears the EmergencyShutdown flag on a service and all child services
+// it returns the number of affected services
+func (s *Server) ClearEmergency(serviceID string, count *int) error {
+	c, err := s.f.ClearEmergencyStopFlag(s.context(), serviceID)
+	if err != nil {
+		return err
+	}
+	*count = c
+	return nil
+}


### PR DESCRIPTION
Adds the cli command
`serviced service clear-emergency SERVICEID`

Which will reset EmergencyShutdown to false for the service and all child services.