### PR TITLE
Feature/cc 3235

### DIFF
--- a/acceptance/mockAgent/daemon.go
+++ b/acceptance/mockAgent/daemon.go
@@ -122,7 +122,7 @@ func (d *daemon) buildHost() error {
 	var err error
 	glog.Infof("Outbound IP: %s", d.hostConfig.OutboundIP)
 
-	d.host, err = host.Build(d.hostConfig.OutboundIP, rpcPort, d.hostConfig.PoolID, fmt.Sprintf("%d", d.hostConfig.Memory))
+	d.host, err = host.Build(d.hostConfig.OutboundIP, rpcPort, d.hostConfig.PoolID, fmt.Sprintf("%d", d.hostConfig.Memory), "")
 	if err != nil {
 		return fmt.Errorf("Failed to build host: %v", err)
 	}

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -439,7 +439,7 @@ func (d *daemon) startMaster() (err error) {
 	}).Info("Determined outbound IP address")
 
 	rpcPort := strings.TrimLeft(options.Listen, ":")
-	thisHost, err := host.Build(agentIP, rpcPort, d.masterPoolID, "")
+	thisHost, err := host.Build(agentIP, rpcPort, d.masterPoolID, "", "")
 
 	if err != nil {
 		log.WithFields(logrus.Fields{
@@ -710,7 +710,7 @@ func (d *daemon) startAgent() error {
 	}).Info("Determined delegate's outbound IP address")
 
 	rpcPort := strings.TrimLeft(options.Listen, ":")
-	thisHost, err := host.Build(agentIP, rpcPort, "unknown", "", options.StaticIPs...)
+	thisHost, err := host.Build(agentIP, rpcPort, "unknown", "", options.NatIP, options.StaticIPs...)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"address": agentIP,
@@ -1018,7 +1018,7 @@ func (d *daemon) startAgent() error {
 
 	}()
 
-	agentServer := agent.NewServer(d.staticIPs)
+	agentServer := agent.NewServer(d.staticIPs, options.NatIP)
 	if err = d.rpcServer.RegisterName("Agent", agentServer); err != nil {
 		log.WithError(err).Fatal("Unable to register Agent RPC service")
 	}

--- a/cli/api/options.go
+++ b/cli/api/options.go
@@ -127,6 +127,7 @@ func GetDefaultOptions(cfg utils.ConfigReader) config.Options {
 		NFSClient:                  cfg.StringVal("NFS_CLIENT", "1"),
 		RPCPort:                    cfg.StringVal("RPC_PORT", fmt.Sprintf("%d", DefaultRPCPort)),
 		OutboundIP:                 cfg.StringVal("OUTBOUND_IP", ""),
+		NatIP:                      cfg.StringVal("NAT_IP", ""),
 		DockerDNS:                  cfg.StringSlice("DOCKER_DNS", []string{}),
 		Master:                     cfg.BoolVal("MASTER", false),
 		MuxPort:                    cfg.IntVal("MUX_PORT", 22250),

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -150,6 +150,8 @@ func New(driver api.API, config utils.ConfigReader, logControl logging.LogContro
 		cli.StringFlag{"log_backtrace_at", "", "when logging hits line file:N, emit a stack trace"},
 		cli.StringFlag{"config-file", "/etc/default/serviced", "path to config"},
 		cli.StringFlag{"allow-loop-back", defaultOps.AllowLoopBack, "allow loop-back device with devicemapper"},
+
+		cli.StringFlag{"nat-ip", defaultOps.NatIP, "this delegate's NAT IP address"},
 	}
 
 	c.initVersion()
@@ -255,6 +257,7 @@ func getRuntimeOptions(cfg utils.ConfigReader, ctx *cli.Context) config.Options 
 		VirtualAddressSubnet:       ctx.GlobalString("virtual-address-subnet"),
 		MasterPoolID:               ctx.GlobalString("master-pool-id"),
 		OutboundIP:                 ctx.GlobalString("outbound"),
+		NatIP:                      ctx.GlobalString("nat-ip"),
 		LogstashES:                 ctx.GlobalString("logstash-es"),
 		LogstashMaxDays:            ctx.GlobalInt("logstash-max-days"),
 		LogstashMaxSize:            ctx.GlobalInt("logstash-max-size"),

--- a/config/options.go
+++ b/config/options.go
@@ -44,6 +44,7 @@ type Options struct {
 	RPCPort                    string
 	Listen                     string
 	OutboundIP                 string // outbound ip to listen on
+	NatIP                      string // The delegate's NAT IP, if set.
 	Master                     bool
 	DockerDNS                  []string
 	Agent                      bool

--- a/domain/host/host.go
+++ b/domain/host/host.go
@@ -191,7 +191,7 @@ func New() *Host {
 // The poolid param is the pool the host should belong to.  Optional list of IP address strings to set as available IP
 // resources, if not set the IP used for the host will be given as an IP Resource. If any IP is not a valid IP on the
 // machine return error.
-func Build(ip string, rpcport string, poolid string, memory string, ipAddrs ...string) (*Host, error) {
+func Build(ip string, rpcport string, poolid string, memory string, natIP string, ipAddrs ...string) (*Host, error) {
 	if strings.TrimSpace(poolid) == "" {
 		return nil, errors.New("empty poolid not allowed")
 	}
@@ -209,7 +209,7 @@ func Build(ip string, rpcport string, poolid string, memory string, ipAddrs ...s
 		}).Debug("Unable to build host object")
 		return nil, err
 	}
-	hostIPs, err := getIPResources(host.ID, host.IPAddr, ipAddrs...)
+	hostIPs, err := getIPResources(host.ID, host.IPAddr, natIP, ipAddrs...)
 	if err != nil {
 		plog.WithError(err).WithFields(log.Fields{
 			"hostid": host.ID,

--- a/domain/host/hoststore_test.go
+++ b/domain/host/hoststore_test.go
@@ -52,6 +52,7 @@ func (s *S) Test_HostCRUD(t *C) {
 	defer s.hs.Delete(s.ctx, HostKey(hostID))
 
 	var host2 Host
+	natIP := "10.10.10.150"
 
 	if err := s.hs.Get(s.ctx, HostKey(hostID), &host2); !datastore.IsErrNoSuchEntity(err) {
 		t.Errorf("Expected ErrNoSuchEntity, got: %v", err)
@@ -71,7 +72,7 @@ func (s *S) Test_HostCRUD(t *C) {
 	}
 
 	//fill host with required values
-	host, err = Build("", "65535", "pool-id", "", []string{}...)
+	host, err = Build("", "65535", "pool-id", "", natIP, []string{}...)
 	host.ID = hostID
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)
@@ -110,8 +111,10 @@ func (s *S) Test_HostCRUD(t *C) {
 }
 
 func (s *S) TestDaoGetHostWithIPs(t *C) {
+	natIP := "10.10.10.150"
+
 	//Add host to test scenario where host exists but no IP resource registered
-	h, err := Build("", "65535", "pool-id", "", []string{}...)
+	h, err := Build("", "65535", "pool-id", "", natIP, []string{}...)
 	h.ID = "deadb41f"
 	h.IPs = []HostIPResource{
 		HostIPResource{h.ID, "testip", "ifname", "address1"},
@@ -139,10 +142,12 @@ func (s *S) TestDaoGetHostWithIPs(t *C) {
 }
 
 func (s *S) Test_GetHosts(t *C) {
+	natIP := "10.10.10.150"
+
 	defer s.hs.Delete(s.ctx, HostKey("Test_GetHosts1"))
 	defer s.hs.Delete(s.ctx, HostKey("Test_GetHosts2"))
 
-	host, err := Build("", "65535", "pool-id", "", []string{}...)
+	host, err := Build("", "65535", "pool-id", "", natIP, []string{}...)
 	host.ID = "deadb51f"
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)
@@ -177,12 +182,13 @@ func (s *S) Test_FindHostsInPool(t *C) {
 	id1 := "deadb61f"
 	id2 := "deadb62f"
 	id3 := "deadb63f"
+	natIP := "10.10.10.150"
 
 	defer s.hs.Delete(s.ctx, HostKey(id1))
 	defer s.hs.Delete(s.ctx, HostKey(id2))
 	defer s.hs.Delete(s.ctx, HostKey(id3))
 
-	host, err := Build("", "65535", "pool1", "", []string{}...)
+	host, err := Build("", "65535", "pool1", "", natIP, []string{}...)
 	host.ID = id1
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)
@@ -226,7 +232,9 @@ func (s *S) Test_FindHostsInPool(t *C) {
 }
 
 func (s *S) Test_GetHostByIP(t *C) {
-	host, err := Build("", "65535", "pool1", "")
+	natIP := "10.10.10.150"
+
+	host, err := Build("", "65535", "pool1", "", natIP)
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)
 	}

--- a/facade/host_test.go
+++ b/facade/host_test.go
@@ -31,10 +31,11 @@ import (
 func (s *FacadeIntegrationTest) Test_HostCRUD(t *C) {
 	testid := "deadb10f"
 	poolid := "pool-id"
+	natIP := "10.10.10.150"
 	defer s.Facade.RemoveHost(s.CTX, testid)
 
 	//fill host with required values
-	h, err := host.Build("", "65535", poolid, "", []string{}...)
+	h, err := host.Build("", "65535", poolid, "", natIP, []string{}...)
 	h.ID = testid
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)
@@ -97,6 +98,7 @@ func (s *FacadeIntegrationTest) Test_HostCRUD(t *C) {
 func (s *FacadeIntegrationTest) Test_HostGetKey(t *C) {
 	testid := "deadb10f"
 	poolid := "pool-id"
+	natIP := "10.10.10.150"
 
 	// confirm error on gethostkey for nonexistent host
 	public, err := s.Facade.GetHostKey(s.CTX, testid)
@@ -109,7 +111,7 @@ func (s *FacadeIntegrationTest) Test_HostGetKey(t *C) {
 	defer s.Facade.RemoveResourcePool(s.CTX, poolid)
 
 	// create host for test
-	h, err := host.Build("", "65535", poolid, "", []string{}...)
+	h, err := host.Build("", "65535", poolid, "", natIP, []string{}...)
 	t.Assert(err, IsNil)
 	h.ID = testid
 	private, err := s.Facade.AddHost(s.CTX, h)

--- a/facade/pool_test.go
+++ b/facade/pool_test.go
@@ -261,6 +261,7 @@ func (ft *FacadeIntegrationTest) Test_GetPoolsIPs(t *C) {
 	hostID := "deadb21f"
 	ipAddress1 := "192.168.100.10"
 	ipAddress2 := "10.50.9.1"
+	natIP := "10.10.10.150"
 
 	assignIPsHostIPResources := []host.HostIPResource{}
 	oneHostIPResource := host.HostIPResource{}
@@ -273,7 +274,7 @@ func (ft *FacadeIntegrationTest) Test_GetPoolsIPs(t *C) {
 	oneHostIPResource.InterfaceName = "eth1"
 	assignIPsHostIPResources = append(assignIPsHostIPResources, oneHostIPResource)
 
-	assignIPsHost, err := host.Build("", "65535", assignIPsPool.ID, "", []string{}...)
+	assignIPsHost, err := host.Build("", "65535", assignIPsPool.ID, "", natIP, []string{}...)
 	if err != nil {
 		t.Fatalf("could not build host for test: %v", err)
 	}
@@ -321,6 +322,7 @@ func (ft *FacadeIntegrationTest) Test_VirtualIPs(t *C) {
 
 	hostID := "deadb22f"
 	ipAddress1 := "192.168.100.10"
+	natIP := "10.10.10.150"
 
 	assignIPsHostIPResources := []host.HostIPResource{}
 	oneHostIPResource := host.HostIPResource{}
@@ -330,7 +332,7 @@ func (ft *FacadeIntegrationTest) Test_VirtualIPs(t *C) {
 	oneHostIPResource.InterfaceName = myInterfaceName
 	assignIPsHostIPResources = append(assignIPsHostIPResources, oneHostIPResource)
 
-	assignIPsHost, err := host.Build("", "65535", assignIPsPool.ID, "", []string{}...)
+	assignIPsHost, err := host.Build("", "65535", assignIPsPool.ID, "", natIP, []string{}...)
 	if err != nil {
 		t.Fatalf("could not build host for test: %v", err)
 	}
@@ -423,6 +425,7 @@ func (ft *FacadeIntegrationTest) Test_InvalidVirtualIPs(t *C) {
 
 	hostID := "deadb22f"
 	ipAddress1 := "192.168.100.10"
+	natIP := "10.10.10.150"
 
 	assignIPsHostIPResources := []host.HostIPResource{}
 	oneHostIPResource := host.HostIPResource{}
@@ -432,7 +435,7 @@ func (ft *FacadeIntegrationTest) Test_InvalidVirtualIPs(t *C) {
 	oneHostIPResource.InterfaceName = myInterfaceName
 	assignIPsHostIPResources = append(assignIPsHostIPResources, oneHostIPResource)
 
-	assignIPsHost, err := host.Build("", "65535", assignIPsPool.ID, "", []string{}...)
+	assignIPsHost, err := host.Build("", "65535", assignIPsPool.ID, "", natIP, []string{}...)
 	if err != nil {
 		t.Fatalf("could not build host for test: %v", err)
 	}
@@ -505,6 +508,7 @@ func (ft *FacadeIntegrationTest) Test_InvalidVirtualIPs(t *C) {
 func (ft *FacadeIntegrationTest) Test_PoolCapacity(t *C) {
 	hostid := "deadb23f"
 	poolid := "pool-id"
+	natIP := "10.10.10.150"
 
 	//create pool for test
 	rp := pool.New(poolid)
@@ -513,7 +517,7 @@ func (ft *FacadeIntegrationTest) Test_PoolCapacity(t *C) {
 	}
 
 	//fill host with required values
-	h, err := host.Build("", "65535", poolid, "", []string{}...)
+	h, err := host.Build("", "65535", poolid, "", natIP, []string{}...)
 	h.ID = hostid
 	if err != nil {
 		t.Fatalf("Unexpected error building host: %v", err)

--- a/rpc/agent/agent.go
+++ b/rpc/agent/agent.go
@@ -27,18 +27,20 @@ import (
 )
 
 // NewServer returns a new AgentServer
-func NewServer(staticIPs []string) *AgentServer {
+func NewServer(staticIPs []string, natIP string) *AgentServer {
 	// make our own copy of the slice of ips
 	ips := make([]string, len(staticIPs))
 	copy(ips, staticIPs)
 	return &AgentServer{
 		staticIPs: ips,
+		natIP: natIP,
 	}
 }
 
 // AgentServer The type is the API for a serviced agent. Get the host information from an agent.
 type AgentServer struct {
 	staticIPs []string
+	natIP     string
 }
 
 //BuildHostRequest request to build a new host. IP and IPResources will be validated to ensure they exist
@@ -55,7 +57,7 @@ func (a *AgentServer) BuildHost(request BuildHostRequest, hostResponse *host.Hos
 	*hostResponse = host.Host{}
 
 	glog.Infof("local static ips %v [%d]", a.staticIPs, len(a.staticIPs))
-	h, err := host.Build(request.IP, fmt.Sprintf("%d", request.Port), request.PoolID, request.Memory, a.staticIPs...)
+	h, err := host.Build(request.IP, fmt.Sprintf("%d", request.Port), request.PoolID, request.Memory, a.natIP, a.staticIPs...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3235
https://zenoss.zendesk.com/agent/tickets/124401

If the delegate is behind a NAT and sets the SERVICED_NAT_IP setting to that address, return an ip resource for the NAT IP when building the host information rather than return an Invalid IP Address error.  Appropriate ports in the NAT will need to be forwarded to the delegate and Master->NAT and Delegate->Master both need to be routable.