### PR TITLE
Feature/cc 892 2

### DIFF
--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -1227,10 +1227,15 @@ func (c *ServicedCli) cmdServiceRun(ctx *cli.Context) error {
 		return c.exit(1)
 	}
 
+	// Bash completion, CC-892
 	if args[len(args)-1] == "--generate-bash-completion" {
+		// if "serviced service run SERVICE_ID --generate-bash-completion" is executed
 		if len(args) == 2 {
-			for _, cmd := range c.serviceCommands(args[0]) {
-				fmt.Println(cmd)
+			svcDetails, _, err := c.searchForService(args[0])
+			if err == nil {
+				for _, cmd := range c.serviceCommands(svcDetails.ID) {
+					fmt.Println(cmd)
+				}
 			}
 		}
 		return c.exit(0)

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -488,15 +488,15 @@ func (c *ServicedCli) services() (data []string) {
 }
 
 // Returns a list of runnable commands for a particular service
-func (c *ServicedCli) serviceRuns(id string) (data []string) {
+func (c *ServicedCli) serviceCommands(id string) (data []string) {
 	svc, err := c.driver.GetService(id)
 	if err != nil || svc == nil {
 		return
 	}
 
-	data = make([]string, len(svc.Runs))
+	data = make([]string, len(svc.Commands))
 	i := 0
-	for r := range svc.Runs {
+	for r := range svc.Commands {
 		data[i] = r
 		i++
 	}
@@ -596,7 +596,7 @@ func (c *ServicedCli) printServiceRun(ctx *cli.Context) {
 	case 0:
 		output = c.services()
 	case 1:
-		output = c.serviceRuns(args[0])
+		output = c.serviceCommands(args[0])
 	}
 	fmt.Println(strings.Join(output, "\n"))
 }
@@ -1142,6 +1142,12 @@ func (c *ServicedCli) cmdServiceShell(ctx *cli.Context) error {
 		return c.exit(1)
 	}
 
+	// Bash completion
+	if args[len(args)-1] == "--generate-bash-completion" {
+		// CC-892: Disable bash completion
+		return c.exit(0)
+	}
+
 	var (
 		command string
 		argv    []string
@@ -1214,11 +1220,20 @@ func (c *ServicedCli) cmdServiceRun(ctx *cli.Context) error {
 	}
 
 	if len(args) < 2 {
-		for _, s := range c.serviceRuns(args[0]) {
+		for _, s := range c.serviceCommands(args[0]) {
 			fmt.Println(s)
 		}
 		fmt.Fprintf(os.Stderr, "serviced service run")
 		return c.exit(1)
+	}
+
+	if args[len(args)-1] == "--generate-bash-completion" {
+		if len(args) == 2 {
+			for _, cmd := range c.serviceCommands(args[0]) {
+				fmt.Println(cmd)
+			}
+		}
+		return c.exit(0)
 	}
 
 	var (
@@ -1285,6 +1300,12 @@ func (c *ServicedCli) cmdServiceAttach(ctx *cli.Context) error {
 		return nil
 	}
 
+	// Bash completion
+	if args[len(args)-1] == "--generate-bash-completion" {
+		// CC-892: Disable bash completion
+		return c.exit(0)
+	}
+
 	svc, instanceID, err := c.searchForService(ctx.Args().First())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -1318,6 +1339,21 @@ func (c *ServicedCli) cmdServiceAction(ctx *cli.Context) error {
 		}
 		cli.ShowSubcommandHelp(ctx)
 		return nil
+	}
+
+	// Bash completion
+	if args[len(args)-1] == "--generate-bash-completion" {
+		// CC-892
+		// if a tab is pressed after serviced service $SERVICE_ID and the
+		// service is found
+		if len(args) == 2 {
+			svc, _, err := c.searchForService(ctx.Args().First())
+			if err == nil {
+				actions := c.serviceActions(svc.ID)
+				fmt.Println(strings.Join(actions, "\n"))
+			}
+		}
+		return c.exit(0)
 	}
 
 	svc, instanceID, err := c.searchForService(ctx.Args().First())
@@ -1363,6 +1399,12 @@ func (c *ServicedCli) cmdServiceLogs(ctx *cli.Context) error {
 		}
 		cli.ShowSubcommandHelp(ctx)
 		return nil
+	}
+
+	// Bash completion
+	if args[len(args)-1] == "--generate-bash-completion" {
+		// CC-892: Disable bash completion
+		return c.exit(0)
 	}
 
 	svc, instanceID, err := c.searchForService(ctx.Args().First())

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -1236,7 +1236,9 @@ func (c *ServicedCli) cmdServiceRun(ctx *cli.Context) error {
 				for _, cmd := range c.serviceCommands(svcDetails.ID) {
 					fmt.Println(cmd)
 				}
-			}
+			} else {
+                return c.exit(1)
+            }
 		}
 		return c.exit(0)
 	}

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -1144,8 +1144,9 @@ func (c *ServicedCli) cmdServiceShell(ctx *cli.Context) error {
 
 	// Bash completion
 	if args[len(args)-1] == "--generate-bash-completion" {
-		// CC-892: Disable bash completion
-		return c.exit(0)
+		// CC-892: Disable bash completion after SERVICE_ID because possible matches
+        // are unavailable outside the container.
+		return c.exit(1)
 	}
 
 	var (
@@ -1309,8 +1310,9 @@ func (c *ServicedCli) cmdServiceAttach(ctx *cli.Context) error {
 
 	// Bash completion
 	if args[len(args)-1] == "--generate-bash-completion" {
-		// CC-892: Disable bash completion
-		return c.exit(0)
+		// CC-892: The attach command does not require an additional argument after
+        // SERVICE_ID. Disable bash completion after SERVICE_ID.
+		return c.exit(1)
 	}
 
 	svc, instanceID, err := c.searchForService(ctx.Args().First())
@@ -1351,14 +1353,16 @@ func (c *ServicedCli) cmdServiceAction(ctx *cli.Context) error {
 	// Bash completion
 	if args[len(args)-1] == "--generate-bash-completion" {
 		// CC-892
-		// if a tab is pressed after serviced service $SERVICE_ID and the
+		// if a tab is pressed after serviced service SERVICE_ID and the
 		// service is found
 		if len(args) == 2 {
 			svc, _, err := c.searchForService(ctx.Args().First())
 			if err == nil {
 				actions := c.serviceActions(svc.ID)
 				fmt.Println(strings.Join(actions, "\n"))
-			}
+			} else {
+                c.exit(1)
+            }
 		}
 		return c.exit(0)
 	}
@@ -1410,8 +1414,9 @@ func (c *ServicedCli) cmdServiceLogs(ctx *cli.Context) error {
 
 	// Bash completion
 	if args[len(args)-1] == "--generate-bash-completion" {
-		// CC-892: Disable bash completion
-		return c.exit(0)
+		// CC-892: The logs command does not require an additional argument after
+        // SERVICE_ID. Disable bash completion after SERVICE_ID.
+		return c.exit(1)
 	}
 
 	svc, instanceID, err := c.searchForService(ctx.Args().First())

--- a/serviced-bash-completion.sh
+++ b/serviced-bash-completion.sh
@@ -8,7 +8,9 @@ _cli_bash_autocomplete() {
      cur="${COMP_WORDS[COMP_CWORD]}"
      prev="${COMP_WORDS[COMP_CWORD-1]}"
      opts=$( ${COMP_WORDS[@]:0:COMP_CWORD} --generate-bash-completion )
-     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+     if [ $? -eq 0 ]; then
+         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+     fi
      return 0
 }
   


### PR DESCRIPTION
Typing "serviced service run zope [TAB]" will display the allowed subcommands. The bash completion will stop after a subcommand, e.g., serviced service run zope zenpack-manager.

The service name won't be bash-completed. For example, typing "serviced service run zo[TAB]" won't complete the service name, zope.

When multiple services are found with the same name, pressing the tab key will do nothing.