### PR TITLE
CC-3275 Service state manager detects "cancel" scenarios and handles them appropriately

### DIFF
--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -160,6 +160,20 @@ func DesiredToCurrentFinalState(state DesiredState, emergency bool) ServiceCurre
 	}
 }
 
+// Determines whether the desiredState acts as a "cancel" to a pending state.
+func DesiredCancelsPending(pendingState ServiceCurrentState, desiredState DesiredState) bool {
+	switch pendingState {
+	case SVCCSPendingStart:
+		return desiredState == SVCStop
+	case SVCCSPendingRestart:
+		return desiredState == SVCRun
+	case SVCCSPendingStop, SVCCSPendingPause:
+		return desiredState == SVCRun
+	}
+
+	return false
+}
+
 // Service A Service that can run in serviced.
 type Service struct {
 	ID                string

--- a/facade/service.go
+++ b/facade/service.go
@@ -1488,6 +1488,8 @@ func (f *Facade) rollingRestart(ctx datastore.Context, svc *service.Service, tim
 		}
 	}
 
+	// Keep track of which instances haven't been restarted yet, so we can revert the current state if we exit
+	// prematurely
 	nextInstance := 0
 	defer func() {
 		for instance := nextInstance; instance < svc.Instances; instance++ {
@@ -1548,6 +1550,7 @@ func (f *Facade) rollingRestart(ctx datastore.Context, svc *service.Service, tim
 			return err
 		}
 
+		// Increment nextInstance now, since we have started the restart process for this instance
 		nextInstance++
 
 		// Wait for the instance's containerID to change

--- a/facade/service.go
+++ b/facade/service.go
@@ -1544,7 +1544,7 @@ func (f *Facade) rollingRestart(ctx datastore.Context, svc *service.Service, tim
 
 		if err = f.zzk.RestartInstance(ctx, svc.PoolID, svc.ID, instanceID); err != nil {
 			close(done)
-			logger.WithError(err).Error("Failed to restart instance")
+			logger.WithError(err).Debug("Failed to restart instance")
 			return err
 		}
 

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -2709,7 +2709,7 @@ func (ft *FacadeIntegrationTest) TestFacade_rollingRestart_Pass(c *C) {
 
 	done := make(chan struct{})
 	go func() {
-		err := ft.Facade.rollingRestart(ft.CTX, &svc, 30*time.Second)
+		err := ft.Facade.rollingRestart(ft.CTX, &svc, 30*time.Second, make(chan interface{}))
 		c.Assert(err, IsNil)
 		close(done)
 	}()
@@ -2825,7 +2825,7 @@ func (ft *FacadeIntegrationTest) TestFacade_rollingRestart_TimeoutWait(c *C) {
 
 	done := make(chan struct{})
 	go func() {
-		err := ft.Facade.rollingRestart(ft.CTX, &svc, timeout)
+		err := ft.Facade.rollingRestart(ft.CTX, &svc, timeout, make(chan interface{}))
 		c.Assert(err, IsNil)
 		close(done)
 	}()
@@ -2915,7 +2915,7 @@ func (ft *FacadeIntegrationTest) TestFacade_rollingRestart_TimeoutHealthcheck(c 
 
 	done := make(chan struct{})
 	go func() {
-		err := ft.Facade.rollingRestart(ft.CTX, &svc, timeout)
+		err := ft.Facade.rollingRestart(ft.CTX, &svc, timeout, make(chan interface{}))
 		c.Assert(err, IsNil)
 		close(done)
 	}()
@@ -2980,7 +2980,7 @@ func (ft *FacadeIntegrationTest) TestFacade_rollingRestart_FailWait(c *C) {
 	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, mock.AnythingOfType("func(*service.State, bool) bool"), mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
 	ft.zzk.On("WaitInstance", ft.CTX, &svc, 1, mock.AnythingOfType("func(*service.State, bool) bool"), mock.AnythingOfType("<-chan struct {}")).Return(testerr).Once()
 
-	err := ft.Facade.rollingRestart(ft.CTX, &svc, 30*time.Second)
+	err := ft.Facade.rollingRestart(ft.CTX, &svc, 30*time.Second, make(chan interface{}))
 	// Make sure our rollingRestart bailed after it failed for one instance
 	c.Assert(err, Equals, testerr)
 }
@@ -3014,7 +3014,7 @@ func (ft *FacadeIntegrationTest) TestFacade_rollingRestart_FailRestartInstance(c
 
 	// Make sure we call WaitInstance once for each insance of svc that gets called
 	ft.zzk.On("WaitInstance", ft.CTX, &svc, 0, mock.AnythingOfType("func(*service.State, bool) bool"), mock.AnythingOfType("<-chan struct {}")).Return(nil).Once()
-	err := ft.Facade.rollingRestart(ft.CTX, &svc, 30*time.Second)
+	err := ft.Facade.rollingRestart(ft.CTX, &svc, 30*time.Second, make(chan interface{}))
 	// Make sure our rollingRestart bailed after it failed for one instance
 	c.Assert(err, Equals, testerr)
 }
@@ -3041,7 +3041,7 @@ func (ft *FacadeIntegrationTest) TestFacade_rollingRestart_FailGetState(c *C) {
 	testerr := errors.New("test error")
 	ft.zzk.On("GetServiceState", ft.CTX, svc.PoolID, svc.ID, 0).Return(nil, testerr).Once()
 
-	err := ft.Facade.rollingRestart(ft.CTX, &svc, 30*time.Second)
+	err := ft.Facade.rollingRestart(ft.CTX, &svc, 30*time.Second, make(chan interface{}))
 	// Make sure our rollingRestart bailed after it failed for one instance
 	c.Assert(err, Equals, testerr)
 }

--- a/scheduler/servicestatemanager/facade.go
+++ b/scheduler/servicestatemanager/facade.go
@@ -23,7 +23,7 @@ type Facade interface {
 	// WaitSingleService blocks until the service has reached the desired state, or the channel is closed
 	WaitSingleService(*service.Service, service.DesiredState, <-chan interface{}) error
 	// ScheduleServiceBatch changes the desired state of a set of services, and returns a list of IDs of services that could not be scheduled
-	ScheduleServiceBatch(datastore.Context, []*service.Service, string, service.DesiredState) ([]string, error)
+	ScheduleServiceBatch(datastore.Context, []CancellableService, string, service.DesiredState) ([]string, error)
 	// UpdateService modifies a service
 	UpdateService(ctx datastore.Context, svc service.Service) error
 	// GetTenantIDs gets a list of all tenant IDs

--- a/scheduler/servicestatemanager/mocks/Facade.go
+++ b/scheduler/servicestatemanager/mocks/Facade.go
@@ -34,18 +34,18 @@ func (_m *Facade) GetTenantIDs(ctx datastore.Context) ([]string, error) {
 }
 
 // ScheduleServiceBatch provides a mock function with given fields: _a0, _a1, _a2, _a3
-func (_m *Facade) ScheduleServiceBatch(_a0 datastore.Context, _a1 []*service.Service, _a2 string, _a3 service.DesiredState) ([]string, error) {
+func (_m *Facade) ScheduleServiceBatch(_a0 datastore.Context, _a1 []servicestatemanager.CancellableService, _a2 string, _a3 service.DesiredState) ([]string, error) {
 	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	var r0 []string
-	if rf, ok := ret.Get(0).(func(datastore.Context, []*service.Service, string, service.DesiredState) []string); ok {
+	if rf, ok := ret.Get(0).(func(datastore.Context, []servicestatemanager.CancellableService, string, service.DesiredState) []string); ok {
 		r0 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r0 = ret.Get(0).([]string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(datastore.Context, []*service.Service, string, service.DesiredState) error); ok {
+	if rf, ok := ret.Get(1).(func(datastore.Context, []servicestatemanager.CancellableService, string, service.DesiredState) error); ok {
 		r1 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r1 = ret.Error(1)


### PR DESCRIPTION
Relaxed locking around the current state updates to allow more immediate updating of current state when a pending state is cancelled.

Use the channel in CancellableService to cancel "-ing" states as best we can, especially for "restarting".