### PR TITLE
Backport changes originally from CC-3518

### DIFF
--- a/cli/api/api.go
+++ b/cli/api/api.go
@@ -128,6 +128,7 @@ func configureLoggingForLogstash(logstashURL string) {
 	if err != nil {
 		hostname = "unknown"
 	}
+	// TODO: CC-3061: Our use of logrus does not support a similar integration with logstash
 	glog.SetLogstashType("serviced-" + hostname)
 	glog.SetLogstashURL(logstashURL)
 }

--- a/makefile
+++ b/makefile
@@ -269,6 +269,7 @@ $(_DESTDIR)$(sysconfdir)/cron.weekly_TARGETS       = pkg/serviced-fstrim:service
 $(_DESTDIR)$(sysconfdir)/cron.weekly_TARGETS      += pkg/serviced-zenossdbpack:serviced-zenossdbpack
 $(_DESTDIR)$(prefix)/etc_TARGETS                   = pkg/serviced.logrotate:logrotate.conf
 $(_DESTDIR)$(prefix)/etc_TARGETS                  += pkg/logconfig-cli.yaml:logconfig-cli.yaml
+$(_DESTDIR)$(prefix)/etc_TARGETS                  += pkg/logconfig-controller.yaml:logconfig-controller.yaml
 $(_DESTDIR)$(prefix)/etc_TARGETS                  += pkg/logconfig-server.yaml:logconfig-server.yaml
 $(_DESTDIR)$(prefix)/bin_TARGETS                   = $(GOBIN)/serviced:serviced
 $(_DESTDIR)$(prefix)/bin_TARGETS                  += $(GOBIN)/serviced-controller:serviced-controller

--- a/node/container.go
+++ b/node/container.go
@@ -659,6 +659,7 @@ func (a *HostAgent) createContainerConfig(tenantID string, svc *service.Service,
 	}
 
 	// Bind mount the keys we need
+	// Note that /etc/serviced also contains logconfig-controller.yaml
 	addBindingToMap(bindsMap, "/etc/serviced", filepath.Dir(a.delegateKeyFile))
 
 	// specify temporary volume paths for docker to create

--- a/pkg/logconfig-controller.yaml
+++ b/pkg/logconfig-controller.yaml
@@ -1,0 +1,2 @@
+- logger: '*'
+  level: info

--- a/pkg/makefile
+++ b/pkg/makefile
@@ -228,6 +228,10 @@ rpm: stage_rpm
 		--after-remove rpm/postuninstall \
 		--rpm-pretrans rpm/pretrans \
 		--config-files /etc/default/serviced \
+		--config-files /opt/serviced/etc/logconfig-cli.yaml \
+		--config-files /opt/serviced/etc/logconfig-controller.yaml \
+		--config-files /opt/serviced/etc/logconfig-server.yaml \
+		--config-files /opt/serviced/etc/logrotate.conf \
 		.
 
 # Make a TGZ

--- a/serviced-controller/proxy.go
+++ b/serviced-controller/proxy.go
@@ -15,16 +15,19 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"os"
 	"strconv"
 
 	"github.com/codegangsta/cli"
 	"github.com/control-center/serviced/container"
+	coordzk "github.com/control-center/serviced/coordinator/client/zookeeper"
 	"github.com/control-center/serviced/logging"
 	"github.com/control-center/serviced/rpc/rpcutils"
 	"github.com/control-center/serviced/utils"
 	"github.com/zenoss/glog"
 	log "github.com/Sirupsen/logrus"
+	"github.com/zenoss/logri"
 )
 
 var plog = logging.PackageLogger()
@@ -82,6 +85,10 @@ func CmdServiceProxy(ctx *cli.Context) {
 }
 
 func StartProxy(options ControllerOptions) error {
+	logri.ApplyConfigFromFile(filepath.Join("/etc/serviced", "logconfig-controller.yaml"))
+	coordzk.RegisterZKLogger()
+
+	// TODO: CC-3061: Our use of logrus does not support a similar integration with logstash
 	glog.SetLogstashType("controller-" + options.ServiceID + "-" + options.InstanceID)
 	glog.SetLogstashURL(options.LogstashURL)
 


### PR DESCRIPTION
Fixes CC-3554

Backport changes to allow configurable logging for `serviced-controller`