### PR TITLE
silently (re)try to updateHost, fix CC-3262

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -849,7 +849,7 @@ func (d *daemon) startAgent() error {
 								case <-d.shutdown:
 									return
 								default:
-									time.Sleep(5)
+									time.Sleep(5 * time.Second)
 							}
 							err = masterClient.UpdateHost(updatedHost)
 						}

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -15,7 +15,7 @@ package api
 
 import (
 	"bytes"
-
+	"errors"
 	"github.com/Sirupsen/logrus"
 	"github.com/control-center/serviced/auth"
 	commonsdocker "github.com/control-center/serviced/commons/docker"
@@ -841,10 +841,21 @@ func (d *daemon) startAgent() error {
 				}
 				err = masterClient.UpdateHost(updatedHost)
 				if err != nil {
-					log.WithError(err).Warn("Unable to update master with delegate host information")
-					return "" // Try again
+					log.WithError(err).Warn("Unable to update master with delegate host information. Retrying silently")
+					go func(masterClient *master.Client, updatedHost host.Host) {
+						err := errors.New("")
+						for err != nil {
+							select {
+								case <-d.shutdown:
+									return
+								default:
+									time.Sleep(5)
+							}
+							err = masterClient.UpdateHost(updatedHost)
+						}
+						log.Info("Updated master with delegate host information")
+					}(masterClient, updatedHost)
 				}
-				log.Info("Updated master with delegate host information")
 				return poolID
 			}()
 			if poolID != "" {


### PR DESCRIPTION
Fixes regression in CC-3262 by not blocking delegate when it fails to update the Master, say for instance if things are locked down during a backup on the Master. It does no kicking off a goroutine that keeps trying to updateHost until no errors are returned.