### PR TITLE
CC-3069 "Warn/Show Error when authorization fails due to clock drifts between hosts"

### DIFF
--- a/auth/header.go
+++ b/auth/header.go
@@ -107,7 +107,7 @@ var (
 	// ErrUnknownAuthProtocol is thrown when the authentication protocol version is not supported
 	ErrUnknownAuthProtocol = errors.New("Unknown authentication protocol version")
 	// ErrHeaderExpired is thrown when an authentication header is more than 10s old
-	ErrHeaderExpired = errors.New("Expired authentication header")
+	ErrHeaderExpired = errors.New("Expired authentication header.")
 )
 
 // AuthHeaderError wraps another error with an accompanying payload, for the
@@ -289,7 +289,7 @@ func readAuthHeaderV1(r io.Reader) (sender Identity, tstamp time.Time, payload [
 		return
 	}
 	tstamp = time.Unix(int64(ts), 0).UTC()
-	cutoff := jwt.TimeFunc().UTC().Add(-expirationDelta)
+	cutoff := jwt.TimeFunc().UTC().Add(-ExpirationDelta)
 	if tstamp.Before(cutoff) {
 		err = eatBytesAndGetPayloadError(teed, remaining, ErrHeaderExpired)
 		return

--- a/auth/token.go
+++ b/auth/token.go
@@ -26,7 +26,7 @@ const (
 	// expirationDelta is a margin of error during which a token should be
 	// considered expired. This should help avoid expiration races when server
 	// times don't match
-	expirationDelta = 10 * time.Second
+	ExpirationDelta = 10 * time.Second
 )
 
 var (
@@ -104,7 +104,6 @@ func WaitForAuthToken(cancel <-chan interface{}) <-chan struct{} {
 	}()
 	return ch
 }
-
 
 // MasterToken() generates a new token with an empty host and pool ID and the master's public key,
 //  signed by the master's private key.  This will return an error if there is no master private
@@ -241,7 +240,7 @@ func expired() bool {
 	if expiration.IsZero() {
 		return false
 	}
-	return expiration.Add(-expirationDelta).Before(now())
+	return expiration.Add(-ExpirationDelta).Before(now())
 }
 
 func updateToken(token string, expires time.Time, filename string) {

--- a/rpc/master/hosts_client.go
+++ b/rpc/master/hosts_client.go
@@ -78,8 +78,8 @@ func (c *Client) FindHostsInPool(poolID string) ([]host.Host, error) {
 // AuthenticateHost authenticates a host
 func (c *Client) AuthenticateHost(hostID string) (string, int64, error) {
 	req := HostAuthenticationRequest{
-		HostID:  hostID,
-		Expires: time.Now().Add(time.Duration(1 * time.Minute)).UTC().Unix(),
+		HostID:    hostID,
+		Timestamp: time.Now().UTC().Unix(),
 	}
 	sig, err := auth.SignAsDelegate(req.toMessage())
 	if err != nil {


### PR DESCRIPTION
On host authentication, we now fail authentication if the timestamp of the request is +/- auth.ExpirationDelta of the master's current time.  This will flip the "Authenticated" icon in the UI to red, and will log an error on the master about re-syncing the clocks.