### PR TITLE
CC-3643:Deploying an applications results empty audit log message

### DIFF
--- a/facade/addressassignment.go
+++ b/facade/addressassignment.go
@@ -181,7 +181,7 @@ func (f *Facade) RemoveAddressAssignment(ctx datastore.Context, id string) error
 }
 
 func (f *Facade) assign(ctx datastore.Context, assignment addressassignment.AddressAssignment) (string, error) {
-	alog := f.auditLogger.Message(ctx, "Adding AddressAssignment").Action(audit.Add).Entity(&assignment)
+	alog := f.auditLogger.Message(ctx, "Adding AddressAssignment").Action(audit.Add).Type(assignment.GetType())
 	if err := assignment.ValidEntity(); err != nil {
 		return "", alog.Error(err)
 	}


### PR DESCRIPTION
Audit log is not necessary for assigning/setting ip addresses. Since, we have audit logging in addressassignment  facade. so, removed it.

Also, fixed audit logging message for adding address assignment which has empty ServiceID message by removing entity object and using just serviceType.