### PR TITLE
Add separate tolerances before and after the token valid duration (#3…

### DIFF
--- a/auth/header.go
+++ b/auth/header.go
@@ -289,7 +289,7 @@ func readAuthHeaderV1(r io.Reader) (sender Identity, tstamp time.Time, payload [
 		return
 	}
 	tstamp = time.Unix(int64(ts), 0).UTC()
-	cutoff := jwt.TimeFunc().UTC().Add(-ExpirationDelta)
+	cutoff := jwt.TimeFunc().UTC().Add(-ClockDriftDelta)
 	if tstamp.Before(cutoff) {
 		err = eatBytesAndGetPayloadError(teed, remaining, ErrHeaderExpired)
 		return

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -111,7 +111,8 @@ func (id *jwtIdentity) Valid() error {
 	}
 
 	now := jwt.TimeFunc().UTC().Unix()
-	if now < id.IssuedAt {
+	// provide tolerance for clockdrifting slower
+	if now < (id.IssuedAt - int64(ClockDriftDelta.Seconds())) {
 		return ErrIdentityTokenNotValidYet
 	}
 
@@ -120,7 +121,7 @@ func (id *jwtIdentity) Valid() error {
 
 func (id *jwtIdentity) Expired() bool {
 	now := jwt.TimeFunc().UTC().Unix()
-	return now >= id.ExpiresAt
+	return now >= (id.ExpiresAt + int64(ClockDriftDelta.Seconds()))
 }
 
 func (id *jwtIdentity) HostID() string {

--- a/rpc/master/hosts_server.go
+++ b/rpc/master/hosts_server.go
@@ -118,10 +118,10 @@ func (req HostAuthenticationRequest) valid(publicKeyPEM []byte) error {
 	}
 	logger := plog.WithField("hostid", req.HostID)
 	timeDiff := time.Now().UTC().Unix() - req.Timestamp
-	if timeDiff > int64(auth.ExpirationDelta/time.Second) {
+	if timeDiff > int64(auth.ClockDriftDelta/time.Second) {
 		logger.WithField("clockdriftsec", timeDiff).Error("Delegate time behind master, re-sync clocks")
 		return ErrRequestExpired
-	} else if -1*timeDiff > int64(auth.ExpirationDelta/time.Second) {
+	} else if -1*timeDiff > int64(auth.ClockDriftDelta/time.Second) {
 		logger.WithField("clockdriftsec", timeDiff).Error("Delegate time ahead of master, re-sync clocks")
 		return ErrRequestFromFuture
 	}

--- a/rpc/rpcutils/client_test.go
+++ b/rpc/rpcutils/client_test.go
@@ -293,7 +293,7 @@ func (s *MySuite) TestExpiredToken(c *C) {
 	c.Assert(err, IsNil)
 
 	// Make RPC call after token has expired
-	fakenow := time.Now().UTC().Add(1 * time.Second)
+	fakenow := time.Now().UTC().Add(auth.ClockDriftDelta).Add(1 * time.Second)
 	auth.At(fakenow, func() {
 		// Attempt RPC call with expired token
 		client, err := newClient("localhost:32111", 1, DiscardClientTimeout, connectRPC)


### PR DESCRIPTION
Back porting the ClockDriftDelta change to support/1.3.x