### PR TITLE
CC-3276 Start Stop & Restart Header buttons

### DIFF
--- a/web/ui/src/ServiceActions/serviceActionsDirective.js
+++ b/web/ui/src/ServiceActions/serviceActionsDirective.js
@@ -35,10 +35,10 @@
             }
 
             update(){
-                if (this.service.isContainer()) {
-                    this.showDefaultActions();
-                } else {
+                if (this.service && !this.service.isContainer()) {
                     this.showValidActions(this.service.currentState);
+                } else {
+                    this.showDefaultActions();
                 }
             }
 

--- a/web/ui/src/Services/view-subservices.html
+++ b/web/ui/src/Services/view-subservices.html
@@ -24,15 +24,15 @@
 
                 <div style="display: inline-block; padding-left: 10px; border-left: 1px solid #CCC; height: 1em; "></div>
                 <div ng-if="currentService.desiredState !== 2" title="{{currentService.emergencyShutdown ? 'Service has been emergency shutdown': ''}}" style="display: inline-block;">
-                    <button ng-class="{disabled: shouldDisable(currentService, 'start')}" ng-click="clickRunning(currentService, 'start')" class="btn btn-link action">
+                    <button ng-click="clickRunning(currentService, 'start')" class="btn btn-link action">
                         <i class="glyphicon glyphicon-play"></i>
                         <span translate>start</span>
                     </button>
-                    <button ng-class="{disabled: shouldDisable(currentService, 'stop')}" ng-click="clickRunning(currentService, 'stop')" class="btn btn-link action">
+                    <button ng-click="clickRunning(currentService, 'stop')" class="btn btn-link action">
                         <i class="glyphicon glyphicon-stop"></i>
                         <span translate>stop</span>
                     </button>
-                    <button ng-class="{disabled: shouldDisable(currentService, 'restart')}" ng-click="clickRunning(currentService, 'restart')" class="btn btn-link action">
+                    <button ng-click="clickRunning(currentService, 'restart')" class="btn btn-link action">
                         <i class="glyphicon glyphicon-refresh"></i>
                         <span translate>action_restart</span>
                     </button>


### PR DESCRIPTION
1. Adjust logic to serviceActionDirective to handle situation when `this.service` is null
2. Remove logic to disable Start, Stop, Restart in header on service page.