### PR TITLE
ensure that prefetch happens onces per active container

### DIFF
--- a/zzk/service/state.go
+++ b/zzk/service/state.go
@@ -61,6 +61,7 @@ type ServiceState struct {
 	Imports     []ImportBinding
 	Exports     []ExportBinding
 	Started     time.Time
+	Restarted   time.Time
 	Terminated  time.Time
 	version     interface{}
 }


### PR DESCRIPTION
Also, when we reconnect an orphaned container from an outage, we need to make sure we write back the service state information.