### PR TITLE
Restrict non-serviced users by setting perms on /opt/serviced

### DIFF
--- a/makefile
+++ b/makefile
@@ -158,15 +158,12 @@ $(GOBIN):
 
 $(GOBIN)/serviced: $(GOSOURCEFILES) | $(GOBIN)
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS} -o $@ .
-	@chmod 750 $@
 
 $(GOBIN)/serviced-controller: $(GOSOURCEFILES) | $(GOBIN)
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS} -o $@ ./serviced-controller
-	@chmod 750 $@
 
 $(GOBIN)/serviced-storage: $(GOSOURCEFILES) | $(GOBIN)
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS} -o $@ ./tools/serviced-storage
-	@chmod 750 $@
 
 .PHONY: serviced
 serviced: $(GOBIN)/serviced
@@ -413,9 +410,7 @@ $(install_DIRS): FORCE
 				exit 1 ;\
 			fi ;\
 		done ;\
-	done ;\
-	chmod 750 $(_DESTDIR)${prefix} ;\
-	chmod 640 pkg/serviced.default
+	done ;
 
 .PHONY: install
 install: $(install_TARGETS)

--- a/pkg/deb/postinstall
+++ b/pkg/deb/postinstall
@@ -1,8 +1,10 @@
 
 mkdir -p /var/log/serviced
 chgrp serviced /var/log/serviced
-chmod 1770 /var/log/serviced
+chmod 770 /var/log/serviced
 
 chgrp serviced /etc/default/serviced
-chgrp -R serviced /opt/serviced
+chmod 640 /etc/default/serviced
+
+chgrp serviced /opt/serviced
 chmod 750 /opt/serviced

--- a/pkg/rpm/postinstall
+++ b/pkg/rpm/postinstall
@@ -8,8 +8,15 @@ mkdir -p /var/log/serviced
 chgrp serviced /var/log/serviced
 chmod 1770 /var/log/serviced
 
+#
+# NOTE: changing ownership/permissions here has the side-effect of causing
+#       "rpm -V serviced" to complain, but we could not get fpm to assign
+#       the ownership/permissions at build time.
+#
 chgrp serviced /etc/default/serviced
-chgrp -R serviced /opt/serviced
+chmod 640 /etc/default/serviced
+
+chgrp serviced /opt/serviced
 chmod 750 /opt/serviced
 
 LIBDEVMAPPER="$(ldconfig -p | grep libdevmapper.so.1.02 | awk {'print $4'})"


### PR DESCRIPTION
If the parent directory is restricted to 750 root:serviced, then no regular user who is NOT in the serviced group can access the serviced files.  This change also minimizes the complaints from `rpm -V serviced` that result from changing permissions/ownership during the post install phase.

The related problem this fix addresses is situations like ZEN-26903 which was caused by the 750 perms on the serviced executable. When the /opt/serviced/bin directory is mounted into the container, the zenoss user in the container was unable to execute commands like `/serviced/serviced version` because of the permissions issues