### PR TITLE
CC-3564: Improve error handling for assigning virtual IPs

### DIFF
--- a/scheduler/leader.go
+++ b/scheduler/leader.go
@@ -49,20 +49,13 @@ func Lead(shutdown <-chan interface{}, conn coordclient.Connection, cpClient dao
 	unassignmentHandler := zkservice.NewZKHostUnassignmentHandler(conn)
 	hreg := zkservice.NewHostRegistryListener(poolID, unassignmentHandler)
 
-	assignmentHandler := zkservice.NewZKAssignmentHandler(
-		&zkservice.RandomHostSelectionStrategy{}, hreg, conn)
-
-	plog.Info("Processing leader duties")
 	leader := leader{shutdown, conn, cpClient, facade, poolID, hreg}
-
-	synchronizer := zkservice.NewZKVirtualIPSynchronizer(assignmentHandler)
-	poolListener := zkservice.NewPoolListener(synchronizer)
 
 	// creates a listener for services
 	serviceListener := zkservice.NewServiceListener(poolID, &leader)
 
 	// starts all of the listeners
-	zzk.Start(shutdown, conn, serviceListener, hreg, poolListener)
+	zzk.Start(shutdown, conn, serviceListener, hreg)
 }
 
 // SelectHost chooses a host from the pool for the specified service. If the

--- a/zzk/connection.go
+++ b/zzk/connection.go
@@ -39,11 +39,10 @@ var (
 // GetConnection describes a generic function for acquiring a connection object
 type GetConnection func(string) (client.Connection, error)
 
-
 func newDelay(baseBackoff time.Duration) *client.Backoff {
 	return &client.Backoff{
 		InitialDelay: baseBackoff,
-		MaxDelay: baseBackoff,
+		MaxDelay:     baseBackoff,
 	}
 }
 

--- a/zzk/service/assignment_test.go
+++ b/zzk/service/assignment_test.go
@@ -41,8 +41,6 @@ type ZKAssignmentHandlerTestSuite struct {
 
 	selectHostCall *mock.Call
 
-	// Data
-	cancel   <-chan interface{}
 	testHost h.Host
 }
 
@@ -50,7 +48,6 @@ func (s *ZKAssignmentHandlerTestSuite) SetUpTest(c *C) {
 	s.ZZKTestSuite.SetUpTest(c)
 
 	s.testHost = h.Host{ID: "testHost", PoolID: "poolid"}
-	s.cancel = make(<-chan interface{})
 
 	var err error
 	s.connection, err = zzk.GetLocalConnection("/")
@@ -78,22 +75,22 @@ func (s *ZKAssignmentHandlerTestSuite) SetUpTest(c *C) {
 }
 
 func (s *ZKAssignmentHandlerTestSuite) TestAssignsCorrectly(c *C) {
-	s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http", s.cancel)
+	s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http")
 	s.assertNodeHasChildren(c, "pools/poolid/ips", []string{"testHost-7.7.7.7"})
 	s.assertNodeHasChildren(c, "pools/poolid/hosts/testHost/ips", []string{"testHost-7.7.7.7"})
 }
 
 func (s *ZKAssignmentHandlerTestSuite) TestMultipleAssignsReturnsError(c *C) {
-	s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http", s.cancel)
+	s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http")
 	s.assertNodeHasChildren(c, "pools/poolid/ips", []string{"testHost-7.7.7.7"})
 	s.assertNodeHasChildren(c, "pools/poolid/hosts/testHost/ips", []string{"testHost-7.7.7.7"})
 
-	err := s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http", s.cancel)
+	err := s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http")
 	c.Assert(err, Equals, ErrAlreadyAssigned)
 }
 
 func (s *ZKAssignmentHandlerTestSuite) TestUnassignsCorrectly(c *C) {
-	s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http", s.cancel)
+	s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http")
 	s.assertNodeHasChildren(c, "pools/poolid/ips", []string{"testHost-7.7.7.7"})
 	s.assertNodeHasChildren(c, "pools/poolid/hosts/testHost/ips", []string{"testHost-7.7.7.7"})
 
@@ -108,7 +105,7 @@ func (s *ZKAssignmentHandlerTestSuite) TestUnassignsWithNoAssignmentReturnsError
 }
 
 func (s *ZKAssignmentHandlerTestSuite) TestExcludesHostAfterAssigning(c *C) {
-	s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http", s.cancel)
+	s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http")
 	request := IPRequest{PoolID: "poolid", HostID: "testHost", IPAddress: "7.7.7.7"}
 	err := DeleteIP(s.connection, request)
 	c.Assert(err, IsNil)
@@ -118,7 +115,7 @@ func (s *ZKAssignmentHandlerTestSuite) TestExcludesHostAfterAssigning(c *C) {
 		c.Assert(hosts, HasLen, 0)
 	}).Once()
 
-	err = s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http", s.cancel)
+	err = s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http")
 	c.Assert(err, Equals, ErrNoHosts)
 
 	time.Sleep(time.Second)
@@ -128,7 +125,7 @@ func (s *ZKAssignmentHandlerTestSuite) TestExcludesHostAfterAssigning(c *C) {
 		c.Assert(hosts, HasLen, 1)
 	}).Once()
 
-	err = s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http", s.cancel)
+	err = s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http")
 	c.Assert(err, IsNil)
 }
 

