### PR TITLE
Feature/CC-3494 Add facilities for CC audit logging

### DIFF
--- a/audit/action.go
+++ b/audit/action.go
@@ -1,0 +1,33 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+// Defined actions for audit logging.
+const (
+
+	// Add is the string for the add action when logging.
+	Add = "add"
+
+	// Remove is the string for the remove action when logging.
+	Remove = "remove"
+
+	// Update is the string for the update action when logging.
+	Update = "update"
+
+	// Stop is the string for the stop action when logging.
+	Stop = "stop"
+
+	// Start is the string for the start action when logging.
+	Start = "start"
+)

--- a/audit/context.go
+++ b/audit/context.go
@@ -1,0 +1,35 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+// Context information necessary for audit logging.
+type Context interface {
+
+	// User returns the user performing the action.
+	User() string
+}
+
+// NewContext returns default implementation of the Context interface that has the
+// provided string for a user.
+func NewContext(user string) Context {
+	return &context{user: user}
+}
+
+type context struct {
+	user string
+}
+
+func (c *context) User() string {
+	return c.user
+}

--- a/audit/doc.go
+++ b/audit/doc.go
@@ -70,9 +70,10 @@
 
 		auditLogger = auditLogger.ID("PoolID")
 
-	The API also provides a generic "WithFields" method.  If a custom, one-off field needs to be added to an entry, this method can be used.
+	The API also provides the methods "WithField" and "WithFields".  If custom, one-off fields needs to be added to an entry, these methods can be used.
 
 		auditLogger = auditLogger.WithField("FieldName", "ItsValue")
+		auditLogger = auditLogger.WithFields(logrus.Fields{"FieldName1": "Value1", "FieldName2":, "Value2"})
 
 	There are a number of ways that can be used to trigger logging which will also signal success or failure.  The signal success, use the "Success"
 	method.

