### PR TITLE
remove printf statements, fix a typo

### DIFF
--- a/dao/elasticsearch/filesystem.go
+++ b/dao/elasticsearch/filesystem.go
@@ -168,7 +168,7 @@ func (dao *ControlPlaneDao) GetBackupEstimate(backupRequest model.BackupRequest,
 	log.WithFields(logrus.Fields{
 		"elapsed":  time.Since(start),
 		"estimate": backupEstimate,
-	}).Info("Backp estimate done")
+	}).Info("Backup estimate done")
 
 	return nil
 }

--- a/volume/utils.go
+++ b/volume/utils.go
@@ -139,14 +139,12 @@ func FilesystemBytesSize(path string) uint64 {
 func FilesystemBytesAvailable(path string) uint64 {
 	s := syscall.Statfs_t{}
 	syscall.Statfs(path, &s)
-	fmt.Printf("syscall.Statfs_t result: %#v\n", s)
 	return uint64(s.Bavail) * uint64(s.Bsize)
 }
 
 func FilesystemBytesUsed(path string) uint64 {
 	s := syscall.Statfs_t{}
 	syscall.Statfs(path, &s)
-	fmt.Printf("syscall.Statfs_t result: %#v\n", s)
 	return (uint64(s.Blocks) - uint64(s.Bavail)) * uint64(s.Bsize)
 }
 


### PR DESCRIPTION
Remove printf statements left in when implementing CC-2421.
Also, fix a typo in a log message.