### PR TITLE
CC-3506: add host IP, service path and resource pool to filebeat cfg

### DIFF
--- a/container/logstash.go
+++ b/container/logstash.go
@@ -27,11 +27,14 @@ const (
 )
 
 //createFields makes the map of tags for the logstash config including the type
-func createFields(hostID string, service *service.Service, instanceID string, logConfig *servicedefinition.LogConfig) map[string]string {
+func createFields(hostID string, hostIPs string, svcPath string, service *service.Service, instanceID string, logConfig *servicedefinition.LogConfig) map[string]string {
 	fields := make(map[string]string)
 	fields["type"] = logConfig.Type
 	fields["service"] = service.ID
 	fields["instance"] = instanceID
+	fields["hostips"] = hostIPs
+	fields["poolid"] = service.PoolID
+	fields["servicepath"] = svcPath
 
 	// CC-2234: Note that logstash is hardcoded to inject a field named 'host' into to every message, but when run from within
 	// a docker container, the value is actually the container id, not the name of the docker host. So this tag is
@@ -59,7 +62,7 @@ func formatTagsForConfFile(tags map[string]string) string {
 }
 
 // writeLogstashAgentConfig creates the logstash forwarder config file
-func writeLogstashAgentConfig(confPath string, hostID string, service *service.Service, instanceID string, resourcePath string) error {
+func writeLogstashAgentConfig(confPath string, hostID string, hostIPs string, svcPath string, service *service.Service, instanceID string, resourcePath string) error {
 	glog.Infof("Using logstash resourcePath: %s", resourcePath)
 
 	// generate the json config.
@@ -72,7 +75,7 @@ func writeLogstashAgentConfig(confPath string, hostID string, service *service.S
         - %s
       fields: %s`
 
-		filebeatLogConf = fmt.Sprintf(filebeatLogConf, logConfig.Path, formatTagsForConfFile(createFields(hostID, service, instanceID, &logConfig)))
+		filebeatLogConf = fmt.Sprintf(filebeatLogConf, logConfig.Path, formatTagsForConfFile(createFields(hostID, hostIPs, svcPath, service, instanceID, &logConfig)))
 	}
 
 	filebeatShipperConf :=

--- a/container/logstash_test.go
+++ b/container/logstash_test.go
@@ -89,7 +89,7 @@ func TestMakeSureTagsMakeItIntoTheJson(t *testing.T) {
 		os.Remove(confFileLocation)
 	}()
 
-	if err := writeLogstashAgentConfig(confFileLocation, "host1", &service, "0", logstashContainerDirectory); err != nil {
+	if err := writeLogstashAgentConfig(confFileLocation, "host1", "192.168.1.1", "service/service/", &service, "0", logstashContainerDirectory); err != nil {
 		t.Errorf("Error writing config file %s", err)
 		return
 	}
@@ -142,7 +142,7 @@ func TestDontWriteToNilMap(t *testing.T) {
 		os.Remove(confFileLocation)
 	}()
 
-	if err := writeLogstashAgentConfig(confFileLocation, "host1", &service, "0", logstashContainerDirectory); err != nil {
+	if err := writeLogstashAgentConfig(confFileLocation, "host1", "192.168.1.1", "service/service/", &service, "0", logstashContainerDirectory); err != nil {
 		t.Errorf("Writing with empty tags produced an error %s", err)
 		return
 	}

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -203,4 +203,6 @@ type FacadeInterface interface {
 	ClearEmergencyStopFlag(ctx datastore.Context, serviceID string) (int, error)
 
 	PredictStorageAvailability(ctx datastore.Context, lookahead time.Duration) (map[string]float64, error)
+
+	GetServiceNamePath(ctx datastore.Context, serviceID string) (tenantID string, servicePath string, err error)
 }

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -1638,3 +1638,34 @@ func (_m *FacadeInterface) WaitService(ctx datastore.Context, dstate service.Des
 
 	return r0
 }
+
+func (_m *FacadeInterface) GetServiceNamePath(ctx datastore.Context, serviceID string) (string, string, error) {
+	ret := _m.Called(ctx, serviceID)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) string); ok {
+		r0 = rf(ctx, serviceID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(string)
+		}
+	}
+
+	var r1 string
+        if rf, ok := ret.Get(0).(func(datastore.Context, string) string); ok {
+                r1 = rf(ctx, serviceID)
+        } else {
+                if ret.Get(0) != nil {
+                        r1 = ret.Get(0).(string)
+                }
+        }
+
+	var r2 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r2 = rf(ctx, serviceID)
+	} else {
+		r2 = ret.Error(1)
+	}
+
+	return r0, r1, r2
+}

--- a/facade/service.go
+++ b/facade/service.go
@@ -2746,3 +2746,8 @@ func (f *Facade) ResolveServicePath(ctx datastore.Context, svcPath string) ([]se
 func isEmptyPath(p string) bool {
 	return p == "" || p == "/"
 }
+
+func (f *Facade) GetServiceNamePath(ctx datastore.Context, serviceID string) (tenantID string, serviceNamePath string, err error) {
+	defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.GetServiceNamePath"))
+	return f.getServiceNamePath(ctx, serviceID)
+}

--- a/facade/serviceconfig.go
+++ b/facade/serviceconfig.go
@@ -173,6 +173,13 @@ func (f *Facade) getServicePath(ctx datastore.Context, serviceID string) (tenant
 	return f.serviceCache.GetServicePath(serviceID, gs)
 }
 
+func (f *Facade) getServiceNamePath(ctx datastore.Context, serviceID string) (tenantID string, serviceNamePath string, err error) {
+        gs := func(id string) (*service.ServiceDetails, error) {
+                return f.GetServiceDetails(ctx, id)
+        }
+        return f.serviceCache.GetServiceNamePath(serviceID, gs)
+}
+
 // updateServiceConfigs adds or updates configuration files.  If forceDelete is
 // set to true, then remove any extranneous service configurations.
 func (f *Facade) updateServiceConfigs(ctx datastore.Context, serviceID string, configFiles []servicedefinition.ConfigFile, forceDelete bool) error {

--- a/facade/servicepath_cache_test.go
+++ b/facade/servicepath_cache_test.go
@@ -44,7 +44,7 @@ func (t *ServicePathCacheTest) TearDownTest(c *C) {
 
 func (t *ServicePathCacheTest) Test_GetTenantID_SeedsCacheForTenantService(c *C) {
 	tenantID := "mockTenantId"
-	expectedService := service.ServiceDetails{ID: tenantID}
+	expectedService := service.ServiceDetails{ID: tenantID, Name: tenantID}
 	t.serviceStore.On("GetServiceDetails", t.unusedCTX, tenantID).Return(&expectedService, nil)
 
 	result, err := t.cache.GetTenantID(tenantID, t.getService)
@@ -55,12 +55,14 @@ func (t *ServicePathCacheTest) Test_GetTenantID_SeedsCacheForTenantService(c *C)
 	// Verify the cache contents
 	expectedCacheEntries := []servicePath{
 		servicePath{
-			serviceID:   tenantID,
-			parentID:    "",
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID,
+			serviceID:       tenantID,
+			parentID:        "",
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID,
+			serviceNamePath: "/" + tenantID,
 		},
 	}
+
 	t.assertExpectedCacheEntries(c, expectedCacheEntries)
 }
 
@@ -69,13 +71,13 @@ func (t *ServicePathCacheTest) Test_GetTenantID_SeedsCacheForNestedServices(c *C
 	childID := "mockChildId"
 	grandchildID := "mockGrandChildId"
 
-	tenant := service.ServiceDetails{ID: tenantID}
+	tenant := service.ServiceDetails{ID: tenantID, Name: tenantID}
 	t.serviceStore.On("GetServiceDetails", t.unusedCTX, tenantID).Return(&tenant, nil)
 
-	child := service.ServiceDetails{ID: childID, ParentServiceID: tenantID}
+	child := service.ServiceDetails{ID: childID, Name: childID, ParentServiceID: tenantID}
 	t.serviceStore.On("GetServiceDetails", t.unusedCTX, childID).Return(&child, nil)
 
-	grandchild := service.ServiceDetails{ID: grandchildID, ParentServiceID: childID}
+	grandchild := service.ServiceDetails{ID: grandchildID, Name: grandchildID, ParentServiceID: childID}
 	t.serviceStore.On("GetServiceDetails", t.unusedCTX, grandchildID).Return(&grandchild, nil)
 
 	result, err := t.cache.GetTenantID(grandchildID, t.getService)
@@ -86,22 +88,25 @@ func (t *ServicePathCacheTest) Test_GetTenantID_SeedsCacheForNestedServices(c *C
 	// Verify the cache contents
 	expectedCacheEntries := []servicePath{
 		servicePath{
-			serviceID:   tenantID,
-			parentID:    "",
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID,
+			serviceID:       tenantID,
+			parentID:        "",
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID,
+			serviceNamePath: "/" + tenantID,
 		},
 		servicePath{
-			serviceID:   childID,
-			parentID:    tenantID,
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID + "/" + childID,
+			serviceID:       childID,
+			parentID:        tenantID,
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID + "/" + childID,
+			serviceNamePath: "/" + tenantID + "/" + childID,
 		},
 		servicePath{
-			serviceID:   grandchildID,
-			parentID:    childID,
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID + "/" + childID + "/" + grandchildID,
+			serviceID:       grandchildID,
+			parentID:        childID,
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID + "/" + childID + "/" + grandchildID,
+			serviceNamePath: "/" + tenantID + "/" + childID + "/" + grandchildID,
 		},
 	}
 	t.assertExpectedCacheEntries(c, expectedCacheEntries)
@@ -115,22 +120,25 @@ func (t *ServicePathCacheTest) Test_GetTenantID_UsesCachedValues(c *C) {
 	// Load the cache manually
 	initialCacheEntries := []servicePath{
 		servicePath{
-			serviceID:   tenantID,
-			parentID:    "",
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID,
+			serviceID:       tenantID,
+			parentID:        "",
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID,
+			serviceNamePath: "/" + tenantID,
 		},
 		servicePath{
-			serviceID:   childID,
-			parentID:    tenantID,
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID + "/" + childID,
+			serviceID:       childID,
+			parentID:        tenantID,
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID + "/" + childID,
+			serviceNamePath: "/" + tenantID + "/" + childID,
 		},
 		servicePath{
-			serviceID:   grandchildID,
-			parentID:    childID,
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID + "/" + childID + "/" + grandchildID,
+			serviceID:       grandchildID,
+			parentID:        childID,
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID + "/" + childID + "/" + grandchildID,
+			serviceNamePath: "/" + tenantID + "/" + childID + "/" + grandchildID,
 		},
 	}
 	for _, expected := range initialCacheEntries {
@@ -153,23 +161,25 @@ func (t *ServicePathCacheTest) Test_GetTenantID_UsesCachedValuesForParents(c *C)
 	// Load the cache manually
 	initialCacheEntries := []servicePath{
 		servicePath{
-			serviceID:   tenantID,
-			parentID:    "",
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID,
+			serviceID:       tenantID,
+			parentID:        "",
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID,
+			serviceNamePath: "/" + tenantID,
 		},
 		servicePath{
-			serviceID:   childID,
-			parentID:    tenantID,
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID + "/" + childID,
+			serviceID:       childID,
+			parentID:        tenantID,
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID + "/" + childID,
+			serviceNamePath: "/" + tenantID + "/" + childID,
 		},
 	}
 	for _, expected := range initialCacheEntries {
 		t.cache.paths[expected.serviceID] = expected
 	}
 
-	grandchild := service.ServiceDetails{ID: grandchildID, ParentServiceID: childID}
+	grandchild := service.ServiceDetails{ID: grandchildID, Name: grandchildID, ParentServiceID: childID}
 	t.serviceStore.On("GetServiceDetails", t.unusedCTX, grandchildID).Return(&grandchild, nil)
 
 	// NOTE: Since no mock expectations are set for parentID or childID, the test will fail if there
@@ -179,10 +189,11 @@ func (t *ServicePathCacheTest) Test_GetTenantID_UsesCachedValuesForParents(c *C)
 	c.Assert(result, Equals, tenantID)
 	c.Assert(err, IsNil)
 	expectedCacheEntries := append(initialCacheEntries, servicePath{
-		serviceID:   grandchildID,
-		parentID:    childID,
-		tenantID:    tenantID,
-		servicePath: "/" + tenantID + "/" + childID + "/" + grandchildID,
+		serviceID:       grandchildID,
+		parentID:        childID,
+		tenantID:        tenantID,
+		servicePath:     "/" + tenantID + "/" + childID + "/" + grandchildID,
+		serviceNamePath: "/" + tenantID + "/" + childID + "/" + grandchildID,
 	})
 	t.assertExpectedCacheEntries(c, expectedCacheEntries)
 }
@@ -202,7 +213,7 @@ func (t *ServicePathCacheTest) Test_GetServicePath_SeedsCacheForTenantService(c 
 	tenantID := "mockTenantId"
 	expectedPath := "/" + tenantID
 
-	expectedService := service.ServiceDetails{ID: tenantID}
+	expectedService := service.ServiceDetails{ID: tenantID, Name: tenantID}
 	t.serviceStore.On("GetServiceDetails", t.unusedCTX, tenantID).Return(&expectedService, nil)
 
 	tenantResult, pathResult, err := t.cache.GetServicePath(tenantID, t.getService)
@@ -214,10 +225,11 @@ func (t *ServicePathCacheTest) Test_GetServicePath_SeedsCacheForTenantService(c 
 	// Verify the cache contents
 	expectedCacheEntries := []servicePath{
 		servicePath{
-			serviceID:   tenantID,
-			parentID:    "",
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID,
+			serviceID:       tenantID,
+			parentID:        "",
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID,
+			serviceNamePath: "/" + tenantID,
 		},
 	}
 	t.assertExpectedCacheEntries(c, expectedCacheEntries)
@@ -229,13 +241,13 @@ func (t *ServicePathCacheTest) Test_GetServicePath_SeedsCacheForNestedServices(c
 	grandchildID := "mockGrandChildId"
 	expectedPath := "/" + tenantID + "/" + childID + "/" + grandchildID
 
-	tenant := service.ServiceDetails{ID: tenantID}
+	tenant := service.ServiceDetails{ID: tenantID, Name: tenantID}
 	t.serviceStore.On("GetServiceDetails", t.unusedCTX, tenantID).Return(&tenant, nil)
 
-	child := service.ServiceDetails{ID: childID, ParentServiceID: tenantID}
+	child := service.ServiceDetails{ID: childID, Name: childID, ParentServiceID: tenantID}
 	t.serviceStore.On("GetServiceDetails", t.unusedCTX, childID).Return(&child, nil)
 
-	grandchild := service.ServiceDetails{ID: grandchildID, ParentServiceID: childID}
+	grandchild := service.ServiceDetails{ID: grandchildID, Name: grandchildID, ParentServiceID: childID}
 	t.serviceStore.On("GetServiceDetails", t.unusedCTX, grandchildID).Return(&grandchild, nil)
 
 	tenantResult, pathResult, err := t.cache.GetServicePath(grandchildID, t.getService)
@@ -247,22 +259,25 @@ func (t *ServicePathCacheTest) Test_GetServicePath_SeedsCacheForNestedServices(c
 	// Verify the cache contents
 	expectedCacheEntries := []servicePath{
 		servicePath{
-			serviceID:   tenantID,
-			parentID:    "",
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID,
+			serviceID:       tenantID,
+			parentID:        "",
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID,
+			serviceNamePath: "/" + tenantID,
 		},
 		servicePath{
-			serviceID:   childID,
-			parentID:    tenantID,
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID + "/" + childID,
+			serviceID:       childID,
+			parentID:        tenantID,
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID + "/" + childID,
+			serviceNamePath: "/" + tenantID + "/" + childID,
 		},
 		servicePath{
-			serviceID:   grandchildID,
-			parentID:    childID,
-			tenantID:    tenantID,
-			servicePath: expectedPath,
+			serviceID:       grandchildID,
+			parentID:        childID,
+			tenantID:        tenantID,
+			servicePath:     expectedPath,
+			serviceNamePath: expectedPath,
 		},
 	}
 	t.assertExpectedCacheEntries(c, expectedCacheEntries)
@@ -277,22 +292,25 @@ func (t *ServicePathCacheTest) Test_GetServicePath_UsesCachedValues(c *C) {
 	// Load the cache manually
 	initialCacheEntries := []servicePath{
 		servicePath{
-			serviceID:   tenantID,
-			parentID:    "",
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID,
+			serviceID:       tenantID,
+			parentID:        "",
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID,
+			serviceNamePath: "/" + tenantID,
 		},
 		servicePath{
-			serviceID:   childID,
-			parentID:    tenantID,
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID + "/" + childID,
+			serviceID:       childID,
+			parentID:        tenantID,
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID + "/" + childID,
+			serviceNamePath: "/" + tenantID + "/" + childID,
 		},
 		servicePath{
-			serviceID:   grandchildID,
-			parentID:    childID,
-			tenantID:    tenantID,
-			servicePath: expectedPath,
+			serviceID:       grandchildID,
+			parentID:        childID,
+			tenantID:        tenantID,
+			servicePath:     expectedPath,
+			serviceNamePath: expectedPath,
 		},
 	}
 	for _, expected := range initialCacheEntries {
@@ -317,23 +335,25 @@ func (t *ServicePathCacheTest) Test_GetServicePath_UsesCachedValuesForParents(c 
 	// Load the cache manually
 	initialCacheEntries := []servicePath{
 		servicePath{
-			serviceID:   tenantID,
-			parentID:    "",
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID,
+			serviceID:       tenantID,
+			parentID:        "",
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID,
+			serviceNamePath: "/" + tenantID,
 		},
 		servicePath{
-			serviceID:   childID,
-			parentID:    tenantID,
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID + "/" + childID,
+			serviceID:       childID,
+			parentID:        tenantID,
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID + "/" + childID,
+			serviceNamePath: "/" + tenantID + "/" + childID,
 		},
 	}
 	for _, expected := range initialCacheEntries {
 		t.cache.paths[expected.serviceID] = expected
 	}
 
-	grandchild := service.ServiceDetails{ID: grandchildID, ParentServiceID: childID}
+	grandchild := service.ServiceDetails{ID: grandchildID, Name: grandchildID, ParentServiceID: childID}
 	t.serviceStore.On("GetServiceDetails", t.unusedCTX, grandchildID).Return(&grandchild, nil)
 
 	// NOTE: Since no mock expectations are set for parentID or childID, the test will fail if there
@@ -345,10 +365,11 @@ func (t *ServicePathCacheTest) Test_GetServicePath_UsesCachedValuesForParents(c 
 	c.Assert(err, IsNil)
 
 	expectedCacheEntries := append(initialCacheEntries, servicePath{
-		serviceID:   grandchildID,
-		parentID:    childID,
-		tenantID:    tenantID,
-		servicePath: expectedPath,
+		serviceID:       grandchildID,
+		parentID:        childID,
+		tenantID:        tenantID,
+		servicePath:     expectedPath,
+		serviceNamePath: expectedPath,
 	})
 
 	t.assertExpectedCacheEntries(c, expectedCacheEntries)
@@ -381,16 +402,18 @@ func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_OnCacheMiss(c *C) {
 	expectedPath := "/" + tenantID + "/" + childID
 	initialCacheEntries := []servicePath{
 		servicePath{
-			serviceID:   tenantID,
-			parentID:    "",
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID,
+			serviceID:       tenantID,
+			parentID:        "",
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID,
+			serviceNamePath: "/" + tenantID,
 		},
 		servicePath{
-			serviceID:   childID,
-			parentID:    tenantID,
-			tenantID:    tenantID,
-			servicePath: expectedPath,
+			serviceID:       childID,
+			parentID:        tenantID,
+			tenantID:        tenantID,
+			servicePath:     expectedPath,
+			serviceNamePath: expectedPath,
 		},
 	}
 	for _, expected := range initialCacheEntries {
@@ -411,16 +434,18 @@ func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_CachedParentMatches(c 
 	expectedPath := "/" + tenantID + "/" + childID
 	initialCacheEntries := []servicePath{
 		servicePath{
-			serviceID:   tenantID,
-			parentID:    "",
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID,
+			serviceID:       tenantID,
+			parentID:        "",
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID,
+			serviceNamePath: "/" + tenantID,
 		},
 		servicePath{
-			serviceID:   childID,
-			parentID:    tenantID,
-			tenantID:    tenantID,
-			servicePath: expectedPath,
+			serviceID:       childID,
+			parentID:        tenantID,
+			tenantID:        tenantID,
+			servicePath:     expectedPath,
+			serviceNamePath: expectedPath,
 		},
 	}
 	for _, expected := range initialCacheEntries {
@@ -439,16 +464,18 @@ func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_CachedParentDifferent(
 	childID := "mockChildId"
 	initialCacheEntries := []servicePath{
 		servicePath{
-			serviceID:   tenantID,
-			parentID:    "",
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID,
+			serviceID:       tenantID,
+			parentID:        "",
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID,
+			serviceNamePath: "/" + tenantID,
 		},
 		servicePath{
-			serviceID:   childID,
-			parentID:    tenantID,
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID + "/" + childID,
+			serviceID:       childID,
+			parentID:        tenantID,
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID + "/" + childID,
+			serviceNamePath: "/" + tenantID + "/" + childID,
 		},
 	}
 	for _, expected := range initialCacheEntries {
@@ -471,28 +498,32 @@ func (t *ServicePathCacheTest) Test_RemoveIfParentChanged_RemoveMultipleEntries(
 	// Load the cache manually
 	initialCacheEntries := []servicePath{
 		servicePath{
-			serviceID:   tenantID,
-			parentID:    "",
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID,
+			serviceID:       tenantID,
+			parentID:        "",
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID,
+			serviceNamePath: "/" + tenantID,
 		},
 		servicePath{
-			serviceID:   childID,
-			parentID:    tenantID,
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID + "/" + childID,
+			serviceID:       childID,
+			parentID:        tenantID,
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID + "/" + childID,
+			serviceNamePath: "/" + tenantID + "/" + childID,
 		},
 		servicePath{
-			serviceID:   grandchildID1,
-			parentID:    childID,
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID + "/" + childID + "/" + grandchildID1,
+			serviceID:       grandchildID1,
+			parentID:        childID,
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID + "/" + childID + "/" + grandchildID1,
+			serviceNamePath: "/" + tenantID + "/" + childID + "/" + grandchildID1,
 		},
 		servicePath{
-			serviceID:   grandchildID2,
-			parentID:    childID,
-			tenantID:    tenantID,
-			servicePath: "/" + tenantID + "/" + childID + "/" + grandchildID2,
+			serviceID:       grandchildID2,
+			parentID:        childID,
+			tenantID:        tenantID,
+			servicePath:     "/" + tenantID + "/" + childID + "/" + grandchildID2,
+			serviceNamePath: "/" + tenantID + "/" + childID + "/" + grandchildID2,
 		},
 	}
 	for _, expected := range initialCacheEntries {
@@ -532,5 +563,6 @@ func (t *ServicePathCacheTest) assertExpectedCacheEntries(c *C, expectedCacheEnt
 		c.Assert(actual.tenantID, Equals, expected.tenantID)
 		c.Assert(actual.parentID, Equals, expected.parentID)
 		c.Assert(actual.servicePath, Equals, expected.servicePath)
+		c.Assert(actual.serviceNamePath, Equals, expected.serviceNamePath)
 	}
 }

--- a/node/agent_proxy.go
+++ b/node/agent_proxy.go
@@ -77,13 +77,14 @@ func (a *HostAgent) GetEvaluatedService(request EvaluateServiceRequest, response
 		"instanceID": request.InstanceID,
 	})
 
-	svc, tenantID, err := a.serviceCache.GetEvaluatedService(request.ServiceID, request.InstanceID)
+	svc, tenantID, svcPath, err := a.serviceCache.GetEvaluatedService(request.ServiceID, request.InstanceID)
 	if err != nil {
 		logger.WithError(err).Error("Failed to get service")
 		return err
 	}
 	response.Service = *svc
 	response.TenantID = tenantID
+	response.ServiceNamePath = svcPath
 	return nil
 }
 

--- a/node/container.go
+++ b/node/container.go
@@ -144,7 +144,7 @@ func (a *HostAgent) StartContainer(cancel <-chan interface{}, serviceID string, 
 	})
 
 	a.serviceCache.Invalidate(serviceID, instanceID)
-	evaluatedService, tenantID, err := a.serviceCache.GetEvaluatedService(serviceID, instanceID)
+	evaluatedService, tenantID, _, err := a.serviceCache.GetEvaluatedService(serviceID, instanceID)
 	if err != nil {
 		logger.WithError(err).Error("Failed to get service")
 		return nil, nil, err
@@ -501,6 +501,7 @@ func (a *HostAgent) getService(serviceID string) (*service.Service, error) {
 
 	return svc, nil
 }
+
 
 // dockerLogsToFile dumps container logs to file
 func dockerLogsToFile(containerid string, numlines int) {

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -103,8 +103,9 @@ type EvaluateServiceRequest struct {
 }
 
 type EvaluateServiceResponse struct {
-	Service  service.Service
-	TenantID string
+	Service         service.Service
+	TenantID        string
+	ServiceNamePath string
 }
 
 // The API for a service proxy.

--- a/rpc/master/interface.go
+++ b/rpc/master/interface.go
@@ -129,7 +129,7 @@ type ClientInterface interface {
 	GetServiceInstances(serviceID string) ([]service.Instance, error)
 
 	// Get a service from serviced where all templated properties have been evaluated
-	GetEvaluatedService(serviceID string, instanceID int) (*service.Service, string, error)
+	GetEvaluatedService(serviceID string, instanceID int) (*service.Service, string, string, error)
 
 	// Get the tenant ID for a service
 	GetTenantID(serviceID string) (string, error)

--- a/rpc/master/mocks/ClientInterface.go
+++ b/rpc/master/mocks/ClientInterface.go
@@ -400,7 +400,7 @@ func (_m *ClientInterface) GetAllServiceDetails(since time.Duration) ([]service.
 }
 
 // GetEvaluatedService provides a mock function with given fields: serviceID, instanceID
-func (_m *ClientInterface) GetEvaluatedService(serviceID string, instanceID int) (*service.Service, string, error) {
+func (_m *ClientInterface) GetEvaluatedService(serviceID string, instanceID int) (*service.Service, string, string, error) {
 	ret := _m.Called(serviceID, instanceID)
 
 	var r0 *service.Service
@@ -419,14 +419,21 @@ func (_m *ClientInterface) GetEvaluatedService(serviceID string, instanceID int)
 		r1 = ret.Get(1).(string)
 	}
 
-	var r2 error
+	var r2 string
+        if rf, ok := ret.Get(1).(func(string, int) string); ok {
+                r2 = rf(serviceID, instanceID)
+        } else {
+                r2 = ret.Get(1).(string)
+        }
+
+	var r3 error
 	if rf, ok := ret.Get(2).(func(string, int) error); ok {
-		r2 = rf(serviceID, instanceID)
+		r3 = rf(serviceID, instanceID)
 	} else {
-		r2 = ret.Error(2)
+		r3 = ret.Error(2)
 	}
 
-	return r0, r1, r2
+	return r0, r1, r2, r3
 }
 
 // GetHost provides a mock function with given fields: hostID

--- a/rpc/master/service_client.go
+++ b/rpc/master/service_client.go
@@ -75,7 +75,7 @@ func (c *Client) GetService(serviceID string) (*service.Service, error) {
 }
 
 // GetEvaluatedService returns a service where an evaluation has been executed against all templated properties.
-func (c *Client) GetEvaluatedService(serviceID string, instanceID int) (*service.Service, string, error) {
+func (c *Client) GetEvaluatedService(serviceID string, instanceID int) (*service.Service, string, string, error) {
 	request := EvaluateServiceRequest{
 		ServiceID:  serviceID,
 		InstanceID: instanceID,
@@ -83,9 +83,9 @@ func (c *Client) GetEvaluatedService(serviceID string, instanceID int) (*service
 	response := EvaluateServiceResponse{}
 	err := c.call("GetEvaluatedService", request, &response)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
-	return &response.Service, response.TenantID, err
+	return &response.Service, response.TenantID, response.ServiceNamePath, err
 }
 
 // GetTenantID returns the ID of the service's tenant (i.e. the root service's ID)

--- a/rpc/master/service_server.go
+++ b/rpc/master/service_server.go
@@ -40,8 +40,9 @@ type EvaluateServiceRequest struct {
 }
 
 type EvaluateServiceResponse struct {
-	Service  service.Service
-	TenantID string
+	Service          service.Service
+	TenantID         string
+	ServiceNamePath  string
 }
 
 type ServiceDetailsByTenantIDRequest struct {
@@ -111,12 +112,13 @@ func (s *Server) GetEvaluatedService(request EvaluateServiceRequest, response *E
 		return err
 	}
 
-	tenantID, err := s.f.GetTenantID(s.context(), request.ServiceID)
+	tenantID, svcPath, err := s.f.GetServiceNamePath(s.context(), request.ServiceID)
 	if err != nil {
 		return err
 	}
 	response.Service = *svc
 	response.TenantID = tenantID
+	response.ServiceNamePath = svcPath
 	return nil
 }
 

--- a/serviced-controller/options.go
+++ b/serviced-controller/options.go
@@ -42,6 +42,7 @@ type ControllerOptions struct {
 	LogstashURL             string // logstash endpoint
 	VirtualAddressSubnet    string // The subnet of virtual addresses, 10.3
 	MetricForwardingEnabled bool   // Enable metric forwarding from the container
+	HostIPs			string // The ip addresses of the host
 }
 
 func (c ControllerOptions) toContainerControllerOptions() (options container.ControllerOptions, err error) {
@@ -63,6 +64,7 @@ func (c ControllerOptions) toContainerControllerOptions() (options container.Con
 	options.MetricForwarding = c.MetricForwardingEnabled
 	options.Metric.RemoteEndoint = "http://localhost:8444/api/metrics/store"
 	options.VirtualAddressSubnet = c.VirtualAddressSubnet
+	options.HostIPs = c.HostIPs
 	options.Logforwarder.SettleTime, err = time.ParseDuration(c.LogstashSettleTime)
 	if err != nil {
 		return options, err

--- a/serviced-controller/proxy.go
+++ b/serviced-controller/proxy.go
@@ -65,6 +65,7 @@ func CmdServiceProxy(ctx *cli.Context) {
 	options.LogstashURL = cfg.StringVal("LOG_ADDRESS", options.LogstashURL)
 	options.VirtualAddressSubnet = cfg.StringVal("VIRTUAL_ADDRESS_SUBNET", options.VirtualAddressSubnet)
 	options.ServicedEndpoint = utils.GetGateway(options.RPCPort)
+	options.HostIPs = os.Getenv("CONTROLPLANE_HOST_IPS")
 
 	if ctx.IsSet("logtostderr") {
 		glog.SetToStderr(ctx.GlobalBool("logtostderr"))


### PR DESCRIPTION
this is port from https://github.com/control-center/serviced/pull/3502

[JIRA](https://jira.zenoss.com/browse/CC-3506)