### PR TITLE
CC-3155: Add consistent naming 

### DIFF
--- a/web/ui/static/i18n/en_US.json
+++ b/web/ui/static/i18n/en_US.json
@@ -118,7 +118,7 @@
     "entry_content": "",
     "error": "Error",
     "failing_health_checks": "Failing Health Checks",
-    "field_description_connection_timeout": "Time the system will wait for disconnected delegate nodes to rejoin this pool before moving services to another host in the pool.",
+    "field_description_connection_timeout": "Time the system will wait for disconnected delegate nodes to rejoin this pool before moving services to another delegate in the pool.",
     "file_name": "File Name",
     "graphs": "Graphs",
     "graph_tbl_cpu": "CPU",


### PR DESCRIPTION
Add more consistent naming to description when changing delegate timeout.