### PR TITLE
CC-3279: Service status not reflective of instance when restarting

### DIFF
--- a/facade/service.go
+++ b/facade/service.go
@@ -1449,7 +1449,7 @@ func (f *Facade) rollingRestart(ctx datastore.Context, svc *service.Service, tim
 	// Build the service health object to use for getting instance health
 	svch := service.BuildServiceHealth(*svc)
 	var punctualLock sync.RWMutex
-	punctualInstances := make([]struct{}, 0)
+	punctualInstances := 0
 
 	for instanceID := 0; instanceID < svc.Instances; instanceID++ {
 		ilogger := logger.WithField("instance", instanceID)
@@ -1464,7 +1464,7 @@ func (f *Facade) rollingRestart(ctx datastore.Context, svc *service.Service, tim
 				ilogger.Warn("Timeout waiting for instance to restart")
 			case <-done:
 				punctualLock.Lock()
-				punctualInstances = append(punctualInstances, struct{}{})
+				punctualInstances++
 				punctualLock.Unlock()
 			}
 			timer.Stop()
@@ -1544,7 +1544,7 @@ func (f *Facade) rollingRestart(ctx datastore.Context, svc *service.Service, tim
 	}
 
 	punctualLock.RLock()
-	instances := len(punctualInstances)
+	instances := punctualInstances
 	punctualLock.RUnlock()
 	if instances == svc.Instances {
 		f.SetServicesCurrentState(ctx, service.SVCCSRunning, svc.ID)

--- a/facade/service.go
+++ b/facade/service.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -33,16 +34,13 @@ import (
 	"github.com/control-center/serviced/domain/addressassignment"
 	"github.com/control-center/serviced/domain/applicationendpoint"
 	"github.com/control-center/serviced/domain/host"
+	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/domain/servicedefinition"
 	"github.com/control-center/serviced/health"
 	"github.com/control-center/serviced/metrics"
 	"github.com/control-center/serviced/scheduler/servicestatemanager"
-	zkservice "github.com/control-center/serviced/zzk/service"
-
-	"github.com/control-center/serviced/domain/service"
-
 	"github.com/control-center/serviced/utils"
-	"sync"
+	zkservice "github.com/control-center/serviced/zzk/service"
 )
 
 const (
@@ -1539,6 +1537,8 @@ func (f *Facade) rollingRestart(ctx datastore.Context, svc *service.Service, tim
 		close(done)
 		<-cancelWait
 	}
+	f.SetServicesCurrentState(ctx, service.SVCCSRunning, svc.ID)
+
 	return nil
 }
 


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3279

These changes set the status of our successfully and completely restarted services earlier, so we don't wait for other services in the batch.