### PR TITLE
Revert "Restrict non-serviced users by setting perms on /opt/serviced"

### DIFF
--- a/makefile
+++ b/makefile
@@ -158,12 +158,15 @@ $(GOBIN):
 
 $(GOBIN)/serviced: $(GOSOURCEFILES) | $(GOBIN)
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS} -o $@ .
+	@chmod 750 $@
 
 $(GOBIN)/serviced-controller: $(GOSOURCEFILES) | $(GOBIN)
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS} -o $@ ./serviced-controller
+	@chmod 750 $@
 
 $(GOBIN)/serviced-storage: $(GOSOURCEFILES) | $(GOBIN)
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS} -o $@ ./tools/serviced-storage
+	@chmod 750 $@
 
 .PHONY: serviced
 serviced: $(GOBIN)/serviced
@@ -410,7 +413,9 @@ $(install_DIRS): FORCE
 				exit 1 ;\
 			fi ;\
 		done ;\
-	done ;
+	done ;\
+	chmod 750 $(_DESTDIR)${prefix} ;\
+	chmod 640 pkg/serviced.default
 
 .PHONY: install
 install: $(install_TARGETS)

--- a/pkg/deb/postinstall
+++ b/pkg/deb/postinstall
@@ -1,10 +1,8 @@
 
 mkdir -p /var/log/serviced
 chgrp serviced /var/log/serviced
-chmod 770 /var/log/serviced
+chmod 1770 /var/log/serviced
 
 chgrp serviced /etc/default/serviced
-chmod 640 /etc/default/serviced
-
-chgrp serviced /opt/serviced
+chgrp -R serviced /opt/serviced
 chmod 750 /opt/serviced

--- a/pkg/rpm/postinstall
+++ b/pkg/rpm/postinstall
@@ -8,15 +8,8 @@ mkdir -p /var/log/serviced
 chgrp serviced /var/log/serviced
 chmod 1770 /var/log/serviced
 
-#
-# NOTE: changing ownership/permissions here has the side-effect of causing
-#       "rpm -V serviced" to complain, but we could not get fpm to assign
-#       the ownership/permissions at build time.
-#
 chgrp serviced /etc/default/serviced
-chmod 640 /etc/default/serviced
-
-chgrp serviced /opt/serviced
+chgrp -R serviced /opt/serviced
 chmod 750 /opt/serviced
 
 LIBDEVMAPPER="$(ldconfig -p | grep libdevmapper.so.1.02 | awk {'print $4'})"


### PR DESCRIPTION
This reverts commit 21dcef5949713117d5aa7a92ce77982d17b2d50b, which was inadvertently picked up with PR #3433.