### PR TITLE
CC-3285: Use mimmax instead of sum for storage aggregator

### DIFF
--- a/facade/dfs.go
+++ b/facade/dfs.go
@@ -750,7 +750,7 @@ func (f *Facade) PredictStorageAvailability(ctx datastore.Context, lookahead tim
 
 	// Next, query metrics for our window
 	window := time.Duration(options.StorageMetricMonitorWindow) * time.Second
-	perfdata, err := f.metricsClient.GetAvailableStorage(window, tenantIDs...)
+	perfdata, err := f.metricsClient.GetAvailableStorage(window, "mimmax", tenantIDs...)
 	if err != nil {
 		return nil, err
 	}

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -34,7 +34,7 @@ import (
 
 type MetricsClient interface {
 	GetInstanceMemoryStats(time.Time, ...metrics.ServiceInstance) ([]metrics.MemoryUsageStats, error)
-	GetAvailableStorage(time.Duration, ...string) (*metrics.StorageMetrics, error)
+	GetAvailableStorage(time.Duration, string, ...string) (*metrics.StorageMetrics, error)
 }
 
 // instantiate the package logger

--- a/facade/mocks/MetricsClient.go
+++ b/facade/mocks/MetricsClient.go
@@ -9,13 +9,13 @@ type MetricsClient struct {
 	mock.Mock
 }
 
-// GetAvailableStorage provides a mock function with given fields: _a0, _a1
-func (_m *MetricsClient) GetAvailableStorage(_a0 time.Duration, _a1 ...string) (*metrics.StorageMetrics, error) {
-	ret := _m.Called(_a0, _a1)
+// GetAvailableStorage provides a mock function with given fields: _a0, _a1, _a2
+func (_m *MetricsClient) GetAvailableStorage(_a0 time.Duration, _a1 string, _a2 ...string) (*metrics.StorageMetrics, error) {
+	ret := _m.Called(_a0, _a1, _a2)
 
 	var r0 *metrics.StorageMetrics
-	if rf, ok := ret.Get(0).(func(time.Duration, ...string) *metrics.StorageMetrics); ok {
-		r0 = rf(_a0, _a1...)
+	if rf, ok := ret.Get(0).(func(time.Duration, string, ...string) *metrics.StorageMetrics); ok {
+		r0 = rf(_a0, _a1, _a2...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*metrics.StorageMetrics)
@@ -23,8 +23,8 @@ func (_m *MetricsClient) GetAvailableStorage(_a0 time.Duration, _a1 ...string) (
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(time.Duration, ...string) error); ok {
-		r1 = rf(_a0, _a1...)
+	if rf, ok := ret.Get(1).(func(time.Duration, string, ...string) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -30,7 +30,7 @@ var (
 
 const (
 	IMAGE_REPO    = "zenoss/serviced-isvcs"
-	IMAGE_TAG     = "v54"
+	IMAGE_TAG     = "v55"
 	ZK_IMAGE_REPO = "zenoss/isvcs-zookeeper"
 	ZK_IMAGE_TAG  = "v8"
 )

--- a/metrics/storage.go
+++ b/metrics/storage.go
@@ -54,7 +54,7 @@ type StorageMetrics struct {
 	Tenants               map[string]MetricSeries
 }
 
-func (c *Client) GetAvailableStorage(window time.Duration, tenants ...string) (*StorageMetrics, error) {
+func (c *Client) GetAvailableStorage(window time.Duration, aggregator string, tenants ...string) (*StorageMetrics, error) {
 	log.WithField("tenants", tenants).Debug("Requesting storage availability metrics")
 
 	options := PerformanceOptions{
@@ -66,19 +66,19 @@ func (c *Client) GetAvailableStorage(window time.Duration, tenants ...string) (*
 		{
 			Metric:     "storage.pool.data.available",
 			Name:       PoolDataAvailableName,
-			Aggregator: "sum",
+			Aggregator: aggregator,
 		},
 		{
 			Metric:     "storage.pool.metadata.available",
 			Name:       PoolMetadataAvailableName,
-			Aggregator: "sum",
+			Aggregator: aggregator,
 		},
 	}
 	for _, tenantID := range tenants {
 		metrics = append(metrics, MetricOptions{
 			Metric:     fmt.Sprintf("storage.filesystem.available.%s", tenantID),
 			Name:       tenantID,
-			Aggregator: "sum",
+			Aggregator: aggregator,
 		})
 	}
 	options.Metrics = metrics


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3285

It is possible for a fail-over to occur in HA but still have some metrics being pushed, which was causing an emergency shutdown when using the sum aggregator.
(note; the commit comment incorrectly states min)

This required updating to latest isvcs, as it has the latest central query, which added the aggregator for mimmax.