### PR TITLE
Feature/cc 3693

### DIFF
--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -224,7 +224,7 @@ type Service struct {
 	ConfigFiles       map[string]servicedefinition.ConfigFile
 	Instances         int
 	InstanceLimits    domain.MinMax
-	ChangeOptions     []string
+	ChangeOptions     []servicedefinition.ChangeOption
 	ImageID           string
 	PoolID            string
 	DesiredState      int

--- a/domain/service/service_unit_test.go
+++ b/domain/service/service_unit_test.go
@@ -32,7 +32,7 @@ func (s *ServiceDomainUnitTestSuite) TestBuildServiceSimple(t *C) {
 	environment := []string{"enviroment:foobar", "a:b", "c:d"}
 	tags := []string{"tags", "foo", "bar"}
 	imageID := "imageid"
-	changeOptions := []string{"changeoptions", "boo"}
+	changeOptions := []servicedefinition.ChangeOption{"changeoptions", "boo"}
 	launch := "launch"
 	hostname := "hostname"
 	privileged := true

--- a/domain/servicedefinition/servicedefinition.go
+++ b/domain/servicedefinition/servicedefinition.go
@@ -203,9 +203,9 @@ const (
 
 // UnmarshalText implements the encoding/TextUnmarshaler interface
 func (co *ChangeOption) UnmarshalText(b []byte) error {
-	s := strings.Trim(string(b), `"`)
+	s := strings.ToLower(strings.Trim(string(b), `"`))
 	switch s {
-	case string(RestartAllOnInstanceChanged), string(RestartAllOnInstanceZeroDown):
+	case strings.ToLower(string(RestartAllOnInstanceChanged)), strings.ToLower(string(RestartAllOnInstanceZeroDown)):
 		*co = ChangeOption(s)
 	case "":
 		*co = DefaultChangeOption
@@ -219,7 +219,7 @@ type ChangeOptions []ChangeOption
 
 func (options ChangeOptions) Contains(co ChangeOption) bool {
 	for _, option := range options {
-		if co == option {
+		if strings.ToLower(string(co)) == strings.ToLower(string(option)) {
 			return true
 		}
 	}

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -369,6 +369,87 @@ func (ft *FacadeIntegrationTest) TestFacade_validateServiceAdd_EnableDuplicatePu
 	t.Assert(ft.Facade.UpdateService(ft.CTX, svc), NotNil)
 }
 
+// Add using the servicedefition defines.
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceAdd_InvalidServiceOptions(t *C) {
+	svc := service.Service{
+		ID:           "svc1",
+		Name:         "TestFacade_InvalidServiceOptions",
+		DeploymentID: "deployment_id",
+		PoolID:       "pool_id",
+		Launch:       "auto",
+		DesiredState: int(service.SVCStop),
+		HostPolicy: servicedefinition.RequireSeparate,
+		ChangeOptions: []servicedefinition.ChangeOption{
+			servicedefinition.RestartAllOnInstanceChanged,
+		},
+	}
+
+	err := ft.Facade.AddService(ft.CTX, svc)
+	// We should have gotten an error here that these options are invalid together.
+	t.Assert(err, NotNil)
+}
+
+// Make these all uppercase; case should not matter for these options in the service def.
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceAdd_InvalidServiceOptions2(t *C) {
+	svc := service.Service{
+		ID:           "svc1",
+		Name:         "TestFacade_InvalidServiceOptions",
+		DeploymentID: "deployment_id",
+		PoolID:       "pool_id",
+		Launch:       "auto",
+		DesiredState: int(service.SVCStop),
+		HostPolicy: "REQUIRE_SEPARATE",
+		ChangeOptions: []servicedefinition.ChangeOption{
+			"RESTARTALLONINSTANCECHANGED",
+		},
+	}
+
+	err := ft.Facade.AddService(ft.CTX, svc)
+	// We should have gotten an error here that these options are invalid together.
+	t.Assert(err, NotNil)
+}
+
+// We should get an error if we add a service with an invalid ChangeOption.
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceAdd_InvalidServiceOptions3(t *C) {
+	svc := service.Service{
+		ID:           "svc1",
+		Name:         "TestFacade_InvalidServiceOptions",
+		DeploymentID: "deployment_id",
+		PoolID:       "pool_id",
+		Launch:       "auto",
+		DesiredState: int(service.SVCStop),
+		ChangeOptions: []servicedefinition.ChangeOption{
+			"InvalidChangeOption",
+		},
+	}
+
+	err := ft.Facade.AddService(ft.CTX, svc)
+	// We should have gotten an error here the change option is invalid.
+	t.Assert(err, NotNil)
+}
+
+// We should get an error if we try to update a service with an invalid set of options.
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceUpdate_InvalidServiceOptions(t *C) {
+	svc := service.Service{
+		ID:           "svc1",
+		Name:         "TestFacade_InvalidServiceOptions",
+		DeploymentID: "deployment_id",
+		PoolID:       "pool_id",
+		Launch:       "auto",
+		DesiredState: int(service.SVCStop),
+		ChangeOptions: []servicedefinition.ChangeOption{
+			servicedefinition.RestartAllOnInstanceChanged,
+		},
+	}
+
+	err := ft.Facade.AddService(ft.CTX, svc)
+	t.Assert(err, IsNil)
+
+	svc.HostPolicy = servicedefinition.RequireSeparate
+	err = ft.Facade.UpdateService(ft.CTX, svc)
+	t.Assert(err, NotNil) // This should have returned an ErrInvalidServiceOption error.
+}
+
 func (ft *FacadeIntegrationTest) TestFacade_migrateServiceConfigs_noConfigs(t *C) {
 	_, newSvc, err := ft.setupMigrationServices(t, nil)
 	t.Assert(err, IsNil)

--- a/scheduler/leader.go
+++ b/scheduler/leader.go
@@ -22,7 +22,6 @@ import (
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain/host"
-	"github.com/control-center/serviced/domain/servicedefinition"
 	"github.com/control-center/serviced/facade"
 	"github.com/control-center/serviced/scheduler/strategy"
 	"github.com/control-center/serviced/zzk"
@@ -148,9 +147,6 @@ func (l *leader) SelectHost(sn *zkservice.ServiceNode) (string, error) {
 	}
 
 	hp := sn.HostPolicy
-	if hp == "" {
-		hp = servicedefinition.Balance
-	}
 	strat, err := strategy.Get(string(hp))
 	if err != nil {
 		return "", err
@@ -158,3 +154,4 @@ func (l *leader) SelectHost(sn *zkservice.ServiceNode) (string, error) {
 
 	return StrategySelectHost(sn, hosts, strat, l.facade)
 }
+

--- a/scheduler/strategy/balance.go
+++ b/scheduler/strategy/balance.go
@@ -13,10 +13,12 @@
 
 package strategy
 
+import "github.com/control-center/serviced/domain/servicedefinition"
+
 type BalanceStrategy struct{}
 
 func (s *BalanceStrategy) Name() string {
-	return "balance"
+	return servicedefinition.Balance
 }
 
 func (s *BalanceStrategy) SelectHost(service ServiceConfig, hosts []Host) (Host, error) {

--- a/scheduler/strategy/pack.go
+++ b/scheduler/strategy/pack.go
@@ -13,10 +13,12 @@
 
 package strategy
 
+import "github.com/control-center/serviced/domain/servicedefinition"
+
 type PackStrategy struct{}
 
 func (s *PackStrategy) Name() string {
-	return "pack"
+	return servicedefinition.Pack
 }
 
 func (s *PackStrategy) SelectHost(service ServiceConfig, hosts []Host) (Host, error) {

--- a/scheduler/strategy/prefer_separate.go
+++ b/scheduler/strategy/prefer_separate.go
@@ -13,10 +13,12 @@
 
 package strategy
 
+import "github.com/control-center/serviced/domain/servicedefinition"
+
 type PreferSeparateStrategy struct{}
 
 func (s *PreferSeparateStrategy) Name() string {
-	return "prefer_separate"
+	return servicedefinition.PreferSeparate
 }
 
 func (s *PreferSeparateStrategy) SelectHost(service ServiceConfig, hosts []Host) (Host, error) {

--- a/scheduler/strategy/require_separate.go
+++ b/scheduler/strategy/require_separate.go
@@ -13,10 +13,12 @@
 
 package strategy
 
+import "github.com/control-center/serviced/domain/servicedefinition"
+
 type RequireSeparateStrategy struct{}
 
 func (s *RequireSeparateStrategy) Name() string {
-	return "require_separate"
+	return servicedefinition.RequireSeparate
 }
 
 func (s *RequireSeparateStrategy) SelectHost(service ServiceConfig, hosts []Host) (Host, error) {

--- a/scheduler/strategy/strategy.go
+++ b/scheduler/strategy/strategy.go
@@ -56,6 +56,10 @@ type Strategy interface {
 }
 
 func Get(name string) (Strategy, error) {
+	// Default to servicedefinition.Balance
+	if len(name) == 0 {
+		name = servicedefinition.Balance
+	}
 	for _, strategy := range strategies {
 		if strings.ToLower(strategy.Name()) == strings.ToLower(name) {
 			return strategy, nil

--- a/zzk/service/service.go
+++ b/zzk/service/service.go
@@ -45,7 +45,7 @@ type ServiceNode struct {
 	Instances                   int
 	RAMCommitment               utils.EngNotation
 	CPUCommitment               int
-	ChangeOptions               []string
+	ChangeOptions               []servicedefinition.ChangeOption
 	AddressAssignment           addressassignment.AddressAssignment
 	ShouldHaveAddressAssignment bool
 	//non-service fields


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3693
Add a new ChangeOption policy "RestartAllOnInstanceZeroDown" that restarts all instances if instance 0 goes down.  This will establish a new instance 0 for the service.
Updated ChangeOption to a string struct.
Reject invalid ChangeOption strings when unmarshaling them.
Raise an error if both HostPolicy RequireSeparate and ChangeOption RestartAllOnInstanceChanged are specified (these are invalid options together).
Add tests to verify the correct behavior for all changes.