### PR TITLE
Prevent duplicate filter entries in logstash.conf

### DIFF
--- a/container/logstash.go
+++ b/container/logstash.go
@@ -92,7 +92,8 @@ output:
         - %s
     timeout: 15
 logging:
-  level: warning`
+  level: warning
+`
 
 	filebeatShipperConf = fmt.Sprintf(filebeatShipperConf,
 		filebeatLogConf,

--- a/facade/logstash.go
+++ b/facade/logstash.go
@@ -60,7 +60,7 @@ func (f *Facade) ReloadLogstashConfig(ctx datastore.Context) error {
 	} else if err != nil {
 		glog.Errorf("Could not write logstash configuration: %s", err)
 		return err
-	} 
+	}
 
 	glog.V(2).Infof("Starting logstash container")
 	if err := isvcs.Mgr.Notify("restart logstash"); err != nil {
@@ -94,8 +94,6 @@ func resourcesDir() string {
 //
 // This method returns nil of logstash configuration was replaced,
 // ErrLogstashUnchanged if the configuration is unchanged, or other errors if there was an I/O problem
-// FIXME: eventually this file should live in the DFS or the config should
-// live in zookeeper to allow the agents to get to this
 func writeLogstashConfiguration(templates map[string]servicetemplate.ServiceTemplate) error {
 	// the definitions are a map of filter name to content
 	// they are found by recursively going through all the service definitions
@@ -110,8 +108,9 @@ func writeLogstashConfiguration(templates map[string]servicetemplate.ServiceTemp
 	// filters will be a syntactically correct logstash filters section
 	filters := ""
 
+	typeFilter := []string{}
 	for _, template := range templates {
-		filters += getFilters(template.Services, filterDefs, []string{})
+		filters += getFilters(template.Services, filterDefs, &typeFilter)
 	}
 	newConfigFile := resourcesDir() + "/logstash/logstash.conf.new"
 	err := writeLogStashConfigFile(filters, newConfigFile)
@@ -162,15 +161,16 @@ func getFilterDefinitions(services []servicedefinition.ServiceDefinition) map[st
 	return filterDefs
 }
 
-func getFilters(services []servicedefinition.ServiceDefinition, filterDefs map[string]string, typeFilter []string) string {
+func getFilters(services []servicedefinition.ServiceDefinition, filterDefs map[string]string, typeFilter *[]string) string {
 	filters := ""
 	for _, service := range services {
 		for _, config := range service.LogConfigs {
 			for _, filtName := range config.Filters {
 				//do not write duplicate types, logstash doesn't handle this
-				if !utils.StringInSlice(config.Type, typeFilter) {
-					filters += fmt.Sprintf("\nif [type] == \"%s\" \n {\n  %s \n}", config.Type, filterDefs[filtName])
-					typeFilter = append(typeFilter, config.Type)
+				if !utils.StringInSlice(config.Type, *typeFilter) {
+					filters += fmt.Sprintf("\n  if [type] == \"%s\" {\n    %s\n  }\n",
+						config.Type, indent(filterDefs[filtName], "    "))
+					*typeFilter = append(*typeFilter, config.Type)
 				}
 			}
 		}
@@ -211,4 +211,13 @@ filter {
 	// generate the filters section
 	// write the log file
 	return ioutil.WriteFile(outputPath, newBytes, 0644)
+}
+
+func indent(src, tab string) string {
+	result := ""
+	lines := strings.Split(src, "\n")
+	for _, line := range lines {
+		result += tab + line + "\n"
+	}
+	return result
 }

--- a/facade/logstash_test.go
+++ b/facade/logstash_test.go
@@ -42,9 +42,6 @@ func getTestingService() servicedefinition.ServiceDefinition {
 				Name:    "s1",
 				Command: "/usr/bin/python -m SimpleHTTPServer",
 				ImageID: "ubuntu",
-				LogFilters: map[string]string{
-					"Pepe2": "My Second Filter",
-				},
 				ConfigFiles: map[string]servicedefinition.ConfigFile{
 					"/etc/my.cnf": servicedefinition.ConfigFile{Filename: "/etc/my.cnf", Content: "\n# SAMPLE config file for mysql\n\n[mysqld]\n\ninnodb_buffer_pool_size = 16G\n\n"},
 				},
@@ -71,6 +68,29 @@ func getTestingService() servicedefinition.ServiceDefinition {
 						},
 					},
 				},
+				LogFilters: map[string]string{
+					"Pepe2": "My Second Filter",
+				},
+				Services: []servicedefinition.ServiceDefinition{
+					servicedefinition.ServiceDefinition{
+						Name:    "s1child",
+						Command: "/usr/bin/python -m SimpleHTTPServer",
+						ImageID: "ubuntu",
+						LogConfigs: []servicedefinition.LogConfig{
+							servicedefinition.LogConfig{
+								Path: "/tmp/foo2",
+								Type: "foo2",
+								Filters: []string{
+									"Pepe4",
+								},
+							},
+						},
+						LogFilters: map[string]string{
+							"Pepe4": "My Fourth Filter",
+						},
+					},
+
+				},
 			},
 			servicedefinition.ServiceDefinition{
 				Name:    "s2",
@@ -88,6 +108,31 @@ func getTestingService() servicedefinition.ServiceDefinition {
 					servicedefinition.LogConfig{
 						Path: "/tmp/foo",
 						Type: "foo",
+						Filters: []string{
+							"Pepe3",
+						},
+					},
+				},
+				LogFilters: map[string]string{
+					"Pepe3": "My Third Filter",
+				},
+				Services: []servicedefinition.ServiceDefinition{
+					servicedefinition.ServiceDefinition{
+						Name:    "s2child",
+						Command: "/usr/bin/python -m SimpleHTTPServer",
+						ImageID: "ubuntu",
+						LogConfigs: []servicedefinition.LogConfig{
+							servicedefinition.LogConfig{
+								Path: "/tmp/foo2",
+								Type: "foo2",
+								Filters: []string{
+									"Pepe4",
+								},
+							},
+						},
+						LogFilters: map[string]string{
+							"Pepe4": "My Fourth Filter",
+						},
 					},
 				},
 			},
@@ -108,8 +153,8 @@ func TestGettingFilterDefinitionsFromServiceDefinitions(t *testing.T) {
 	}
 
 	// make sure the number matches the number we define
-	if len(filterDefs) != 2 {
-		t.Error("Found " + string(len(filterDefs)) + " instead of 2 filter definitions")
+	if len(filterDefs) != 4 {
+		t.Error(fmt.Sprintf("Found %d instead of 2 filter definitions", len(filterDefs)))
 	}
 }
 
@@ -117,12 +162,26 @@ func TestConstructingFilterString(t *testing.T) {
 	services := make([]servicedefinition.ServiceDefinition, 1)
 	services[0] = getTestingService()
 	filterDefs := getFilterDefinitions(services)
-	filters := getFilters(services, filterDefs, []string{})
+	typeFilter := []string{}
+	filters := getFilters(services, filterDefs, &typeFilter)
 	testString := "My Test Filter"
 
 	// make sure our test filter definition is in the constructed filters
 	if !strings.Contains(filters, testString) {
 		t.Error(fmt.Sprintf("Was unable to find %s in the filters", testString))
+	}
+}
+
+func TestNoDuplicateFilters(t *testing.T) {
+	services := make([]servicedefinition.ServiceDefinition, 1)
+	services[0] = getTestingService()
+	filterDefs := getFilterDefinitions(services)
+	typeFilter := []string{}
+	filters := getFilters(services, filterDefs, &typeFilter)
+
+	filterCount := strings.Count(filters, "if [type] == \"foo2\"")
+	if filterCount != 1 {
+		t.Error(fmt.Sprintf("expected only 1 filter for 'foo2', but found %d: filters=%s", filterCount, filters))
 	}
 }
 

--- a/facade/logstash_test.go
+++ b/facade/logstash_test.go
@@ -154,7 +154,7 @@ func TestGettingFilterDefinitionsFromServiceDefinitions(t *testing.T) {
 
 	// make sure the number matches the number we define
 	if len(filterDefs) != 4 {
-		t.Error(fmt.Sprintf("Found %d instead of 2 filter definitions", len(filterDefs)))
+		t.Error(fmt.Sprintf("Found %d instead of 4 filter definitions", len(filterDefs)))
 	}
 }
 


### PR DESCRIPTION
This fix is targeted at CC 1.3.3. DO NOT MERGE UNTIl 1.3.2 is released.

Fixes CC-3519 

Merge pull request #3468 from control-center/feature/CC-3445