### PR TITLE
Add custom UnmarshalJSON for Usage slice.

### DIFF
--- a/volume/status.go
+++ b/volume/status.go
@@ -110,7 +110,7 @@ func (u *UsageData) UnmarshalJSON(data []byte) error {
 			})
 		}
 	}
-	u = &usageData
+	*u = usageData
 	return nil
 }
 


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3197

Status and SimpleStatus had a slice of an interface, which didn't know how to get unmarshaled.
These changes fix that by defining a type for a Usage slice to allow a custom UnmarshalJSON function.