### PR TITLE
Improve docker.IsImageNotFound check to work with docker 17.06

### DIFF
--- a/dfs/docker/docker.go
+++ b/dfs/docker/docker.go
@@ -47,10 +47,11 @@ func IsImageNotFound(err error) bool {
 			return true
 		}
 		var checks = []*regexp.Regexp{
-			regexp.MustCompile("Tag .* not found in repository .*"),
-			regexp.MustCompile("Error: image .* not found"),
-			regexp.MustCompile("could not find image"),
-			regexp.MustCompile("no such id"),
+			regexp.MustCompile("(?i)Tag .* not found in repository .*"),
+			regexp.MustCompile("(?i)Error: image .* not found"),
+			regexp.MustCompile("(?i)could not find image"),
+			regexp.MustCompile("(?i)no such id"),
+			regexp.MustCompile("(?i)no such image"),
 		}
 		for _, check := range checks {
 			if ok := check.MatchString(err.Error()); ok {


### PR DESCRIPTION
Apparently Docker 17.06 modified the text of it's error message for image-not-found

Two changes in this commit:
1. Add a check for the new error message, "No such image"
2. Change all checks to be case-insensitive in an attempt to be more resilient in the future.