--- a/audit/doc.go
+++ b/audit/doc.go
@@ -1,0 +1,204 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+	Package audit implements audit logging.
+
+	This package provides an implementation of the Logger interface that can
+	be used to perform audit logging.
+
+	Entries
+
+	The default logger implementation will create entries in the log file with the following fields.
+
+		time: 	 The time that the action took place.
+		level: 	 The log level for the action.  Warnings will be for failed actions, and info for successful actions.
+		action:	 The action being performed (e.g. add, remove, update, start, stop, etc).
+		type:    Entity being changed if applicable (e.g. resourcepool, host, service, etc).
+		id:      Id of entity being changed if applicable.
+		msg:     User friending message about what action took place.
+		success: Either true or false.
+		user: 	 The user performing the action.  This will default to "system" if no user is provided.
+
+	An entry for a successful attempt to add a resouce pool.
+
+		time="2017-05-11T19:41:10Z" level=info msg="Adding Resource Pool Swimming" action=add success=true user=system type=resourcepool id=Swimming
+
+	An entry for a failed attempt to add a resouce pool.
+
+		time="2017-05-11T19:41:10Z" level=warning msg="Adding Resource Pool Swimming" action=add success=false user=system type=resourcepool id=Swimming
+
+	API
+
+	The Logger interface provides a fluent API for creating log entries.  A new Logger can be retrieved by calling the NewLogger method.
+
+		var auditLogger = audit.NewLogger()
+
+	The default implementation that is returned is a wrapped logri Logger.  Logri is a package owned by Zenoss that adds additional
+	functionality to Loggers from the third party package, logrus.
+
+	Contextual information can be passed into the Logger through the Context method.  The Context method will take a Context interface that is defined in
+	this package.   Currently the context only takes a user.  In the future, additional contextual information can be added to this object.  A new context
+	object can be retrieved through the NewContext method.
+
+		var ctx = audit.NewContext("Alice")
+
+	The context, like the other fields is optional.  If one is not provied the user will default to "system".  To set the Context call the following.
+
+		auditLogger = auditLogger.Context(ctx)
+
+	A friendly message can be set on the audit logger through the use of the "Message" method.  This will set the "msg" field:
+
+		auditLogger = auditLogger.Message("Adding Resource Pool: " + entity.ID)
+
+	The "action field is set through the "Action" method.  Some constants are provided in this package to normalized the values.  Examples are "add", "update",
+	"delete", "start", "stop", etc.  If addition actions need to be added, new constants should be added to this package.
+
+		auditLogger = auditLogger.Action(audit.Add)
+
+	The type of entity being modified is set through the "Type" method.  To normalize these values, constants found in the domain package should be used.
+
+		auditLogger = auditLogger.Type(domain.ResourcePoolType)
+
+	To set the "id" field, use the "ID" method.
+
+		auditLogger = auditLogger.ID("PoolID")
+
+	The API also provides a generic "WithFields" method.  If a custom, one-off field needs to be added to an entry, this method can be used.
+
+		auditLogger = auditLogger.WithField("FieldName", "ItsValue")
+
+	There are a number of ways that can be used to trigger logging which will also signal success or failure.  The signal success, use the "Success"
+	method.
+
+		auditLogger.Success()
+
+	The "Success" method will set the "success" field to "true" and the "level" to "info".  This will also signal the audit logger to log.
+
+	To log a failed action, use the "Failure" method.  This will set "success" to "false" and the "level" to "warning".
+
+		auditLogger.Failure()
+
+	There are also a couple of methods that have been added for convenience.  These are the "SucceededIf" and "Error" methods.  The "SucceededIf"
+	method takes a boolean.  If passed in true, it will log that the action was successful in the same way that the "Success" method does.  If
+	passed in false, it will log failure in similar fashion to the "Failure" message.
+
+		auditLogger.SucceededIf(returnedValue == "EverythingOK")
+
+	The "Error" method is convenient for working with methods that return only a single error type.  The convention is that a method will return
+	a nil error if it was successful.  If something went wrong, the method will return a non-nil error.  The "Error" method will take an error and check to see
+	if it is nil.  If it is, the audit logger  will then log success. If it is not nil, it will log failure.  The method also returns the error that
+	was passed in.  This is convenient for wrapping calls.  For example, method could be defined that returns a single error.
+
+		func DoSomething() error { ... }
+
+	The could be code that we want to audit where that method is used.
+
+		err := DoSomething()
+		if err != nil {
+			...
+		}
+
+	If we wanted to audit the success of failure of the "DoSomething" call, we could wrap it with a call to the "Error" method on the auditLogger.
+
+		err := auditLogger.Error(DoSomething())
+		if err != nil {
+			...
+		}
+
+	In this case, the err variable will still have the same value as the previous call because the error returned by "DoSomething" is just passed through.
+	Success or failure will be logged depending on the value of the error that is returned from the "DoSomething" method.
+
+	The API is designed to be fluent so the method calls can be chained together.  For example, setting the fields and logging success can be done
+	at the same time.  The following sets the context, message, action, id, type, and success:
+
+		auditLogger.Context(ctx).
+		            Message("Adding Resource Pool: " + entity.ID).
+		            Action(audit.Add).
+		            ID(entity.ID).
+		            Type(domain.ResourcePoolType).
+					Success()
+
+
+	This can also be seperated, into multiple groups of calls.  The values could be defined at the top of a method, and "Success" for "Failure" called later.
+
+		func SomethingWeAuditing() {
+			alog := auditLogger.Context(ctx).
+						Message("Adding Resource Pool: " + entity.ID).
+						Action(audit.Add).
+						ID(entity.ID).
+						Type(domain.ResourcePoolType).
+
+
+			// Do processing
+			// ...
+
+			if everythingOK {
+				alog.Success()
+			} else {
+				alog.Failed()
+			}
+
+			return
+		}
+
+
+	Common Patterns
+
+	Here is an example using the "SucceededIf" and "Failed" pattern to add audit logging to a method that adds resource pools.
+
+		func (f *Facade) AddResourcePool(ctx datastore.Context, entity *pool.ResourcePool) error {
+			defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.AddResourcePool"))
+
+			glog.Infof("Adding Resource Pool %s", entity.ID)
+
+			alog := f.auditLogger.Context(ctx).Message("Adding Resource Pool: " + entity.ID).
+				Action(audit.Add).ID(entity.ID).Type(domain.ResourcePoolType)
+
+			if err := f.DFSLock(ctx).LockWithTimeout("add resource pool", userLockTimeout); err != nil {
+				glog.Warningf("Cannot add resource pool: %s", err)
+				alog.Failure()
+				return err
+			}
+			defer f.DFSLock(ctx).Unlock()
+
+			err := f.addResourcePool(ctx, entity)
+
+			alog.SuceededIf(err == nil)
+
+			return err
+		}
+
+	Since this method return just an error, the "Error" method can be used to make things more concise.
+
+		func (f *Facade) AddResourcePool(ctx datastore.Context, entity *pool.ResourcePool) error {
+			defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.AddResourcePool"))
+
+			glog.Infof("Adding Resource Pool %s", entity.ID)
+
+			alog := f.auditLogger.Context(ctx).Message("Adding Resource Pool: " + entity.ID).
+				Action(audit.Add).ID(entity.ID).Type(domain.ResourcePoolType)
+
+			if err := f.DFSLock(ctx).LockWithTimeout("add resource pool", userLockTimeout); err != nil {
+				glog.Warningf("Cannot add resource pool: %s", err)
+				return alog.Error(err)
+			}
+			defer f.DFSLock(ctx).Unlock()
+
+			return alog.Error(f.addResourcePool(ctx, entity))
+		}
+
+	In some methods, wrapping with the "Error" method might be more concise or easier to add.  However, there may be situations where the "Error" method is not adequate or a good fit.
+	When the success or failure of an action is not dependent on an error, the "Succeeded", "SucceededIf", and "Failure" methods can then be used.
+*/
+package audit

--- a/audit/logger.go
+++ b/audit/logger.go
@@ -15,9 +15,10 @@ package audit
 
 import (
 	"strconv"
+
+	"github.com/Sirupsen/logrus"
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/logging"
-	"github.com/Sirupsen/logrus"
 	"github.com/zenoss/logri"
 )
 
