### PR TITLE
Feature/cc 3663

### DIFF
--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -224,7 +224,7 @@ type Service struct {
 	ConfigFiles       map[string]servicedefinition.ConfigFile
 	Instances         int
 	InstanceLimits    domain.MinMax
-	ChangeOptions     []string
+	ChangeOptions     []servicedefinition.ChangeOption
 	ImageID           string
 	PoolID            string
 	DesiredState      int

--- a/domain/service/service_unit_test.go
+++ b/domain/service/service_unit_test.go
@@ -32,7 +32,7 @@ func (s *ServiceDomainUnitTestSuite) TestBuildServiceSimple(t *C) {
 	environment := []string{"enviroment:foobar", "a:b", "c:d"}
 	tags := []string{"tags", "foo", "bar"}
 	imageID := "imageid"
-	changeOptions := []string{"changeoptions", "boo"}
+	changeOptions := []servicedefinition.ChangeOption{"changeoptions", "boo"}
 	launch := "launch"
 	hostname := "hostname"
 	privileged := true

--- a/domain/servicedefinition/servicedefinition.go
+++ b/domain/servicedefinition/servicedefinition.go
@@ -203,9 +203,9 @@ const (
 
 // UnmarshalText implements the encoding/TextUnmarshaler interface
 func (co *ChangeOption) UnmarshalText(b []byte) error {
-	s := strings.Trim(string(b), `"`)
+	s := strings.ToLower(strings.Trim(string(b), `"`))
 	switch s {
-	case string(RestartAllOnInstanceChanged), string(RestartAllOnInstanceZeroDown):
+	case strings.ToLower(string(RestartAllOnInstanceChanged)), strings.ToLower(string(RestartAllOnInstanceZeroDown)):
 		*co = ChangeOption(s)
 	case "":
 		*co = DefaultChangeOption
@@ -219,7 +219,7 @@ type ChangeOptions []ChangeOption
 
 func (options ChangeOptions) Contains(co ChangeOption) bool {
 	for _, option := range options {
-		if co == option {
+		if strings.ToLower(string(co)) == strings.ToLower(string(option)) {
 			return true
 		}
 	}

--- a/facade/service.go
+++ b/facade/service.go
@@ -63,6 +63,15 @@ var (
 	ErrEmergencyShutdownNoOp    = errors.New("Cannot perform operation; Service has Emergency Shutdown flag set")
 )
 
+// A type for invalid service options; the details are specified when creating the error.
+type ErrInvalidServiceOption struct {
+	error string
+}
+
+func (err ErrInvalidServiceOption) Error() string {
+	return fmt.Sprintf("Invalid service option specified: %s", err.error)
+}
+
 type IpArgs struct {
 	AuditName	string
 	Portmap		Ports
@@ -127,20 +136,26 @@ func (f *Facade) addService(ctx datastore.Context, tenantID string, svc service.
 }
 
 func (f *Facade) validateServiceAdd(ctx datastore.Context, svc *service.Service) error {
+	logger := plog.WithFields(log.Fields{
+		"name": svc.Name,
+		"id": svc.ID,
+		"parentserviceid": svc.ParentServiceID,
+	})
+
 	store := f.serviceStore
 	// verify that the service does not already exist
 	if _, err := store.Get(ctx, svc.ID); !datastore.IsErrNoSuchEntity(err) {
 		if err != nil {
-			glog.Errorf("Could not check the existance of service %s (%s): %s", svc.Name, svc.ID, err)
+			logger.WithError(err).Error("Could not check the existance of service")
 			return err
 		} else {
-			glog.Errorf("Could not add service %s (%s): %s", svc.Name, svc.ID, ErrServiceExists)
+			logger.WithError(ErrServiceExists).Error("Could not add service")
 			return ErrServiceExists
 		}
 	}
 	// verify no collision with the service name
 	if err := f.validateServiceName(ctx, svc); err != nil {
-		glog.Errorf("Could not add service %s to parent %s: %s", svc.Name, svc.ParentServiceID, err)
+		logger.WithField("parentserviceid", svc.ParentServiceID).WithError(err).Error("Could not add service with parent")
 		return err
 	}
 
@@ -150,11 +165,15 @@ func (f *Facade) validateServiceAdd(ctx datastore.Context, svc *service.Service)
 			if vhost.Enabled {
 				serviceID, application, err := f.zzk.GetVHost(vhost.Name)
 				if err != nil {
-					glog.Errorf("Could not check public endpoint for virtual host %s: %s", vhost.Name, err)
+					logger.WithField("vhost", vhost.Name).WithError(err).Error("Could not check public endpoint for virtual host")
 					return err
 				}
 				if serviceID != "" || application != "" {
-					glog.Warningf("VHost %s already in use by another application %s (%s)", vhost.Name, serviceID, application)
+					logger.WithFields(log.Fields{
+						"vhost": vhost.Name,
+						"otherservice": serviceID,
+						"otherapplication": application,
+					}).Warning("VHost already in use by another application")
 					svc.Endpoints[i].VHostList[j].Enabled = false
 				}
 			}
@@ -164,15 +183,24 @@ func (f *Facade) validateServiceAdd(ctx datastore.Context, svc *service.Service)
 			if port.Enabled {
 				serviceID, application, err := f.zzk.GetPublicPort(port.PortAddr)
 				if err != nil {
-					glog.Errorf("Could not check public endpoint for port %s: %s", port.PortAddr, err)
+					logger.WithField("portaddr", port.PortAddr).WithError(err).Error("Could not check public endpoint for port")
 					return err
 				}
 				if serviceID != "" || application != "" {
-					glog.Warningf("Public port %s already in use by another application %s (%s)", port.PortAddr, serviceID, application)
+					logger.WithFields(log.Fields{
+						"portaddr": port.PortAddr,
+						"otherservice": serviceID,
+						"otherapplication": application,
+					}).Warning("Public port already in use by another application")
 					svc.Endpoints[i].PortList[j].Enabled = false
 				}
 			}
 		}
+	}
+
+	if err := validateServiceOptions(svc); err != nil {
+		logger.WithError(err).Error("Could not add service")
+		return err
 	}
 
 	// remove any BuiltIn enabled monitoring configs
@@ -211,6 +239,19 @@ func (f *Facade) validateServiceAdd(ctx datastore.Context, svc *service.Service)
 			svc.OriginalConfigs = svc.ConfigFiles
 		} else {
 			svc.OriginalConfigs = make(map[string]servicedefinition.ConfigFile)
+		}
+	}
+	return nil
+}
+
+// Validates that the service doesn't have invalid options specified.  This is called when adding,
+// updating, or trying to start services.
+func validateServiceOptions(svc *service.Service) error {
+	// ChangeOption RestartAllOnInstanceChanged and HostPolicy RequireSeparate are invalid together.
+	if svc.HostPolicy == servicedefinition.RequireSeparate &&
+		servicedefinition.ChangeOptions(svc.ChangeOptions).Contains(servicedefinition.RestartAllOnInstanceChanged) {
+		return ErrInvalidServiceOption{
+			error: "HostPolicy RequireSeparate cannot be used with ChangeOption RestartAllOnInstanceChanged",
 		}
 	}
 	return nil
@@ -311,11 +352,18 @@ func (f *Facade) updateService(ctx datastore.Context, tenantID string, svc servi
 
 func (f *Facade) validateServiceUpdate(ctx datastore.Context, svc *service.Service) (*service.Service, error) {
 	defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.validateServiceUpdate"))
+
+	logger := plog.WithFields(log.Fields{
+		"name": svc.Name,
+		"id": svc.ID,
+		"parentserviceid": svc.ParentServiceID,
+	})
+
 	store := f.serviceStore
 	// verify that the service exists
 	cursvc, err := store.Get(ctx, svc.ID)
 	if err != nil {
-		glog.Errorf("Could not load service %s (%s) from database: %s", svc.Name, svc.ID, err)
+		logger.WithError(err).Error("Could not load service from database")
 		return nil, err
 	}
 	// verify no collision with the service name
@@ -323,12 +371,12 @@ func (f *Facade) validateServiceUpdate(ctx datastore.Context, svc *service.Servi
 		// if the parent changed, make sure it shares the same tenant
 		if svc.ParentServiceID != cursvc.ParentServiceID {
 			if err := f.validateServiceTenant(ctx, svc.ParentServiceID, svc.ID); err != nil {
-				glog.Errorf("Could not validate tenant for updated service %s: %s", svc.ID, err)
+				logger.WithError(err).Error("Could not validate tenant for updated service")
 				return nil, err
 			}
 		}
 		if err := f.validateServiceName(ctx, svc); err != nil {
-			glog.Errorf("Could not validate service name for updated service %s: %s", svc.ID, err)
+			logger.WithError(err).Error("Could not validate service name for updated service")
 			return nil, err
 		}
 
@@ -344,11 +392,14 @@ func (f *Facade) validateServiceUpdate(ctx datastore.Context, svc *service.Servi
 			if vhost.Enabled {
 				serviceID, application, err := f.zzk.GetVHost(vhost.Name)
 				if err != nil {
-					glog.Errorf("Could not check public endpoint for virtual host %s: %s", vhost.Name, err)
+					logger.WithField("vhost", vhost.Name).WithError(err).Error("Could not check public endpoint for virtual host")
 					return nil, err
 				}
 				if (serviceID != "" && serviceID != svc.ID) || (application != "" && application != ep.Application) {
-					glog.Errorf("VHost %s already in use by another application %s (%s)", vhost.Name, serviceID, application)
+					logger.WithFields(log.Fields{
+						"vhost": vhost.Name,
+						"application": application,
+					}).Error("VHost already in use by another application")
 					return nil, fmt.Errorf("vhost %s is already in use", vhost.Name)
 				}
 			}
@@ -358,11 +409,14 @@ func (f *Facade) validateServiceUpdate(ctx datastore.Context, svc *service.Servi
 			if port.Enabled {
 				serviceID, application, err := f.zzk.GetPublicPort(port.PortAddr)
 				if err != nil {
-					glog.Errorf("Could not check public endpoint for port %s: %s", port.PortAddr, err)
+					logger.WithField("portaddr", port.PortAddr).WithError(err).Error("Could not check public endpoint for port")
 					return nil, err
 				}
 				if (serviceID != "" && serviceID != svc.ID) || (application != "" && application != ep.Application) {
-					glog.Errorf("Public port %s already in use by another application %s (%s)", port.PortAddr, serviceID, application)
+					logger.WithFields(log.Fields{
+						"portaddr": port.PortAddr,
+						"application": application,
+					}).WithError(err).Error("Public port already in use by another application")
 					return nil, fmt.Errorf("port %s is already in use", port.PortAddr)
 				}
 			}
@@ -399,10 +453,15 @@ func (f *Facade) validateServiceUpdate(ctx datastore.Context, svc *service.Servi
 	}
 	svc.MonitoringProfile.GraphConfigs = graphs
 
+	if err := validateServiceOptions(svc); err != nil {
+		logger.WithError(err).Error("Could not validate service for update")
+		return nil, err
+	}
+
 	// verify the desired state of the service
 	if svc.DesiredState != int(service.SVCStop) {
 		if err := f.validateServiceStart(ctx, svc); err != nil {
-			glog.Warningf("Could not validate %s for starting: %s", svc.ID, err)
+			logger.WithError(err).Warning("Could not validate service for starting")
 			svc.DesiredState = int(service.SVCStop)
 		}
 	}
@@ -459,6 +518,12 @@ func (f *Facade) validateServiceTenant(ctx datastore.Context, serviceA, serviceB
 // start.
 func (f *Facade) validateServiceStart(ctx datastore.Context, svc *service.Service) error {
 	defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.validateServiceStart"))
+	logger := plog.WithFields(log.Fields{
+		"service": svc.Name,
+		"id":      svc.ID,
+		"parentserviceid": svc.ParentServiceID,
+	})
+
 	if svc.EmergencyShutdown {
 		return ErrEmergencyShutdownNoOp
 	}
@@ -475,6 +540,12 @@ func (f *Facade) validateServiceStart(ctx datastore.Context, svc *service.Servic
 			}
 		}
 	}
+
+	if err := validateServiceOptions(svc); err != nil {
+		logger.WithError(err).Error("Could not start service")
+		return err
+	}
+
 	return nil
 }
 

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -369,6 +369,87 @@ func (ft *FacadeIntegrationTest) TestFacade_validateServiceAdd_EnableDuplicatePu
 	t.Assert(ft.Facade.UpdateService(ft.CTX, svc), NotNil)
 }
 
+// Add using the servicedefition defines.
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceAdd_InvalidServiceOptions(t *C) {
+	svc := service.Service{
+		ID:           "svc1",
+		Name:         "TestFacade_InvalidServiceOptions",
+		DeploymentID: "deployment_id",
+		PoolID:       "pool_id",
+		Launch:       "auto",
+		DesiredState: int(service.SVCStop),
+		HostPolicy: servicedefinition.RequireSeparate,
+		ChangeOptions: []servicedefinition.ChangeOption{
+			servicedefinition.RestartAllOnInstanceChanged,
+		},
+	}
+
+	err := ft.Facade.AddService(ft.CTX, svc)
+	// We should have gotten an error here that these options are invalid together.
+	t.Assert(err, NotNil)
+}
+
+// Make these all uppercase; case should not matter for these options in the service def.
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceAdd_InvalidServiceOptions2(t *C) {
+	svc := service.Service{
+		ID:           "svc1",
+		Name:         "TestFacade_InvalidServiceOptions",
+		DeploymentID: "deployment_id",
+		PoolID:       "pool_id",
+		Launch:       "auto",
+		DesiredState: int(service.SVCStop),
+		HostPolicy: "REQUIRE_SEPARATE",
+		ChangeOptions: []servicedefinition.ChangeOption{
+			"RESTARTALLONINSTANCECHANGED",
+		},
+	}
+
+	err := ft.Facade.AddService(ft.CTX, svc)
+	// We should have gotten an error here that these options are invalid together.
+	t.Assert(err, NotNil)
+}
+
+// We should get an error if we add a service with an invalid ChangeOption.
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceAdd_InvalidServiceOptions3(t *C) {
+	svc := service.Service{
+		ID:           "svc1",
+		Name:         "TestFacade_InvalidServiceOptions",
+		DeploymentID: "deployment_id",
+		PoolID:       "pool_id",
+		Launch:       "auto",
+		DesiredState: int(service.SVCStop),
+		ChangeOptions: []servicedefinition.ChangeOption{
+			"InvalidChangeOption",
+		},
+	}
+
+	err := ft.Facade.AddService(ft.CTX, svc)
+	// We should have gotten an error here the change option is invalid.
+	t.Assert(err, NotNil)
+}
+
+// We should get an error if we try to update a service with an invalid set of options.
+func (ft *FacadeIntegrationTest) TestFacade_validateServiceUpdate_InvalidServiceOptions(t *C) {
+	svc := service.Service{
+		ID:           "svc1",
+		Name:         "TestFacade_InvalidServiceOptions",
+		DeploymentID: "deployment_id",
+		PoolID:       "pool_id",
+		Launch:       "auto",
+		DesiredState: int(service.SVCStop),
+		ChangeOptions: []servicedefinition.ChangeOption{
+			servicedefinition.RestartAllOnInstanceChanged,
+		},
+	}
+
+	err := ft.Facade.AddService(ft.CTX, svc)
+	t.Assert(err, IsNil)
+
+	svc.HostPolicy = servicedefinition.RequireSeparate
+	err = ft.Facade.UpdateService(ft.CTX, svc)
+	t.Assert(err, NotNil) // This should have returned an ErrInvalidServiceOption error.
+}
+
 func (ft *FacadeIntegrationTest) TestFacade_migrateServiceConfigs_noConfigs(t *C) {
 	_, newSvc, err := ft.setupMigrationServices(t, nil)
 	t.Assert(err, IsNil)

--- a/scheduler/leader.go
+++ b/scheduler/leader.go
@@ -22,7 +22,6 @@ import (
 	"github.com/control-center/serviced/dao"
 	"github.com/control-center/serviced/datastore"
 	"github.com/control-center/serviced/domain/host"
-	"github.com/control-center/serviced/domain/servicedefinition"
 	"github.com/control-center/serviced/facade"
 	"github.com/control-center/serviced/scheduler/strategy"
 	"github.com/control-center/serviced/zzk"
@@ -148,9 +147,6 @@ func (l *leader) SelectHost(sn *zkservice.ServiceNode) (string, error) {
 	}
 
 	hp := sn.HostPolicy
-	if hp == "" {
-		hp = servicedefinition.Balance
-	}
 	strat, err := strategy.Get(string(hp))
 	if err != nil {
 		return "", err
@@ -158,3 +154,4 @@ func (l *leader) SelectHost(sn *zkservice.ServiceNode) (string, error) {
 
 	return StrategySelectHost(sn, hosts, strat, l.facade)
 }
+

--- a/scheduler/strategy/balance.go
+++ b/scheduler/strategy/balance.go
@@ -13,10 +13,12 @@
 
 package strategy
 
+import "github.com/control-center/serviced/domain/servicedefinition"
+
 type BalanceStrategy struct{}
 
 func (s *BalanceStrategy) Name() string {
-	return "balance"
+	return servicedefinition.Balance
 }
 
 func (s *BalanceStrategy) SelectHost(service ServiceConfig, hosts []Host) (Host, error) {

--- a/scheduler/strategy/pack.go
+++ b/scheduler/strategy/pack.go
@@ -13,10 +13,12 @@
 
 package strategy
 
+import "github.com/control-center/serviced/domain/servicedefinition"
+
 type PackStrategy struct{}
 
 func (s *PackStrategy) Name() string {
-	return "pack"
+	return servicedefinition.Pack
 }
 
 func (s *PackStrategy) SelectHost(service ServiceConfig, hosts []Host) (Host, error) {

--- a/scheduler/strategy/prefer_separate.go
+++ b/scheduler/strategy/prefer_separate.go
@@ -13,10 +13,12 @@
 
 package strategy
 
+import "github.com/control-center/serviced/domain/servicedefinition"
+
 type PreferSeparateStrategy struct{}
 
 func (s *PreferSeparateStrategy) Name() string {
-	return "prefer_separate"
+	return servicedefinition.PreferSeparate
 }
 
 func (s *PreferSeparateStrategy) SelectHost(service ServiceConfig, hosts []Host) (Host, error) {

--- a/scheduler/strategy/require_separate.go
+++ b/scheduler/strategy/require_separate.go
@@ -13,10 +13,12 @@
 
 package strategy
 
+import "github.com/control-center/serviced/domain/servicedefinition"
+
 type RequireSeparateStrategy struct{}
 
 func (s *RequireSeparateStrategy) Name() string {
-	return "require_separate"
+	return servicedefinition.RequireSeparate
 }
 
 func (s *RequireSeparateStrategy) SelectHost(service ServiceConfig, hosts []Host) (Host, error) {

--- a/scheduler/strategy/strategy.go
+++ b/scheduler/strategy/strategy.go
@@ -56,6 +56,10 @@ type Strategy interface {
 }
 
 func Get(name string) (Strategy, error) {
+	// Default to servicedefinition.Balance
+	if len(name) == 0 {
+		name = servicedefinition.Balance
+	}
 	for _, strategy := range strategies {
 		if strings.ToLower(strategy.Name()) == strings.ToLower(name) {
 			return strategy, nil

--- a/zzk/service/service.go
+++ b/zzk/service/service.go
@@ -45,7 +45,7 @@ type ServiceNode struct {
 	Instances                   int
 	RAMCommitment               utils.EngNotation
 	CPUCommitment               int
-	ChangeOptions               []string
+	ChangeOptions               []servicedefinition.ChangeOption
 	AddressAssignment           addressassignment.AddressAssignment
 	ShouldHaveAddressAssignment bool
 	//non-service fields


### PR DESCRIPTION
Cherry-picked from https://github.com/control-center/serviced/pull/3596
https://jira.zenoss.com/browse/CC-3663

Add a new ChangeOption policy "RestartAllOnInstanceZeroDown" that restarts all instances if instance 0 goes down. This will establish a new instance 0 for the service.
Updated ChangeOption to a string struct.
Reject invalid ChangeOption strings when unmarshaling them.
Raise an error if both HostPolicy RequireSeparate and ChangeOption RestartAllOnInstanceChanged are specified (these are invalid options together).
Add tests to verify the correct behavior for all changes.