### PR TITLE
Add in support for multiple health checks for ISVCs.

### DIFF
--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -895,7 +895,7 @@ func (svc *IService) setHealthStatus(result error, currentTime int64, healthChec
 			if healthStatus.Status != "passed" && healthStatus.Status != "unknown" {
 				log.WithFields(logrus.Fields{
 					"healthcheck": healthCheckName,
-				}).Info("Internal service health check is healthy")
+				}).Info("Internal service health check passed")
 			}
 			healthStatus.Status = "passed"
 			healthStatus.Failure = ""

--- a/isvcs/zk.go
+++ b/isvcs/zk.go
@@ -19,13 +19,26 @@ import (
 	"io/ioutil"
 	"net"
 	"time"
+	"github.com/control-center/serviced/config"
+	"fmt"
 )
 
 var Zookeeper IServiceDefinition
 var zookeeper *IService
 
+const QUORUM_HEALTHCHECK_NAME = "Participating in Quorum"
+
 func initZK() {
 	var err error
+
+	// build the list of ZooKeeper connect strings for use in health checks.
+	zkConnectStrings := config.GetOptions().Zookeepers
+
+	if len(zkConnectStrings) == 0 {
+		zkConnectStrings = append(zkConnectStrings, "127.0.0.1:2181")
+	}
+
+	// Build the service definition for the Zookeeper instance.
 	Zookeeper = IServiceDefinition{
 		ID:      ZookeeperISVC.ID,
 		Name:    "zookeeper",
@@ -61,82 +74,97 @@ func initZK() {
 		Volumes: map[string]string{"data": "/var/zookeeper"},
 	}
 
-	defaultHealthCheck := healthCheckDefinition{
-		healthCheck: zkHealthCheck,
-		Interval:    DEFAULT_HEALTHCHECK_INTERVAL,
-		Timeout:     DEFAULT_HEALTHCHECK_TIMEOUT,
-	}
+	// setup the health check definitions
+	Zookeeper.HealthChecks 	= make(map[string]healthCheckDefinition)
 
-	Zookeeper.HealthChecks = map[string]healthCheckDefinition{
-		DEFAULT_HEALTHCHECK_NAME: defaultHealthCheck,
+	for _, zkIP := range zkConnectStrings {
+
+		defaultHealthCheck := healthCheckDefinition{
+			healthCheck: SetZKHealthCheck(zkIP),
+			Interval:    DEFAULT_HEALTHCHECK_INTERVAL,
+			Timeout:     DEFAULT_HEALTHCHECK_TIMEOUT,
+		}
+
+		quorumHealthCheck := healthCheckDefinition{
+			healthCheck: SetZKQuorumCheck(zkIP),
+			Interval:    DEFAULT_HEALTHCHECK_INTERVAL,
+			Timeout:     DEFAULT_HEALTHCHECK_TIMEOUT,
+		}
+
+		Zookeeper.HealthChecks[DEFAULT_HEALTHCHECK_NAME] = defaultHealthCheck
+		Zookeeper.HealthChecks[QUORUM_HEALTHCHECK_NAME] = quorumHealthCheck
 	}
 
 	zookeeper, err = NewIService(Zookeeper)
+
 	if err != nil {
 		log.WithError(err).Fatal("Unable to initialize ZooKeeper internal service container")
 	}
 }
 
-// a health check for zookeeper
-func zkHealthCheck(halt <-chan struct{}) error {
-	healthy := true
-	times := -1
-	for {
-		if !healthy && times == 3 {
-			log.Warn("Unable to validate health of ZooKeeper. Retrying silently")
-		}
-		select {
-		case <-halt:
-			log.Debug("Stopped health checks for ZooKeeper")
-			return nil
-		default:
-			// Try ruok.
-			times++
-			ruok, err := zkFourLetterWord("127.0.0.1:2181", "ruok", time.Second*10)
-			if err != nil {
-				log.WithError(err).Debug("No response to ruok from ZooKeeper")
-				healthy = false
-				time.Sleep(1 * time.Second)
-				continue
-			}
+// This function sets up a ZooKeeper health check function parameterized with the connection string eg: "127.0.0.1:2181".
+func SetZKHealthCheck(connectString string) HealthCheckFunction {
+	return func(halt <-chan struct{}) error {
+		for {
+			select {
+			case <-halt:
+				log.Debug("Stopped health checks for ZooKeeper")
+				return nil
+			default:
+				// Try ruok.
 
-			// ruok should respond either with "imok" or not at all.
-			// If for some reason that isn't the case, there's a problem.
-			if string(ruok) != "imok" {
-				log.WithFields(logrus.Fields{
-					"response": ruok,
-				}).Debug("Improper response to ruok from ZooKeeper")
-				healthy = false
-				time.Sleep(1 * time.Second)
-				continue
-			}
+				ruok, err := zkFourLetterWord(connectString, "ruok", time.Second*2)
+				if err != nil {
+					log.WithError(err).Debug("No response to ruok from ZooKeeper")
+					return fmt.Errorf("No response to \"ruok\" from ZooKeeper instance (%s)", connectString)
+				}
 
-			// Since ruok works, try stat next.
-			stat, err := zkFourLetterWord("127.0.0.1:2181", "stat", time.Second*10)
-			if err != nil {
-				log.WithError(err).Debug("No response to stat from ZooKeeper")
-				healthy = false
-				time.Sleep(1 * time.Second)
-				continue
-			}
+				// ruok should respond either with "imok" or not at all.
+				// If for some reason that isn't the case, there's a problem.
+				if string(ruok) != "imok" {
+					log.WithFields(logrus.Fields{
+						"response": ruok,
+					}).Debug("Improper response to ruok from ZooKeeper")
+					return fmt.Errorf("Improper response to \"ruok\" from ZooKeeper instance (%s)", connectString)
+				}
 
-			// If we get "This ZooKeeper instance is not currently serving requests", we know it's waiting for quorum and can at least note that in the logs.
-			if string(stat) == "This ZooKeeper instance is not currently serving requests\n" {
-				log.Debug("ZooKeeper is running, but still establishing a quorum")
-				healthy = false
-				time.Sleep(1 * time.Second)
-				continue
-			}
-
-			if !healthy {
-				log.Info("ZooKeeper checked in healthy")
-			} else {
 				log.Debug("ZooKeeper checked in healthy")
+
+				return nil
 			}
-			return nil
 		}
 	}
+}
 
+// This function sets up a ZooKeeper quorum check function parameterized with the connection string eg: "127.0.0.1:2181".
+func SetZKQuorumCheck(connectString string) HealthCheckFunction {
+	return func(halt <-chan struct{}) error {
+
+		for {
+			select {
+			case <-halt:
+				log.Debug("Stopped health checks for ZooKeeper")
+				return nil
+			default:
+				// check the 'stat' command and see what the instance returns to the caller.
+				stat, err := zkFourLetterWord(connectString, "stat", time.Second*2)
+				if err != nil {
+					log.WithError(err).Debug("No response to stat from ZooKeeper")
+					return fmt.Errorf("No response to stat from ZooKeeper instance (%s)", connectString)
+				}
+
+				// If we get "This ZooKeeper instance is not currently serving requests", we know it's waiting for quorum and can at least note that in the logs.
+				if string(stat) == "This ZooKeeper instance is not currently serving requests\n" {
+					log.Debug("ZooKeeper is running, but still establishing a quorum")
+					return fmt.Errorf("ZooKeeper instance (%s) is running, but still establishing a quorum", connectString)
+				}
+
+				log.Debug("ZooKeeper Quorum checked in healthy")
+
+				return nil
+			}
+		}
+	}
 }
 
 // transcribed from upstream samuel/go-zookeeper


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3676

zk.go:
- Created a separate health check for quorum.
- modified the creation of health checks to do so for each ZK member from config file.
- optimized the health check functions to return immediately so multiple health checks don't stall
- cleaned up logging in the health status functions so we get a more clear indication in the logs about what is happening when something fails a health check.

container.go:
- doHealthChecks() now iterates over all healthchecks instead of just hitting the default.
- startupHealthcheck() now takes into account all the healthchecks before starting up not just the default.
- setHeathStatus() now takes the key for the health check so that health check status gets set properly.
- setStoppedHealthStatus() now properly sets stopped state for all health statues instead of just the default health check.