### PR TITLE
CC-3211: Loading services page causes JS errors

### DIFF
--- a/web/ui/src/Services/ServiceDetailsController.js
+++ b/web/ui/src/Services/ServiceDetailsController.js
@@ -1064,6 +1064,9 @@
                 };
 
                 $scope.shouldDisable = function(service, button) {
+                    if (service === undefined) {
+                        return false;
+                    }
                     if (button === 'start') {
                         return service.desiredState === 1 ||
                             service.emergencyShutdown;


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3211

Make sure service is defined before trying to check desiredState or emergencyShutdown.