### PR TITLE
CC-3266 Health icon never turns red

### DIFF
--- a/web/ui/karma.conf.js
+++ b/web/ui/karma.conf.js
@@ -107,7 +107,7 @@ module.exports = function(config) {
     // For more info, see https://www.npmjs.com/package/karma-threshold-reporter
     thresholdReporter: {
       statements: 17,
-      branches: 12,
+      branches: 13,
       functions: 15,
       lines: 17
     }

--- a/web/ui/src/Health/serviceHealth.js
+++ b/web/ui/src/Health/serviceHealth.js
@@ -209,6 +209,10 @@
                     } else if(this.statusRollup.allOK()){
                         this.status = OK;
                         this.description = $translate.instant("passing_health_checks");
+                    // if all are failed, fail
+                    } else if(this.statusRollup.allFailed()){
+                        this.status = FAILED;
+                        this.description = $translate.instant("failed");
                     // if all are stopped, stopped
                     } else if(this.statusRollup.allNotRunning()){
                         this.status = NOT_RUNNING;

--- a/web/ui/test/Health/serviceHealthSpec.js
+++ b/web/ui/test/Health/serviceHealthSpec.js
@@ -102,18 +102,18 @@ describe('serviceHealth', function() {
         expect(status.status).toBe(hcStatus.OK);
     });
 
-    // shouldnt be running, health checks failing, maybe shutting down?
+    // shouldnt be running, health checks failing, fail.
     it("marks a stopped service with a failed health check as unknown", function(){
         var id = createServiceWithHealthCheck(STOPPED, hcStatus.FAILED);
         var status = serviceHealth.get(id);
-        expect(status.status).toBe(hcStatus.UNKNOWN);
+        expect(status.status).toBe(hcStatus.FAILED);
     });
 
-    // should be running, but health checks failing, unknown.
+    // should be running, but health checks failing, fail.
     it("marks a started service with a failed health check as failed", function(){
         var id = createServiceWithHealthCheck(STARTED, hcStatus.FAILED);
         var status = serviceHealth.get(id);
-        expect(status.status).toBe(hcStatus.UNKNOWN);
+        expect(status.status).toBe(hcStatus.FAILED);
     });
 
     // shouldnt be running, health checks marked not running, good!


### PR DESCRIPTION
Adjusted logic to show red-bang-circle (failed-status) when all associated health indicators show failed status.  Includes unit test adjustments.