### PR TITLE
CC-3308: "Starting an application shows "pending start" for a subset of services that are already started"

### DIFF
--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -174,6 +174,26 @@ func DesiredCancelsPending(pendingState ServiceCurrentState, desiredState Desire
 	return false
 }
 
+// Determines whether setting the desired state would be unnecessary
+func DesiredStateIsRedundant(desiredState DesiredState, emergency bool, currentState ServiceCurrentState) bool {
+	switch desiredState {
+	case SVCRun:
+		return currentState == SVCCSRunning || currentState == SVCCSStarting || currentState == SVCCSPendingStart
+	case SVCRestart:
+		return currentState == SVCCSRestarting || currentState == SVCCSPendingRestart
+	case SVCStop:
+		if emergency {
+			return currentState == SVCCSEmergencyStopped || currentState == SVCCSEmergencyStopping || currentState == SVCCSPendingEmergencyStop
+		} else {
+			return currentState == SVCCSStopped || currentState == SVCCSStopping || currentState == SVCCSPendingStop
+		}
+	case SVCPause:
+		return currentState == SVCCSPaused || currentState == SVCCSPausing || currentState == SVCCSPendingPause
+	}
+
+	return false
+}
+
 // Service A Service that can run in serviced.
 type Service struct {
 	ID                string

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -2356,7 +2356,7 @@ func (ft *FacadeIntegrationTest) TestFacade_SnapshotAlwaysPauses(c *C) {
 		ImageID:        "test/pinger",
 		PoolID:         "default",
 		DeploymentID:   "deployment_id",
-		DesiredState:   int(service.SVCRun),
+		DesiredState:   int(service.SVCStop),
 		Launch:         "auto",
 		Endpoints:      []service.ServiceEndpoint{},
 		CreatedAt:      time.Now(),
@@ -2435,7 +2435,8 @@ func (ft *FacadeIntegrationTest) TestFacade_SnapshotAlwaysPauses(c *C) {
 	c.Assert(err, IsNil)
 
 	// Make sure services returned to their original state
-	ft.Facade.WaitService(ft.CTX, service.SVCRun, 5*time.Second, false, "ParentServiceID")
+	err = ft.Facade.WaitService(ft.CTX, service.SVCRun, 5*time.Second, false, "ParentServiceID")
+	c.Assert(err, IsNil)
 	services, err := ft.Facade.GetServices(ft.CTX, dao.ServiceRequest{})
 	c.Assert(err, IsNil)
 	for _, s := range services {

--- a/scheduler/servicestatemanager/servicestatemanager.go
+++ b/scheduler/servicestatemanager/servicestatemanager.go
@@ -711,7 +711,7 @@ func (s *ServiceStateQueue) reconcileWithPendingBatch(newBatch ServiceStateChang
 		"newdesiredstate":      newBatch.DesiredState,
 		"newemergency":         newBatch.Emergency,
 		"newservices":          len(reconciledBatch.Services),
-	}).Info("finished reconcile with pending batch")
+	}).Debug("finished reconcile with pending batch")
 
 	return reconciledBatch
 }


### PR DESCRIPTION
Service state manager now ignores and re-syncs the state of services if the desired state has already been reached.