### PR TITLE
Leave DM_BASESIZE unspecified if not given in conf.

### DIFF
--- a/cli/api/storageoptions.go
+++ b/cli/api/storageoptions.go
@@ -36,7 +36,7 @@ func getDefaultStorageOptions(driverType volume.DriverType, config utils.ConfigR
 		addStorageOption(config, "DM_THINPOOLDEV", "", func(v string) {
 			options = append(options, fmt.Sprintf("dm.thinpooldev=%s", v))
 		})
-		addStorageOption(config, "DM_BASESIZE", "100G", func(v string) {
+		addStorageOption(config, "DM_BASESIZE", "", func(v string) {
 			options = append(options, fmt.Sprintf("dm.basesize=%s", v))
 		})
 		addStorageOption(config, "DM_LOOPDATASIZE", "", func(v string) {

--- a/cli/api/storageoptions_test.go
+++ b/cli/api/storageoptions_test.go
@@ -78,7 +78,7 @@ func (s *TestAPISuite) TestGetDefaultBtrfsOptions(c *C) {
 func (s *TestAPISuite) TestGetDefaultDevicemapperOptions(c *C) {
 	configReader := utils.TestConfigReader(map[string]string{})
 	options := getDefaultStorageOptions(volume.DriverTypeDeviceMapper, configReader)
-	verifyOptions(c, options, []string{"dm.basesize=100G"})
+	verifyOptions(c, options, emptystrarray)
 }
 
 func (s *TestAPISuite) TestGetDefaultNFSOptionsWithDMOptionsSet(c *C) {
@@ -102,7 +102,7 @@ func (s *TestAPISuite) TestGetDefaultBrtrfsOptionsWithDMOptionsSet(c *C) {
 func (s *TestAPISuite) TestGetDefaultDevicemapperOptionsForThinpoolDevice(c *C) {
 	configReader := utils.TestConfigReader(map[string]string{"DM_THINPOOLDEV": "foo"})
 	options := getDefaultStorageOptions(volume.DriverTypeDeviceMapper, configReader)
-	verifyOptions(c, options, []string{"dm.thinpooldev=foo", "dm.basesize=100G"})
+	verifyOptions(c, options, []string{"dm.thinpooldev=foo"})
 }
 
 func (s *TestAPISuite) TestGetDefaultDevicemapperOptionsForAll(c *C) {

--- a/volume/devicemapper/devmapper/deviceset.go
+++ b/volume/devicemapper/devmapper/deviceset.go
@@ -1127,7 +1127,7 @@ func (devices *DeviceSet) checkGrowBaseDeviceFS(info *devInfo) error {
 	}
 
 	if devices.baseFsSize < devices.getBaseDeviceSize() {
-		return fmt.Errorf("devmapper: Base device size cannot be smaller than %s", units.HumanSize(float64(devices.getBaseDeviceSize())))
+		return fmt.Errorf("devmapper: Base device size cannot be smaller than %s", units.BytesSize(float64(devices.getBaseDeviceSize())))
 	}
 
 	if devices.baseFsSize == devices.getBaseDeviceSize() {


### PR DESCRIPTION
This change sets DM_BASESIZE (or "dm.basesize") as an unspecified option to allow code to determine whether a default base size value should be used.  Having DM_BASESIZE automatically acquire a value when it's not given in the config file means that other code has to assume that the value is specified and not a default.

Also changed the associated message when a specified DM_BASESIZE is less than the current base size so the message displays values in a multiple of 1024 (e.g. "100 GiB" instead of "107.4 GB").

Fixes CC-3522.