### PR TITLE
Add configurable logging to serviced-controller

### DIFF
--- a/cli/api/api.go
+++ b/cli/api/api.go
@@ -128,6 +128,7 @@ func configureLoggingForLogstash(logstashURL string) {
 	if err != nil {
 		hostname = "unknown"
 	}
+	// TODO: CC-3061: Our use of logrus does not support a similar integration with logstash
 	glog.SetLogstashType("serviced-" + hostname)
 	glog.SetLogstashURL(logstashURL)
 }

--- a/node/container.go
+++ b/node/container.go
@@ -658,6 +658,7 @@ func (a *HostAgent) createContainerConfig(tenantID string, svc *service.Service,
 	}
 
 	// Bind mount the keys we need
+	// Note that /etc/serviced also contains logconfig-controller.yaml
 	addBindingToMap(bindsMap, "/etc/serviced", filepath.Dir(a.delegateKeyFile))
 
 	// specify temporary volume paths for docker to create

--- a/pkg/logconfig-controller.yaml
+++ b/pkg/logconfig-controller.yaml
@@ -1,0 +1,2 @@
+- logger: '*'
+  level: info

--- a/serviced-controller/proxy.go
+++ b/serviced-controller/proxy.go
@@ -15,16 +15,19 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"os"
 	"strconv"
 
 	"github.com/codegangsta/cli"
 	"github.com/control-center/serviced/container"
+	coordzk "github.com/control-center/serviced/coordinator/client/zookeeper"
 	"github.com/control-center/serviced/logging"
 	"github.com/control-center/serviced/rpc/rpcutils"
 	"github.com/control-center/serviced/utils"
 	"github.com/zenoss/glog"
 	log "github.com/Sirupsen/logrus"
+	"github.com/zenoss/logri"
 )
 
 var plog = logging.PackageLogger()
@@ -81,6 +84,10 @@ func CmdServiceProxy(ctx *cli.Context) {
 }
 
 func StartProxy(options ControllerOptions) error {
+	logri.ApplyConfigFromFile(filepath.Join("/etc/serviced", "logconfig-controller.yaml"))
+	coordzk.RegisterZKLogger()
+
+	// TODO: CC-3061: Our use of logrus does not support a similar integration with logstash
 	glog.SetLogstashType("controller-" + options.ServiceID + "-" + options.InstanceID)
 	glog.SetLogstashURL(options.LogstashURL)
 


### PR DESCRIPTION
Fixes CC-3518

Allows logrus-based log messages to be seen in docker logs for containers running serviced-controller.