### PR TITLE
Update IPs for host for CC-3346

### DIFF
--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -828,6 +828,10 @@ func (d *daemon) startAgent() error {
 					log.WithError(err).Warn("Unable to acquire delegate host information")
 					return "" // Try again
 				}
+
+				// Update the IPs for the host in case something has changed (like the interface name)
+				updatedHost.IPs = thisHost.IPs
+
 				err = masterClient.UpdateHost(updatedHost)
 				if err != nil {
 					log.WithError(err).Warn("Unable to update master with delegate host information. Retrying silently")

--- a/test_lib.sh
+++ b/test_lib.sh
@@ -24,7 +24,8 @@ fi
 
 export START_TIMEOUT=300
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
-IP=$(ip addr show docker0 | grep -w inet | awk {'print $2'} | cut -d/ -f1)
+DEFAULT_INTERFACE=$(ip route | awk '/default/ { print $5 }')
+IP=$(ip -f inet -o addr show $DEFAULT_INTERFACE | awk '{print $4}' | cut -d / -f 1)
 HOSTNAME=$(hostname)
 
 export SERVICED_ETC_PATH=${TEST_VAR_PATH}/etc


### PR DESCRIPTION
At start up, when the host information is retrieved update the IPs of the host to pick up any changes like the interface name.