### PR TITLE
Revert changes for CC-3067

### DIFF
--- a/makefile
+++ b/makefile
@@ -161,12 +161,11 @@ serviced: $(GO)
 serviced: FORCE
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS}
 	make govet
-	@chmod 750 $@
 	if [ -n "$(GOBIN)" ]; then mkdir -p $(GOBIN); cp serviced $(GOBIN)/serviced; fi
 
 serviced-controller: $(GO)
 serviced-controller: FORCE
-	cd serviced-controller && $(GO) build $(GOBUILD_FLAGS) ${LDFLAGS} && chmod 750 $@
+	cd serviced-controller && $(GO) build $(GOBUILD_FLAGS) ${LDFLAGS}
 	if [ -n "$(GOBIN)" ]; then mkdir -p $(GOBIN); cp serviced-controller/serviced-controller $(GOBIN)/serviced-controller; fi
 
 
@@ -174,7 +173,7 @@ tools: serviced-storage
 
 serviced-storage: $(GO)
 serviced-storage: FORCE
-	cd tools/serviced-storage && $(GO) build $(GOBUILD_FLAGS) ${LDFLAGS} && chmod 750 $@
+	cd tools/serviced-storage && $(GO) build $(GOBUILD_FLAGS) ${LDFLAGS}
 	if [ -n "$(GOBIN)" ]; then mkdir -p $(GOBIN); cp tools/serviced-storage/serviced-storage $(GOBIN)/serviced-storage; fi
 
 #
@@ -410,9 +409,7 @@ $(install_DIRS): FORCE
 				exit 1 ;\
 			fi ;\
 		done ;\
-	done ;\
-	chmod 750 $(_DESTDIR)${prefix} ;\
-	chmod 640 pkg/serviced.default
+	done
 
 .PHONY: install
 install: $(install_TARGETS)

--- a/pkg/deb/postinstall
+++ b/pkg/deb/postinstall
@@ -2,5 +2,3 @@
 mkdir -p /var/log/serviced
 chmod 1777 /var/log/serviced
 
-chgrp serviced /etc/default/serviced
-chgrp -R serviced /opt/serviced

--- a/pkg/deb/preinstall
+++ b/pkg/deb/preinstall
@@ -1,2 +1,0 @@
-getent group serviced >/dev/null 2>&1 || groupadd serviced
-usermod -aG serviced root

--- a/pkg/makefile
+++ b/pkg/makefile
@@ -181,7 +181,6 @@ deb: stage_deb
 		--vendor $(VENDOR) \
 		--url $(URL) \
 		--category $(CATEGORY) \
-		--before-install deb/preinstall \
 		--after-install deb/postinstall \
 		--config-files /etc/default/serviced \
 		.
@@ -217,7 +216,6 @@ rpm: stage_rpm
 		--vendor $(VENDOR) \
 		--url $(URL) \
 		--category $(CATEGORY) \
-		--before-install rpm/preinstall \
 		--after-install rpm/postinstall \
 		--before-remove rpm/preuninstall \
 		--after-remove rpm/postuninstall \

--- a/pkg/rpm/postinstall
+++ b/pkg/rpm/postinstall
@@ -15,6 +15,3 @@ if ! (python -c "import sys; sys.exit(0 if \"${LIBDEVMAPPER}\".endswith('.1') el
     [ -f "${LIBDEVMAPPER}.1" -o -h "${LIBDEVMAPPER}.1" ] || ln -sf ${LIBDEVMAPPER} ${LIBDEVMAPPER}.1
     ldconfig
 fi
-
-chgrp serviced /etc/default/serviced
-chgrp -R serviced /opt/serviced

--- a/pkg/rpm/preinstall
+++ b/pkg/rpm/preinstall
@@ -1,2 +1,0 @@
-getent group serviced >/dev/null 2>&1 || groupadd serviced
-usermod -aG serviced root


### PR DESCRIPTION
Due to the lateness of the hour and other problems associated with changing permissions, we decided to revert CC-3067 for the CC 1.2.3 release and wait until every thing has been resolved on the develop branch before back porting any changes for CC-3067