### PR TITLE
CC-3210: DFS Usage graph only shows data on tenant service page

### DIFF
--- a/web/resources.go
+++ b/web/resources.go
@@ -145,7 +145,7 @@ func restGetAllServices(w *rest.ResponseWriter, r *rest.Request, ctx *requestCon
 	tenantID := r.URL.Query().Get("tenantID")
 
 	// load the internal monitoring data
-	config, err := getInternalMetrics(tenantID)
+	config, err := getInternalMetrics()
 	if err != nil {
 		glog.Errorf("Could not get internal monitoring metrics: %s", err)
 		restServerError(w, err)
@@ -351,7 +351,7 @@ func restGetService(w *rest.ResponseWriter, r *rest.Request, client *daoclient.C
 	}
 
 	// load the internal monitoring data
-	config, err := getInternalMetrics(serviceID)
+	config, err := getInternalMetrics()
 	if err != nil {
 		glog.Errorf("Could not get internal monitoring metrics: %s", err)
 		restServerError(w, err)


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3210

These changes separate tenant metrics from docker metrics and fixes the missing data issue by using the correct metric location.

The deprecated API calls `restGetAllServices` and `restGetService` will not return the metric configs for the tenant, which plays nicely with the CC Zenpack, as it added an unnecessary (and unpopulated) graph on each Service component that was already available in the Volumes component.