### PR TITLE
Fix pathing bug which broke upgrades and ZP installs

### DIFF
--- a/acceptance.sh
+++ b/acceptance.sh
@@ -13,7 +13,7 @@
 #######################################################
 
 # Use a directory unique to this test to avoid collisions with other kinds of tests
-TEST_VAR_PATH=/tmp/serviced-acceptance/var
+TEST_BASE_PATH=/tmp/serviced-acceptance/
 . test_lib.sh
 
 trap cleanup EXIT

--- a/api_acceptance.sh
+++ b/api_acceptance.sh
@@ -13,7 +13,7 @@
 #######################################################
 
 # Use a directory unique to this test to avoid collisions with other kinds of tests
-TEST_VAR_PATH=/tmp/serviced-api-acceptance/var
+TEST_BASE_PATH=/tmp/serviced-api-acceptance
 . test_lib.sh
 
 trap cleanup EXIT

--- a/cli/api/options.go
+++ b/cli/api/options.go
@@ -199,14 +199,14 @@ func GetDefaultOptions(cfg utils.ConfigReader) config.Options {
 	defaultControllerBinary := filepath.Join(dir, "serviced-controller")
 	options.ControllerBinary = cfg.StringVal("CONTROLLER_BINARY", defaultControllerBinary)
 
-	homepath := cfg.StringVal("HOME", DefaultHomeDir)
-	varpath := filepath.Join(homepath, "var")
+	options.HomePath = cfg.StringVal("HOME", DefaultHomeDir)
+	varpath := filepath.Join(options.HomePath, "var")
 
 	options.IsvcsPath = cfg.StringVal("ISVCS_PATH", filepath.Join(varpath, "isvcs"))
 	options.LogPath  = cfg.StringVal("LOG_PATH", "/var/log/serviced")
 	options.VolumesPath = cfg.StringVal("VOLUMES_PATH", filepath.Join(varpath, "volumes"))
 	options.BackupsPath = cfg.StringVal("BACKUPS_PATH", filepath.Join(varpath, "backups"))
-	options.EtcPath = cfg.StringVal("ETC_PATH", filepath.Join(homepath, "etc"))
+	options.EtcPath = cfg.StringVal("ETC_PATH", filepath.Join(options.HomePath, "etc"))
 	options.StorageArgs = getDefaultStorageOptions(options.FSType, cfg)
 
 	return options

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -236,6 +236,7 @@ func getRuntimeOptions(cfg utils.ConfigReader, ctx *cli.Context) config.Options 
 		MuxDisableTLS:              ctx.GlobalString("mux-disable-tls"),
 		MUXTLSCiphers:              ctx.GlobalStringSlice("mux-tls-ciphers"),
 		MUXTLSMinVersion:           ctx.GlobalString("mux-tls-min-version"),
+		HomePath:                   api.GetDefaultOptions(cfg).HomePath,
 		VolumesPath:                ctx.GlobalString("volumes-path"),
 		IsvcsPath:                  ctx.GlobalString("isvcs-path"),
 		BackupsPath:                ctx.GlobalString("backups-path"),

--- a/config/options.go
+++ b/config/options.go
@@ -36,7 +36,9 @@ var (
 	log     = logging.PackageLogger()
 )
 
-// Options are the server options
+// Options are the server options.
+// Default values and environment variable overrides defined by api.GetDefaultOptions()
+// Command line overrides defined by cmd.New()
 type Options struct {
 	Endpoint                   string // the endpoint address to make RPC requests to
 	UIPort                     string
@@ -51,12 +53,13 @@ type Options struct {
 	MuxDisableTLS              string //  Disable TLS for MUX connections, string val of bool
 	KeyPEMFile                 string
 	CertPEMFile                string
+	HomePath                   string // serviced's root directory; e.g. /opt/serviced
 	VolumesPath                string
 	EtcPath                    string
 	IsvcsPath                  string
 	BackupsPath                string
 	ResourcePath               string
-	LogPath                    string   //Serviced logs directory 
+	LogPath                    string // Serviced logs directory
 	Zookeepers                 []string
 	ReportStats                bool
 	HostStats                  string

--- a/container/controller.go
+++ b/container/controller.go
@@ -343,7 +343,7 @@ func NewController(options ControllerOptions) (*Controller, error) {
 		return c, ErrInvalidHostID
 	}
 
-	if options.Logforwarder.Enabled {
+	if options.Logforwarder.Enabled && len(service.LogConfigs) > 0 {
 		if err := setupLogstashFiles(c.hostID, options.HostIPs, options.ServiceNamePath, service,
 				options.Service.InstanceID, options.Logforwarder); err != nil {
 			glog.Errorf("Could not setup logstash files error:%s", err)

--- a/facade/logstash.go
+++ b/facade/logstash.go
@@ -240,7 +240,7 @@ func getAuditLogSection(configs []servicedefinition.LogConfig, auditTypes *[]str
 	auditSection := ""
 	fileSection := `file {
   path => "%s"
-  codec => line { format => "%{message}"}
+  codec => line { format => "%%{message}"}
 }`
 	auditLogFile := filepath.Join(utils.LOGSTASH_LOCAL_SERVICED_LOG_DIR, "application-audit.log")
 	fileSection = fmt.Sprintf(fileSection, auditLogFile)

--- a/facade/logstash.go
+++ b/facade/logstash.go
@@ -19,18 +19,17 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"sync"
 	"strings"
 
+	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain/servicedefinition"
 	"github.com/control-center/serviced/domain/servicetemplate"
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/utils"
 	log "github.com/Sirupsen/logrus"
-	"github.com/control-center/serviced/dao"
-	"path/filepath"
-	"github.com/control-center/serviced/isvcs"
 )
 
 
@@ -243,7 +242,7 @@ func getAuditLogSection(configs []servicedefinition.LogConfig, auditTypes *[]str
   path => "%s"
   codec => line { format => "%{message}"}
 }`
-	auditLogFile := filepath.Join(isvcs.LOGSTASH_LOCAL_SERVICED_LOG_DIR, "application-audit.log")
+	auditLogFile := filepath.Join(utils.LOGSTASH_LOCAL_SERVICED_LOG_DIR, "application-audit.log")
 	fileSection = fmt.Sprintf(fileSection, auditLogFile)
 	for _, config := range configs {
 		if config.IsAudit {

--- a/facade/logstash.go
+++ b/facade/logstash.go
@@ -30,6 +30,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/control-center/serviced/dao"
 	"path/filepath"
+	"github.com/control-center/serviced/isvcs"
 )
 
 
@@ -239,9 +240,11 @@ func getAuditLogSectionFromTemplates(services []servicedefinition.ServiceDefinit
 func getAuditLogSection(configs []servicedefinition.LogConfig, auditTypes *[]string) string {
 	auditSection := ""
 	fileSection := `file {
-  path => "/var/log/serviced/application-audit.log"
+  path => "%s"
   codec => line { format => "%{message}"}
 }`
+	auditLogFile := filepath.Join(isvcs.LOGSTASH_LOCAL_SERVICED_LOG_DIR, "application-audit.log")
+	fileSection = fmt.Sprintf(fileSection, auditLogFile)
 	for _, config := range configs {
 		if config.IsAudit {
 			if !utils.StringInSlice(config.Type, *auditTypes){

--- a/facade/logstash_test.go
+++ b/facade/logstash_test.go
@@ -249,7 +249,7 @@ func TestGettingFilterDefinitionsFromServiceDefinitions(t *testing.T) {
 
 	// make sure the number matches the number we define
 	if len(filterDefs) != 4 {
-		t.Error(fmt.Sprintf("Found %d instead of 2 filter definitions", len(filterDefs)))
+		t.Error(fmt.Sprintf("Found %d instead of 4 filter definitions", len(filterDefs)))
 	}
 }
 

--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -44,7 +44,7 @@ var UseServicedLogDir = "UseServicedLogDir"
 func loadvolumes() {
 	if isvcsVolumes == nil {
 		isvcsVolumes = map[string]string{
-			utils.ResourcesDir(): "/usr/local/serviced/resources",
+			utils.ResourcesDir(): utils.RESOURCES_CONTAINER_DIRECTORY,
 		}
 	}
 }

--- a/isvcs/logstash.go
+++ b/isvcs/logstash.go
@@ -13,16 +13,20 @@
 
 package isvcs
 
-var logstash *IService
+import (
+	"path/filepath"
 
-// The container-local path logstash uses to write the shared directory for serviced logs
-const LOGSTASH_LOCAL_SERVICED_LOG_DIR = "/var/log/serviced"
+	"github.com/control-center/serviced/utils"
+)
+
+var logstash *IService
 
 func initLogstash() {
 	var err error
 
+	confFile := filepath.Join(utils.LOGSTASH_CONTAINER_DIRECTORY, "logstash.conf")
 	command := "exec /opt/logstash/bin/logstash agent " +
-		"-f /usr/local/serviced/resources/logstash/logstash.conf --auto-reload"
+		"-f " + confFile + " --auto-reload"
 	localFilePortBinding := portBinding{
 		HostIp:         "0.0.0.0",
 		HostIpOverride: "", // logstash should always be open
@@ -50,7 +54,7 @@ func initLogstash() {
 				localFilePortBinding,
 				filebeatPortBinding,
 				webserverPortBinding},
-			Volumes:    map[string]string{UseServicedLogDir : LOGSTASH_LOCAL_SERVICED_LOG_DIR},
+			Volumes:    map[string]string{UseServicedLogDir : utils.LOGSTASH_LOCAL_SERVICED_LOG_DIR},
 			Links:      []string{"serviced-isvcs_elasticsearch-logstash:elasticsearch"},
 			StartGroup: 1,
 		})

--- a/isvcs/logstash.go
+++ b/isvcs/logstash.go
@@ -15,6 +15,9 @@ package isvcs
 
 var logstash *IService
 
+// The container-local path logstash uses to write the shared directory for serviced logs
+const LOGSTASH_LOCAL_SERVICED_LOG_DIR = "/var/log/serviced"
+
 func initLogstash() {
 	var err error
 
@@ -47,7 +50,7 @@ func initLogstash() {
 				localFilePortBinding,
 				filebeatPortBinding,
 				webserverPortBinding},
-			Volumes:    map[string]string{UseServicedLogDir : "/var/log/serviced"},
+			Volumes:    map[string]string{UseServicedLogDir : LOGSTASH_LOCAL_SERVICED_LOG_DIR},
 			Links:      []string{"serviced-isvcs_elasticsearch-logstash:elasticsearch"},
 			StartGroup: 1,
 		})

--- a/isvcs/resources/logstash/filebeat.conf.in
+++ b/isvcs/resources/logstash/filebeat.conf.in
@@ -2,6 +2,10 @@ filebeat:
   idle_timeout: 5s
   prospectors: ${PROSPECTORS_SECTION}
 
+path:
+  data: /var/lib/beat
+  logs: /var/log/beat
+
 output:
   logstash:
     enabled: true

--- a/node/container.go
+++ b/node/container.go
@@ -37,6 +37,7 @@ import (
 	dockerclient "github.com/fsouza/go-dockerclient"
 )
 
+
 func (a *HostAgent) setInstanceState(serviceID string, instanceID int, state service.InstanceCurrentState) error {
 	logger := plog.WithFields(log.Fields{
 		"serviceid":  serviceID,
@@ -653,9 +654,8 @@ func (a *HostAgent) createContainerConfig(tenantID string, svc *service.Service,
 
 	// bind mount everything we need for filebeat
 	if len(svc.LogConfigs) != 0 {
-		const LOGSTASH_CONTAINER_DIRECTORY = "/usr/local/serviced/resources/logstash"
-		logstashPath := utils.ResourcesDir() + "/logstash"
-		addBindingToMap(bindsMap, LOGSTASH_CONTAINER_DIRECTORY, logstashPath)
+		logstashPath := filepath.Join(utils.ResourcesDir(), "logstash")
+		addBindingToMap(bindsMap, utils.LOGSTASH_CONTAINER_DIRECTORY, logstashPath)
 	}
 
 	// Bind mount the keys we need

--- a/serviced-controller/daemon.go
+++ b/serviced-controller/daemon.go
@@ -17,10 +17,12 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/control-center/serviced/servicedversion"
+	"github.com/control-center/serviced/utils"
 )
 
 func main() {
@@ -37,8 +39,10 @@ func main() {
 	app.Name = "serviced-controller"
 	app.Usage = "serviced container controller"
 	app.Version = fmt.Sprintf("%s - %s ", servicedversion.Version, servicedversion.Gitcommit)
+
+	filebeatPath := filepath.Join(utils.LOGSTASH_CONTAINER_DIRECTORY, "filebeat")
 	app.Flags = []cli.Flag{
-		cli.StringFlag{"forwarder-binary", "/usr/local/serviced/resources/logstash/filebeat", "path to the filebeat binary"},
+		cli.StringFlag{"forwarder-binary", filebeatPath, "path to the filebeat binary"},
 		cli.StringFlag{"forwarder-config", "/etc/filebeat.conf", "path to the filebeat config file"},
 		cli.IntFlag{"muxport", defaultMuxPort, "multiplexing port to use"},
 		cli.StringFlag{"keyfile", "", "path to private key file (defaults to compiled in private keys"},

--- a/shell/server.go
+++ b/shell/server.go
@@ -20,9 +20,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -51,22 +49,6 @@ const (
 	DOCKER_ENDPOINT        = "unix:///var/run/docker.sock"
 )
 
-var webroot string
-
-func init() {
-	servicedHome := os.Getenv("SERVICED_HOME")
-	if len(servicedHome) > 0 {
-		webroot = servicedHome + "/share/shell/static"
-	}
-}
-
-func staticRoot() string {
-	if len(webroot) == 0 {
-		_, filename, _, _ := runtime.Caller(1)
-		return path.Join(path.Dir(path.Dir(filename)), "shell", "static")
-	}
-	return webroot
-}
 
 func NewProcessForwarderServer(addr string) *ProcessServer {
 	server := &ProcessServer{

--- a/shell/server.go
+++ b/shell/server.go
@@ -398,7 +398,8 @@ func StartDocker(cfg *ProcessConfig, masterAddress, workerAddress, dockerRegistr
 		logger.WithError(err).Error("Docker not found")
 		return nil, err
 	}
-	argv := []string{"run", "-v", servicedVolume, "-v", pwdVolume, "-v", utils.ResourcesDir() + ":" + "/usr/local/serviced/resources", "-u", "root", "-w", "/"}
+	resourceBinding := fmt.Sprintf("%s:%s", utils.ResourcesDir(), utils.RESOURCES_CONTAINER_DIRECTORY )
+	argv := []string{"run", "-v", servicedVolume, "-v", pwdVolume, "-v", resourceBinding, "-u", "root", "-w", "/"}
 	for _, mount := range cfg.Mount {
 		hostPath, containerPath, err := parseMountArg(mount)
 		if err != nil {

--- a/smoke.sh
+++ b/smoke.sh
@@ -8,7 +8,7 @@
 #######################################################
 
 # Use a directory unique to this test to avoid collisions with other kinds of tests
-TEST_VAR_PATH=/tmp/serviced-smoke/var
+TEST_BASE_PATH=/tmp/serviced-smoke
 . test_lib.sh
 
 add_template() {
@@ -213,7 +213,7 @@ test_service_run_command() {
 
 # Whitelist serviced.default values that don't need to be documented in the
 # defaults file.
-# Note: SERVICE_D_ISVCS_ENV_0 exists and is parsed as a list of entries.
+# Note: SERVICED_ISVCS_ENV_0 exists and is parsed as a list of entries.
 #       SERVICED_LOG_CONFIG documentation has been deferred as per Ian.
 #       SERVICED_BACKUP_ESTIMATED_COMPRESSION and SERVICED_BACKUP_MIN_OVERHEAD are
 #       intentionally undocumented (available to tweak backup estimates for CC-2421)
@@ -272,6 +272,7 @@ echo "SERVICED=${SERVICED}"
 retry 20 add_host          && succeed "Added host successfully"                  || fail "Unable to add host"
 add_template               && succeed "Added template successfully"              || fail "Unable to add template"
 deploy_service             && succeed "Deployed service successfully"            || fail "Unable to deploy service"
+
 retry 20 test_service_run  && succeed "Service run ran successfully"             || fail "Unable to run service run"
 start_service              && succeed "Started service"                          || fail "Unable to start service"
 retry 10 test_started      && succeed "Service containers started"               || fail "Unable to see service containers"

--- a/utils/directory.go
+++ b/utils/directory.go
@@ -31,6 +31,17 @@ import (
 )
 
 
+// The container-local path to the resources directory.
+// This directory is bind mounted into both isvcs and service containers
+const RESOURCES_CONTAINER_DIRECTORY = "/usr/local/serviced/resources"
+
+// The container-local path to the directory for logstash/filebeat configuration.
+// This directory is bind mounted into both isvcs and service containers
+const LOGSTASH_CONTAINER_DIRECTORY = "/usr/local/serviced/resources/logstash"
+
+// The container-local path to the directory logstash uses to write application audit logs
+const LOGSTASH_LOCAL_SERVICED_LOG_DIR = "/var/log/serviced"
+
 //ServiceDHome gets the home location of serviced by looking at the environment
 func ServiceDHome() string {
 	homeDir := config.GetOptions().HomePath
@@ -81,3 +92,4 @@ func ServicedLogDir() string {
 		return os.Getenv("SERVICED_LOG_PATH")
 	}
 }
+

--- a/utils/directory.go
+++ b/utils/directory.go
@@ -23,12 +23,13 @@ import (
 	"os"
 	"os/user"
 	"path"
-	"path/filepath"
+	"runtime"
 	"strings"
+
 	"github.com/control-center/serviced/config"
 	"github.com/zenoss/glog"
-	"runtime"
 )
+
 
 //ServiceDHome gets the home location of serviced by looking at the environment
 func ServiceDHome() string {
@@ -56,15 +57,6 @@ func LocalDir(p string) string {
 // ResourcesDir points to internal services resources directory
 func ResourcesDir() string {
 	return LocalDir("isvcs/resources")
-}
-
-// BackupDir gets the directory where backup files are stored
-func BackupDir(basepath string) string {
-	if backupDir := strings.TrimSpace(basepath); backupDir == "" {
-		return TempDir("backups")
-	} else {
-		return filepath.Join(filepath.Clean(backupDir), "backups")
-	}
 }
 
 // TempDir gets the temp serviced directory

--- a/utils/directory_test.go
+++ b/utils/directory_test.go
@@ -20,50 +20,50 @@
 package utils
 
 import (
-	"os"
 	"strings"
 	"testing"
+	"github.com/control-center/serviced/config"
 )
 
 func TestLocalDir(t *testing.T) {
-	original := os.Getenv("SERVICED_HOME")
+	original := config.GetOptions()
 	// make sure we clean up after ourselves
 	defer func() {
-		os.Setenv("SERVICED_HOME", original)
+		config.LoadOptions(original)
 	}()
 
-	os.Setenv("SERVICED_HOME", "test")
+	config.LoadOptions(config.Options{HomePath: "/testRoot"})
 	testDir := LocalDir("test")
-	if testDir != "test/test" {
+	if testDir != "/testRoot/test" {
 		t.Errorf("Expected test directory to be test/test instead it was %s", testDir)
 	}
 }
 
 func TestResourcesDir(t *testing.T) {
-	original := os.Getenv("SERVICED_HOME")
+	original := config.GetOptions()
 	// make sure we clean up after ourselves
 	defer func() {
-		os.Setenv("SERVICED_HOME", original)
+		config.LoadOptions(original)
 	}()
 
-	os.Setenv("SERVICED_HOME", "test")
+	config.LoadOptions(config.Options{HomePath: "/testRoot"})
 	testDir := ResourcesDir()
-	if testDir != "test/isvcs/resources" {
+	if testDir != "/testRoot/isvcs/resources" {
 		t.Errorf("Resources directory was an unexpected value  %s", testDir)
 	}
 }
 
 func TestDefaultDir(t *testing.T) {
-	original := os.Getenv("SERVICED_HOME")
+	original := config.GetOptions()
 	// make sure we clean up after ourselves
 	defer func() {
-		os.Setenv("SERVICED_HOME", original)
+		config.LoadOptions(original)
 	}()
 
-	os.Setenv("SERVICED_HOME", "")
+	config.LoadOptions(config.Options{HomePath: ""})
 	testDir := LocalDir("test")
 	if !strings.Contains(testDir, "/serviced/") {
-		t.Errorf("Making sure the local directory includes serviced	 %s", testDir)
+		t.Errorf("Making sure the local directory includes serviced: %s", testDir)
 	}
 
 	if strings.Contains(testDir, "utils") {

--- a/web/cpserver.go
+++ b/web/cpserver.go
@@ -122,7 +122,7 @@ func (sc *ServiceConfig) Serve(shutdown <-chan (interface{})) {
 	mime.AddExtensionType(".json", "application/json")
 	mime.AddExtensionType(".woff", "application/font-woff")
 
-	accessLogDir := "/var/log/serviced"
+	accessLogDir := utils.ServicedLogDir()
 	if _, err := os.Stat(accessLogDir); os.IsNotExist(err) {
 		// This block of code is more for the zendev scenario (i.e. no rpm install).
 		// See the postinstall script in the RPM for the setting that typically occurs in production installs.

--- a/web/util.go
+++ b/web/util.go
@@ -14,26 +14,14 @@
 package web
 
 import (
-	"flag"
 	"fmt"
 	"net/http"
-	"os"
 	"path"
-	"runtime"
 
 	"github.com/zenoss/go-json-rest"
+	"github.com/control-center/serviced/utils"
 )
 
-var webroot string
-
-func init() {
-	webrootDefault := ""
-	servicedHome := os.Getenv("SERVICED_HOME")
-	if len(servicedHome) > 0 {
-		webrootDefault = servicedHome + "/share/web/static"
-	}
-	flag.StringVar(&webroot, "webroot", webrootDefault, "static director for web content, defaults to GO runtime path of src")
-}
 
 /*******************************************************************************
  *
@@ -269,12 +257,7 @@ func noCache(w *rest.ResponseWriter) {
  * Hack to get us the location on the filesystem of our static files.
  */
 func staticRoot() string {
-	if len(webroot) == 0 {
-		// this should only be the case when running locally for dev out of the serviced directory
-		_, thisFilename, _, _ := runtime.Caller(0)
-		return path.Join(path.Dir(thisFilename), "ui/build")
-	}
-	return webroot
+	return utils.LocalDir("share/web/static")
 }
 
 const servicesURI = "/services"


### PR DESCRIPTION
Fixes CC-3540

The problems in CC-3540 were rooted in the fact that we had different sets of logic to determine the value of SERVICED_HOME. When running `serviced service shell ...` that particular code path would end up with the incorrect location of SERVICED_HOME.  

So I removed all of the duplication and/or alternate path finding mechanisms such that all code uses the same value (the one set by the command line argument processing). The only time that value is not used, is during unit-tests where we fallback to the older code that derives SERVICED_HOME from the path to the serviced executable (see `ServiceDHome()` in utils/directory.go).

After going through that effort for SERVICED_HOME, I noticed that we had a lot of copy/paste code for the paths `/var/log/serviced` and `/usr/local/serviced/resources`, so I added some additional refactoring to consolidate those string references into a single set of constants defined in utils/directory.go.

Lastly, I had to make adjustments to some of our test harnesses to setup a test-specific SERVICED_HOME rather than just overriding a handful of the paths - see changes to `test_lib.sh`