### PR TITLE
Make sure /var/log/serviced is in the root group

### DIFF
--- a/pkg/deb/postinstall
+++ b/pkg/deb/postinstall
@@ -1,6 +1,6 @@
 
 mkdir -p /var/log/serviced
-chgrp serviced /var/log/serviced
+chgrp root /var/log/serviced
 chmod 750 /var/log/serviced
 
 chgrp serviced /etc/default/serviced

--- a/pkg/rpm/postinstall
+++ b/pkg/rpm/postinstall
@@ -5,7 +5,7 @@ if [ $1 -eq 1 ] ; then
 fi
 
 mkdir -p /var/log/serviced
-chgrp serviced /var/log/serviced
+chgrp root /var/log/serviced
 chmod 1750 /var/log/serviced
 
 #


### PR DESCRIPTION
Fixes CC_3508

To be consistent with best-practice conventions and other directories/files in `/var/log` 