--- a/zzk/service/assignment_test.go
+++ b/zzk/service/assignment_test.go
@@ -67,7 +67,7 @@ func (s *ZKAssignmentHandlerTestSuite) SetUpTest(c *C) {
 		s.connection)
 	s.assignmentHandler.Timeout = time.Second
 
-	s.registeredHostHandler.On("GetRegisteredHosts", s.cancel).
+	s.registeredHostHandler.On("GetRegisteredHosts", "poolid").
 		Return([]h.Host{s.testHost}, nil)
 
 	err = s.connection.Create(

--- a/zzk/service/hostunassign_test.go
+++ b/zzk/service/hostunassign_test.go
@@ -59,7 +59,7 @@ func (s *ZKHostUnassignHandlerTestSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	s.registeredHostHandler = mocks.RegisteredHostHandler{}
-	s.registeredHostHandler.On("GetRegisteredHosts", s.cancel).
+	s.registeredHostHandler.On("GetRegisteredHosts", "poolid").
 		Return([]h.Host{s.testHost}, nil)
 
 	s.assignmentHandler = NewZKAssignmentHandler(

--- a/zzk/service/hostunassign_test.go
+++ b/zzk/service/hostunassign_test.go
@@ -38,8 +38,6 @@ type ZKHostUnassignHandlerTestSuite struct {
 	assignmentHandler     *ZKAssignmentHandler
 	connection            client.Connection
 
-	// Data
-	cancel   <-chan interface{}
 	testHost h.Host
 }
 
@@ -47,7 +45,6 @@ func (s *ZKHostUnassignHandlerTestSuite) SetUpTest(c *C) {
 	s.ZZKTestSuite.SetUpTest(c)
 
 	s.testHost = h.Host{ID: "testHost", PoolID: "poolid"}
-	s.cancel = make(<-chan interface{})
 
 	var err error
 	s.connection, err = zzk.GetLocalConnection("/")
@@ -70,10 +67,10 @@ func (s *ZKHostUnassignHandlerTestSuite) SetUpTest(c *C) {
 }
 
 func (s *ZKHostUnassignHandlerTestSuite) TestUnassignsVirtualIPsFromHostCorrectly(c *C) {
-	err := s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http", s.cancel)
+	err := s.assignmentHandler.Assign("poolid", "7.7.7.7", "netmask", "http")
 	c.Assert(err, IsNil)
 
-	err = s.assignmentHandler.Assign("poolid", "9.9.9.9", "netmask", "http", s.cancel)
+	err = s.assignmentHandler.Assign("poolid", "9.9.9.9", "netmask", "http")
 	c.Assert(err, IsNil)
 
 	unassignmentHandler := NewZKHostUnassignmentHandler(s.connection)

--- a/zzk/service/mocks/AssignmentHandler.go
+++ b/zzk/service/mocks/AssignmentHandler.go
@@ -21,12 +21,12 @@ type AssignmentHandler struct {
 	mock.Mock
 }
 
-func (_m *AssignmentHandler) Assign(poolID, ipAddress, netmask, binding string, cancel <-chan interface{}) error {
-	ret := _m.Called(poolID, ipAddress, netmask, binding, cancel)
+func (_m *AssignmentHandler) Assign(poolID, ipAddress, netmask, binding string) error {
+	ret := _m.Called(poolID, ipAddress, netmask, binding)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, <-chan interface{}) error); ok {
-		r0 = rf(poolID, ipAddress, netmask, binding, cancel)
+	if rf, ok := ret.Get(0).(func(string, string, string, string) error); ok {
+		r0 = rf(poolID, ipAddress, netmask, binding)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/zzk/service/mocks/RegisteredHostHandler.go
+++ b/zzk/service/mocks/RegisteredHostHandler.go
@@ -22,19 +22,19 @@ type RegisteredHostHandler struct {
 	mock.Mock
 }
 
-func (_m *RegisteredHostHandler) GetRegisteredHosts(cancel <-chan interface{}) ([]host.Host, error) {
-	ret := _m.Called(cancel)
+func (_m *RegisteredHostHandler) GetRegisteredHosts(pool string) ([]host.Host, error) {
+	ret := _m.Called(pool)
 
 	var r0 []host.Host
-	if rf, ok := ret.Get(0).(func(<-chan interface{}) []host.Host); ok {
-		r0 = rf(cancel)
+	if rf, ok := ret.Get(0).(func(string) []host.Host); ok {
+		r0 = rf(pool)
 	} else {
 		r0 = ret.Get(0).([]host.Host)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(<-chan interface{}) error); ok {
-		r1 = rf(cancel)
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(pool)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/zzk/service/mocks/VirtualIPSynchronizer.go
+++ b/zzk/service/mocks/VirtualIPSynchronizer.go
@@ -22,12 +22,12 @@ type VirtualIPSynchronizer struct {
 	mock.Mock
 }
 
-func (_m *VirtualIPSynchronizer) Sync(resourcePool pool.ResourcePool, assignments map[string]string, cancel <-chan interface{}) error {
-	ret := _m.Called(resourcePool, assignments, cancel)
+func (_m *VirtualIPSynchronizer) Sync(resourcePool pool.ResourcePool, assignments map[string]string) error {
+	ret := _m.Called(resourcePool, assignments)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(pool.ResourcePool, map[string]string, <-chan interface{}) error); ok {
-		r0 = rf(resourcePool, assignments, cancel)
+	if rf, ok := ret.Get(0).(func(pool.ResourcePool, map[string]string) error); ok {
+		r0 = rf(resourcePool, assignments)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/zzk/service/path.go
+++ b/zzk/service/path.go
@@ -58,6 +58,11 @@ func (p *ZKPath) IPs() *ZKPath {
 	return p.concat("ips")
 }
 
+// Locked appends the node name for locked to the zookeeper path.
+func (p *ZKPath) Locked() *ZKPath {
+	return p.concat("locked")
+}
+
 // ID appends the given id to the zookeeper path.  If the string is empty,
 // the method will add nothing to the path.  If this behavior is not desired,
 // then checks for a empty string should be done before this method is called.

--- a/zzk/service/poollistener.go
+++ b/zzk/service/poollistener.go
@@ -113,7 +113,7 @@ func (l *PoolListener) Spawn(shutdown <-chan interface{}, poolID string) {
 
 			// The sync will add nodes to the ips path which will trigger an ipsEvent
 			// causing the loop to occur twice.
-			err = l.synchronizer.Sync(*node.ResourcePool, assignments, shutdown)
+			err = l.synchronizer.Sync(*node.ResourcePool, assignments)
 			if syncError, ok := err.(SyncError); ok {
 				logger.WithError(syncError).WithField("count", len(syncError)).
 					Warn("Errors encountered while syncing virtual IPs")

--- a/zzk/service/poollistener.go
+++ b/zzk/service/poollistener.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/control-center/serviced/coordinator/client"
 	"github.com/control-center/serviced/domain/pool"
+	"github.com/control-center/serviced/zzk"
 )
 
 // PoolListener implements zzk.Listener.  The PoolListener will watch
@@ -96,25 +97,34 @@ func (l *PoolListener) Spawn(shutdown <-chan interface{}, poolID string) {
 			if ipsExists && err == nil {
 				children, ipsEvent, err = l.connection.ChildrenW(poolPath.IPs().Path(), stop)
 				if err != nil {
-					logger.WithError(err).Error(err, "Unable to watch IPs")
+					logger.WithError(err).Error("Unable to watch IPs")
 					return
 				}
 			} else if err != nil {
-				logger.WithError(err).Error(err, "Unable to watch IPs node")
+				logger.WithError(err).Error("Unable to watch IPs node")
 				return
 			}
 
 			assignments, err := l.getAssignmentMap(children)
 			if err != nil {
-				logger.WithError(err).Error(err, "Unable to get assignments")
+				logger.WithError(err).Error("Unable to get assignments")
 				return
 			}
 
 			// The sync will add nodes to the ips path which will trigger an ipsEvent
 			// causing the loop to occur twice.
 			err = l.synchronizer.Sync(*node.ResourcePool, assignments, shutdown)
-			if err != nil {
-				logger.WithError(err).Warn(err, "Unable to sync virtual IPs")
+			if syncError, ok := err.(SyncError); ok {
+				logger.WithError(syncError).WithField("count", len(syncError)).
+					Warn("Errors encountered while syncing virtual IPs")
+
+				for _, e := range syncError {
+					logger.WithError(e).Debug("Sync error")
+				}
+
+				timeout.Reset(l.Timeout)
+			} else if err != nil {
+				logger.WithError(err).Warn("Error Syncing")
 				timeout.Reset(l.Timeout)
 			}
 		}
@@ -151,4 +161,16 @@ func (l *PoolListener) getAssignmentMap(hostIPs []string) (map[string]string, er
 		assignments[ip] = host
 	}
 	return assignments, nil
+}
+
+func StartPoolListener(shutdown <-chan interface{}, connection client.Connection) {
+	assignmentHandler := NewZKAssignmentHandler(
+		&RandomHostSelectionStrategy{},
+		NewRegisteredHostHandler(connection),
+		connection)
+
+	synchronizer := NewZKVirtualIPSynchronizer(assignmentHandler)
+	poolListener := NewPoolListener(synchronizer)
+
+	zzk.Start(shutdown, connection, poolListener)
 }

--- a/zzk/service/poollistener_test.go
+++ b/zzk/service/poollistener_test.go
@@ -81,7 +81,7 @@ func (s *PoolListenerTestSuite) SetUpTest(c *C) {
 	s.poolExistsCall = connection.On("ExistsW", "/pools/test", mock.AnythingOfType("<-chan struct {}")).
 		Return(true, (<-chan client.Event)(s.poolExistsEvent), nil)
 
-	s.syncCall = synchronizer.On("Sync", s.pool, mock.AnythingOfType("map[string]string"), s.shutdown).
+	s.syncCall = synchronizer.On("Sync", s.pool, mock.AnythingOfType("map[string]string")).
 		Return(nil)
 
 	s.listener = NewPoolListener(&synchronizer)

--- a/zzk/service/registeredhost.go
+++ b/zzk/service/registeredhost.go
@@ -14,6 +14,7 @@
 package service
 
 import (
+	"github.com/control-center/serviced/coordinator/client"
 	"github.com/control-center/serviced/domain/host"
 )
 
@@ -21,5 +22,17 @@ import (
 // to get the registered hosts should block until a host comes online.  The cancel
 // parameter can be used to stop the call.
 type RegisteredHostHandler interface {
-	GetRegisteredHosts(cancel <-chan interface{}) ([]host.Host, error)
+	GetRegisteredHosts(pool string) ([]host.Host, error)
+}
+
+func NewRegisteredHostHandler(conn client.Connection) RegisteredHostHandler {
+	return &DefaultRegisteredHostHandler{connection: conn}
+}
+
+type DefaultRegisteredHostHandler struct {
+	connection client.Connection
+}
+
+func (h *DefaultRegisteredHostHandler) GetRegisteredHosts(pool string) ([]host.Host, error) {
+	return GetRegisteredHostsForPool(h.connection, pool)
 }

--- a/zzk/service/synchronizer.go
+++ b/zzk/service/synchronizer.go
@@ -19,7 +19,7 @@ import (
 
 type SyncError []error
 
-func (e *SyncError) Error() string {
+func (e SyncError) Error() string {
 	return "errors encountered while syncing"
 }
 
@@ -60,7 +60,7 @@ func (s *ZKVirtualIPSynchronizer) Sync(pool p.ResourcePool, assignments map[stri
 	}
 
 	if len(errorList) > 0 {
-		return &errorList
+		return errorList
 	}
 
 	return nil

--- a/zzk/service/synchronizer.go
+++ b/zzk/service/synchronizer.go
@@ -25,7 +25,7 @@ func (e SyncError) Error() string {
 
 // VirtualIPSynchronizer will sync virtual IP assignments for a pool.
 type VirtualIPSynchronizer interface {
-	Sync(pool p.ResourcePool, assignments map[string]string, cancel <-chan interface{}) error
+	Sync(pool p.ResourcePool, assignments map[string]string) error
 }
 
 // ZKVirtualIPSynchronizer implements the VirtualIPSynchronizer interface for ZooKeeper.
@@ -41,12 +41,12 @@ func NewZKVirtualIPSynchronizer(handler AssignmentHandler) *ZKVirtualIPSynchroni
 // Sync will synchronize virtual IP assignments for a pool.  It will assign virtual IPs that
 // are not assigned to a host.  It will unassign any active assignments if the virtual IP as been
 // removed from the pool.
-func (s *ZKVirtualIPSynchronizer) Sync(pool p.ResourcePool, assignments map[string]string, cancel <-chan interface{}) error {
+func (s *ZKVirtualIPSynchronizer) Sync(pool p.ResourcePool, assignments map[string]string) error {
 	virtualIPMap := s.getVirtualIPMap(pool)
 
 	errorList := SyncError{}
 	for _, ip := range s.virtualIPsWithNoAssignment(virtualIPMap, assignments) {
-		err := s.handler.Assign(ip.PoolID, ip.IP, ip.Netmask, ip.BindInterface, cancel)
+		err := s.handler.Assign(ip.PoolID, ip.IP, ip.Netmask, ip.BindInterface)
 		if err != nil {
 			errorList = append(errorList, err)
 		}

--- a/zzk/service/synchronizer_test.go
+++ b/zzk/service/synchronizer_test.go
@@ -35,7 +35,7 @@ type SynchronizerTestSuite struct {
 func (s *SynchronizerTestSuite) SetUpTest(c *C) {
 	s.handler = mocks.AssignmentHandler{}
 
-	s.handler.On("Assign", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	s.handler.On("Assign", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	s.handler.On("Unassign", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	s.pool = p.ResourcePool{ID: "pool", VirtualIPs: []p.VirtualIP{}}
@@ -65,17 +65,16 @@ func (s *SynchronizerTestSuite) TestSyncsVirtualIPAssignments(c *C) {
 		"7.7.7.7": "host",
 	}
 
-	cancel := make(<-chan interface{})
-	s.synchronizer.Sync(s.pool, assignments, cancel)
+	s.synchronizer.Sync(s.pool, assignments)
 
 	// 1.2.3.4 has a virtual IP but is not assigned so Assign should be called
-	s.handler.AssertCalled(c, "Assign", s.pool.ID, "1.2.3.4", "255.255.255.0", "eth1", cancel)
+	s.handler.AssertCalled(c, "Assign", s.pool.ID, "1.2.3.4", "255.255.255.0", "eth1")
 
 	// 4.3.2.1 has an assignment but does not have a virtual IP so it should be unassigned
 	s.handler.AssertCalled(c, "Unassign", s.pool.ID, "4.3.2.1")
 
 	// 7.7.7.7 has an assignment and virtual IP so nothing should be done
-	s.handler.AssertNotCalled(c, "Assign", s.pool.ID, "7.7.7.7", "255.255.255.0", "eth1", cancel)
+	s.handler.AssertNotCalled(c, "Assign", s.pool.ID, "7.7.7.7", "255.255.255.0", "eth1")
 	s.handler.AssertNotCalled(c, "Unassign", s.pool.ID, "7.7.7.7")
 
 }
@@ -100,11 +99,10 @@ func (s *SynchronizerTestSuite) TestSyncsAssignsAllIfNoneAssigned(c *C) {
 	// No assignments
 	assignments := map[string]string{}
 
-	cancel := make(<-chan interface{})
-	s.synchronizer.Sync(s.pool, assignments, cancel)
+	s.synchronizer.Sync(s.pool, assignments)
 
-	s.handler.AssertCalled(c, "Assign", s.pool.ID, "1.2.3.4", "255.255.255.0", "eth1", cancel)
-	s.handler.AssertCalled(c, "Assign", s.pool.ID, "7.7.7.7", "255.255.255.0", "eth1", cancel)
+	s.handler.AssertCalled(c, "Assign", s.pool.ID, "1.2.3.4", "255.255.255.0", "eth1")
+	s.handler.AssertCalled(c, "Assign", s.pool.ID, "7.7.7.7", "255.255.255.0", "eth1")
 }
 
 func (s *SynchronizerTestSuite) TestSyncUnassignsAll(c *C) {
@@ -117,8 +115,7 @@ func (s *SynchronizerTestSuite) TestSyncUnassignsAll(c *C) {
 		"7.7.7.7": "host",
 	}
 
-	cancel := make(<-chan interface{})
-	s.synchronizer.Sync(s.pool, assignments, cancel)
+	s.synchronizer.Sync(s.pool, assignments)
 
 	s.handler.AssertCalled(c, "Unassign", s.pool.ID, "4.3.2.1")
 	s.handler.AssertCalled(c, "Unassign", s.pool.ID, "7.7.7.7")


### PR DESCRIPTION
Changes to prevent logs from being spammed.  Also, additional fixes for wiring up dependencies and initializing a single pool listener.