### PR TITLE
CC-3199 "Add support for rolling restart"

### DIFF
--- a/cli/api/apimocks/API.go
+++ b/cli/api/apimocks/API.go
@@ -1264,6 +1264,27 @@ func (_m *API) RestartService(_a0 api.SchedulerConfig) (int, error) {
 	return r0, r1
 }
 
+// RebalanceService provides a mock function with given fields: _a0
+func (_m *API) RebalanceService(_a0 api.SchedulerConfig) (int, error) {
+	ret := _m.Called(_a0)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(api.SchedulerConfig) int); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(api.SchedulerConfig) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Restore provides a mock function with given fields: _a0
 func (_m *API) Restore(_a0 string) error {
 	ret := _m.Called(_a0)

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -1118,6 +1118,7 @@ func (d *daemon) initFacade() *facade.Facade {
 	if err := f.UpdateServiceCache(d.dsContext); err != nil {
 		log.WithError(err).Fatal("Unable to update the service cache")
 	}
+	f.SetRollingRestartTimeout(time.Duration(options.ServiceRunLevelTimeout) * time.Second)
 	return f
 }
 

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -74,6 +74,7 @@ type API interface {
 	UpdateService(io.Reader) (*service.ServiceDetails, error)
 	StartService(SchedulerConfig) (int, error)
 	RestartService(SchedulerConfig) (int, error)
+	RebalanceService(SchedulerConfig) (int, error)
 	StopService(SchedulerConfig) (int, error)
 	AssignIP(IPConfig) error
 	GetEndpoints(serviceID string, reportImports, reportExports, validate bool) ([]applicationendpoint.EndpointReport, error)

--- a/cli/api/service.go
+++ b/cli/api/service.go
@@ -366,6 +366,18 @@ func (a *api) RestartService(config SchedulerConfig) (int, error) {
 	return affected, err
 }
 
+// Rebalance
+func (a *api) RebalanceService(config SchedulerConfig) (int, error) {
+	client, err := a.connectDAO()
+	if err != nil {
+		return 0, err
+	}
+
+	var affected int
+	err = client.RebalanceService(dao.ScheduleServiceRequest{config.ServiceIDs, config.AutoLaunch, config.Synchronous}, &affected)
+	return affected, err
+}
+
 // StopService stops a service
 func (a *api) StopService(config SchedulerConfig) (int, error) {
 	client, err := a.connectDAO()

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -178,6 +178,10 @@ func (c *ServicedCli) initService() {
 						Name:  "sync, s",
 						Usage: "Schedules services synchronously",
 					},
+					cli.BoolFlag{
+						Name:  "rebalance",
+						Usage: "Stops all instances before restarting them, instead of performing a rolling restart",
+					},
 				},
 			}, {
 				Name:         "stop",
@@ -1119,10 +1123,18 @@ func (c *ServicedCli) cmdServiceRestart(ctx *cli.Context) {
 
 	// Batch start services
 	if len(sIds) > 0 {
-		if affected, err := c.driver.RestartService(api.SchedulerConfig{sIds, ctx.Bool("auto-launch"), ctx.Bool("sync")}); err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if ctx.Bool("rebalance") {
+			if affected, err := c.driver.RebalanceService(api.SchedulerConfig{sIds, ctx.Bool("auto-launch"), ctx.Bool("sync")}); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			} else {
+				fmt.Printf("Restarting %d service(s)\n", affected)
+			}
 		} else {
-			fmt.Printf("Restarting %d service(s)\n", affected)
+			if affected, err := c.driver.RestartService(api.SchedulerConfig{sIds, ctx.Bool("auto-launch"), ctx.Bool("sync")}); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			} else {
+				fmt.Printf("Restarting %d service(s)\n", affected)
+			}
 		}
 	}
 

--- a/cli/cmd/service_test.go
+++ b/cli/cmd/service_test.go
@@ -799,6 +799,7 @@ func ExampleServicedCLI_CmdServiceRestart_usage() {
 	// OPTIONS:
 	//    --auto-launch	Recursively schedules child services
 	//    --sync, -s		Schedules services synchronously
+	//    --rebalance		Stops all instances before restarting them, instead of performing a rolling restart
 }
 
 func ExampleServicedCLI_CmdServiceRestart_fail() {

--- a/dao/client/cp_client.go
+++ b/dao/client/cp_client.go
@@ -70,7 +70,7 @@ func (s *ControlClient) GetServiceEndpoints(serviceId string, response *map[stri
 	return s.rpcClient.Call("ControlCenter.GetServiceEndpoints", serviceId, response, 0)
 }
 
-func (s *ControlClient) GetTenantIDs(unused struct {}, tenantIDs *[]string) error {
+func (s *ControlClient) GetTenantIDs(unused struct{}, tenantIDs *[]string) error {
 	return s.rpcClient.Call("ControlCenter.GetTenantIDs", unused, tenantIDs, 0)
 }
 
@@ -144,6 +144,10 @@ func (s *ControlClient) StartService(request dao.ScheduleServiceRequest, affecte
 
 func (s *ControlClient) RestartService(request dao.ScheduleServiceRequest, affected *int) (err error) {
 	return s.rpcClient.Call("ControlCenter.RestartService", request, affected, 0)
+}
+
+func (s *ControlClient) RebalanceService(request dao.ScheduleServiceRequest, affected *int) (err error) {
+	return s.rpcClient.Call("ControlCenter.RebalanceService", request, affected, 0)
 }
 
 func (s *ControlClient) StopService(request dao.ScheduleServiceRequest, affected *int) (err error) {

--- a/dao/elasticsearch/service.go
+++ b/dao/elasticsearch/service.go
@@ -129,7 +129,7 @@ func (this *ControlPlaneDao) GetService(id string, myService *service.Service) e
 }
 
 // Get a list of tenant IDs
-func (this *ControlPlaneDao) GetTenantIDs(unused struct {}, tenantIDs *[]string) error {
+func (this *ControlPlaneDao) GetTenantIDs(unused struct{}, tenantIDs *[]string) error {
 	ctx := datastore.Get()
 	defer ctx.Metrics().Stop(ctx.Metrics().Start("dao.GetTenantIDs"))
 	if ids, err := this.facade.GetTenantIDs(ctx); err == nil {
@@ -166,6 +166,12 @@ func (this *ControlPlaneDao) StartService(request dao.ScheduleServiceRequest, af
 // restart the provided service
 func (this *ControlPlaneDao) RestartService(request dao.ScheduleServiceRequest, affected *int) (err error) {
 	*affected, err = this.facade.RestartService(datastore.Get(), request)
+	return err
+}
+
+// rebalance the provided service
+func (this *ControlPlaneDao) RebalanceService(request dao.ScheduleServiceRequest, affected *int) (err error) {
+	*affected, err = this.facade.RebalanceService(datastore.Get(), request)
 	return err
 }
 

--- a/dao/interface.go
+++ b/dao/interface.go
@@ -173,6 +173,9 @@ type ControlPlane interface {
 	// Schedule the given service to restart
 	RestartService(request ScheduleServiceRequest, affected *int) error
 
+	// Schedule the given service to rebalance
+	RebalanceService(request ScheduleServiceRequest, affected *int) error
+
 	// Schedule the given service to stop
 	StopService(request ScheduleServiceRequest, affected *int) error
 

--- a/dao/mocks/ControlPlane.go
+++ b/dao/mocks/ControlPlane.go
@@ -95,11 +95,11 @@ func (_m *ControlPlane) GetService(serviceId string, svc *service.Service) error
 
 	return r0
 }
-func (_m *ControlPlane) GetTenantIDs(unused struct {}, tenantIDs *[]string) error {
+func (_m *ControlPlane) GetTenantIDs(unused struct{}, tenantIDs *[]string) error {
 	ret := _m.Called(unused, tenantIDs)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(struct {}, *[]string) error); ok {
+	if rf, ok := ret.Get(0).(func(struct{}, *[]string) error); ok {
 		r0 = rf(unused, tenantIDs)
 	} else {
 		r0 = ret.Error(0)
@@ -144,6 +144,18 @@ func (_m *ControlPlane) StartService(request dao.ScheduleServiceRequest, affecte
 	return r0
 }
 func (_m *ControlPlane) RestartService(request dao.ScheduleServiceRequest, affected *int) error {
+	ret := _m.Called(request, affected)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(dao.ScheduleServiceRequest, *int) error); ok {
+		r0 = rf(request, affected)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *ControlPlane) RebalanceService(request dao.ScheduleServiceRequest, affected *int) error {
 	ret := _m.Called(request, affected)
 
 	var r0 error

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -83,6 +83,8 @@ type Facade struct {
 	deployments   *PendingDeploymentMgr
 	ssm           servicestatemanager.ServiceStateManager
 	isvcsPath     string
+
+	rollingRestartTimeout time.Duration
 }
 
 func (f *Facade) SetZZK(zzk ZZK) { f.zzk = zzk }
@@ -127,3 +129,5 @@ func (f *Facade) SetHostExpirationRegistry(hostRegistry auth.HostExpirationRegis
 }
 
 func (f *Facade) SetDeploymentMgr(mgr *PendingDeploymentMgr) { f.deployments = mgr }
+
+func (f *Facade) SetRollingRestartTimeout(t time.Duration) { f.rollingRestartTimeout = t }

--- a/facade/host.go
+++ b/facade/host.go
@@ -38,6 +38,7 @@ const (
 
 var (
 	ErrHostDoesNotExist = errors.New("facade: host does not exist")
+	ErrHostOffline      = errors.New("host is offline")
 )
 
 //---------------------------------------------------------------------------

--- a/facade/mocks/ZZK.go
+++ b/facade/mocks/ZZK.go
@@ -26,16 +26,16 @@ func (_m *ZZK) UpdateService(ctx datastore.Context, tenantID string, svc *servic
 	return r0
 }
 func (_m *ZZK) UpdateServices(ctx datastore.Context, tenantID string, svcs []*service.Service, setLockOnCreate bool, setLockOnUpdate bool) error {
-        ret := _m.Called(ctx, tenantID, svcs, setLockOnCreate, setLockOnUpdate)
+	ret := _m.Called(ctx, tenantID, svcs, setLockOnCreate, setLockOnUpdate)
 
-        var r0 error
-        if rf, ok := ret.Get(0).(func(datastore.Context, string, []*service.Service, bool, bool) error); ok {
-                r0 = rf(ctx, tenantID, svcs, setLockOnCreate, setLockOnUpdate)
-        } else {
-                r0 = ret.Error(0)
-        }
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, []*service.Service, bool, bool) error); ok {
+		r0 = rf(ctx, tenantID, svcs, setLockOnCreate, setLockOnUpdate)
+	} else {
+		r0 = ret.Error(0)
+	}
 
-        return r0
+	return r0
 }
 func (_m *ZZK) SyncServiceRegistry(ctx datastore.Context, tenantID string, svc *service.Service) error {
 	ret := _m.Called(ctx, tenantID, svc)

--- a/facade/mocks/ZZK.go
+++ b/facade/mocks/ZZK.go
@@ -97,12 +97,12 @@ func (_m *ZZK) WaitService(svc *service.Service, state service.DesiredState, can
 
 	return r0
 }
-func (_m *ZZK) WaitInstance(ctx datastore.Context, svc *service.Service, instanceID int, state service.DesiredState, cancel <-chan struct{}) error {
-	ret := _m.Called(ctx, svc, instanceID, state, cancel)
+func (_m *ZZK) WaitInstance(ctx datastore.Context, svc *service.Service, instanceID int, checkInstance func(*zkservice.State, bool) bool, cancel <-chan struct{}) error {
+	ret := _m.Called(ctx, svc, instanceID, checkInstance, cancel)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(datastore.Context, *service.Service, int, service.DesiredState, <-chan struct{}) error); ok {
-		r0 = rf(ctx, svc, instanceID, state, cancel)
+	if rf, ok := ret.Get(0).(func(datastore.Context, *service.Service, int, func(*zkservice.State, bool) bool, <-chan struct{}) error); ok {
+		r0 = rf(ctx, svc, instanceID, checkInstance, cancel)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/facade/mocks/ZZK.go
+++ b/facade/mocks/ZZK.go
@@ -97,6 +97,18 @@ func (_m *ZZK) WaitService(svc *service.Service, state service.DesiredState, can
 
 	return r0
 }
+func (_m *ZZK) WaitInstance(ctx datastore.Context, svc *service.Service, instanceID int, state service.DesiredState, cancel <-chan struct{}) error {
+	ret := _m.Called(ctx, svc, instanceID, state, cancel)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, *service.Service, int, service.DesiredState, <-chan struct{}) error); ok {
+		r0 = rf(ctx, svc, instanceID, state, cancel)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
 func (_m *ZZK) GetPublicPort(portAddress string) (string, string, error) {
 	ret := _m.Called(portAddress)
 
@@ -445,6 +457,18 @@ func (_m *ZZK) StopServiceInstances(ctx datastore.Context, poolID string, servic
 	var r0 error
 	if rf, ok := ret.Get(0).(func(datastore.Context, string, string) error); ok {
 		r0 = rf(ctx, poolID, serviceID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *ZZK) RestartInstance(ctx datastore.Context, poolID string, serviceID string, instanceID int) error {
+	ret := _m.Called(ctx, poolID, serviceID, instanceID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string, int) error); ok {
+		r0 = rf(ctx, poolID, serviceID, instanceID)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/facade/service.go
+++ b/facade/service.go
@@ -1233,11 +1233,11 @@ func (f *Facade) clearEmergencyStopFlag(ctx datastore.Context, tenantID, service
 
 // countServices will count how many unique services in the given list (including children) satisfy the check function
 func (f *Facade) countServices(ctx datastore.Context, serviceIDs []string, check func(*service.Service) bool) (int, error) {
-	alreadyChecked := make(map[string]bool)
+	alreadyChecked := make(map[string]struct{})
 	count := 0
 	visitor := func(svc *service.Service) error {
-		if !alreadyChecked[svc.ID] {
-			alreadyChecked[svc.ID] = true
+		if _, ok := alreadyChecked[svc.ID]; !ok {
+			alreadyChecked[svc.ID] = struct{}{}
 
 			if check(svc) {
 				count++
@@ -1276,13 +1276,13 @@ func (f *Facade) scheduleServiceParents(ctx datastore.Context, tenantID string, 
 		isRequested[serviceID] = true
 	}
 
-	alreadyChecked := make(map[string]bool)
+	alreadyChecked := make(map[string]struct{})
 	// Build a list of services to be scheduled
 	svcs := []*service.Service{}
 	var svcIDs []string
 	visitor := func(svc *service.Service) error {
-		if !alreadyChecked[svc.ID] {
-			alreadyChecked[svc.ID] = true
+		if _, ok := alreadyChecked[svc.ID]; !ok {
+			alreadyChecked[svc.ID] = struct{}{}
 
 			if svc.Launch == commons.MANUAL && !emergency && !isRequested[svc.ID] {
 				return nil

--- a/facade/service.go
+++ b/facade/service.go
@@ -1638,21 +1638,7 @@ func (f *Facade) StartService(ctx datastore.Context, request dao.ScheduleService
 
 func (f *Facade) RestartService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error) {
 	defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.RestartService"))
-	forceRestart := func() (int, error) {
-		count, err := f.ScheduleServices(ctx, request.ServiceIDs, request.AutoLaunch, true, service.SVCStop, false)
-		if err != nil {
-			return count, err
-		}
-
-		return f.ScheduleServices(ctx, request.ServiceIDs, request.AutoLaunch, request.Synchronous, service.SVCRun, false)
-	}
-
-	if request.Synchronous {
-		return forceRestart()
-	} else {
-		go forceRestart()
-		return 0, nil
-	}
+	return f.ScheduleServices(ctx, request.ServiceIDs, request.AutoLaunch, request.Synchronous, service.SVCRestart, false)
 }
 
 func (f *Facade) PauseService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error) {

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/control-center/serviced/domain/serviceconfigfile"
 	"github.com/control-center/serviced/domain/servicedefinition"
 	zzkmocks "github.com/control-center/serviced/facade/mocks"
+	"github.com/control-center/serviced/health"
 	ssmmocks "github.com/control-center/serviced/scheduler/servicestatemanager/mocks"
 	zks "github.com/control-center/serviced/zzk/service"
 
@@ -2484,6 +2485,493 @@ func (ft *FacadeIntegrationTest) TestFacade_ClearEmergencyStopFlag(c *C) {
 	}
 }
 
+func (ft *FacadeIntegrationTest) TestFacade_rollingRestart_Pass(c *C) {
+	svc := service.Service{
+		ID:                "serviceID",
+		Name:              "Service",
+		Startup:           "/usr/bin/ping -c localhost",
+		Description:       "Ping a remote host a fixed number of times",
+		Instances:         3,
+		InstanceLimits:    domain.MinMax{1, 1, 1},
+		ImageID:           "test/pinger",
+		PoolID:            "default",
+		DeploymentID:      "deployment_id",
+		DesiredState:      int(service.SVCRun),
+		Launch:            "auto",
+		Endpoints:         []service.ServiceEndpoint{},
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+		EmergencyShutdown: false,
+		HealthChecks:      map[string]health.HealthCheck{"healthcheck": health.HealthCheck{}},
+	}
+
+	hcache := health.New()
+	ft.Facade.SetHealthCache(hcache)
+	key0 := health.HealthStatusKey{
+		ServiceID:       svc.ID,
+		InstanceID:      0,
+		HealthCheckName: "healthcheck",
+	}
+	key1 := health.HealthStatusKey{
+		ServiceID:       svc.ID,
+		InstanceID:      1,
+		HealthCheckName: "healthcheck",
+	}
+	key2 := health.HealthStatusKey{
+		ServiceID:       svc.ID,
+		InstanceID:      2,
+		HealthCheckName: "healthcheck",
+	}
+
+	statusOK := health.HealthStatus{
+		Status:    health.OK,
+		StartedAt: time.Now(),
+		Duration:  time.Minute,
+	}
+	statusFailed := health.HealthStatus{
+		Status:    health.Failed,
+		StartedAt: time.Now(),
+		Duration:  time.Minute,
+	}
+
+	hcache.Set(key0, statusFailed, time.Hour)
+	hcache.Set(key1, statusFailed, time.Hour)
+	hcache.Set(key2, statusFailed, time.Hour)
+
+	restarted0 := make(chan struct{})
+	restarted1 := make(chan struct{})
+	restarted2 := make(chan struct{})
+
+	// Make sure we call RestartInstance once for each instance of svc
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 0).Return(nil).Once()
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 1).Return(nil).Once()
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 2).Return(nil).Once()
+
+	// Make sure we call WaitInstance once for each instance of svc
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 2, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, service.SVCRun, mock.AnythingOfType("<-chan struct {}")).Run(func(args mock.Arguments) {
+		close(restarted0)
+	}).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, service.SVCRun, mock.AnythingOfType("<-chan struct {}")).Run(func(args mock.Arguments) {
+		close(restarted1)
+	}).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 2, service.SVCRun, mock.AnythingOfType("<-chan struct {}")).Run(func(args mock.Arguments) {
+		close(restarted2)
+	}).Return(nil).Once()
+
+	done := make(chan struct{})
+	go func() {
+		err := ft.Facade.rollingRestart(ft.CTX, &svc, 30*time.Second)
+		c.Assert(err, IsNil)
+		close(done)
+	}()
+	timer := time.NewTimer(5 * time.Second)
+	// Should see instance 0 restarted first
+	select {
+	case <-restarted1:
+		c.Fatalf("Instance 1 restarted before 0")
+	case <-restarted2:
+		c.Fatalf("Instance 2 restarted before 0")
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for instance 0 to restart")
+	case <-restarted0:
+	}
+
+	// Instance 1 won't restart until healthchecks pass for instance 0
+	timer.Reset(2 * time.Second)
+	select {
+	case <-restarted1:
+		c.Fatalf("Instance 1 restarted before 0 passed healthcheck")
+	case <-restarted2:
+		c.Fatalf("Instance 2 restarted before 0 passed healthcheck")
+	case <-timer.C:
+	}
+
+	// Pass the healthchecks for instance 0
+	hcache.Set(key0, statusOK, time.Hour)
+
+	// Now we should see instance 1 restart
+	timer.Reset(5 * time.Second)
+	select {
+	case <-restarted2:
+		c.Fatalf("Instance 2 restarted before 1")
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for instance 1 to restart")
+	case <-restarted1:
+	}
+
+	// Instance 2 won't restart until healthchecks pass for instance 1
+	timer.Reset(2 * time.Second)
+	select {
+	case <-restarted2:
+		c.Fatalf("Instance 2 restarted before 1 passed healthcheck")
+	case <-timer.C:
+	}
+
+	// Pass the healthchecks for instance 1
+	hcache.Set(key1, statusOK, time.Hour)
+
+	// Now we should see instance 2 restart
+	timer.Reset(5 * time.Second)
+	select {
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for instance 1 to restart")
+	case <-restarted2:
+	}
+
+	// Pass the healthchecks for instance 2
+	hcache.Set(key2, statusOK, time.Hour)
+
+	select {
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for rolling restart")
+	case <-done:
+	}
+}
+
+func (ft *FacadeIntegrationTest) TestFacade_rollingRestart_TimeoutWaitStop(c *C) {
+	svc := service.Service{
+		ID:                "serviceID",
+		Name:              "Service",
+		Startup:           "/usr/bin/ping -c localhost",
+		Description:       "Ping a remote host a fixed number of times",
+		Instances:         2,
+		InstanceLimits:    domain.MinMax{1, 1, 1},
+		ImageID:           "test/pinger",
+		PoolID:            "default",
+		DeploymentID:      "deployment_id",
+		DesiredState:      int(service.SVCRun),
+		Launch:            "auto",
+		Endpoints:         []service.ServiceEndpoint{},
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+		EmergencyShutdown: false,
+	}
+
+	// Use a timeout of 1 second
+	timeout := 1 * time.Second
+
+	restarted1 := make(chan struct{})
+
+	// Make sure we call RestartInstance once for each instance of svc
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 0).Return(nil).Once()
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 1).Return(nil).Once()
+
+	// Make sure we call WaitInstance once for each instance of svc
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Run(func(args mock.Arguments) {
+		cancel := args[4].(<-chan struct{})
+		// Wait twice the timeout or until cancelled to force a timeout
+		select {
+		case <-cancel:
+		case <-time.After(2 * timeout):
+			c.Fatalf("Wait not cancelled after timeout")
+		}
+	}).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+
+	// We should not be waiting on instace 0 to start back up due to the timeout
+
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, service.SVCRun, mock.AnythingOfType("<-chan struct {}")).Run(func(args mock.Arguments) {
+		close(restarted1)
+	}).Return(nil).Once()
+
+	done := make(chan struct{})
+	go func() {
+		err := ft.Facade.rollingRestart(ft.CTX, &svc, timeout)
+		c.Assert(err, IsNil)
+		close(done)
+	}()
+	timer := time.NewTimer(3 * timeout)
+	// instance 0 will timeout, but we should see instance 1 restart
+	select {
+	case <-restarted1:
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for instance 1 to restart")
+	}
+
+	timer.Reset(3 * timeout)
+	select {
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for rolling restart")
+	case <-done:
+	}
+}
+
+func (ft *FacadeIntegrationTest) TestFacade_rollingRestart_TimeoutWaitStart(c *C) {
+	svc := service.Service{
+		ID:                "serviceID",
+		Name:              "Service",
+		Startup:           "/usr/bin/ping -c localhost",
+		Description:       "Ping a remote host a fixed number of times",
+		Instances:         2,
+		InstanceLimits:    domain.MinMax{1, 1, 1},
+		ImageID:           "test/pinger",
+		PoolID:            "default",
+		DeploymentID:      "deployment_id",
+		DesiredState:      int(service.SVCRun),
+		Launch:            "auto",
+		Endpoints:         []service.ServiceEndpoint{},
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+		EmergencyShutdown: false,
+	}
+
+	// Use a timeout of 1 second
+	timeout := 1 * time.Second
+
+	restarted1 := make(chan struct{})
+
+	// Make sure we call RestartInstance once for each instance of svc
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 0).Return(nil).Once()
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 1).Return(nil).Once()
+
+	// Make sure we call WaitInstance once for each instance of svc
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, service.SVCRun, mock.AnythingOfType("<-chan struct {}")).Run(func(args mock.Arguments) {
+		cancel := args[4].(<-chan struct{})
+		// Wait twice the timeout or until cancelled to force a timeout
+		select {
+		case <-cancel:
+		case <-time.After(2 * timeout):
+			c.Fatalf("Wait not cancelled after timeout")
+		}
+	}).Return(nil).Once()
+
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, service.SVCRun, mock.AnythingOfType("<-chan struct {}")).Run(func(args mock.Arguments) {
+		close(restarted1)
+	}).Return(nil).Once()
+
+	done := make(chan struct{})
+	go func() {
+		err := ft.Facade.rollingRestart(ft.CTX, &svc, timeout)
+		c.Assert(err, IsNil)
+		close(done)
+	}()
+	timer := time.NewTimer(3 * timeout)
+	// instance 0 will timeout, but we should see instance 1 restart
+	select {
+	case <-restarted1:
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for instance 1 to restart")
+	}
+
+	timer.Reset(3 * timeout)
+	select {
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for rolling restart")
+	case <-done:
+	}
+}
+
+func (ft *FacadeIntegrationTest) TestFacade_rollingRestart_TimeoutHealthcheck(c *C) {
+	svc := service.Service{
+		ID:                "serviceID",
+		Name:              "Service",
+		Startup:           "/usr/bin/ping -c localhost",
+		Description:       "Ping a remote host a fixed number of times",
+		Instances:         2,
+		InstanceLimits:    domain.MinMax{1, 1, 1},
+		ImageID:           "test/pinger",
+		PoolID:            "default",
+		DeploymentID:      "deployment_id",
+		DesiredState:      int(service.SVCRun),
+		Launch:            "auto",
+		Endpoints:         []service.ServiceEndpoint{},
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+		EmergencyShutdown: false,
+		HealthChecks:      map[string]health.HealthCheck{"healthcheck": health.HealthCheck{}},
+	}
+
+	hcache := health.New()
+	ft.Facade.SetHealthCache(hcache)
+	key0 := health.HealthStatusKey{
+		ServiceID:       svc.ID,
+		InstanceID:      0,
+		HealthCheckName: "healthcheck",
+	}
+	key1 := health.HealthStatusKey{
+		ServiceID:       svc.ID,
+		InstanceID:      1,
+		HealthCheckName: "healthcheck",
+	}
+
+	statusOK := health.HealthStatus{
+		Status:    health.OK,
+		StartedAt: time.Now(),
+		Duration:  time.Minute,
+	}
+	statusFailed := health.HealthStatus{
+		Status:    health.Failed,
+		StartedAt: time.Now(),
+		Duration:  time.Minute,
+	}
+
+	// set a 1 second timeout
+	timeout := 1 * time.Second
+
+	hcache.Set(key0, statusFailed, time.Hour)
+	hcache.Set(key1, statusFailed, time.Hour)
+
+	restarted0 := make(chan struct{})
+	restarted1 := make(chan struct{})
+
+	// Make sure we call RestartInstance once for each instance of svc
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 0).Return(nil).Once()
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 1).Return(nil).Once()
+
+	// Make sure we call WaitInstance once for each instance of svc
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, service.SVCRun, mock.AnythingOfType("<-chan struct {}")).Run(func(args mock.Arguments) {
+		close(restarted0)
+	}).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, service.SVCRun, mock.AnythingOfType("<-chan struct {}")).Run(func(args mock.Arguments) {
+		close(restarted1)
+	}).Return(nil).Once()
+
+	done := make(chan struct{})
+	go func() {
+		err := ft.Facade.rollingRestart(ft.CTX, &svc, timeout)
+		c.Assert(err, IsNil)
+		close(done)
+	}()
+	timer := time.NewTimer(5 * time.Second)
+	// Should see instance 0 restarted first
+	select {
+	case <-restarted1:
+		c.Fatalf("Instance 1 restarted before 0")
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for instance 0 to restart")
+	case <-restarted0:
+	}
+
+	// Leave Instance 0's healthchecks failing and make sure we move on
+	// Now we should see instance 1 restart
+	timer.Reset(3 * timeout)
+	select {
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for instance 1 to restart")
+	case <-restarted1:
+	}
+
+	// Pass the healthchecks for instance 1
+	hcache.Set(key1, statusOK, time.Hour)
+
+	timer.Reset(3 * timeout)
+	select {
+	case <-timer.C:
+		c.Fatalf("Timeout waiting for rolling restart")
+	case <-done:
+	}
+}
+
+func (ft *FacadeIntegrationTest) TestFacade_rollingRestart_FailWaitStop(c *C) {
+	svc := service.Service{
+		ID:                "serviceID",
+		Name:              "Service",
+		Startup:           "/usr/bin/ping -c localhost",
+		Description:       "Ping a remote host a fixed number of times",
+		Instances:         3,
+		InstanceLimits:    domain.MinMax{1, 1, 1},
+		ImageID:           "test/pinger",
+		PoolID:            "default",
+		DeploymentID:      "deployment_id",
+		DesiredState:      int(service.SVCRun),
+		Launch:            "auto",
+		Endpoints:         []service.ServiceEndpoint{},
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+		EmergencyShutdown: false,
+	}
+
+	// Make sure we call RestartInstance once for each insance of svc that gets called
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 0).Return(nil).Once()
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 1).Return(nil).Once()
+
+	// Make sure we call WaitInstance once for each insance of svc that gets called
+	testerr := errors.New("test error")
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(testerr).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, service.SVCRun, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	err := ft.Facade.rollingRestart(ft.CTX, &svc, 30*time.Second)
+	// Make sure our rollingRestart bailed after it failed for one instance
+	c.Assert(err, Equals, testerr)
+}
+
+func (ft *FacadeIntegrationTest) TestFacade_rollingRestart_FailWaitStart(c *C) {
+	svc := service.Service{
+		ID:                "serviceID",
+		Name:              "Service",
+		Startup:           "/usr/bin/ping -c localhost",
+		Description:       "Ping a remote host a fixed number of times",
+		Instances:         3,
+		InstanceLimits:    domain.MinMax{1, 1, 1},
+		ImageID:           "test/pinger",
+		PoolID:            "default",
+		DeploymentID:      "deployment_id",
+		DesiredState:      int(service.SVCRun),
+		Launch:            "auto",
+		Endpoints:         []service.ServiceEndpoint{},
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+		EmergencyShutdown: false,
+	}
+
+	// Make sure we call RestartInstance once for each insance of svc that gets called
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 0).Return(nil).Once()
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 1).Return(nil).Once()
+
+	// Make sure we call WaitInstance once for each insance of svc that gets called
+	testerr := errors.New("test error")
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, service.SVCRun, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, service.SVCRun, mock.AnythingOfType("<-chan struct {}")).Return(testerr).Once()
+	err := ft.Facade.rollingRestart(ft.CTX, &svc, 30*time.Second)
+	// Make sure our rollingRestart bailed after it failed for one instance
+	c.Assert(err, Equals, testerr)
+}
+
+func (ft *FacadeIntegrationTest) TestFacade_rollingRestart_FailRestartInstance(c *C) {
+	svc := service.Service{
+		ID:                "serviceID",
+		Name:              "Service",
+		Startup:           "/usr/bin/ping -c localhost",
+		Description:       "Ping a remote host a fixed number of times",
+		Instances:         3,
+		InstanceLimits:    domain.MinMax{1, 1, 1},
+		ImageID:           "test/pinger",
+		PoolID:            "default",
+		DeploymentID:      "deployment_id",
+		DesiredState:      int(service.SVCRun),
+		Launch:            "auto",
+		Endpoints:         []service.ServiceEndpoint{},
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+		EmergencyShutdown: false,
+	}
+
+	// Make sure we call RestartInstance once for each insance of svc that gets called
+	testerr := errors.New("test error")
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 0).Return(nil).Once()
+	ft.zzk.On("RestartInstance", ft.CTX, svc.PoolID, svc.ID, 1).Return(testerr).Once()
+
+	// Make sure we call WaitInstance once for each insance of svc that gets called
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, service.SVCStop, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, service.SVCRun, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, service.SVCRun, mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
+	err := ft.Facade.rollingRestart(ft.CTX, &svc, 30*time.Second)
+	// Make sure our rollingRestart bailed after it failed for one instance
+	c.Assert(err, Equals, testerr)
+}
+
 func (ft *FacadeIntegrationTest) TestFacade_StartMultipleServices(c *C) {
 	// create a service tree that looks like this:
 	// ParentServiceID
@@ -2664,7 +3152,6 @@ func (ft *FacadeIntegrationTest) TestFacade_StartMultipleServices(c *C) {
 	c.Assert(count, Equals, 6)
 
 	mockedSSM.AssertExpectations(c)
-
 }
 
 func (ft *FacadeIntegrationTest) setupMigrationTestWithoutEndpoints(t *C) error {

--- a/facade/zkapi.go
+++ b/facade/zkapi.go
@@ -312,7 +312,7 @@ func (zk *zkf) WaitInstance(ctx datastore.Context, svc *service.Service, instanc
 	select {
 	case err := <-errC:
 		if err != nil {
-			logger.WithError(err).Debug("Could not monitor the service's containerID in zookeeper")
+			logger.WithError(err).Debug("Could not monitor the instance in zookeeper")
 			return err
 		}
 		return err

--- a/facade/zzk.go
+++ b/facade/zzk.go
@@ -30,7 +30,7 @@ type ZZK interface {
 	RemoveServiceEndpoints(serviceID string) error
 	RemoveTenantExports(tenantID string) error
 	WaitService(svc *service.Service, state service.DesiredState, cancel <-chan interface{}) error
-	WaitInstance(ctx datastore.Context, svc *service.Service, instanceID int, state service.DesiredState, cancel <-chan struct{}) error
+	WaitInstance(ctx datastore.Context, svc *service.Service, instanceID int, checkInstance func(*zkservice.State, bool) bool, cancel <-chan struct{}) error
 	GetPublicPort(portAddress string) (string, string, error)
 	GetVHost(subdomain string) (string, string, error)
 	AddHost(_host *host.Host) error

--- a/facade/zzk.go
+++ b/facade/zzk.go
@@ -30,6 +30,7 @@ type ZZK interface {
 	RemoveServiceEndpoints(serviceID string) error
 	RemoveTenantExports(tenantID string) error
 	WaitService(svc *service.Service, state service.DesiredState, cancel <-chan interface{}) error
+	WaitInstance(ctx datastore.Context, svc *service.Service, instanceID int, state service.DesiredState, cancel <-chan struct{}) error
 	GetPublicPort(portAddress string) (string, string, error)
 	GetVHost(subdomain string) (string, string, error)
 	AddHost(_host *host.Host) error

--- a/facade/zzk.go
+++ b/facade/zzk.go
@@ -54,6 +54,7 @@ type ZZK interface {
 	GetServiceState(ctx datastore.Context, poolID, serviceID string, instanceID int) (*zkservice.State, error)
 	StopServiceInstance(poolID, serviceID string, instanceID int) error
 	StopServiceInstances(ctx datastore.Context, poolID, serviceID string) error
+	RestartInstance(ctx datastore.Context, poolID, serviceID string, instanceID int) error
 	SendDockerAction(poolID, serviceID string, instanceID int, command string, args []string) error
 	GetServiceStateIDs(poolID, serviceID string) ([]zkservice.StateRequest, error)
 	GetServiceNodes() ([]zkservice.ServiceNode, error)

--- a/zzk/service/hoststate.go
+++ b/zzk/service/hoststate.go
@@ -406,7 +406,7 @@ func (l *HostStateListener) handleContainerExit(timeExit time.Time, ssdat *Servi
 	// set the service state
 	ssdat.Terminated = timeExit
 	l.setExistingThread(stateID, ssdat, nil)
-	logger.WithField("terminated", timeExit).Warn("Container exited unexpectedly, restarting")
+	logger.WithField("terminated", timeExit).Warn("Container exited, restarting")
 
 	if err := l.updateServiceStateInZK(ssdat, req); err != nil {
 		logger.WithError(err).Error("Could not set state for stopped container")

--- a/zzk/service/service_test.go
+++ b/zzk/service/service_test.go
@@ -97,3 +97,70 @@ func (t *ZZKTest) TestWaitService(c *C) {
 		c.Fatalf("Timed out waiting for listener")
 	}
 }
+
+func (t *ZZKTest) TestWaitInstance(c *C) {
+
+	conn, err := zzk.GetLocalConnection("/")
+	c.Assert(err, IsNil)
+
+	// add 1 service
+	err = conn.CreateDir("/pools/poolid/services/serviceid")
+	c.Assert(err, IsNil)
+
+	// add 1 host
+	err = conn.CreateDir("/pools/poolid/hosts/hostid")
+	c.Assert(err, IsNil)
+
+	// add 1 instance
+	// create the state
+	req := StateRequest{
+		PoolID:     "poolid",
+		HostID:     "hostid",
+		ServiceID:  "serviceid",
+		InstanceID: 0,
+	}
+
+	err = CreateState(conn, req)
+	c.Assert(err, IsNil)
+
+	instanceID := 0
+
+	// Start our wait and check/return when the state is SVCRun and started is after terminated
+	shutdown := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		checkState := func(s *State, ok bool) bool {
+			if !ok {
+				return false
+			}
+			return s.DesiredState == service.SVCRun && s.Started.After(s.Terminated)
+		}
+
+		err := WaitInstance(shutdown, conn, "poolid", "serviceid", instanceID, checkState)
+		c.Assert(err, IsNil)
+		close(done)
+	}()
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+		c.Fatalf("Listener exited unexpectedly")
+	case <-timer.C:
+	}
+
+	// the state is "running", our wait should see that and return
+	err = UpdateState(conn, req, func(s *State) bool {
+		s.Started = time.Now()
+		return true
+	})
+	c.Assert(err, IsNil)
+
+	timer.Reset(time.Second)
+	select {
+	case <-done:
+	case <-timer.C:
+		c.Fatalf("Timed out waiting for listener")
+	}
+}


### PR DESCRIPTION
The default restart behavior is now to restart multi-instance services one instance at a time.  We wait for an instance to restart and pass healthchecks before restarting the next one, with a timeout specified by SERVICED_RUN_LEVEL_TIMEOUT.

To perform the old-style restart (stopping all instances before restarting them), the user can use the new CLI option:
`serviced service restart --rebalance SERVICE`