### PR TITLE
Update host IPs for CC-3182

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -839,6 +839,10 @@ func (d *daemon) startAgent() error {
 					log.WithError(err).Warn("Unable to acquire delegate host information")
 					return "" // Try again
 				}
+
+				// Update the IPs for the host in case something has changed (like the interface name)
+				updatedHost.IPs = thisHost.IPs
+
 				err = masterClient.UpdateHost(updatedHost)
 				if err != nil {
 					log.WithError(err).Warn("Unable to update master with delegate host information. Retrying silently")


### PR DESCRIPTION
At start up, when the host information is retrieved update the IPs of the host to pick up any changes like the interface name.