### PR TITLE
Convert fields to string in logstash.conf

### DIFF
--- a/facade/logstash.go
+++ b/facade/logstash.go
@@ -276,6 +276,12 @@ filter {
     rename => {
       "source" => "file"
     }
+
+    convert => {
+      "[fields][instance]" => "string"
+      "[fields][ccWorkerID]" => "string"
+      "[fields][poolid]" => "string"
+    }
   }
 # NOTE the filters are generated from the service definitions
 ` + string(filters) + `


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3719
The changes in facade tell logstash to store 3 of these fields as strings, even if they look like numbers.
Changes in the api logs command handle cases where both types of values exist in elastic.