### PR TITLE
Upgrade to filebeat 5.2.3

### DIFF
--- a/cli/api/shell.go
+++ b/cli/api/shell.go
@@ -43,7 +43,6 @@ type ShellConfig struct {
 	LogStash         struct {
 		Enable        bool
 		SettleTime    string
-		IdleFlushTime string
 	}
 }
 
@@ -188,11 +187,6 @@ func (a *api) RunShell(config ShellConfig, stopChan chan struct{}) (int, error) 
 
 	cfg.LogStash.Enable = config.LogStash.Enable
 	cfg.LogStash.SettleTime, err = time.ParseDuration(config.LogStash.SettleTime)
-	if err != nil {
-		return 1, err
-	}
-
-	cfg.LogStash.IdleFlushTime, err = time.ParseDuration(config.LogStash.IdleFlushTime)
 	if err != nil {
 		return 1, err
 	}

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -241,11 +241,6 @@ func (c *ServicedCli) initService() {
 						Usage: "enable/disable log stash (true by default)",
 					},
 					cli.StringFlag{
-						Name:  "logstash-idle-flush-time",
-						Value: "100ms",
-						Usage: "time duration for logstash to flush log messages",
-					},
-					cli.StringFlag{
 						Name:  "logstash-settle-time",
 						Value: "5s",
 						Usage: "time duration to wait for logstash to flush log messages before closing",
@@ -1332,7 +1327,6 @@ func (c *ServicedCli) cmdServiceRun(ctx *cli.Context) error {
 
 	config.LogStash.Enable = ctx.GlobalBool("logstash")
 	config.LogStash.SettleTime = ctx.GlobalString("logstash-settle-time")
-	config.LogStash.IdleFlushTime = ctx.GlobalString("logstash-idle-flush-time")
 
 	exitcode := 1
 	if exitcode, err = c.driver.RunShell(config, stopChan); err != nil {

--- a/container/controller.go
+++ b/container/controller.go
@@ -72,13 +72,12 @@ const (
 	containerTokenFile       = "/etc/serviced/auth.token"
 )
 
-// Logforwarder configuration
+// Logforwarder configuration for filebeat
 type LogforwarderOptions struct {
 	Enabled       bool          // True if enabled
-	Path          string        // Path to the logforwarder program
+	Path          string        // Path to the logforwarder program (e.g. filebeat)
 	ConfigFile    string        // Path to the config file for filebeat
-	IdleFlushTime time.Duration // period for log stash to flush its buffer
-	SettleTime    time.Duration // time to wait for logstash to flush its buffer before exiting
+	SettleTime    time.Duration // time to wait for forwarder to flush its buffer before exiting
 }
 
 // ControllerOptions are options to be run when starting a new proxy server

--- a/container/controller.go
+++ b/container/controller.go
@@ -72,6 +72,15 @@ const (
 	containerTokenFile       = "/etc/serviced/auth.token"
 )
 
+// Logforwarder configuration
+type LogforwarderOptions struct {
+	Enabled       bool          // True if enabled
+	Path          string        // Path to the logforwarder program
+	ConfigFile    string        // Path to the config file for filebeat
+	IdleFlushTime time.Duration // period for log stash to flush its buffer
+	SettleTime    time.Duration // time to wait for logstash to flush its buffer before exiting
+}
+
 // ControllerOptions are options to be run when starting a new proxy server
 type ControllerOptions struct {
 	ServicedEndpoint string
@@ -89,13 +98,7 @@ type ControllerOptions struct {
 		KeyPEMFile  string // Path to the key file when TLS is used
 		CertPEMFile string // Path to the cert file when TLS is used
 	}
-	Logforwarder struct { // Logforwarder configuration
-		Enabled       bool          // True if enabled
-		Path          string        // Path to the logforwarder program
-		ConfigFile    string        // Path to the config file for filebeat
-		IdleFlushTime time.Duration // period for log stash to flush its buffer
-		SettleTime    time.Duration // time to wait for logstash to flush its buffer before exiting
-	}
+	Logforwarder LogforwarderOptions
 	Metric struct {
 		Address       string // TCP port to host the metric service, :22350
 		RemoteEndoint string // The url to forward metric queries
@@ -257,10 +260,10 @@ func setupConfigFiles(svc *service.Service) error {
 }
 
 // setupLogstashFiles sets up logstash files
-func setupLogstashFiles(hostID string, hostIPs string, svcPath string, service *service.Service, instanceID string, resourcePath string) error {
+func setupLogstashFiles(hostID string, hostIPs string, svcPath string, service *service.Service, instanceID string, logforwarderOptions LogforwarderOptions) error {
 	// write out logstash files
 	if len(service.LogConfigs) != 0 {
-		err := writeLogstashAgentConfig(logstashContainerConfig, hostID, hostIPs, svcPath, service, instanceID, resourcePath)
+		err := writeLogstashAgentConfig(hostID, hostIPs, svcPath, service, instanceID, logforwarderOptions)
 		if err != nil {
 			return err
 		}
@@ -342,10 +345,12 @@ func NewController(options ControllerOptions) (*Controller, error) {
 	}
 
 	if options.Logforwarder.Enabled {
-		if err := setupLogstashFiles(c.hostID, options.HostIPs, options.ServiceNamePath, service, options.Service.InstanceID, filepath.Dir(options.Logforwarder.Path)); err != nil {
+		if err := setupLogstashFiles(c.hostID, options.HostIPs, options.ServiceNamePath, service,
+				options.Service.InstanceID, options.Logforwarder); err != nil {
 			glog.Errorf("Could not setup logstash files error:%s", err)
 			return c, fmt.Errorf("container: invalid LogStashFiles error:%s", err)
 		}
+
 		logforwarder, exited, err := subprocess.New(time.Second,
 			nil,
 			options.Logforwarder.Path,

--- a/container/logstash_test.go
+++ b/container/logstash_test.go
@@ -1,5 +1,4 @@
 // Copyright 2014 The Serviced Authors.
-// Copyright 2014 The Serviced Authors.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/container/logstash_test.go
+++ b/container/logstash_test.go
@@ -1,4 +1,5 @@
 // Copyright 2014 The Serviced Authors.
+// Copyright 2014 The Serviced Authors.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -73,7 +74,6 @@ func getTestService() service.Service {
 	}
 }
 
-const logstashContainerDirectory = "/usr/local/serviced/resources/logstash"
 
 func TestMakeSureTagsMakeItIntoTheJson(t *testing.T) {
 	service := getTestService()
@@ -89,7 +89,8 @@ func TestMakeSureTagsMakeItIntoTheJson(t *testing.T) {
 		os.Remove(confFileLocation)
 	}()
 
-	if err := writeLogstashAgentConfig(confFileLocation, "host1", "192.168.1.1", "service/service/", &service, "0", logstashContainerDirectory); err != nil {
+	logforwarderOptions := LogforwarderOptions{Enabled: true, ConfigFile: confFileLocation}
+	if err := writeLogstashAgentConfig("host1", "192.168.1.1", "service/service/", &service, "0", logforwarderOptions); err != nil {
 		t.Errorf("Error writing config file %s", err)
 		return
 	}
@@ -142,7 +143,8 @@ func TestDontWriteToNilMap(t *testing.T) {
 		os.Remove(confFileLocation)
 	}()
 
-	if err := writeLogstashAgentConfig(confFileLocation, "host1", "192.168.1.1", "service/service/", &service, "0", logstashContainerDirectory); err != nil {
+	logforwarderOptions := LogforwarderOptions{Enabled: true, ConfigFile: confFileLocation}
+	if err := writeLogstashAgentConfig("host1", "192.168.1.1", "service/service/", &service, "0", logforwarderOptions); err != nil {
 		t.Errorf("Writing with empty tags produced an error %s", err)
 		return
 	}

--- a/container/logstash_test.go
+++ b/container/logstash_test.go
@@ -24,12 +24,14 @@ import (
 	"github.com/control-center/serviced/domain"
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/domain/servicedefinition"
+	"github.com/control-center/serviced/utils"
 
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 	"time"
+	"path/filepath"
 )
 
 func getTestService() service.Service {
@@ -89,7 +91,8 @@ func TestMakeSureTagsMakeItIntoTheJson(t *testing.T) {
 		os.Remove(confFileLocation)
 	}()
 
-	logforwarderOptions := LogforwarderOptions{Enabled: true, ConfigFile: confFileLocation}
+	fileBeatBinary := filepath.Join(utils.ResourcesDir(), "logstash/filebeat")
+	logforwarderOptions := LogforwarderOptions{Enabled: true, Path: fileBeatBinary, ConfigFile: confFileLocation}
 	if err := writeLogstashAgentConfig("host1", "192.168.1.1", "service/service/", &service, "0", logforwarderOptions); err != nil {
 		t.Errorf("Error writing config file %s", err)
 		return
@@ -143,7 +146,8 @@ func TestDontWriteToNilMap(t *testing.T) {
 		os.Remove(confFileLocation)
 	}()
 
-	logforwarderOptions := LogforwarderOptions{Enabled: true, ConfigFile: confFileLocation}
+	fileBeatBinary := filepath.Join(utils.ResourcesDir(), "logstash/filebeat")
+	logforwarderOptions := LogforwarderOptions{Enabled: true, Path: fileBeatBinary, ConfigFile: confFileLocation}
 	if err := writeLogstashAgentConfig("host1", "192.168.1.1", "service/service/", &service, "0", logforwarderOptions); err != nil {
 		t.Errorf("Writing with empty tags produced an error %s", err)
 		return

--- a/isvcs/resources/logstash/filebeat.conf.in
+++ b/isvcs/resources/logstash/filebeat.conf.in
@@ -1,0 +1,22 @@
+filebeat:
+  idle_timeout: 5s
+  prospectors: ${PROSPECTORS_SECTION}
+
+output:
+  logstash:
+    enabled: true
+    hosts:
+      - ${HOSTS_SECTION}
+    tls:
+      insecure: true
+      certificate: ${CERT_SECTION}
+      certificate_key: ${CERT_KEY_SECTION}
+      certificate_authorities:
+        - ${CERT_AUTH_SECTION}
+    timeout: 15
+
+logging:
+  level: warning
+# Uncomment selectors and change level to debug to get full debugging from filebeat
+#  selectors: ["*"]
+

--- a/isvcs/resources/logstash/filebeat.conf.in
+++ b/isvcs/resources/logstash/filebeat.conf.in
@@ -7,10 +7,10 @@ output:
     enabled: true
     hosts:
       - ${HOSTS_SECTION}
-    tls:
-      insecure: true
+    ssl:
+      verification_mode: none
       certificate: ${CERT_SECTION}
-      certificate_key: ${CERT_KEY_SECTION}
+      key: ${CERT_KEY_SECTION}
       certificate_authorities:
         - ${CERT_AUTH_SECTION}
     timeout: 15

--- a/serviced-controller/daemon.go
+++ b/serviced-controller/daemon.go
@@ -50,7 +50,6 @@ func main() {
 		cli.BoolFlag{"disable-metric-forwarding", "disable forwarding of metrics for this container"},
 		cli.StringFlag{"metric-forwarder-port", defaultMetricsForwarderPort, "the port the container processes send performance data to"},
 		cli.BoolTFlag{"logstash", "forward service logs via filebeat"},
-		cli.StringFlag{"logstash-idle-flush-time", "5s", "time duration for logstash to flush log messages"},
 		cli.StringFlag{"logstash-settle-time", "0s", "time duration to wait for logstash to flush log messages before closing"},
 		cli.StringFlag{"virtual-address-subnet", "10.3.0.0/16", "/16 subnet for virtual addresses"},
 		cli.BoolTFlag{"logtostderr", "log to standard error instead of files"},

--- a/serviced-controller/options.go
+++ b/serviced-controller/options.go
@@ -37,7 +37,6 @@ type ControllerOptions struct {
 	Logstash                bool
 	LogstashBinary          string // path to the filebeat binary
 	LogstashConfig          string // path to the filebeat config file
-	LogstashIdleFlushTime   string // how often should log stash flush its logs
 	LogstashSettleTime      string // how long to wait for log stash to flush its logs before exiting
 	LogstashURL             string // logstash endpoint
 	VirtualAddressSubnet    string // The subnet of virtual addresses, 10.3
@@ -69,7 +68,6 @@ func (c ControllerOptions) toContainerControllerOptions() (options container.Con
 	if err != nil {
 		return options, err
 	}
-	options.Logforwarder.IdleFlushTime, err = time.ParseDuration(c.LogstashIdleFlushTime)
 	if err != nil {
 		return options, err
 	}

--- a/serviced-controller/proxy.go
+++ b/serviced-controller/proxy.go
@@ -49,7 +49,6 @@ func CmdServiceProxy(ctx *cli.Context) {
 		Autorestart:             ctx.GlobalBool("autorestart"),
 		MetricForwarderPort:     ctx.GlobalString("metric-forwarder-port"),
 		Logstash:                ctx.GlobalBool("logstash"),
-		LogstashIdleFlushTime:   ctx.GlobalString("logstash-idle-flush-time"),
 		LogstashSettleTime:      ctx.GlobalString("logstash-settle-time"),
 		LogstashBinary:          ctx.GlobalString("forwarder-binary"),
 		LogstashConfig:          ctx.GlobalString("forwarder-config"),

--- a/shell/interfaces.go
+++ b/shell/interfaces.go
@@ -44,7 +44,6 @@ type ProcessConfig struct {
 	LogStash    struct {
 		Enable        bool          //enable log stash
 		SettleTime    time.Duration //how long to wait for log stash to flush logs before exiting, ex. 1s
-		IdleFlushTime time.Duration //interval log stash flushes its buffer, ex 1ms
 	}
 }
 

--- a/shell/server.go
+++ b/shell/server.go
@@ -404,7 +404,6 @@ func StartDocker(cfg *ProcessConfig, masterAddress, workerAddress, dockerRegistr
 		"--autorestart=false",
 		"--disable-metric-forwarding",
 		fmt.Sprintf("--logstash=%t", cfg.LogStash.Enable),
-		fmt.Sprintf("--logstash-idle-flush-time=%s", cfg.LogStash.IdleFlushTime),
 		fmt.Sprintf("--logstash-settle-time=%s", cfg.LogStash.SettleTime),
 		svc.ID,
 		"0",


### PR DESCRIPTION
Fixes CC-3537

Includes some refactor to remove duplicate variables/properties for `/etc/filebeat.conf`.

Support for `idle-flush-time` argument was lost when we upgraded to filebeat last fall (not sure it every really worked anyway), so I removed it to lower the cruft factor. Also, I externalized the filebeat configuration into a template, so now if someone wants to adjust the idle-flush-time, they can modify the default value in the template file.