### PR TITLE
ZEN-26171 zenossdbpack logging not captured

### DIFF
--- a/pkg/serviced-zenossdbpack
+++ b/pkg/serviced-zenossdbpack
@@ -1,3 +1,8 @@
 #!/bin/sh
 
-${SERVICED:=/opt/serviced/bin/serviced} service run zope zenossdbpack
+if [ ! -d /opt/serviced/log/zenossdbpack ]; then
+    mkdir -p /opt/serviced/log/zenossdbpack
+    chmod 1777 /opt/serviced/log/zenossdbpack
+fi
+
+${SERVICED:=/opt/serviced/bin/serviced} service run --mount /opt/serviced/log/zenossdbpack,/opt/zenoss/log zope zenossdbpack


### PR DESCRIPTION
ZEN-26171
port from https://github.com/control-center/serviced/pull/3330
[Jira](https://jira.zenoss.com/browse/ZEN-26171)