@@ -80,9 +81,9 @@ func (l *logger) Action(action string) Logger {
 }
 
 func (l *logger) Message(ctx datastore.Context, message string) Logger {
-    l.addField("user", ctx.User())
-    l.message = message
-    return l
+	l.addField("user", ctx.User())
+	l.message = message
+	return l
 }
 
 func (l *logger) Type(theType string) Logger {
@@ -97,35 +98,29 @@ func (l *logger) Entity(entity datastore.Entity) Logger {
 	return l.addFields(logrus.Fields{
 		"id":   entity.GetID(),
 		"type": entity.GetType(),
-		})
+	})
 }
 
 func (l *logger) WithField(name string, value string) Logger {
-    return l.addField(name, value)
+	return l.addField(name, value)
 }
 
 func (l *logger) addField(name string, value string) Logger {
-    if l.entry != nil {
-        l.entry = l.entry.WithField(name, value)
-    } else {
-        l.entry = l.loggeri.WithField(name, value)
-        l.entry.Logger.Hooks = make(map[logrus.Level][]logrus.Hook)
-    }
-    return l
+	return l.addFields(logrus.Fields{name: value})
 }
 
 func (l *logger) WithFields(fields logrus.Fields) Logger {
-    return l.addFields(fields)
+	return l.addFields(fields)
 }
 
