### PR TITLE
Move url rewrites to only vhosts (not all cc ui)

### DIFF
--- a/web/cpserver.go
+++ b/web/cpserver.go
@@ -106,29 +106,6 @@ func NewServiceConfig(bindPort string, agentPort string, stats bool, hostaliases
 	return &cfg
 }
 
-type epHandler struct {
-	handler func(w http.ResponseWriter, r *http.Request)
-}
-
-func (h epHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// If RawPath is given, Golang's url object has canonized the original URL.  We
-	// want to route the original url instead, so remake it with Opaque to allow
-	// any special characters that got translated. see: CC-3510
-	if len(r.URL.RawPath) > 0 {
-		plog.WithFields(logrus.Fields{
-			"r.URL.Path":    r.URL.Path,
-			"r.URL.RawPath": r.URL.RawPath,
-		}).Debug("handler: rewriting url")
-		r.URL = &url.URL{
-			RawPath: r.URL.RawPath,
-			Opaque:  r.URL.RawPath,
-			Scheme:  r.URL.Scheme,
-			Host:    r.URL.Host,
-		}
-	}
-	h.handler(w, r)
-}
-
 // Serve handles control center web UI requests and virtual host requests for zenoss web based services.
 // The UI server actually listens on port 7878, the uihandler defined here just reverse proxies to it.
 // Virtual host routing to zenoss web based services is done by the publicendpointhandler function.
@@ -233,7 +210,7 @@ func (sc *ServiceConfig) Serve(shutdown <-chan (interface{})) {
 			PreferServerCipherSuites: true,
 			CipherSuites:             utils.CipherSuites("http"),
 		}
-		server := &http.Server{Addr: sc.bindPort, TLSConfig: config, Handler: epHandler{httphandler}}
+		server := &http.Server{Addr: sc.bindPort, TLSConfig: config, Handler: http.HandlerFunc(httphandler)}
 		logger.WithField("ciphersuite", utils.CipherSuitesByName(config)).Info("Creating HTTP server")
 		err := server.ListenAndServeTLS(certFile, keyFile)
 		if err != nil {

--- a/web/vhost.go
+++ b/web/vhost.go
@@ -148,6 +148,8 @@ func (h *VHostHandler) Handle(useTLS bool, w http.ResponseWriter, r *http.Reques
 		return true
 	}
 
+	RouteOriginalURL(r)
+
 	logger := plog.WithFields(log.Fields{
 		"application": export.Application,
 		"hostip":      export.HostIP,
@@ -166,7 +168,7 @@ func (h *VHostHandler) Handle(useTLS bool, w http.ResponseWriter, r *http.Reques
 		r.Header.Set("X-Forwarded-Proto", "https")
 	}
 
-	w.Header().Add("Strict-Transport-Security","max-age=31536000")
+	w.Header().Add("Strict-Transport-Security", "max-age=31536000")
 	rp.ServeHTTP(w, r)
 
 	return true


### PR DESCRIPTION
The previous fix for rabbit's admin console broke Logstash.

For an unknown reason, setting this property caused the Logstash requests to change from, ie:
    "url": "/elasticsearch/kibana-int/_mapping/*/field/_source?_=1492467383132",
.. to..
    "url": "/api/controlplane/kibana/elasticsearch/kibana-int/_mapping/*/field/_source?_=1492467383132",
Resulting in a 404 from Logstash (note the prefixed /api/controlplane/kibana" in the broken request).

This change only applies the Opaque property to Vhost and Port public-endpoints, but not to other CC urls.
---------------------------------------------------------------
With this change: 
---------------------------------------------------------------
![image](https://cloud.githubusercontent.com/assets/15878956/25150535/ecbb3744-2447-11e7-8adb-24a35f9ecf4c.png)
---------------------------------------------------------------
![image](https://cloud.githubusercontent.com/assets/15878956/25150565/08718fa6-2448-11e7-889c-f59b3f3e4add.png)
---------------------------------------------------------------
![image](https://cloud.githubusercontent.com/assets/15878956/25150605/22cb747a-2448-11e7-89ce-2775b5add136.png)
---------------------------------------------------------------
![image](https://cloud.githubusercontent.com/assets/15878956/25150627/358aaf7c-2448-11e7-9458-f9768b65b34f.png)
