### PR TITLE
CC-3690: zenpack list command provides additional errors and warnings

### DIFF
--- a/container/logstash.go
+++ b/container/logstash.go
@@ -69,7 +69,7 @@ func writeLogstashAgentConfig(hostID string, hostIPs string, svcPath string, ser
 	for _, logConfig := range service.LogConfigs {
 		prospectorsConf = prospectorsConf + `
     - ignore_older: 10s
-      close_older: 5m
+      close_inactive: 5m
       paths:
         - %s
       fields: %s`


### PR DESCRIPTION
The cause of CC-3690 is `filebeat` v.5.2.3 from https://github.com/control-center/serviced/commit/63435b36cab07eb7e36db9ac99a323dd62b56cad
`.keep` in `isvcs/resources/logstash/module/` is a stub file as git doesn't add empty folders.