### PR TITLE
Replace glog with logrus in coordinator

### DIFF
--- a/coordinator/client/client.go
+++ b/coordinator/client/client.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/control-center/serviced/coordinator/client/retry"
-	"github.com/zenoss/glog"
+	"github.com/control-center/serviced/logging"
 )
 
 // EventType is a numerical type to identify event types.
@@ -83,6 +83,10 @@ var (
 	ErrNothing                 = errors.New("coord-client: no server responsees to process")
 	ErrSessionMoved            = errors.New("coord-client: session moved to another server, so operation is ignored")
 	ErrNoServer                = errors.New("coord-client: could not connect to a server")
+)
+
+var (
+	plog = logging.PackageLogger()
 )
 
 // Dir is an empty path node
@@ -278,7 +282,7 @@ func (client *Client) loop() {
 				func() {
 					defer func() {
 						if r := recover(); r != nil {
-							glog.Errorf("recovered from: %s", r)
+							plog.Errorf("recovered from: %v", r)
 						}
 					}()
 					(*connections[id]).Close()

--- a/coordinator/client/mocks/Connection.go
+++ b/coordinator/client/mocks/Connection.go
@@ -1,9 +1,8 @@
 package mocks
 
-import "github.com/control-center/serviced/coordinator/client"
 import (
+	"github.com/control-center/serviced/coordinator/client"
 	"github.com/stretchr/testify/mock"
-	"github.com/zenoss/glog"
 )
 
 type Connection struct {
@@ -11,15 +10,12 @@ type Connection struct {
 }
 
 func (_m *Connection) Close() {
-	glog.Infof("Close() START")
 	_m.Called()
 }
 func (_m *Connection) SetID(_a0 int) {
-	glog.Infof("SetID(%d) START", _a0)
 	_m.Called(_a0)
 }
 func (_m *Connection) ID() int {
-	glog.Infof("ID() START")
 	ret := _m.Called()
 
 	var r0 int
@@ -35,7 +31,6 @@ func (_m *Connection) SetOnClose(_a0 func(int)) {
 	_m.Called(_a0)
 }
 func (_m *Connection) NewTransaction() client.Transaction {
-	glog.Infof("NewTransaction() START")
 	ret := _m.Called()
 
 	var r0 client.Transaction
@@ -48,7 +43,6 @@ func (_m *Connection) NewTransaction() client.Transaction {
 	return r0
 }
 func (_m *Connection) Create(path string, node client.Node) error {
-	glog.Infof("Create(%s,%v) START", path, node)
 	ret := _m.Called(path, node)
 
 	var r0 error
@@ -61,7 +55,6 @@ func (_m *Connection) Create(path string, node client.Node) error {
 	return r0
 }
 func (_m *Connection) CreateDir(path string) error {
-	glog.Infof("CreateDir(%s) START", path)
 	ret := _m.Called(path)
 
 	var r0 error
@@ -74,7 +67,6 @@ func (_m *Connection) CreateDir(path string) error {
 	return r0
 }
 func (_m *Connection) CreateEphemeral(path string, node client.Node) (string, error) {
-	glog.Infof("CreateEphemeral(%s,%v) START", path, node)
 	ret := _m.Called(path, node)
 
 	var r0 string
@@ -94,7 +86,6 @@ func (_m *Connection) CreateEphemeral(path string, node client.Node) (string, er
 	return r0, r1
 }
 func (_m *Connection) EnsurePath(path string) error {
-	glog.Infof("EnsurePath(%s) START", path)
 	ret := _m.Called(path)
 
 	var r0 error
@@ -107,7 +98,6 @@ func (_m *Connection) EnsurePath(path string) error {
 	return r0
 }
 func (_m *Connection) Exists(path string) (bool, error) {
-	glog.Infof("Exists(%s) START", path)
 	ret := _m.Called(path)
 
 	var r0 bool
@@ -127,7 +117,6 @@ func (_m *Connection) Exists(path string) (bool, error) {
 	return r0, r1
 }
 func (_m *Connection) Delete(path string) error {
-	glog.Infof("Delete(%s) START", path)
 	ret := _m.Called(path)
 
 	var r0 error
@@ -140,7 +129,6 @@ func (_m *Connection) Delete(path string) error {
 	return r0
 }
 func (_m *Connection) ChildrenW(path string, done <-chan struct{}) (children []string, event <-chan client.Event, err error) {
-	glog.Infof("Childrenw(%s,%v) START", path, done)
 	ret := _m.Called(path, done)
 
 	var r0 []string
@@ -173,7 +161,6 @@ func (_m *Connection) ChildrenW(path string, done <-chan struct{}) (children []s
 }
 
 func (_m *Connection) Children(p string) (children []string, err error) {
-	glog.Infof("Children(%s) START", p)
 	ret := _m.Called(p)
 
 	//var r0 []string
@@ -195,7 +182,6 @@ func (_m *Connection) Children(p string) (children []string, err error) {
 	return children, err
 }
 func (_m *Connection) Get(path string, node client.Node) error {
-	glog.Infof("Get(%s,%v) START", path, node)
 	ret := _m.Called(path, node)
 
 	var r0 error
@@ -208,7 +194,6 @@ func (_m *Connection) Get(path string, node client.Node) error {
 	return r0
 }
 func (_m *Connection) Set(path string, node client.Node) error {
-	glog.Infof("Set(%s,%v) START", path, node)
 	ret := _m.Called(path, node)
 
 	var r0 error
@@ -221,7 +206,6 @@ func (_m *Connection) Set(path string, node client.Node) error {
 	return r0
 }
 func (_m *Connection) NewLock(path string) client.Lock {
-	glog.Infof("NewLock(%s) START", path)
 	ret := _m.Called(path)
 
 	var r0 client.Lock
@@ -234,7 +218,6 @@ func (_m *Connection) NewLock(path string) client.Lock {
 	return r0
 }
 func (_m *Connection) NewLeader(path string, data client.Node) client.Leader {
-	glog.Infof("NewLeader(%s,%v) START", path, data)
 	ret := _m.Called(path, data)
 
 	var r0 client.Leader
@@ -248,7 +231,6 @@ func (_m *Connection) NewLeader(path string, data client.Node) client.Leader {
 }
 
 func (_m *Connection) GetW(path string, node client.Node, done <-chan struct{}) (<-chan client.Event, error) {
-	glog.Infof("GetW(%s,%v,%v) START", path, node, done)
 	ret := _m.Called(path, node, done)
 
 	var r0 <-chan client.Event

--- a/coordinator/client/zookeeper/connection_test.go
+++ b/coordinator/client/zookeeper/connection_test.go
@@ -24,7 +24,6 @@ import (
 
 	coordclient "github.com/control-center/serviced/coordinator/client"
 	zzktest "github.com/control-center/serviced/zzk/test"
-	"github.com/zenoss/glog"
 )
 
 type testNodeT struct {
@@ -33,7 +32,7 @@ type testNodeT struct {
 }
 
 func (n *testNodeT) SetVersion(version interface{}) {
-	glog.Infof("seting version to: %v", version)
+	fmt.Printf("setting version to: %v", version)
 	n.version = version
 }
 func (n *testNodeT) Version() interface{} { return n.version }

--- a/coordinator/client/zookeeper/driver.go
+++ b/coordinator/client/zookeeper/driver.go
@@ -19,7 +19,11 @@ import (
 
 	zklib "github.com/control-center/go-zookeeper/zk"
 	"github.com/control-center/serviced/coordinator/client"
-	"github.com/zenoss/glog"
+	"github.com/control-center/serviced/logging"
+)
+
+var (
+	plog = logging.PackageLogger() // the standard package logger
 )
 
 // Driver implements a Zookeeper based client.Driver interface
@@ -87,19 +91,17 @@ func (driver *Driver) GetConnection(dsn, basePath string) (client.Connection, er
 		case e := <-event:
 			if e.State == zklib.StateHasSession {
 				connected = true
-				glog.V(1).Infof("zk connection has session %v", e)
+				plog.WithField("session", e).Debug("zk connection has session")
 			} else {
-				glog.V(1).Infof("waiting for zk connection to have session %v", e)
+				plog.WithField("session", e).Debug("waiting for zk connection to have session")
 			}
 		}
 	}
 	go func() {
 		for {
 			select {
-			case e, ok := <-event:
-				glog.V(1).Infof("zk event %s", e)
+			case _, ok := <-event:
 				if !ok {
-					glog.V(1).Infoln("zk eventchannel closed")
 					return
 				}
 			}

--- a/coordinator/client/zookeeper/logger.go
+++ b/coordinator/client/zookeeper/logger.go
@@ -13,10 +13,7 @@
 package zookeeper
 
 import (
-	"fmt"
-
 	zklib "github.com/control-center/go-zookeeper/zk"
-	"github.com/zenoss/glog"
 )
 
 type zkLogger struct {}
@@ -30,5 +27,5 @@ func RegisterZKLogger() {
 }
 
 func (logger zkLogger) Printf(format string, args ...interface{}) {
-	glog.V(1).Infof("zklib: %s", fmt.Sprintf(format, args))
+	plog.Debugf("zklib: " + format, args...)
 }

--- a/coordinator/storage/client_test.go
+++ b/coordinator/storage/client_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/control-center/serviced/domain/host"
 	"github.com/control-center/serviced/zzk"
 	"github.com/control-center/serviced/zzk/test"
-	"github.com/zenoss/glog"
 
 	"encoding/json"
 	"fmt"
@@ -78,7 +77,7 @@ func TestClient(t *testing.T) {
 
 	// therefore, we need to check that the client was added under the pool from root
 	nodePath := fmt.Sprintf("/storage/clients/%s", h.IPAddr)
-	glog.Infof("about to check for %s", nodePath)
+	t.Logf("about to check for %s", nodePath)
 	if exists, err := conn.Exists(nodePath); err != nil {
 		t.Fatalf("did not expect error checking for existence of %s: %s", nodePath, err)
 	} else {

--- a/coordinator/storage/server_test.go
+++ b/coordinator/storage/server_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/control-center/serviced/utils"
 	"github.com/control-center/serviced/zzk"
 	"github.com/control-center/serviced/zzk/test"
-	"github.com/zenoss/glog"
 
 	"encoding/json"
 	"fmt"
@@ -99,7 +98,7 @@ func TestServer(t *testing.T) {
 
 	var local, remote string
 	nfsMount = func(driver nfs.Driver, a, b string) error {
-		glog.Infof("client is mounting %s to %s", a, b)
+		t.Logf("client is mounting %s to %s", a, b)
 		remote = a
 		local = b
 		return nil
@@ -179,7 +178,7 @@ func TestServer(t *testing.T) {
 		t.Fatalf("remote should be %s, not %s", remote, shareName)
 	}
 
-	glog.Info("about to call c1.Close()")
+	t.Logf("about to call c1.Close()")
 	c1.Close()
 }
 


### PR DESCRIPTION
Fixes CC-3057

This also includes changes to integrate log messages from the go-zookeeper library as debug-level messages; see `coordinator/client/zookeeper/logger.go`