### PR TITLE
CC-3267 "No "pending restart" state on instances"

### DIFF
--- a/domain/service/servicestore.go
+++ b/domain/service/servicestore.go
@@ -433,11 +433,12 @@ func (s *storeImpl) addUpdatedServicesFromCache(ctx datastore.Context, svcs []Se
 // mutex lock needed.
 func (s *storeImpl) updateServiceFromVolatileService(svc *Service, cacheEntry volatileService) {
 	svc.DesiredState = cacheEntry.DesiredState
+	svc.CurrentState = cacheEntry.CurrentState
 }
 
 // updateVolatileInfo updates the local cache for volatile information
 func (s *storeImpl) updateVolatileInfo(serviceID string, desiredState int, updatedAt time.Time) error {
-	// Validate desired state
+	// Only update desired state.  Current state should only be set explicitly
 	return s.updateDesiredState(serviceID, desiredState, updatedAt)
 }
 

--- a/facade/mocks/ZZK.go
+++ b/facade/mocks/ZZK.go
@@ -553,3 +553,15 @@ func (_m *ZZK) UnregisterDfsClients(clients ...host.Host) error {
 
 	return r0
 }
+func (_m *ZZK) UpdateInstanceCurrentState(ctx datastore.Context, poolID, serviceID string, instanceID int, state service.InstanceCurrentState) error {
+	ret := _m.Called(ctx, poolID, serviceID, instanceID, state)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string, int, service.InstanceCurrentState) error); ok {
+		r0 = rf(ctx, poolID, serviceID, instanceID, state)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/facade/service.go
+++ b/facade/service.go
@@ -1449,7 +1449,11 @@ func (f *Facade) rollingRestart(ctx datastore.Context, svc *service.Service, tim
 
 	// Run through and set all instances to "Pending Restart"
 	for instanceID := 0; instanceID < svc.Instances; instanceID++ {
-		f.zzk.UpdateInstanceCurrentState(ctx, svc.PoolID, svc.ID, instanceID, service.StatePendingRestart)
+		err := f.zzk.UpdateInstanceCurrentState(ctx, svc.PoolID, svc.ID, instanceID, service.StatePendingRestart)
+		if err != nil {
+			logger.WithError(err).Debug("Failed to update instance current state to pending restart")
+			return err
+		}
 	}
 
 	// Build the service health object to use for getting instance health

--- a/facade/service.go
+++ b/facade/service.go
@@ -1447,6 +1447,11 @@ func (f *Facade) rollingRestart(ctx datastore.Context, svc *service.Service, tim
 		"servicename": svc.Name,
 	})
 
+	// Run through and set all instances to "Pending Restart"
+	for instanceID := 0; instanceID < svc.Instances; instanceID++ {
+		f.zzk.UpdateInstanceCurrentState(ctx, svc.PoolID, svc.ID, instanceID, service.StatePendingRestart)
+	}
+
 	// Build the service health object to use for getting instance health
 	svch := service.BuildServiceHealth(*svc)
 	var punctualLock sync.RWMutex

--- a/facade/testutils.go
+++ b/facade/testutils.go
@@ -114,6 +114,7 @@ func (ft *FacadeIntegrationTest) setupMockZZK(c *gocheck.C) {
 	ft.zzk.On("LockServices", ft.CTX, mock.AnythingOfType("[]service.ServiceDetails")).Return(nil)
 	ft.zzk.On("UnlockServices", ft.CTX, mock.AnythingOfType("[]service.ServiceDetails")).Return(nil)
 	ft.zzk.On("UnregisterDfsClients", mock.AnythingOfType("[]host.Host")).Return(nil)
+	ft.zzk.On("UpdateInstanceCurrentState", ft.CTX, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("service.InstanceCurrentState")).Return(nil)
 
 	ft.zzk.On("WaitService", mock.AnythingOfType("*service.Service"), mock.AnythingOfType("service.DesiredState"),
 		mock.AnythingOfType("<-chan interface {}")).Return(nil)

--- a/facade/zkapi.go
+++ b/facade/zkapi.go
@@ -792,6 +792,59 @@ func (zk *zkf) RestartInstance(ctx datastore.Context, poolID, serviceID string, 
 	return nil
 }
 
+// UpdateInstanceCurrentState sets the current state of the instance
+func (zk *zkf) UpdateInstanceCurrentState(ctx datastore.Context, poolID, serviceID string, instanceID int, state service.InstanceCurrentState) error {
+	defer ctx.Metrics().Stop(ctx.Metrics().Start(fmt.Sprintf("zzk.UpdateInstanceCurrentState")))
+	logger := plog.WithFields(log.Fields{
+		"poolid":     poolID,
+		"serviceid":  serviceID,
+		"instanceid": instanceID,
+		"state":      state,
+	})
+
+	// get the root-based connection to update the service instance
+	conn, err := getLocalConnection(ctx, "/")
+	if err != nil {
+		logger.WithError(err).Debug("Could not acquire root-based connection")
+		return err
+	}
+
+	// get the hostid and make a state request for the service
+	hostID, err := zks.GetServiceStateHostID(conn, poolID, serviceID, instanceID)
+	if err != nil {
+		return err
+	}
+	logger = logger.WithField("hostid", hostID)
+	isOnline, err := zks.IsHostOnline(conn, poolID, hostID)
+	if err != nil {
+		logger.WithError(err).Debug("Could not check if host is online")
+		return err
+	}
+
+	req := zks.StateRequest{
+		PoolID:     poolID,
+		HostID:     hostID,
+		ServiceID:  serviceID,
+		InstanceID: instanceID,
+	}
+	// manage the service
+	if isOnline {
+		if err := zks.UpdateState(conn, req, func(s *zks.State) bool {
+			s.Status = state
+			return true
+		}); err != nil {
+			logger.WithError(err).Debug("Could not update current state of service instance")
+			return err
+		}
+		logger.Debug("Set current state on service instance")
+	} else {
+		logger.Warning("Could not update current state on service instance, host is not online")
+		return ErrHostOffline
+	}
+
+	return nil
+}
+
 // SendDockerAction submits an action to the docker queue
 func (zk *zkf) SendDockerAction(poolID, serviceID string, instanceID int, command string, args []string) error {
 	logger := plog.WithFields(log.Fields{

--- a/facade/zzk.go
+++ b/facade/zzk.go
@@ -60,4 +60,5 @@ type ZZK interface {
 	GetServiceNodes() ([]zkservice.ServiceNode, error)
 	RegisterDfsClients(clients ...host.Host) error
 	UnregisterDfsClients(clients ...host.Host) error
+	UpdateInstanceCurrentState(ctx datastore.Context, poolID, serviceID string, instanceID int, state service.InstanceCurrentState) error
 }

--- a/scheduler/servicestatemanager/servicestatemanager_unit_test.go
+++ b/scheduler/servicestatemanager/servicestatemanager_unit_test.go
@@ -1931,7 +1931,7 @@ func (s *ServiceStateManagerSuite) TestServiceStateManager_StartShutdown(c *C) {
 	}
 }
 
-func (s *ServiceStateManagerSuite) TestServiceStateManager_queueLoop(c *C) {
+func (s *ServiceStateManagerSuite) TestServiceStateManager_queueLoop_WaitScheduled(c *C) {
 	// Setup a tenant
 	s.facade.On("GetTenantIDs", s.ctx).Return([]string{"tenant1"}, nil).Once()
 
@@ -1963,129 +1963,37 @@ func (s *ServiceStateManagerSuite) TestServiceStateManager_queueLoop(c *C) {
 		c.Assert(found["H"], Equals, true)
 	}).Once()
 
-	// The first batch should contain A, D, H because of startlevel
-	// Those should get waited on by a call to the facade from runLoop
-	s.facade.On("ScheduleServiceBatch", s.ctx, mock.AnythingOfType("[]*service.Service"), "tenant1", service.SVCRun).Return([]string{}, nil).Once()
-	s.facade.On("WaitSingleService", svcA, service.SVCRun, mock.AnythingOfType("<-chan interface {}")).
-		Return(nil).Run(func(mock.Arguments) { c.Logf("Waited on A") }).Twice()
-	s.facade.On("WaitSingleService", svcD, service.SVCRun, mock.AnythingOfType("<-chan interface {}")).
-		Return(nil).Run(func(mock.Arguments) { c.Logf("Waited on D") }).Twice()
-	s.facade.On("WaitSingleService", svcH, service.SVCRun, mock.AnythingOfType("<-chan interface {}")).
-		Return(nil).Run(func(mock.Arguments) { c.Logf("Waited on H") }).Twice()
+	scheduledServices := struct {
+		sync.Mutex
+		IDs map[string]bool
+	}{IDs: make(map[string]bool)}
 
-	// A, D, and H will go to "Starting" first.
-	s.facade.On("SetServicesCurrentState", s.ctx, service.SVCCSStarting, mock.AnythingOfType("[]string")).Run(func(args mock.Arguments) {
-		serviceIDs := args.Get(2).([]string)
-		c.Assert(len(serviceIDs), Equals, 3)
-		found := make(map[string]bool)
-		for _, sid := range serviceIDs {
-			found[sid] = true
+	// ScheduleServiceBatch will get called twice (2 different batches)
+	s.facade.On("ScheduleServiceBatch", s.ctx, mock.AnythingOfType("[]*service.Service"), "tenant1", service.SVCRun).Return([]string{}, nil).Run(func(args mock.Arguments) {
+		services := args.Get(1).([]*service.Service)
+		scheduledServices.Lock()
+		defer scheduledServices.Unlock()
+		firstRun := len(scheduledServices.IDs) == 0
+		for _, s := range services {
+			scheduledServices.IDs[s.ID] = true
 		}
 
-		c.Assert(found["A"], Equals, true)
-		c.Assert(found["D"], Equals, true)
-		c.Assert(found["H"], Equals, true)
-	}).Once()
-
-	// It should grab another batch off of the queue (which will just contain G at this point) and it should get processed
-	s.facade.On("ScheduleServiceBatch", s.ctx, []*service.Service{svcG}, "tenant1", service.SVCRun).Return([]string{}, nil).Once()
-	s.facade.On("WaitSingleService", svcG, service.SVCRun, mock.AnythingOfType("<-chan interface {}")).
-		Return(nil).Run(func(mock.Arguments) { c.Logf("Waited on G") }).Twice()
-
-	// G will go to "starting" when its batch comes.
-	s.facade.On("SetServicesCurrentState", s.ctx, service.SVCCSStarting, []string{"G"}).Once()
-
-	// After they are scheduled in the facade, they'll get set to Starting again
-	s.facade.On("SetServicesCurrentState", s.ctx, service.SVCCSStarting, []string{"A"}).Once()
-	s.facade.On("SetServicesCurrentState", s.ctx, service.SVCCSStarting, []string{"D"}).Once()
-	s.facade.On("SetServicesCurrentState", s.ctx, service.SVCCSStarting, []string{"G"}).Once()
-	s.facade.On("SetServicesCurrentState", s.ctx, service.SVCCSStarting, []string{"H"}).Once()
-
-	// They will eventually go to "started"
-	var wg sync.WaitGroup
-	wg.Add(4)
-	s.facade.On("SetServicesCurrentState", s.ctx, service.SVCCSRunning, []string{"A"}).Run(func(args mock.Arguments) {
-		wg.Done()
-	}).Once()
-	s.facade.On("SetServicesCurrentState", s.ctx, service.SVCCSRunning, []string{"D"}).Run(func(args mock.Arguments) {
-		wg.Done()
-	}).Once()
-	s.facade.On("SetServicesCurrentState", s.ctx, service.SVCCSRunning, []string{"G"}).Run(func(args mock.Arguments) {
-		wg.Done()
-	}).Once()
-	s.facade.On("SetServicesCurrentState", s.ctx, service.SVCCSRunning, []string{"H"}).Run(func(args mock.Arguments) {
-		wg.Done()
-	}).Once()
-
-	err := s.serviceStateManager.ScheduleServices(svcs, "tenant1", service.SVCRun, false)
-	c.Assert(err, IsNil)
-
-	// Wait on the waitgroup
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		// Wait for all services to get scheduled so we don't randomly fail assertExpectations below
-		s.serviceStateManager.WaitScheduled("tenant1", "A", "D", "G", "H")
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		c.Fatalf("Timeout waiting for services to start")
-	}
-
-	s.facade.AssertExpectations(c)
-
-	// Stop the manager
-	done = make(chan struct{})
-	go func() {
-		s.serviceStateManager.Shutdown()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		c.Fatalf("Timeout waiting for manager to shutdown")
-	}
-}
-
-func (s *ServiceStateManagerSuite) TestServiceStateManager_WaitScheduled(c *C) {
-	// Setup a tenant
-	s.facade.On("GetTenantIDs", s.ctx).Return([]string{"tenant1"}, nil).Once()
-
-	svcs := getTestServicesADGH()
-
-	svcA := svcs[0]
-	svcD := svcs[1]
-	svcG := svcs[2]
-	svcH := svcs[3]
-
-	// Start the manager
-	s.serviceStateManager.Start()
-
-	s.facade.On("GetServicesForScheduling", s.ctx, mock.AnythingOfType("[]string")).Return([]*service.Service{svcA, svcD, svcH}).Once()
-	s.facade.On("GetServicesForScheduling", s.ctx, mock.AnythingOfType("[]string")).Return([]*service.Service{svcG}).Once()
-
-	// All 4 services will get set to "Pending Start" at once
-	s.facade.On("SetServicesCurrentState", s.ctx, service.SVCCSPendingStart, mock.AnythingOfType("[]string")).Run(func(args mock.Arguments) {
-		serviceIDs := args.Get(2).([]string)
-		c.Assert(len(serviceIDs), Equals, 4)
-		found := make(map[string]bool)
-		for _, sid := range serviceIDs {
-			found[sid] = true
+		// Check that the batches are scheduled in the correct order
+		if firstRun {
+			c.Assert(len(scheduledServices.IDs), Equals, 3)
+			c.Assert(scheduledServices.IDs["A"], Equals, true)
+			c.Assert(scheduledServices.IDs["D"], Equals, true)
+			c.Assert(scheduledServices.IDs["H"], Equals, true)
+		} else {
+			c.Assert(len(scheduledServices.IDs), Equals, 4)
+			c.Assert(scheduledServices.IDs["G"], Equals, true)
 		}
 
-		c.Assert(found["A"], Equals, true)
-		c.Assert(found["D"], Equals, true)
-		c.Assert(found["G"], Equals, true)
-		c.Assert(found["H"], Equals, true)
-	}).Once()
+	}).Twice()
 
 	// The first batch should contain A, D, H because of startlevel
 	// Those should get waited on by a call to the facade from runLoop
-	s.facade.On("ScheduleServiceBatch", s.ctx, mock.AnythingOfType("[]*service.Service"), "tenant1", service.SVCRun).Return([]string{}, nil).Once()
+
 	s.facade.On("WaitSingleService", svcA, service.SVCRun, mock.AnythingOfType("<-chan interface {}")).
 		Return(nil).Run(func(mock.Arguments) {
 		time.Sleep(100 * time.Millisecond)
@@ -2116,9 +2024,7 @@ func (s *ServiceStateManagerSuite) TestServiceStateManager_WaitScheduled(c *C) {
 		c.Assert(found["H"], Equals, true)
 	}).Once()
 
-	// We'll sleep a bit to make sure those services reach desired state in zk (mocked),
-	// then it should grab another batch off of the queue (which will just contain G at this point) and it should get processed
-	s.facade.On("ScheduleServiceBatch", s.ctx, []*service.Service{svcG}, "tenant1", service.SVCRun).Return([]string{}, nil).Once()
+	// Next it should grab another batch off of the queue (which will just contain G at this point) and it should get processed
 	s.facade.On("WaitSingleService", svcG, service.SVCRun, mock.AnythingOfType("<-chan interface {}")).
 		Return(nil).Run(func(mock.Arguments) {
 		time.Sleep(100 * time.Millisecond)
@@ -2156,22 +2062,15 @@ func (s *ServiceStateManagerSuite) TestServiceStateManager_WaitScheduled(c *C) {
 	done := make(chan struct{})
 	go func() {
 		s.serviceStateManager.WaitScheduled("tenant1", "A", "D", "G", "H")
-		for _, queue := range s.serviceStateManager.TenantQueues["tenant1"] {
-			queue.RLock()
-			if len(queue.CurrentBatch.Services) != 0 {
-				queue.RUnlock()
-				c.Fatal("WaitScheduled failed to wait for current batch to be empty")
-			}
-			for _, batch := range queue.BatchQueue {
-				if len(batch.Services) != 0 {
-					queue.RUnlock()
-					c.Fatal("WaitScheduled failed to wait for current batch to be empty")
-				}
-			}
-			queue.RUnlock()
-		}
-		// There is technically a race, where the services are scheduled, but
-		// have not had SetServicesCurrentState called yet, this wg makes sure we don't hit that
+		// Make sure all services were scheduled
+		scheduledServices.Lock()
+		c.Assert(scheduledServices.IDs["A"], Equals, true)
+		c.Assert(scheduledServices.IDs["D"], Equals, true)
+		c.Assert(scheduledServices.IDs["G"], Equals, true)
+		c.Assert(scheduledServices.IDs["H"], Equals, true)
+		scheduledServices.Unlock()
+
+		// Wait for all services to get their current state set so we don't fail assertExpectations below
 		wg.Wait()
 		close(done)
 	}()


### PR DESCRIPTION
During a rolling restart, when we begin restarting a service, instances that have not yet restarted will show up as "Pending restart" in both the UI and CLI.