### PR TITLE
Feature/cc 3656

### DIFF
--- a/web/ui/src/Services/Service.js
+++ b/web/ui/src/Services/Service.js
@@ -202,6 +202,11 @@
             let deferred = $q.defer();
             resourcesFactory.v2.getServiceInstances(this.id)
                 .then(results => {
+                    if (results.length < this.instances.length) {
+                        // If our results count decreased, we need to refresh our data to
+                        // eliminate stale data (ie: iid [0, 1] and 0 drops off).
+                        this.instances = [];
+                    }
                     results.forEach(data => {
                         // new-ing instances will cause UI bounce and force rebuilding
                         // of the popover. To minimize UI churn, update/merge status info
@@ -214,8 +219,6 @@
                             this.instances[iid] = new Instance(data);
                         }
                     });
-                    // chop off any extraneous instances
-                    this.instances.splice(results.length);
                     deferred.resolve();
                 },
                 error => {

--- a/web/ui/src/Services/view-subservices.html
+++ b/web/ui/src/Services/view-subservices.html
@@ -191,7 +191,7 @@
     <div ng-show="hasCurrentInstances() && !currentService.isIsvc()">
         <h3 class="pull-left" translate>running_tbl_instances</h3>
         <table jelly-table data-data="currentService.instances" data-config="instancesTable" class="table">
-            <tr ng-repeat="instance in $data" data-id="{{instance.id}}.{{instance.model.InstanceID}}">
+            <tr ng-repeat="instance in $data" ng-if="instance !== undefined" data-id="{{instance.id}}.{{instance.model.InstanceID}}">
                 <td data-title="'running_tbl_instance_id'|translate" sortable="'instance.model.InstanceID'">{{instance.model.InstanceID}}</td>
                 <td data-title="'label_service_status'|translate">
                     <span class="svcstate {{instance.model.CurrentState}}" translate>{{instance.model.CurrentState}}</span>


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3656
When instance 0 goes down, the UI ends up with an empty entry in the instance list (due to the way it indexes by instanceID and trims the list).  Fix that so it doesn't trim the list and prevent showing empty entries.
In the servicestate, if the host policy returns "", nil (no host available per the policy, no error), this case wasn't handled.  Add a log warning and return false to prevent scheduling on an empty host.