-func (l *logger) addFields(fields logrus.Fields)  Logger {
-    if l.entry != nil {
-        l.entry = l.entry.WithFields(fields)
-    } else {
-        l.entry = l.loggeri.WithFields(fields)
-        l.entry.Logger.Hooks = make(map[logrus.Level][]logrus.Hook)
-    }
-    return l
+func (l *logger) addFields(fields logrus.Fields) Logger {
+	if l.entry != nil {
+		l.entry = l.entry.WithFields(fields)
+	} else {
+		l.entry = l.loggeri.WithFields(fields)
+		l.entry.Logger.Hooks = make(map[logrus.Level][]logrus.Hook)
+	}
+	return l
 }
 
 func (l *logger) Succeeded() {
@@ -146,8 +141,8 @@ func (l *logger) Error(err error) error {
 }
 
 func (l *logger) log(success bool) {
-    l.addField("success", strconv.FormatBool(success))
-    entry := l.entry
+	l.addField("success", strconv.FormatBool(success))
+	entry := l.entry
 	if len(l.message) == 0 {
 		pkgLogger := plog.WithFields(entry.Data)
 		pkgLogger.Error("Attempting to audit log empty message")
@@ -158,4 +153,3 @@ func (l *logger) log(success bool) {
 		entry.Warn(l.message)
 	}
 }
-

--- a/audit/logger.go
+++ b/audit/logger.go
@@ -14,9 +14,10 @@
 package audit
 
 import (
-	"github.com/Sirupsen/logrus"
+	"strconv"
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/logging"
+	"github.com/Sirupsen/logrus"
 	"github.com/zenoss/logri"
 )
 
@@ -41,8 +42,11 @@ type Logger interface {
 	// Set the type of entity being modified.
 	Entity(entity datastore.Entity) Logger
 
-	// Add additional fields to the entry.
+	// Add an additional field to the entry.
 	WithField(name string, value string) Logger
+
+	// Add additional fields to the entry.
+	WithFields(fields logrus.Fields) Logger
 
 	// Log that the action succeeded.
 	Succeeded()
@@ -61,45 +65,67 @@ type Logger interface {
 // to "system" unless otherwise specified in the context.  This wraps a logri Logger,
 // and will write to the location specified in the logger config.
 func NewLogger() Logger {
-	entry := logri.GetLogger("audit").WithField("user", "system")
-
-	// Clear hooks on the logri logger to remove extra fields that we don't need for
-	// the audit log (the "logger" and "location" fields).
-	entry.Logger.Hooks = make(map[logrus.Level][]logrus.Hook)
-
-	return &logger{entry: entry}
+	l := logri.GetLogger("audit")
+	return &logger{loggeri: l}
 }
 
 type logger struct {
 	entry   *logrus.Entry
 	message string
+	loggeri *logri.Logger
 }
 
 func (l *logger) Action(action string) Logger {
-	return l.newLoggerWith("action", action)
+	return l.addField("action", action)
 }
 
 func (l *logger) Message(ctx datastore.Context, message string) Logger {
-	return &logger{entry: l.entry.WithField("user", ctx.User()), message: message}
+    l.addField("user", ctx.User())
+    l.message = message
+    return l
 }
 
 func (l *logger) Type(theType string) Logger {
-	return l.newLoggerWith("type", theType)
+	return l.addField("type", theType)
 }
 
 func (l *logger) ID(id string) Logger {
-	return l.newLoggerWith("id", id)
+	return l.addField("id", id)
 }
 
 func (l *logger) Entity(entity datastore.Entity) Logger {
-	return &logger{entry: l.entry.WithFields(logrus.Fields{
+	return l.addFields(logrus.Fields{
 		"id":   entity.GetID(),
-		"type": entity.GetType()}),
-		message: l.message}
+		"type": entity.GetType(),
+		})
 }
 
 func (l *logger) WithField(name string, value string) Logger {
-	return l.newLoggerWith(name, value)
+    return l.addField(name, value)
+}
+
+func (l *logger) addField(name string, value string) Logger {
+    if l.entry != nil {
+        l.entry = l.entry.WithField(name, value)
+    } else {
+        l.entry = l.loggeri.WithField(name, value)
+        l.entry.Logger.Hooks = make(map[logrus.Level][]logrus.Hook)
+    }
+    return l
+}
+
+func (l *logger) WithFields(fields logrus.Fields) Logger {
+    return l.addFields(fields)
+}
+
+func (l *logger) addFields(fields logrus.Fields)  Logger {
+    if l.entry != nil {
+        l.entry = l.entry.WithFields(fields)
+    } else {
+        l.entry = l.loggeri.WithFields(fields)
+        l.entry.Logger.Hooks = make(map[logrus.Level][]logrus.Hook)
+    }
+    return l
 }
 
 func (l *logger) Succeeded() {
@@ -120,7 +146,8 @@ func (l *logger) Error(err error) error {
 }
 
 func (l *logger) log(success bool) {
-	entry := l.entry.WithField("success", success)
+    l.addField("success", strconv.FormatBool(success))
+    entry := l.entry
 	if len(l.message) == 0 {
 		pkgLogger := plog.WithFields(entry.Data)
 		pkgLogger.Error("Attempting to audit log empty message")
@@ -132,9 +159,3 @@ func (l *logger) log(success bool) {
 	}
 }
 
-func (l *logger) newLoggerWith(name string, value string) Logger {
-	return &logger{
-		entry:   l.entry.WithField(name, value),
-		message: l.message,
-	}
-}

--- a/audit/logger.go
+++ b/audit/logger.go
@@ -1,0 +1,134 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/zenoss/logri"
+)
+
+// Logger is the interface for audit logging.  Any implementations for
+// audit logging should implement this interface.
+type Logger interface {
+
+	// Context sets contextual information on the logger.
+	Context(context Context) Logger
+
+	// Set the action that we auditing.
+	Action(action string) Logger
+
+	// Set the action that we auditing.
+	Message(message string) Logger
+
+	// Set the type of entity being modified.
+	Type(theType string) Logger
+
+	// Set the id of the entity being modified.
+	ID(id string) Logger
+
+	// Add additional fields to the entry.
+	WithField(name string, value string) Logger
+
+	// Log that the action succeeded.
+	Succeeded()
+
+	// Log that the action failed.
+	Failed()
+
+	// Log whether the action succeeded or failed based on the value passed in.
+	SucceededIf(value bool)
+
+	// Log whether the action succeeded or failed based on the error passed in.
+	Error(err error) error
+}
+
+// NewLogger returns a default implmentation of the audit logger.  The "user" will default
+// to "system" unless otherwise specified in the context.  This wraps a logri Logger,
+// and will write to the location specified in the logger config.
+func NewLogger() Logger {
+	entry := logri.GetLogger("audit").WithField("user", "system")
+
+	// Clear hooks on the logri logger to remove extra fields that we don't need for
+	// the audit log (the "logger" and "location" fields).
+	entry.Logger.Hooks = make(map[logrus.Level][]logrus.Hook)
+
+	return &logger{entry: entry}
+}
+
+type logger struct {
+	entry   *logrus.Entry
+	message string
+}
+
+func (l *logger) Context(context Context) Logger {
+	if len(context.User()) > 0 {
+		return l.newLoggerWith("user", context.User())
+	}
+
+	return l.newLoggerWith("user", "system")
+}
+
+func (l *logger) Action(action string) Logger {
+	return l.newLoggerWith("action", action)
+}
+
+func (l *logger) Message(message string) Logger {
+	entry := logrus.NewEntry(l.entry.Logger)
+	return &logger{entry: entry, message: message}
+}
+
+func (l *logger) Type(theType string) Logger {
+	return l.newLoggerWith("type", theType)
+}
+
+func (l *logger) ID(id string) Logger {
+	return l.newLoggerWith("id", id)
+}
+
+func (l *logger) WithField(name string, value string) Logger {
+	return l.newLoggerWith(name, value)
+}
+
+func (l *logger) Succeeded() {
+	l.log(true)
+}
+
+func (l *logger) Failed() {
+	l.log(false)
+}
+
+func (l *logger) SucceededIf(value bool) {
+	l.log(value)
+}
+
+func (l *logger) Error(err error) error {
+	l.log(err == nil)
+	return err
+}
+
+func (l *logger) log(success bool) {
+	entry := l.entry.WithField("success", success)
+	if success {
+		entry.Info(l.message)
+	} else {
+		entry.Warn(l.message)
+	}
+}
+
+func (l *logger) newLoggerWith(name string, value string) Logger {
+	return &logger{
+		entry:   l.entry.WithField(name, value),
+		message: l.message,
+	}
+}

--- a/audit/mocks/logger.go
+++ b/audit/mocks/logger.go
@@ -2,6 +2,7 @@ package mocks
 
 import "github.com/control-center/serviced/audit"
 import "github.com/control-center/serviced/datastore"
+import "github.com/Sirupsen/logrus"
 import "github.com/stretchr/testify/mock"
 
 type Logger struct {
@@ -82,6 +83,18 @@ func (_m *Logger) Entity(entity datastore.Entity) audit.Logger {
 }
 func (_m *Logger) WithField(name string, value string) audit.Logger {
 	ret := _m.Called(name, value)
+
+	var r0 audit.Logger
+	if rf, ok := ret.Get(0).(func() audit.Logger); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(audit.Logger)
+	}
+
+	return r0
+}
+func (_m *Logger) WithFields(fields logrus.Fields) audit.Logger {
+	ret := _m.Called(fields)
 
 	var r0 audit.Logger
 	if rf, ok := ret.Get(0).(func() audit.Logger); ok {

--- a/audit/mocks/logger.go
+++ b/audit/mocks/logger.go
@@ -1,13 +1,14 @@
 package mocks
 
 import "github.com/control-center/serviced/audit"
+import "github.com/control-center/serviced/datastore"
 import "github.com/stretchr/testify/mock"
 
 type Logger struct {
 	mock.Mock
 }
 
-func (_m *Logger) Context(context audit.Context) audit.Logger {
+func (_m *Logger) Context(context datastore.Context) audit.Logger {
 	ret := _m.Called(context)
 
 	var r0 audit.Logger
@@ -31,8 +32,8 @@ func (_m *Logger) Action(action string) audit.Logger {
 
 	return r0
 }
-func (_m *Logger) Message(message string) audit.Logger {
-	ret := _m.Called(message)
+func (_m *Logger) Message(ctx datastore.Context, message string) audit.Logger {
+	ret := _m.Called(ctx, message)
 
 	var r0 audit.Logger
 	if rf, ok := ret.Get(0).(func() audit.Logger); ok {
@@ -57,6 +58,18 @@ func (_m *Logger) Type(theType string) audit.Logger {
 }
 func (_m *Logger) ID(id string) audit.Logger {
 	ret := _m.Called(id)
+
+	var r0 audit.Logger
+	if rf, ok := ret.Get(0).(func() audit.Logger); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(audit.Logger)
+	}
+
+	return r0
+}
+func (_m *Logger) Entity(entity datastore.Entity) audit.Logger {
+	ret := _m.Called(entity)
 
 	var r0 audit.Logger
 	if rf, ok := ret.Get(0).(func() audit.Logger); ok {

--- a/audit/mocks/logger.go
+++ b/audit/mocks/logger.go
@@ -1,0 +1,94 @@
+package mocks
+
+import "github.com/control-center/serviced/audit"
+import "github.com/stretchr/testify/mock"
+
+type Logger struct {
+	mock.Mock
+}
+
+func (_m *Logger) Context(context audit.Context) audit.Logger {
+	ret := _m.Called(context)
+
+	var r0 audit.Logger
+	if rf, ok := ret.Get(0).(func() audit.Logger); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(audit.Logger)
+	}
+
+	return r0
+}
+func (_m *Logger) Action(action string) audit.Logger {
+	ret := _m.Called(action)
+
+	var r0 audit.Logger
+	if rf, ok := ret.Get(0).(func() audit.Logger); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(audit.Logger)
+	}
+
+	return r0
+}
+func (_m *Logger) Message(message string) audit.Logger {
+	ret := _m.Called(message)
+
+	var r0 audit.Logger
+	if rf, ok := ret.Get(0).(func() audit.Logger); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(audit.Logger)
+	}
+
+	return r0
+}
+func (_m *Logger) Type(theType string) audit.Logger {
+	ret := _m.Called(theType)
+
+	var r0 audit.Logger
+	if rf, ok := ret.Get(0).(func() audit.Logger); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(audit.Logger)
+	}
+
+	return r0
+}
+func (_m *Logger) ID(id string) audit.Logger {
+	ret := _m.Called(id)
+
+	var r0 audit.Logger
+	if rf, ok := ret.Get(0).(func() audit.Logger); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(audit.Logger)
+	}
+
+	return r0
+}
+func (_m *Logger) WithField(name string, value string) audit.Logger {
+	ret := _m.Called(name, value)
+
+	var r0 audit.Logger
+	if rf, ok := ret.Get(0).(func() audit.Logger); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(audit.Logger)
+	}
+
+	return r0
+}
+func (_m *Logger) Succeeded() {
+	_m.Called()
+}
+func (_m *Logger) Failed() {
+	_m.Called()
+}
+func (_m *Logger) Error(err error) error {
+	_m.Called(err)
+	return err
+}
+func (_m *Logger) SucceededIf(value bool) {
+	_m.Called(value)
+}

--- a/datastore/context.go
+++ b/datastore/context.go
@@ -24,6 +24,10 @@ type Context interface {
 
 	// Get the Metrics object from the context
 	Metrics() *metrics.Metrics
+
+	// Get and set the user for audit logging
+	SetUser(user string)
+	User() string
 }
 
 var savedDriver Driver
@@ -46,16 +50,23 @@ func GetNew() Context {
 	return newCtx(savedDriver)
 }
 
+// GetNewInstance returns a new instance of the context object, but with the metrics and connections
+// from the global context object.
+func GetNewInstance() Context {
+	return &context{savedDriver, ctx.Metrics(), "system"}
+}
+
 var ctx Context
 
 //new Creates a new context with a Driver to a datastore
 func newCtx(driver Driver) Context {
-	return &context{driver, metrics.NewMetrics()}
+	return &context{driver, metrics.NewMetrics(), "system"}
 }
 
 type context struct {
 	driver  Driver
 	metrics *metrics.Metrics
+	user    string
 }
 
 func (c *context) Connection() (Connection, error) {
@@ -64,4 +75,12 @@ func (c *context) Connection() (Connection, error) {
 
 func (c *context) Metrics() *metrics.Metrics {
 	return c.metrics
+}
+
+func (c *context) SetUser(user string) {
+	c.user = user
+}
+
+func (c *context) User() string {
+	return c.user
 }

--- a/datastore/entity.go
+++ b/datastore/entity.go
@@ -11,25 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package audit
+package datastore
 
-// Context information necessary for audit logging.
-type Context interface {
-
-	// User returns the user performing the action.
-	User() string
-}
-
-// NewContext returns default implementation of the Context interface that has the
-// provided string for a user.
-func NewContext(user string) Context {
-	return &context{user: user}
-}
-
-type context struct {
-	user string
-}
-
-func (c *context) User() string {
-	return c.user
+// Entity is the interface for encapsulating an object's name
+// and type for use with modules such as a logger.
+type Entity interface {
+	GetID() string
+	GetType() string
 }

--- a/datastore/mocks/Context.go
+++ b/datastore/mocks/Context.go
@@ -54,3 +54,19 @@ func (_m *Context) Metrics() *metrics.Metrics {
 	}
 	return r0
 }
+
+func (_m *Context) SetUser(user string) {
+	_m.Called(user)
+}
+
+func (_m *Context) User() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}

--- a/domain/common.go
+++ b/domain/common.go
@@ -70,3 +70,9 @@ type Prereq struct {
 	Name   string
 	Script string
 }
+
+const (
+	ResourcePoolType = "resourcepool"
+	HostType         = "host"
+	ServiceType      = "service"
+)

--- a/domain/common.go
+++ b/domain/common.go
@@ -71,8 +71,3 @@ type Prereq struct {
 	Script string
 }
 
-const (
-	ResourcePoolType = "resourcepool"
-	HostType         = "host"
-	ServiceType      = "service"
-)

--- a/domain/pool/pool.go
+++ b/domain/pool/pool.go
@@ -153,3 +153,15 @@ func (a *ResourcePool) HasDfsAccess() bool {
 func (a *ResourcePool) HasAdminAccess() bool {
 	return a.Permissions&AdminAccess != 0
 }
+
+// GetID returns its ResourcePool's ID.
+// It return the ID as a string
+func (a *ResourcePool) GetID() string {
+	return a.ID
+}
+
+// GetType return a ResourcePool's Entity type or kind.
+// It returns the Kind as a string.
+func (a *ResourcePool) GetType() string {
+	return kind
+}

--- a/domain/pool/pool.go
+++ b/domain/pool/pool.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain"
-	"github.com/control-center/serviced/logging"
 	"github.com/control-center/serviced/domain/host"
+	"github.com/control-center/serviced/logging"
 )
 
 // initialize the package logger

--- a/domain/pool/pool.go
+++ b/domain/pool/pool.go
@@ -154,6 +154,13 @@ func (a *ResourcePool) HasAdminAccess() bool {
 	return a.Permissions&AdminAccess != 0
 }
 
+// GetType returns a ResourcePool's type or kind, can be used to get
+// the string value of ResourcePool's type without a ResourcePool instance.
+// It returns the kind as a string.
+func GetType() string {
+	return kind
+}
+
 // GetID returns its ResourcePool's ID.
 // It return the ID as a string
 func (a *ResourcePool) GetID() string {
@@ -163,12 +170,5 @@ func (a *ResourcePool) GetID() string {
 // GetType return a ResourcePool's Entity type or kind.
 // It returns the Kind as a string.
 func (a *ResourcePool) GetType() string {
-	return kind
-}
-
-// GetType returns a ResourcePool's type or kind, can be used to get 
-// the string value of ResourcePool's type without a ResourcePool instance.
-// It returns the kind as a string.
-func GetType() string {
-	return kind
+	return GetType()
 }

--- a/domain/pool/pool.go
+++ b/domain/pool/pool.go
@@ -165,3 +165,10 @@ func (a *ResourcePool) GetID() string {
 func (a *ResourcePool) GetType() string {
 	return kind
 }
+
+// GetType returns a ResourcePool's type or kind, can be used to get 
+// the string value of ResourcePool's type without a ResourcePool instance.
+// It returns the kind as a string.
+func GetType() string {
+	return kind
+}

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -16,6 +16,7 @@ package facade
 import (
 	"time"
 
+	"github.com/control-center/serviced/audit"
 	"github.com/control-center/serviced/auth"
 	"github.com/control-center/serviced/dfs"
 	"github.com/control-center/serviced/domain/host"
@@ -36,6 +37,7 @@ type MetricsClient interface {
 	GetInstanceMemoryStats(time.Time, ...metrics.ServiceInstance) ([]metrics.MemoryUsageStats, error)
 	GetAvailableStorage(time.Duration, string, ...string) (*metrics.StorageMetrics, error)
 }
+
 // instantiate the package logger
 var plog = logging.PackageLogger()
 
@@ -45,6 +47,7 @@ var _ FacadeInterface = &Facade{}
 // New creates an initialized Facade instance
 func New() *Facade {
 	return &Facade{
+		auditLogger:   audit.NewLogger(),
 		hostStore:     host.NewStore(),
 		hostkeyStore:  hostkey.NewStore(),
 		registryStore: registry.NewStore(),
@@ -72,6 +75,7 @@ type Facade struct {
 	configStore   serviceconfigfile.Store
 	userStore     user.Store
 
+	auditLogger   audit.Logger
 	zzk           ZZK
 	dfs           dfs.DFS
 	hcache        *health.HealthStatusCache
@@ -85,6 +89,8 @@ type Facade struct {
 
 	rollingRestartTimeout time.Duration
 }
+
+func (f *Facade) SetAuditLogger(logger audit.Logger) { f.auditLogger = logger }
 
 func (f *Facade) SetZZK(zzk ZZK) { f.zzk = zzk }
 

--- a/facade/facade_unit_test.go
+++ b/facade/facade_unit_test.go
@@ -18,6 +18,7 @@ package facade_test
 import (
 	"time"
 
+	auditmocks "github.com/control-center/serviced/audit/mocks"
 	"github.com/control-center/serviced/auth"
 	authmocks "github.com/control-center/serviced/auth/mocks"
 	datastoremocks "github.com/control-center/serviced/datastore/mocks"
@@ -64,6 +65,8 @@ func (ft *FacadeUnitTest) SetUpSuite(c *C) {
 
 func (ft *FacadeUnitTest) SetUpTest(c *C) {
 	ft.ctx = &datastoremocks.Context{}
+
+	ft.Facade.SetAuditLogger(&auditmocks.Logger{})
 
 	ft.dfs = &dfsmocks.DFS{}
 	ft.Facade.SetDFS(ft.dfs)

--- a/facade/pool.go
+++ b/facade/pool.go
@@ -16,7 +16,6 @@ package facade
 import (
 	"github.com/control-center/serviced/audit"
 	"github.com/control-center/serviced/datastore"
-	"github.com/control-center/serviced/domain"
 	"github.com/control-center/serviced/domain/addressassignment"
 	"github.com/control-center/serviced/domain/host"
 	"github.com/control-center/serviced/domain/pool"
@@ -359,7 +358,7 @@ func (f *Facade) removeVirtualIP(ctx datastore.Context, poolID, ipAddr string) e
 func (f *Facade) RemoveResourcePool(ctx datastore.Context, id string) error {
 	alog := f.auditLogger.
 		Message(ctx, "Removing Resource Pool").
-		Action(audit.Remove).ID(id).Type(domain.ResourcePoolType)
+		Action(audit.Remove).ID(id).Type(pool.GetType())
 
 	defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.RemoveResourcePool"))
 	glog.V(2).Infof("Facade.RemoveResourcePool: %s", id)

--- a/facade/pool.go
+++ b/facade/pool.go
@@ -52,8 +52,8 @@ func (f *Facade) AddResourcePool(ctx datastore.Context, entity *pool.ResourcePoo
 
 	glog.Infof("Adding Resource Pool %s", entity.ID)
 
-	alog := f.auditLogger.Context(ctx).Message("Adding Resource Pool: " + entity.ID).
-		Action(audit.Add).ID(entity.ID).Type(domain.ResourcePoolType)
+	alog := f.auditLogger.Message(ctx, "Adding Resource Pool").
+		Action(audit.Add).Entity(entity)
 
 	if err := f.DFSLock(ctx).LockWithTimeout("add resource pool", userLockTimeout); err != nil {
 		glog.Warningf("Cannot add resource pool: %s", err)
@@ -358,7 +358,7 @@ func (f *Facade) removeVirtualIP(ctx datastore.Context, poolID, ipAddr string) e
 // RemoveResourcePool removes a resource pool
 func (f *Facade) RemoveResourcePool(ctx datastore.Context, id string) error {
 	alog := f.auditLogger.
-		Context(ctx).Message("Removing Resource Pool: " + id).
+		Message(ctx, "Removing Resource Pool").
 		Action(audit.Remove).ID(id).Type(domain.ResourcePoolType)
 
 	defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.RemoveResourcePool"))

--- a/facade/testutils.go
+++ b/facade/testutils.go
@@ -73,11 +73,11 @@ func (ft *FacadeIntegrationTest) SetUpSuite(c *gocheck.C) {
 
 	ft.Facade = New()
 	mockLogger := &auditmocks.Logger{}
-	mockLogger.On("Context", mock.AnythingOfType("*datastore.context")).Return(mockLogger)
-	mockLogger.On("Message", mock.AnythingOfType("string")).Return(mockLogger)
+	mockLogger.On("Message", mock.AnythingOfType("*datastore.Context"), mock.AnythingOfType("string")).Return(mockLogger)
 	mockLogger.On("Action", mock.AnythingOfType("string")).Return(mockLogger)
 	mockLogger.On("Type", mock.AnythingOfType("string")).Return(mockLogger)
 	mockLogger.On("ID", mock.AnythingOfType("string")).Return(mockLogger)
+	mockLogger.On("Entity", mock.AnythingOfType("*datastore.Entity")).Return(mockLogger)
 	mockLogger.On("WithField", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(mockLogger)
 	mockLogger.On("Error", mock.Anything)
 

--- a/facade/testutils.go
+++ b/facade/testutils.go
@@ -73,11 +73,11 @@ func (ft *FacadeIntegrationTest) SetUpSuite(c *gocheck.C) {
 
 	ft.Facade = New()
 	mockLogger := &auditmocks.Logger{}
-	mockLogger.On("Message", mock.AnythingOfType("*datastore.Context"), mock.AnythingOfType("string")).Return(mockLogger)
+	mockLogger.On("Message", mock.AnythingOfType("*datastore.context"), mock.AnythingOfType("string")).Return(mockLogger)
 	mockLogger.On("Action", mock.AnythingOfType("string")).Return(mockLogger)
 	mockLogger.On("Type", mock.AnythingOfType("string")).Return(mockLogger)
 	mockLogger.On("ID", mock.AnythingOfType("string")).Return(mockLogger)
-	mockLogger.On("Entity", mock.AnythingOfType("*datastore.Entity")).Return(mockLogger)
+	mockLogger.On("Entity", mock.AnythingOfType("*pool.ResourcePool")).Return(mockLogger)
 	mockLogger.On("WithField", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(mockLogger)
 	mockLogger.On("Error", mock.Anything)
 

--- a/facade/testutils.go
+++ b/facade/testutils.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	auditmocks "github.com/control-center/serviced/audit/mocks"
 	"github.com/control-center/serviced/auth"
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/datastore/elastic"
@@ -71,6 +72,16 @@ func (ft *FacadeIntegrationTest) SetUpSuite(c *gocheck.C) {
 	ft.CTX = datastore.Get()
 
 	ft.Facade = New()
+	mockLogger := &auditmocks.Logger{}
+	mockLogger.On("Context", mock.AnythingOfType("*datastore.context")).Return(mockLogger)
+	mockLogger.On("Message", mock.AnythingOfType("string")).Return(mockLogger)
+	mockLogger.On("Action", mock.AnythingOfType("string")).Return(mockLogger)
+	mockLogger.On("Type", mock.AnythingOfType("string")).Return(mockLogger)
+	mockLogger.On("ID", mock.AnythingOfType("string")).Return(mockLogger)
+	mockLogger.On("WithField", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(mockLogger)
+	mockLogger.On("Error", mock.Anything)
+
+	ft.Facade.SetAuditLogger(mockLogger)
 	ft.dfs = &dfsmocks.DFS{}
 	ft.Facade.SetDFS(ft.dfs)
 	ft.setupMockDFS()
@@ -130,4 +141,3 @@ func (ft *FacadeIntegrationTest) TearDownTest(c *gocheck.C) {
 func (ft *FacadeIntegrationTest) BeforeTest(suiteName, testName string) {
 	fmt.Printf("Starting test %s\n", testName)
 }
-

--- a/pkg/logconfig-server.yaml
+++ b/pkg/logconfig-server.yaml
@@ -1,8 +1,8 @@
 - logger: '*'
   level: info
 - logger: audit
-  level: warn
+  level: info
   out:
   - type: file
     options:
-      file: /var/log/serviced/cc_server_audit.log
+      file: /var/log/serviced/serviced-audit.log

--- a/pkg/logconfig-server.yaml
+++ b/pkg/logconfig-server.yaml
@@ -1,2 +1,8 @@
 - logger: '*'
   level: info
+- logger: audit
+  level: warn
+  out:
+  - type: file
+    options:
+      file: /var/log/serviced/cc_server_audit.log

--- a/web/poolresource.go
+++ b/web/poolresource.go
@@ -99,6 +99,7 @@ func restAddPool(w *rest.ResponseWriter, r *rest.Request, ctx *requestContext) {
 		restServerError(w, err)
 		return
 	}
+
 	glog.V(0).Info("Added pool ", payload.ID)
 	w.WriteJson(&simpleResponse{"Added resource pool", poolLinks(payload.ID)})
 }

--- a/web/session.go
+++ b/web/session.go
@@ -335,3 +335,12 @@ func deleteSessionT(sid string) {
 
 	delete(sessions, sid)
 }
+
+func getUser(r *rest.Request) (string, error) {
+	for _, cookie := range r.Cookies() {
+		if cookie.Name == usernameCookie {
+			return cookie.Value, nil
+		}
+	}
+	return "", errors.New("Unable to retriever user name")
+}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -34,7 +34,7 @@ import (
 // Wire gocheck into the go test runner
 func TestWeb(t *testing.T) { TestingT(t) }
 
-type TestWebSuite struct{
+type TestWebSuite struct {
 	ctx        *requestContext
 	recorder   *httptest.ResponseRecorder
 	writer     rest.ResponseWriter
@@ -116,16 +116,16 @@ func (s *TestWebSuite) assertLinks(c *C, actual, expected []link) {
 
 func (s *TestWebSuite) assertBadRequest(c *C) {
 	c.Assert(s.recorder.Code, Equals, http.StatusInternalServerError)
-	s.assertSimpleResponse(c, "Bad Request: .*",  homeLink())
+	s.assertSimpleResponse(c, "Bad Request: .*", homeLink())
 }
 
 func (s *TestWebSuite) assertServerError(c *C, expectedError error) {
 	c.Assert(s.recorder.Code, Equals, http.StatusInternalServerError)
-	s.assertSimpleResponse(c, fmt.Sprintf("Internal Server Error: %s", expectedError),  homeLink())
+	s.assertSimpleResponse(c, fmt.Sprintf("Internal Server Error: %s", expectedError), homeLink())
 }
 
 // Some methods return a slightly different response on error
 func (s *TestWebSuite) assertAltServerError(c *C, expectedError error) {
 	c.Assert(s.recorder.Code, Equals, http.StatusInternalServerError)
-	s.assertSimpleResponse(c, expectedError.Error(),  homeLink())
+	s.assertSimpleResponse(c, expectedError.Error(), homeLink())
 }


### PR DESCRIPTION
This PR adds a new package to support audit logging of CC user actions. This new API is used audit log the addition and removal of Resource Pool objects.