### PR TITLE
Add endpoint to test shutting down

### DIFF
--- a/web/emergencyshutdown.go
+++ b/web/emergencyshutdown.go
@@ -1,0 +1,26 @@
+package web
+
+import (
+	"github.com/control-center/serviced/dao"
+	rest "github.com/zenoss/go-json-rest"
+)
+
+type EmergencyShutdownRequest struct {
+	TenantID string
+}
+
+func restEmergencyShutdown(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
+	req := EmergencyShutdownRequest{}
+	err := r.DecodeJsonPayload(&req)
+	if err != nil {
+		plog.WithError(err).Error("Could not decode json payload for emergency shutdown request")
+		restBadRequest(w, err)
+		return
+	}
+	_, err = ctx.getFacade().EmergencyStopService(ctx.getDatastoreContext(), dao.ScheduleServiceRequest{req.TenantID, true, false})
+	if err != nil {
+		plog.WithError(err).Error("Facade could not process Emergency Shutdown Request")
+		restBadRequest(w, err)
+	}
+	restSuccess(w)
+}

--- a/web/routes.go
+++ b/web/routes.go
@@ -146,6 +146,8 @@ func (sc *ServiceConfig) getRoutes() []rest.Route {
 		rest.Route{"GET", "/api/v2/serviceconfigs/:fileId", gz(sc.checkAuth(restGetServiceConfigFile))},
 		rest.Route{"PUT", "/api/v2/serviceconfigs/:fileId", gz(sc.checkAuth(restUpdateServiceConfigFile))},
 		rest.Route{"DELETE", "/api/v2/serviceconfigs/:fileId", gz(sc.checkAuth(restDeleteServiceConfigFile))},
+
+		rest.Route{"POST", "/emergencyshutdown", gz(sc.checkAuth(restEmergencyShutdown))},
 	}
 
 	// Hardcoding these target URLs for now.


### PR DESCRIPTION
UNDO THIS BEFORE RELEASING

This commit adds a rest endpoint that will trigger an emergency shutdown, useful for testing.