### PR TITLE
Include UI resources in setup for test env

### DIFF
--- a/test_lib.sh
+++ b/test_lib.sh
@@ -70,6 +70,9 @@ setup_serviced_config() {
     local SERVICED_RESOURCES_PATH=${SERVICED_HOME}/isvcs/resources
     mkdir -p ${SERVICED_RESOURCES_PATH}
     cp -r ${DIR}/isvcs/resources/* ${SERVICED_RESOURCES_PATH}
+
+    mkdir -p ${SERVICED_HOME}/share/web
+    ln -s ${DIR}/web/ui/build ${SERVICED_HOME}/share/web/static
 }
 
 print_env_info() {


### PR DESCRIPTION
Fixes broken UI acceptance tests like http://platform-jenkins.zenoss.eng/job/ControlCenter/job/develop/job/merge-ui-acceptance/69/

The problem was that the refactoring for CC-3540 now requires a more explicit setup of the CC execution environment, rather than relying a couple of adhoc runtime adjustments based on the binary's current working directory