### PR TITLE
ZEN-25802 zenossdbpack logging not captured

### DIFF
--- a/pkg/serviced-zenossdbpack
+++ b/pkg/serviced-zenossdbpack
@@ -1,3 +1,8 @@
 #!/bin/sh
 
-${SERVICED:=/opt/serviced/bin/serviced} service run zope zenossdbpack
+if [ ! -d /opt/serviced/log/zenossdbpack ]; then
+    mkdir -p /opt/serviced/log/zenossdbpack
+    chmod 1777 /opt/serviced/log/zenossdbpack
+fi
+
+${SERVICED:=/opt/serviced/bin/serviced} service run --mount /opt/serviced/log/zenossdbpack,/opt/zenoss/log zope zenossdbpack


### PR DESCRIPTION
fix update the cron command to redirect output to a log file that is located under /opt/serviced/log/zenossdbpack at master.
[Jira](https://jira.zenoss.com/browse/ZEN-25802)