### PR TITLE
Fix up some logstash filtering stuff

### DIFF
--- a/facade/logstash.go
+++ b/facade/logstash.go
@@ -285,6 +285,8 @@ filter {
     rename => {
       "source" => "file"
     }
+    # Save the time each message was received by logstash as rcvd_datetime
+    add_field => [ "rcvd_datetime", "%{@timestamp}" ]
   }
 # NOTE the filters are generated from the service definitions
 ` + string(filters) + `


### PR DESCRIPTION
Fixes CC-3669

* Do not write multiple sections to logstash.conf for the same file; e.g. Zope and zenreports both have a Z2.log, but logstash.conf should have a single filter for that file
* Do not write empty sections to the logstash.conf like
```
    if [file] == "/opt/zenoss/log/zenmail.log" {
    
    }
```
* Add `rcvd_datetime` to each message to record when logstash received the message, as opposed to `@timestamp` which should record the time parsed out of the message itself.