### PR TITLE
CC-3317 Manual launch only applies to stopped services

### DIFF
--- a/facade/service.go
+++ b/facade/service.go
@@ -1301,7 +1301,7 @@ func (f *Facade) scheduleServiceParents(ctx datastore.Context, tenantID string, 
 		if _, ok := alreadyChecked[svc.ID]; !ok {
 			alreadyChecked[svc.ID] = struct{}{}
 			_, explicit := isRequested[svc.ID]
-			if svc.Launch == commons.MANUAL && !emergency && !explicit {
+			if svc.Launch == commons.MANUAL && !emergency && !explicit && svc.CurrentState == string(service.SVCCSStopped) {
 				return nil
 			}
 			// Are we skipping this pool?


### PR DESCRIPTION
Services that are set to "manual" launch but are currently running will still be stopped/restarted if their parent service is stopped/restarted.