### PR TITLE
Graceful Shutdown: Only parent service getting stopped on storage full

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -1231,8 +1231,8 @@ func (d *daemon) startStorageMonitor() {
 				}).Error("Application storage is predicted to be full within the configured period")
 				if n, err := d.facade.EmergencyStopService(d.dsContext, dao.ScheduleServiceRequest{
 					ServiceID:   tenant,
-					AutoLaunch:  false,
-					Synchronous: true,
+					AutoLaunch:  true,
+					Synchronous: false,
 				}); err != nil {
 					log.WithError(err).Error("Unable to perform emergency stop of application")
 				} else {


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3179

The AutoLaunch flag is used as the arg to traverse the child services in facade.walkServices, so we need it to be true when shutting down with EmergencyStopService, otherwise, only the parent service shuts down.