### PR TITLE
Add support for --no-children option on log export

### DIFF
--- a/cli/api/logs.go
+++ b/cli/api/logs.go
@@ -228,6 +228,10 @@ func (a *api) ExportLogs(configParam ExportLogsConfig) (err error) {
 	}
 	sort.Strings(indexData)
 
+	servicesDesc := make([]string, 0)
+	for _, id := range configParam.ServiceIDs {
+		servicesDesc = append(servicesDesc, fmt.Sprintf("%s (%s)", exporter.getServiceName(id), id))
+	}
 	indexData = append([]string{
 		"LOG EXPORT SUMMARY",
 		fmt.Sprintf("       Export Ran On: %s", exporter.startTime.Format(time.RFC1123)),
@@ -235,6 +239,7 @@ func (a *api) ExportLogs(configParam ExportLogsConfig) (err error) {
 		fmt.Sprintf("     Requested Dates: %s - %s", configParam.FromDate, configParam.ToDate),
 		fmt.Sprintf("      Exported Dates: %s - %s", exporter.minDateFound, exporter.maxDateFound),
 		fmt.Sprintf("          Grouped By: %s", configParam.GroupBy),
+		fmt.Sprintf("Requested Service(s): %s", strings.Join(servicesDesc, ", ")),
 		fmt.Sprintf("Child Svcs Excluded?: %s", strconv.FormatBool(configParam.ExcludeChildren)),
 		"",
 		"INDEX OF LOG FILES",

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -48,7 +48,7 @@ func (c *ServicedCli) initLog() {
 					cli.StringSliceFlag{
 						Name:  "service",
 						Value: &cli.StringSlice{},
-						Usage: "service ID or name (includes all sub-services)",
+						Usage: "service ID or name (includes all child services)",
 					},
 					cli.StringFlag{
 						Name:  "out",
@@ -63,6 +63,10 @@ func (c *ServicedCli) initLog() {
 						Name:  "group-by",
 						Value: "container",
 						Usage: "Group results either by container, service or day",
+					},
+					cli.BoolFlag{
+						Name:  "no-children, n",
+						Usage: "Do not export child services",
 					},
 				},
 			},
@@ -101,12 +105,13 @@ func (c *ServicedCli) cmdExportLogs(ctx *cli.Context) {
 	}
 
 	cfg := api.ExportLogsConfig{
-		ServiceIDs:  serviceIDs,
-		FromDate:    from,
-		ToDate:      to,
-		OutFileName: outfile,
-		Debug:       ctx.Bool("debug"),
-		GroupBy:     groupBy,
+		ServiceIDs:       serviceIDs,
+		FromDate:         from,
+		ToDate:           to,
+		OutFileName:      outfile,
+		Debug:            ctx.Bool("debug"),
+		GroupBy:          groupBy,
+		ExcludeChildren:  ctx.Bool("no-children"),
 	}
 
 	if err := c.driver.ExportLogs(cfg); err != nil {

--- a/cli/cmd/logs_test.go
+++ b/cli/cmd/logs_test.go
@@ -48,11 +48,11 @@ func ExampleServicedCLI_CmdLogExport_usage() {
 	// OPTIONS:
 	//    --from 						yyyy.mm.dd
 	//    --to 						yyyy.mm.dd
-	//    --service '--service option --service option'	service ID or name (includes all sub-services)
+	//    --service '--service option --service option'	service ID or name (includes all child services)
 	//    --out 						path to output file
 	//    --debug, -d						Show additional diagnostic messages
 	//    --group-by 'container'				Group results either by container, service or day
-
+	//    --no-children, -n					Do not export child services
 }
 
 func TestLogsCLI_CmdLogExport_SingleServiceName(t *testing.T) {


### PR DESCRIPTION
Fixes CC-3627

The following export logs for all services in Zenoss.remsgr:
```
serviced log export --service Zenoss.resmgr
```
Using the new option added this in the PR, the following will export logs *only* for the Zenoss.resmgr service:
```
serviced log export --service Zenoss.resmgr --no-children
```