### PR TITLE
Fixes CC-3440 "Race condition in Smoke and API Acceptance tests"

### DIFF
--- a/api_acceptance.sh
+++ b/api_acceptance.sh
@@ -31,11 +31,7 @@ add_to_etc_hosts
 start_serviced             && succeed "Serviced started within timeout"    || fail "serviced failed to start within $START_TIMEOUT seconds."
 
 # add the local host as a CC host so there will be available IP assignments.
-${SERVICED} host add --register "${HOSTNAME}:4979" "default" --memory "100%" -k /dev/null
-if [ $? -ne 0 ]; then
-    echo "Failed to add CC host for api acceptance test, exiting";
-    exit 1;
-fi
+retry 20 add_host          && succeed "Added host successfully"                  || fail "Unable to add host"
 
 # build/start mock agents
 cd ${DIR}

--- a/smoke.sh
+++ b/smoke.sh
@@ -11,14 +11,6 @@
 TEST_VAR_PATH=/tmp/serviced-smoke/var
 . test_lib.sh
 
-# Add a host
-add_host() {
-    HOST_ID=$(sudo ${SERVICED} host add "${IP}:4979" default --register | tail -n 1)
-    sleep 1
-    [ -z "$(${SERVICED} host list ${HOST_ID} 2>/dev/null)" ] && return 1
-    return 0
-}
-
 add_template() {
     TEMPLATE_ID=$(${SERVICED} template compile ${DIR}/dao/testsvc | ${SERVICED} template add)
     sleep 1
@@ -280,7 +272,7 @@ echo "SERVICED=${SERVICED}"
 retry 20 add_host          && succeed "Added host successfully"                  || fail "Unable to add host"
 add_template               && succeed "Added template successfully"              || fail "Unable to add template"
 deploy_service             && succeed "Deployed service successfully"            || fail "Unable to deploy service"
-test_service_run           && succeed "Service run ran successfully"             || fail "Unable to run service run"
+retry 20 test_service_run  && succeed "Service run ran successfully"             || fail "Unable to run service run"
 start_service              && succeed "Started service"                          || fail "Unable to start service"
 retry 10 test_started      && succeed "Service containers started"               || fail "Unable to see service containers"
 

--- a/test_lib.sh
+++ b/test_lib.sh
@@ -116,6 +116,14 @@ start_serviced() {
     return $?
 }
 
+# Add a host
+add_host() {
+    HOST_ID=$(sudo ${SERVICED} host add "${IP}:4979" default --register | tail -n 1)
+    sleep 1
+    [ -z "$(${SERVICED} host list ${HOST_ID} 2>/dev/null)" ] && return 1
+    return 0
+}
+
 retry() {
     TIMEOUT=$1
     shift


### PR DESCRIPTION
API Acceptance test will now retry a failed "host add" and smoke tests will retry a failed "service run" to allow time for the Agent and ControlCenterAgent RPC services to get registered.