### PR TITLE
tighten permissions on some directories post install

### DIFF
--- a/pkg/deb/postinstall
+++ b/pkg/deb/postinstall
@@ -1,6 +1,8 @@
 
 mkdir -p /var/log/serviced
-chmod 1777 /var/log/serviced
+chgrp serviced /var/log/serviced
+chmod 1770 /var/log/serviced
 
 chgrp serviced /etc/default/serviced
 chgrp -R serviced /opt/serviced
+chmod 750 /opt/serviced

--- a/pkg/rpm/postinstall
+++ b/pkg/rpm/postinstall
@@ -5,7 +5,12 @@ if [ $1 -eq 1 ] ; then
 fi
 
 mkdir -p /var/log/serviced
-chmod 1777 /var/log/serviced
+chgrp serviced /var/log/serviced
+chmod 1770 /var/log/serviced
+
+chgrp serviced /etc/default/serviced
+chgrp -R serviced /opt/serviced
+chmod 750 /opt/serviced
 
 LIBDEVMAPPER="$(ldconfig -p | grep libdevmapper.so.1.02 | awk {'print $4'})"
 if [ -z "${LIBDEVMAPPER}" ]; then
@@ -15,6 +20,3 @@ if ! (python -c "import sys; sys.exit(0 if \"${LIBDEVMAPPER}\".endswith('.1') el
     [ -f "${LIBDEVMAPPER}.1" -o -h "${LIBDEVMAPPER}.1" ] || ln -sf ${LIBDEVMAPPER} ${LIBDEVMAPPER}.1
     ldconfig
 fi
-
-chgrp serviced /etc/default/serviced
-chgrp -R serviced /opt/serviced


### PR DESCRIPTION
The goal is to prevent users who are not in the new `serviced` group from looking at serviced files or executing serviced binaries.