### PR TITLE
CC-3587: add audit-logging of DFS back/restore actions

### DIFF
--- a/audit/action.go
+++ b/audit/action.go
@@ -34,8 +34,11 @@ const (
 	// Migrate is the string for the migrate action when logging.
 	Migrate = "migrate"
 
+	// Backup is the string for the backup action when logging.
+	Backup = "backup"
+
 	// Restore is the string for the restore action when logging.
-	Restore= "restore"
+	Restore = "restore"
 
 	// Deploy is the string value for the deploy action when logging.
 	Deploy = "deploy"

--- a/cli/api/backup.go
+++ b/cli/api/backup.go
@@ -62,7 +62,7 @@ func (a *api) Restore(path string) error {
 		return fmt.Errorf("could not convert '%s' to an absolute file path: %v", path, err)
 	}
 
-	return client.Restore(filepath.Clean(fp), &unusedInt)
+	return client.Restore(dao.RestoreRequest{Filename: filepath.Clean(fp)}, &unusedInt)
 }
 
 

--- a/dao/client/cp_client.go
+++ b/dao/client/cp_client.go
@@ -205,12 +205,12 @@ func (s *ControlClient) AsyncBackup(backupRequest dao.BackupRequest, filename *s
 	return s.rpcClient.Call("ControlCenter.AsyncBackup", backupRequest, filename, 0)
 }
 
-func (s *ControlClient) Restore(filename string, unused *int) (err error) {
-	return s.rpcClient.Call("ControlCenter.Restore", filename, unused, 0)
+func (s *ControlClient) Restore(restoreRequest dao.RestoreRequest, unused *int) (err error) {
+	return s.rpcClient.Call("ControlCenter.Restore", restoreRequest, unused, 0)
 }
 
-func (s *ControlClient) AsyncRestore(filename string, unused *int) (err error) {
-	return s.rpcClient.Call("ControlCenter.AsyncRestore", filename, unused, 0)
+func (s *ControlClient) AsyncRestore(restoreRequest dao.RestoreRequest, unused *int) (err error) {
+	return s.rpcClient.Call("ControlCenter.AsyncRestore", restoreRequest, unused, 0)
 }
 
 func (s *ControlClient) ListBackups(dirpath string, files *[]dao.BackupFile) (err error) {

--- a/dao/interface.go
+++ b/dao/interface.go
@@ -232,10 +232,10 @@ type ControlPlane interface {
 	AsyncBackup(backupRequest BackupRequest, filename *string) (err error)
 
 	// Restore reverts the full application stack from a backup file
-	Restore(filename string, unused *int) (err error)
+	Restore(restoreRequest RestoreRequest, unused *int) (err error)
 
 	// AsyncRestore is the same as restore but asynchronous
-	AsyncRestore(filename string, unused *int) (err error)
+	AsyncRestore(restoreRequest RestoreRequest, unused *int) (err error)
 
 	// Adds 1 or more tags to an existing snapshot
 	TagSnapshot(request TagSnapshotRequest, unused *int) error

--- a/dao/mocks/ControlPlane.go
+++ b/dao/mocks/ControlPlane.go
@@ -347,24 +347,24 @@ func (_m *ControlPlane) AsyncBackup(backupRequest dao.BackupRequest, filename *s
 
 	return r0
 }
-func (_m *ControlPlane) Restore(filename string, unused *int) error {
-	ret := _m.Called(filename, unused)
+func (_m *ControlPlane) Restore(restoreRequest dao.RestoreRequest, unused *int) error {
+	ret := _m.Called(restoreRequest, unused)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *int) error); ok {
-		r0 = rf(filename, unused)
+	if rf, ok := ret.Get(0).(func(dao.RestoreRequest, *int) error); ok {
+		r0 = rf(restoreRequest, unused)
 	} else {
 		r0 = ret.Error(0)
 	}
 
 	return r0
 }
-func (_m *ControlPlane) AsyncRestore(filename string, unused *int) error {
-	ret := _m.Called(filename, unused)
+func (_m *ControlPlane) AsyncRestore(restoreRequest dao.RestoreRequest, unused *int) error {
+	ret := _m.Called(restoreRequest, unused)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *int) error); ok {
-		r0 = rf(filename, unused)
+	if rf, ok := ret.Get(0).(func(dao.RestoreRequest, *int) error); ok {
+		r0 = rf(restoreRequest, unused)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/dao/model.go
+++ b/dao/model.go
@@ -125,6 +125,12 @@ type BackupRequest struct {
 	SnapshotSpacePercent int
 	Excludes             []string
 	Force                bool
+	Username             string
+}
+
+type RestoreRequest struct {
+	Filename string
+	Username string
 }
 
 type BackupEstimate struct {

--- a/web/resources.go
+++ b/web/resources.go
@@ -900,9 +900,14 @@ func RestBackupCheck(w *rest.ResponseWriter, r *rest.Request, client *daoclient.
 func RestBackupCreate(w *rest.ResponseWriter, r *rest.Request, client *daoclient.ControlClient) {
 	dir := ""
 	filePath := ""
+	username, getUserErr := getUser(r)
+	if getUserErr != nil {
+		plog.WithError(getUserErr).Error("Unable to get user name")
+	}
 	req := dao.BackupRequest{
 		Dirpath:              dir,
 		SnapshotSpacePercent: snapshotSpacePercent,
+		Username:             username,
 	}
 	err := client.AsyncBackup(req, &filePath)
 	if err != nil {
@@ -923,8 +928,15 @@ func RestBackupRestore(w *rest.ResponseWriter, r *rest.Request, client *daoclien
 	}
 
 	unused := 0
-
-	err = client.AsyncRestore(filePath, &unused)
+	username, getUserErr := getUser(r)
+	if getUserErr != nil {
+		plog.WithError(getUserErr).Error("Unable to get user name")
+	}
+	req := dao.RestoreRequest{
+		Filename: filePath,
+		Username: username,
+	}
+	err = client.AsyncRestore(req, &unused)
 	if err != nil {
 		plog.WithError(err).Error("Unexpected error during restore")
 		restServerError(w, err)


### PR DESCRIPTION
This PR adds audit-logging for DFS backups/restores with the following changes:
- dao
    * add username field to BackupRequest struct
    * add RestoreRequest struct to encapsulate filename and username
    * changed Restore method to use RestoreRequest param instead of
filename
    * updated clients of Restore to use new API
- web
    * pass username with backup/restore requests
- facade
    * audit logging for Backup and Restore