### PR TITLE
Add simple backoff for glog:logstash integration

### DIFF
--- a/vendor/github.com/zenoss/glog/glog_logstash.go
+++ b/vendor/github.com/zenoss/glog/glog_logstash.go
@@ -17,46 +17,60 @@ type logstashMessage struct {
 // handleLogstashMessages sends logs to logstash.
 func (l *loggingT) handleLogstashMessages() {
 	var conn net.Conn
-	ticker := time.Tick(1 * time.Second)
+
+	initialDelay := 500.0 * time.Millisecond
+	maxDelay := 90.0 * time.Second
+	delay := initialDelay
+	conn, _ = net.DialTimeout("tcp", l.logstashURL, 1*time.Second)
 	for {
 		select {
 		case _ = <-l.logstashStop:
 			conn.Close()
 			return
-		case _ = <-ticker:
-			var err error
-			if conn == nil {
-				//fmt.Fprintln(os.Stderr, "Trying to connect to logstash server...", l.logstashURL)
-				conn, err = net.Dial("tcp", l.logstashURL)
-				if err != nil {
-					conn = nil
-				} else {
-					//fmt.Fprintln(os.Stderr, "Connected to logstash server.")
-				}
-			}
 		case data := <-l.logstashChan:
 			lm := logstashMessage{}
 			lm.Type = l.logstashType
 			lm.Message = strings.TrimSpace(data)
 			packet, err := json.Marshal(lm)
 			if err != nil {
-				fmt.Fprintln(os.Stderr, "Failed to marshal logstashMessage.")
+				fmt.Fprintf(os.Stderr, "%s: Failed to marshall logstashMessage.\n",  msgPrefix())
 				continue
-			}
-			if conn != nil {
+			} else if conn != nil {
 				_, err := fmt.Fprintln(conn, string(packet))
 				if err != nil {
-					//fmt.Fprintln(os.Stderr, "Not connected to logstash server, attempting reconnect.")
 					conn = nil
-					continue
+				} else {
+					// reset the delay once we were able to write something to logstash
+					delay = initialDelay
 				}
 			} else {
 				// There is no connection, so the log line is dropped.
 				// Might be nice to add a buffer here so that we can ship
 				// logs after the connection is up.
 			}
+		default:
+			time.Sleep(1 * time.Second)
+		}
+
+		if conn == nil {
+			delay *= 2.0
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+			time.Sleep(delay)
+
+			var err error
+			conn, err = net.DialTimeout("tcp", l.logstashURL, 1*time.Second)
+			if err != nil {
+				conn = nil
+			}
 		}
 	}
+}
+
+// Message prefix for direct writes to stderr
+func msgPrefix() string {
+	return fmt.Sprintf("glog: %s: ", time.Now().Format("15:04:05.00000"))
 }
 
 // StartLogstash creates the logstash channel and kicks off handleLogstashMessages.


### PR DESCRIPTION
Fixes ZEN-27545

This is a simple approach to keep this integration from spamming connect attempts when logstash is not reachable. Will likely be removed altogether in the near future