### PR TITLE
Feature/cc 3691

### DIFF
--- a/facade/logstash.go
+++ b/facade/logstash.go
@@ -217,7 +217,8 @@ func getFilters(configs []servicedefinition.LogConfig, filterDefs map[string]str
 			if !utils.StringInSlice(config.Type, *typeFilter) {
 				// Ruby Regex used in logstash conf uses / as a special character so we escape it.
 				path := strings.Replace(config.Path, "/", "\\/", -1)
-				filters += fmt.Sprintf("\n  if [file] =~ \"%s\" {\n    %s\n  }\n",
+				filters += fmt.Sprintf("\n%s\n  if [file] =~ \"%s\" {\n    %s\n  }\n",
+					"  # Regex pattern used must overlap golang glob format to be valid in filebeat",
 					path, indent(filterDefs[filtName], "    "))
 				*typeFilter = append(*typeFilter, config.Type)
 			}

--- a/facade/logstash.go
+++ b/facade/logstash.go
@@ -215,8 +215,10 @@ func getFilters(configs []servicedefinition.LogConfig, filterDefs map[string]str
 		for _, filtName := range config.Filters {
 			//do not write duplicate types, logstash doesn't handle this
 			if !utils.StringInSlice(config.Type, *typeFilter) {
-				filters += fmt.Sprintf("\n  if [file] == \"%s\" {\n    %s\n  }\n",
-					config.Path, indent(filterDefs[filtName], "    "))
+				// Ruby Regex used in logstash conf uses / as a special character so we escape it.
+				path := strings.Replace(config.Path, "/", "\\/", -1)
+				filters += fmt.Sprintf("\n  if [file] =~ \"%s\" {\n    %s\n  }\n",
+					path, indent(filterDefs[filtName], "    "))
 				*typeFilter = append(*typeFilter, config.Type)
 			}
 		}

--- a/facade/logstash_test.go
+++ b/facade/logstash_test.go
@@ -314,7 +314,7 @@ func TestNoDuplicateFilters(t *testing.T) {
 	typeFilter := []string{}
 	filters := getFiltersFromTemplates(services, filterDefs, &typeFilter)
 
-	filterCount := strings.Count(filters, "if [file] == \"/tmp/foo2\"")
+	filterCount := strings.Count(filters, "if [file] =~ \"\\/tmp\\/foo2\"")
 	if filterCount != 1 {
 		t.Error(fmt.Sprintf("expected only 1 filter for 'foo2', but found %d: filters=%s", filterCount, filters))
 	}

--- a/isvcs/resources/logstash/filebeat.conf.in
+++ b/isvcs/resources/logstash/filebeat.conf.in
@@ -1,5 +1,6 @@
 filebeat:
   idle_timeout: 5s
+  # Glob pattern used in path must overlap logstash.conf regex to be valid.
   prospectors: ${PROSPECTORS_SECTION}
 
 path:


### PR DESCRIPTION
Modified the building of the logstash.conf to use regex with the log file paths to support https://jira.zenoss.com/browse/CC-3691 1 of 3.

Serviced, zenoss-service, prodbin.