### PR TITLE
Update new docker package name

### DIFF
--- a/pkg/makefile
+++ b/pkg/makefile
@@ -164,7 +164,7 @@ deb: stage_deb
 		-d libdevmapper1.02.1 \
 		-d libdevmapper-event1.02.1 \
 		-d nfs-common \
-		-d 'docker-engine (= 17.03.1.ce)' \
+		-d 'docker-ce (= 17.03.1.ce)' \
 		-d logrotate \
 		-d conntrack \
 		-d rsync \
@@ -203,7 +203,7 @@ rpm: stage_rpm
 		-d device-mapper-event \
 		-d device-mapper-event-libs \
 		-d device-mapper-libs \
-		-d 'docker-engine = 17.03.1.ce' \
+		-d 'docker-ce = 17.03.1.ce' \
 		-d logrotate \
 		-d rsync \
 		-d sysstat \


### PR DESCRIPTION
Package name changed from 'docker-engine' to 'docker-ce'. Oversight in previous commit.