### PR TITLE
Feature/cc 3692

### DIFF
--- a/web/ui/src/Services/Service.js
+++ b/web/ui/src/Services/Service.js
@@ -202,6 +202,11 @@
             let deferred = $q.defer();
             resourcesFactory.v2.getServiceInstances(this.id)
                 .then(results => {
+                    if (results.length < this.instances.length) {
+                        // If our results count decreased, we need to refresh our data to
+                        // eliminate stale data (ie: iid [0, 1] and 0 drops off).
+                        this.instances = [];
+                    }
                     results.forEach(data => {
                         // new-ing instances will cause UI bounce and force rebuilding
                         // of the popover. To minimize UI churn, update/merge status info
@@ -214,8 +219,6 @@
                             this.instances[iid] = new Instance(data);
                         }
                     });
-                    // chop off any extraneous instances
-                    this.instances.splice(results.length);
                     deferred.resolve();
                 },
                 error => {

--- a/web/ui/src/Services/view-subservices.html
+++ b/web/ui/src/Services/view-subservices.html
@@ -191,7 +191,7 @@
     <div ng-show="hasCurrentInstances() && !currentService.isIsvc()">
         <h3 class="pull-left" translate>running_tbl_instances</h3>
         <table jelly-table data-data="currentService.instances" data-config="instancesTable" class="table">
-            <tr ng-repeat="instance in $data" data-id="{{instance.id}}.{{instance.model.InstanceID}}">
+            <tr ng-repeat="instance in $data" ng-if="instance !== undefined" data-id="{{instance.id}}.{{instance.model.InstanceID}}">
                 <td data-title="'running_tbl_instance_id'|translate" sortable="'instance.model.InstanceID'">{{instance.model.InstanceID}}</td>
                 <td data-title="'label_service_status'|translate">
                     <span class="svcstate {{instance.model.CurrentState}}" translate>{{instance.model.CurrentState}}</span>


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3692

For the UI front-end, we were trimming the instances down to the number of service instances we had.  We're also indexing this list by the instance ID.  When we have instance 0 and 1, and instance 0 goes down.. this list then only contains instance 1.  Because the list is indexed by the instance ID, js creates a length 2 array (0 is empty and 1 contains instance 1).  We trimmed this to 1 resulting in having only the empty entry.  Don't trim the list, and don't show undefined entries.

For the back-end, we weren't handling the case where the host policy returns (nil, nil) (no error and no host selected).  Afaik this only happened when REQUIRE_SEPARATE was specified but there weren't enough hosts available.  We weren't handling this case, resulting in us storing a nil host entry for the service state.