### PR TITLE
Move serviced.access.log to a different directory

### DIFF
--- a/pkg/deb/postinstall
+++ b/pkg/deb/postinstall
@@ -1,7 +1,7 @@
 
 mkdir -p /var/log/serviced
 chgrp serviced /var/log/serviced
-chmod 770 /var/log/serviced
+chmod 750 /var/log/serviced
 
 chgrp serviced /etc/default/serviced
 chmod 640 /etc/default/serviced

--- a/pkg/makefile
+++ b/pkg/makefile
@@ -224,10 +224,14 @@ rpm: stage_rpm
 		--before-upgrade rpm/preupgrade \
 		--before-install rpm/preinstall \
 		--after-install rpm/postinstall \
+		--after-upgrade rpm/postupgrade \
 		--before-remove rpm/preuninstall \
 		--after-remove rpm/postuninstall \
 		--rpm-pretrans rpm/pretrans \
 		--config-files /etc/default/serviced \
+		--config-files /opt/serviced/etc/logconfig-cli.yaml \
+		--config-files /opt/serviced/etc/logconfig-server.yaml \
+		--config-files /opt/serviced/etc/logrotate.conf \
 		.
 
 # Make a TGZ

--- a/pkg/rpm/postinstall
+++ b/pkg/rpm/postinstall
@@ -6,7 +6,7 @@ fi
 
 mkdir -p /var/log/serviced
 chgrp serviced /var/log/serviced
-chmod 1770 /var/log/serviced
+chmod 1750 /var/log/serviced
 
 #
 # NOTE: changing ownership/permissions here has the side-effect of causing

--- a/pkg/rpm/postupgrade
+++ b/pkg/rpm/postupgrade
@@ -1,0 +1,45 @@
+mkdir -p /var/log/serviced
+chgrp root /var/log/serviced
+chmod 1750 /var/log/serviced
+
+#
+# CC-3482: preserve the existing access log
+#
+if [ -f /var/log/serviced.access.log ]; then
+    echo "Moving /var/log/serviced.access.log to /var/log/serviced/serviced.access.log"
+    mv /var/log/serviced.access.log /var/log/serviced
+fi
+
+#
+# CC-3482: If the current logrotate configuration file uses the old location, then
+#      replace it with the new configuration file. Otherwise, the log files might grow
+#      without bounds, potentially bringing down the system.
+#
+grep /var/log/serviced.access.log /opt/serviced/etc/logrotate.conf 2>/dev/null >/dev/null
+if [ $? -eq 0 ]; then
+    echo "Saving /opt/serviced/etc/logrotate.conf as /opt/serviced/etc/logrotate.conf.bak"
+    mv /opt/serviced/etc/logrotate.conf /opt/serviced/etc/logrotate.conf.bak
+
+    echo "Replacing /opt/serviced/etc/logrotate.conf with /opt/serviced/etc/logrotate.conf.rpmnew"
+    cp /opt/serviced/etc/logrotate.conf.rpmnew /opt/serviced/etc/logrotate.conf
+
+    echo " "
+    echo "WARNING: The location of serviced.access.log has moved to /var/log/serviced."
+    echo "         /opt/serviced/etc/logrotate.conf has been updated to reflect the new location."
+    echo "         Your original settings were saved in /opt/serviced/etc/logrotate.conf.bak"
+    echo "         Review both files to see if any settings from /opt/serviced/etc/logrotate.conf.bak"
+    echo "         need to be applied to /opt/serviced/etc/logrotate.conf"
+    echo "         See the Control Center Release Notes for more information."
+fi
+
+#
+# NOTE: changing ownership/permissions here has the side-effect of causing
+#       "rpm -V serviced" to complain, but we could not get fpm to assign
+#       the ownership/permissions at build time.
+#
+chgrp serviced /etc/default/serviced
+chmod 640 /etc/default/serviced
+
+chgrp serviced /opt/serviced
+chmod 750 /opt/serviced
+

--- a/pkg/serviced.logrotate
+++ b/pkg/serviced.logrotate
@@ -1,5 +1,5 @@
 compress
-/var/log/serviced.access.log {
+/var/log/serviced/serviced.access.log {
 	su root root
 	rotate 5
 	weekly


### PR DESCRIPTION
Fixes CC-3482

In addition to moving the file to a different directory, this PR includes a few other changes:
* Make the `/var/log/serviced` directory at runtime to handle scenarios involving zendev (i.e. CC not installed via rpm/yum).
* Change the packaging so that logrotate.conf and the new logging config files are not overwritten on upgrades
* Tighten the permissions on `/var/log/serviced` to group=root and read-only access for root. This consistent with other default files/directories in `/var/log`
* Add postupgrade script to the packaging so that we can insure the proper permissions on files; also warns if we replace a modified logrotate.conf
