### PR TITLE
Add --group-by option to serviced log export

### DIFF
--- a/cli/api/logs_test.go
+++ b/cli/api/logs_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"time"
 
 	"github.com/control-center/serviced/cli/api/mocks"
 	"github.com/control-center/serviced/domain/host"
@@ -517,7 +518,7 @@ func setupRetrieveLogTest(logstashDays, serviceIDs []string, fromDate, toDate st
 		return make(map[string]host.Host), nil
 	}
 
-	exporter, err := buildExporter(config, getServices, getHostMap)
+	exporter, err := buildExporter(config, time.Now().UTC(), "timestamp", getServices, getHostMap)
 	return exporter, mockLogDriver, err
 }
 

--- a/cli/cmd/logs_test.go
+++ b/cli/cmd/logs_test.go
@@ -31,13 +31,13 @@ type LogsCLITestCase struct {
 }
 
 func ExampleServicedCLI_CmdLogExport_usage() {
-	runLogsAPITest(&mocks.API{}, "serviced", "log", "export", "service")
+	runLogsAPITest(&mocks.API{}, "serviced", "log", "export", "badbad")
 
 	// Output:
 	// Incorrect Usage.
 	//
 	// NAME:
-	//    export - Exports all logs
+	//    export - Exports application log data
 	//
 	// USAGE:
 	//    command export [command options] [arguments...]
@@ -51,6 +51,8 @@ func ExampleServicedCLI_CmdLogExport_usage() {
 	//    --service '--service option --service option'	service ID or name (includes all sub-services)
 	//    --out 						path to output file
 	//    --debug, -d						Show additional diagnostic messages
+	//    --group-by 'container'				Group results either by container, service or day
+
 }
 
 func TestLogsCLI_CmdLogExport_SingleServiceName(t *testing.T) {
@@ -125,6 +127,52 @@ func TestLogsCLI_CmdLogExport_OutFileName(t *testing.T) {
 		},
 	}
 	testCmdLogExport(t, testCase)
+}
+
+func TestLogsCLI_CmdLogExport_GroupByDefault(t *testing.T) {
+	testCase := LogsCLITestCase{
+		Args: []string{"serviced", "log", "export"},
+		ExpectedExportLogsConfig: api.ExportLogsConfig{
+			GroupBy: api.GroupByContainerID,
+		},
+	}
+	testCmdLogExport(t, testCase)
+}
+
+func TestLogsCLI_CmdLogExport_GroupByContainer(t *testing.T) {
+	testCase := LogsCLITestCase{
+		Args: []string{"serviced", "log", "export", "--group-by", "container"},
+		ExpectedExportLogsConfig: api.ExportLogsConfig{
+			GroupBy: api.GroupByContainerID,
+		},
+	}
+	testCmdLogExport(t, testCase)
+}
+
+func TestLogsCLI_CmdLogExport_GroupByDay(t *testing.T) {
+	testCase := LogsCLITestCase{
+		Args: []string{"serviced", "log", "export", "--group-by", "day"},
+		ExpectedExportLogsConfig: api.ExportLogsConfig{
+			GroupBy: api.GroupByDay,
+		},
+	}
+	testCmdLogExport(t, testCase)
+}
+
+func TestLogsCLI_CmdLogExport_GroupByService(t *testing.T) {
+	testCase := LogsCLITestCase{
+		Args: []string{"serviced", "log", "export", "--group-by", "service"},
+		ExpectedExportLogsConfig: api.ExportLogsConfig{
+			GroupBy: api.GroupByService,
+		},
+	}
+	testCmdLogExport(t, testCase)
+}
+
+func ExampleServicedCLI_CmdLogExport_InvalidGroupBy() {
+	runLogsAPITest(&mocks.API{}, "serviced", "log", "export", "--group-by", "badbad")
+
+	// ERROR: --group-by value 'badbad' is invalid; only 'container', 'day' or 'service' allowed
 }
 
 // compareStringSlices compares the contents of two string slices, without order.


### PR DESCRIPTION
Fixes CC-3546

Enhance `serviced log export` to support an optional `--group-by` argument which controls which messages are grouped together in the same exported `x.log` file.  Also, updated the content of `index.txt` to include a record of the export arguments, and tweaked the tar file content such that the directory created by unpacking the tar file matches the name of the tar file (previously, the unpacked directory name was random).