### PR TITLE
CC-3327: The Query visualization library shouldn't depend on Zenoss

### DIFF
--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -30,7 +30,7 @@ var (
 
 const (
 	IMAGE_REPO    = "zenoss/serviced-isvcs"
-	IMAGE_TAG     = "v55"
+	IMAGE_TAG     = "v56"
 	ZK_IMAGE_REPO = "zenoss/isvcs-zookeeper"
 	ZK_IMAGE_TAG  = "v8"
 )


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3327

New release of isvcs image contains fix CC-3327.