### PR TITLE
Revert "Revert "Restrict non-serviced users by setting perms on /opt/serviced"

### DIFF
--- a/makefile
+++ b/makefile
@@ -158,15 +158,12 @@ $(GOBIN):
 
 $(GOBIN)/serviced: $(GOSOURCEFILES) | $(GOBIN)
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS} -o $@ .
-	@chmod 750 $@
 
 $(GOBIN)/serviced-controller: $(GOSOURCEFILES) | $(GOBIN)
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS} -o $@ ./serviced-controller
-	@chmod 750 $@
 
 $(GOBIN)/serviced-storage: $(GOSOURCEFILES) | $(GOBIN)
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS} -o $@ ./tools/serviced-storage
-	@chmod 750 $@
 
 .PHONY: serviced
 serviced: $(GOBIN)/serviced
@@ -413,9 +410,7 @@ $(install_DIRS): FORCE
 				exit 1 ;\
 			fi ;\
 		done ;\
-	done ;\
-	chmod 750 $(_DESTDIR)${prefix} ;\
-	chmod 640 pkg/serviced.default
+	done ;
 
 .PHONY: install
 install: $(install_TARGETS)

--- a/pkg/deb/postinstall
+++ b/pkg/deb/postinstall
@@ -1,8 +1,10 @@
 
 mkdir -p /var/log/serviced
 chgrp serviced /var/log/serviced
-chmod 1770 /var/log/serviced
+chmod 770 /var/log/serviced
 
 chgrp serviced /etc/default/serviced
-chgrp -R serviced /opt/serviced
+chmod 640 /etc/default/serviced
+
+chgrp serviced /opt/serviced
 chmod 750 /opt/serviced

--- a/pkg/rpm/postinstall
+++ b/pkg/rpm/postinstall
@@ -8,8 +8,15 @@ mkdir -p /var/log/serviced
 chgrp serviced /var/log/serviced
 chmod 1770 /var/log/serviced
 
+#
+# NOTE: changing ownership/permissions here has the side-effect of causing
+#       "rpm -V serviced" to complain, but we could not get fpm to assign
+#       the ownership/permissions at build time.
+#
 chgrp serviced /etc/default/serviced
-chgrp -R serviced /opt/serviced
+chmod 640 /etc/default/serviced
+
+chgrp serviced /opt/serviced
 chmod 750 /opt/serviced
 
 LIBDEVMAPPER="$(ldconfig -p | grep libdevmapper.so.1.02 | awk {'print $4'})"


### PR DESCRIPTION
This reverts commit a93d05bcc340d7023914786dd8d1c819e08c14ba.

History: See CC-2421 for details. 

After I checked in the original fix, a problem was found. Since I was out of office that day, the fix was reverted. 

When I returned, we discussed the fix, and I reinstated the fix with some agreed-upon changes. That reinstatement was done by reverting the original revert. However, I was unaware that the support branch had been created between my original changes and the reversion, so I applied the reversion to develop. In the process of doing that, two extra commits were picked up. One of those commits was [21dcef59](https://github.com/control-center/serviced/commit/21dcef5949713117d5aa7a92ce77982d17b2d50b). 

Glen was out of office at that time, so I was unable to confirm his intentions. Because the commit was not intended to be part of the reversion, I reverted that commit from develop (see commit [a93d05b](https://github.com/control-center/serviced/commit/a93d05bcc340d7023914786dd8d1c819e08c14ba), merged [here](https://github.com/control-center/serviced/commit/7a8334ddcae7a23d47efd238d30cab2aa6cc86c7)).

Now that Glen has returned, he has indicated that he wanted the changes from [21dcef59](https://github.com/control-center/serviced/commit/21dcef5949713117d5aa7a92ce77982d17b2d50b) in develop. 

This merge reverts [a93d05b](https://github.com/control-center/serviced/commit/a93d05bcc340d7023914786dd8d1c819e08c14ba), which should restore the affected files to their intended state.