### PR TITLE
Support upgrades for application logfilters

### DIFF
--- a/dao/interface.go
+++ b/dao/interface.go
@@ -30,6 +30,7 @@ import (
 	"github.com/control-center/serviced/domain/addressassignment"
 	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/metrics"
+	"github.com/control-center/serviced/domain/logfilter"
 )
 
 // A generic ControlPlane error
@@ -58,10 +59,11 @@ type ServiceCloneRequest struct {
 }
 
 type ServiceMigrationRequest struct {
-	ServiceID string
-	Modified  []*service.Service
-	Added     []*service.Service
-	Deploy    []*ServiceDeploymentRequest
+	ServiceID string				// The tenant service ID
+	Modified  []*service.Service			// Services modified by the migration
+	Added     []*service.Service			// Services added by the migration
+	Deploy    []*ServiceDeploymentRequest		// A services to be deployed by the migration
+	LogFilters map[string]logfilter.LogFilter	// LogFilters to add/replace
 }
 
 type ServiceStateRequest struct {

--- a/domain/hostkey/store_test.go
+++ b/domain/hostkey/store_test.go
@@ -49,8 +49,17 @@ func (s *S) SetUpTest(c *C) {
 
 func (s *S) Test_HostKeyCRUD(c *C) {
 	hostID := "hostID"
+	keyText := `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxeGhO/4jJ7fPwXHjtZx+
+q/Ne+fhMEzGB41aD6QKij6u0LPBWynmXdJeLdIW1N8ZFF7PdpA4qAu6ouMRvOuSJ
+1qPt1hToahBxxducEp64nQ/fWN0uANjPqjlKcjj/fiSZ2ewrXYAOmnbaIQgt3fjv
+VYQgdGmHA5uyROclsutOF0shyprU2x/S8uXIK1fJM/yxukcDG6GvymW0b5mqLZZA
+Zmpt11QJ8YV5yiBtziSyYfiXTFs5yoydvRqmTIRm1CBnV3JYXio9fXv4C1BVTk11
+miqYybTUZga1O9mykjDbrwtaigb2rP1EjQzJoMLHW27edXBZUFQjedD0N20+WkUx
+0wIDAQAB
+-----END PUBLIC KEY-----`
 	expected := &HostKey{
-		PEM: DefaultKeyText,
+		PEM: keyText,
 	}
 	actual, err := s.store.Get(s.ctx, hostID)
 	c.Assert(err, NotNil)

--- a/domain/hostkey/validation_test.go
+++ b/domain/hostkey/validation_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package hostkey
 
 import (

--- a/domain/logfilter/logfilter.go
+++ b/domain/logfilter/logfilter.go
@@ -1,0 +1,62 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logfilter
+
+import (
+	"github.com/control-center/serviced/datastore"
+)
+
+// LogFilter is the definition of a log filter
+type LogFilter struct {
+	Name                   string                 // Name of the filter
+	Version                string                 // Version of the parent service
+	Filter                 string                 // the filter string
+	datastore.VersionedEntity
+}
+
+func (lf LogFilter) String() string {
+	return lf.GetID()
+}
+
+// Equals checks the equality of two log filters
+func (a *LogFilter) Equals(b *LogFilter) bool {
+	if a.Name != b.Name {
+		return false
+	}
+	if a.Version != b.Version {
+		return false
+	}
+	if a.Filter != b.Filter {
+		return false
+	}
+	return true
+}
+
+// GetType return the LogFilter's type
+// It returns the type as a string
+func GetType() string {
+	return kind
+}
+
+// GetType returns the LogFilter instance's type
+// It returns the type as a string
+func (lf *LogFilter) GetType() string {
+	return GetType()
+}
+
+// GetID return a LogFilter instance's ID
+// It returns the ID as a string
+func (lf *LogFilter) GetID() string {
+	return buildID(lf.Name, lf.Version)
+}

--- a/domain/logfilter/logfilter_test.go
+++ b/domain/logfilter/logfilter_test.go
@@ -1,0 +1,74 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit integration
+
+package logfilter
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// This plumbs gocheck into testing
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type unitTestSuite struct{}
+
+var _ = Suite(&unitTestSuite{})
+
+func (s *unitTestSuite) Test_GetType(c *C) {
+	c.Assert(GetType(), Equals, kind)
+	actual := &LogFilter{
+		Name:    "filter name",
+		Version: "1.0",
+		Filter:  "filter it",
+	}
+	c.Assert(actual.GetType(), Equals, kind)
+}
+
+func (s *unitTestSuite) Test_String(c *C) {
+	lf := &LogFilter{
+		Name:    "filter name",
+		Version: "1.0",
+		Filter:  "filter it",
+	}
+
+	c.Assert(lf.String(), Equals, "filter name-1.0")
+}
+
+func (s *unitTestSuite) Test_Equals(c *C) {
+	a := &LogFilter{
+		Name:    "filter name",
+		Version: "1.0",
+		Filter:  "filter it",
+	}
+	a2 := *a
+	c.Assert(a.Equals(a), Equals, true)
+	c.Assert(a.Equals(&a2), Equals, true)
+
+	nameDiffers := *a
+	nameDiffers.Name = "foo"
+	c.Assert(a.Equals(&nameDiffers), Equals, false)
+
+	versionDiffers := *a
+	versionDiffers.Version = "1.2"
+	c.Assert(a.Equals(&versionDiffers), Equals, false)
+
+	filterDiffers := *a
+	filterDiffers.Filter = "something different"
+	c.Assert(a.Equals(&filterDiffers), Equals, false)
+}

--- a/domain/logfilter/mapping.go
+++ b/domain/logfilter/mapping.go
@@ -1,0 +1,45 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logfilter
+
+import (
+	"fmt"
+
+	"github.com/control-center/serviced/datastore/elastic"
+	"github.com/control-center/serviced/logging"
+)
+
+var (
+	kind = "logfilter"
+	plog = logging.PackageLogger()
+	mappingString = fmt.Sprintf(`
+{
+     "%s": {
+      "properties":{
+        "Name":           {"type": "string", "index":"not_analyzed"},
+        "Version":        {"type": "string", "index":"not_analyzed"},
+        "Filter":         {"type": "string", "index":"not_analyzed"}
+      }
+    }
+}
+`, kind)
+	// MAPPING is the elastic mapping for a log filter
+	MAPPING, mappingError = elastic.NewMapping(mappingString)
+)
+
+func init() {
+	if mappingError != nil {
+		plog.WithError(mappingError).Fatal("error creating mapping for the logfilter object")
+	}
+}

--- a/domain/logfilter/mocks/store.go
+++ b/domain/logfilter/mocks/store.go
@@ -68,3 +68,24 @@ func (_m *Store) Delete(ctx datastore.Context, name, version string) error {
 
 	return r0
 }
+func (_m *Store) GetLogFilters(ctx datastore.Context) ([]*logfilter.LogFilter, error) {
+	ret := _m.Called(ctx)
+
+	var r0 *logfilter.LogFilter
+	if rf, ok := ret.Get(0).(func(datastore.Context) []*logfilter.LogFilter); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*logfilter.LogFilter)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/domain/logfilter/mocks/store.go
+++ b/domain/logfilter/mocks/store.go
@@ -1,0 +1,70 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocks
+
+import (
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain/logfilter"
+	"github.com/stretchr/testify/mock"
+)
+
+type Store struct {
+	mock.Mock
+}
+
+func (_m *Store) Get(ctx datastore.Context, name, version string) (*logfilter.LogFilter, error) {
+	ret := _m.Called(ctx, name, version)
+
+	var r0 *logfilter.LogFilter
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string) *logfilter.LogFilter); ok {
+		r0 = rf(ctx, name, version)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*logfilter.LogFilter)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string, string) error); ok {
+		r1 = rf(ctx, name, version)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Store) Put(ctx datastore.Context, val *logfilter.LogFilter) error {
+	ret := _m.Called(ctx, val)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, *logfilter.LogFilter) error); ok {
+		r0 = rf(ctx, val)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Store) Delete(ctx datastore.Context, name, version string) error {
+	ret := _m.Called(ctx, name, version)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, string, string) error); ok {
+		r0 = rf(ctx, name, version)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/domain/logfilter/mocks/store.go
+++ b/domain/logfilter/mocks/store.go
@@ -71,7 +71,7 @@ func (_m *Store) Delete(ctx datastore.Context, name, version string) error {
 func (_m *Store) GetLogFilters(ctx datastore.Context) ([]*logfilter.LogFilter, error) {
 	ret := _m.Called(ctx)
 
-	var r0 *logfilter.LogFilter
+	var r0 []*logfilter.LogFilter
 	if rf, ok := ret.Get(0).(func(datastore.Context) []*logfilter.LogFilter); ok {
 		r0 = rf(ctx)
 	} else {

--- a/domain/logfilter/store.go
+++ b/domain/logfilter/store.go
@@ -1,0 +1,77 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logfilter
+
+import (
+	"strings"
+
+	"github.com/control-center/serviced/datastore"
+	"fmt"
+)
+
+
+// Store is the database for the LogFilters
+type Store interface {
+	// Get a LogFilter by name and version. Return ErrNoSuchEntity if not found
+	Get(ctx datastore.Context, name, version string) (*LogFilter, error)
+
+	// Put adds or updates a LogFilter
+	Put(ctx datastore.Context, lf *LogFilter) error
+
+	// Delete removes the a LogFilter if it exists
+	Delete(ctx datastore.Context, name, version string) error
+
+}
+
+type storeImpl struct {
+	ds datastore.DataStore
+}
+
+// NewStore creates a Store for LogFilters
+func NewStore() Store {
+	return &storeImpl{}
+}
+
+// Get a LogFilter by id.  Return ErrNoSuchEntity if not found
+func (s *storeImpl) Get(ctx datastore.Context, name, version string) (*LogFilter, error) {
+	defer ctx.Metrics().Stop(ctx.Metrics().Start("LogFilterStore.Get"))
+	val := &LogFilter{}
+	if err := s.ds.Get(ctx, Key(name, version), val); err != nil {
+		return nil, err
+	}
+	return val, nil
+}
+
+// Put adds/updates a LogFilter
+func (s *storeImpl) Put(ctx datastore.Context, lf *LogFilter) error {
+	defer ctx.Metrics().Stop(ctx.Metrics().Start("LogFilterStore.Put"))
+	return s.ds.Put(ctx, Key(lf.Name, lf.Version), lf)
+}
+
+// Delete removes a LogFilter
+func (s *storeImpl) Delete(ctx datastore.Context, name, version string) error {
+	defer ctx.Metrics().Stop(ctx.Metrics().Start("LogFilterStore.Delete"))
+	return s.ds.Delete(ctx, Key(name, version))
+}
+
+//Key creates a Key suitable for getting, putting and deleting LogFilters
+func Key(name, version string) datastore.Key {
+	name = strings.TrimSpace(name)
+	version = strings.TrimSpace(version)
+	return datastore.NewKey(kind, buildID(name, version))
+}
+
+func buildID(name, version string) string {
+	return fmt.Sprintf("%s-%s", name, version)
+}

--- a/domain/logfilter/store_test.go
+++ b/domain/logfilter/store_test.go
@@ -1,0 +1,98 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build integration
+
+package logfilter
+
+import (
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/datastore/elastic"
+	. "gopkg.in/check.v1"
+)
+
+var _ = Suite(&S{
+	ElasticTest: elastic.ElasticTest{
+		Index:    "controlplane",
+		Mappings: []elastic.Mapping{MAPPING},
+	}})
+
+type S struct {
+	elastic.ElasticTest
+	ctx   datastore.Context
+	store Store
+}
+
+func (s *S) SetUpTest(c *C) {
+	s.ElasticTest.SetUpTest(c)
+	datastore.Register(s.Driver())
+	s.ctx = datastore.Get()
+	s.store = NewStore()
+}
+
+func (s *S) Test_LogFilterCRUD(c *C) {
+	expected := &LogFilter{
+		Name:    "filter name",
+		Version: "1.0",
+		Filter:  "filter it",
+	}
+	actual, err := s.store.Get(s.ctx, expected.Name, expected.Version)
+	c.Assert(err, NotNil)
+	c.Assert(actual, IsNil)
+	c.Assert(datastore.IsErrNoSuchEntity(err), Equals, true)
+
+
+	err = s.store.Put(s.ctx, expected)
+	expected.DatabaseVersion++
+	c.Assert(err, IsNil)
+
+	actual, err = s.store.Get(s.ctx, expected.Name, expected.Version)
+	c.Assert(err, IsNil)
+	c.Assert(actual, DeepEquals, expected)
+
+	err = s.store.Put(s.ctx, expected)
+	expected.DatabaseVersion++
+	c.Assert(err, IsNil)
+
+	actual, err = s.store.Get(s.ctx, expected.Name, expected.Version)
+	c.Assert(err, IsNil)
+	c.Assert(actual, DeepEquals, expected)
+
+	err = s.store.Delete(s.ctx, expected.Name, expected.Version)
+	c.Assert(err, IsNil)
+
+	actual, err = s.store.Get(s.ctx, expected.Name, expected.Version)
+	c.Assert(err, NotNil)
+	c.Assert(datastore.IsErrNoSuchEntity(err), Equals, true)
+}
+
+func (s *S) Test_GetRequiresNameAndVersion(c *C) {
+	actual := &LogFilter{
+		Name:    "filter name",
+		Version: "1.0",
+		Filter:  "filter it",
+	}
+
+	err := s.store.Put(s.ctx, actual)
+	c.Assert(err, IsNil)
+
+	result, err2 := s.store.Get(s.ctx, "", actual.Version)
+	c.Assert(err2, NotNil)
+	c.Assert(result, IsNil)
+	c.Assert(datastore.IsErrNoSuchEntity(err2), Equals, true)
+
+	result, err2 = s.store.Get(s.ctx, actual.Name, "")
+	c.Assert(err2, NotNil)
+	c.Assert(result, IsNil)
+	c.Assert(datastore.IsErrNoSuchEntity(err2), Equals, true)
+}

--- a/domain/logfilter/store_test.go
+++ b/domain/logfilter/store_test.go
@@ -51,7 +51,6 @@ func (s *S) Test_LogFilterCRUD(c *C) {
 	c.Assert(actual, IsNil)
 	c.Assert(datastore.IsErrNoSuchEntity(err), Equals, true)
 
-
 	err = s.store.Put(s.ctx, expected)
 	expected.DatabaseVersion++
 	c.Assert(err, IsNil)
@@ -95,4 +94,56 @@ func (s *S) Test_GetRequiresNameAndVersion(c *C) {
 	c.Assert(err2, NotNil)
 	c.Assert(result, IsNil)
 	c.Assert(datastore.IsErrNoSuchEntity(err2), Equals, true)
+}
+
+func (s *S) Test_GetLogFilters(c *C) {
+	// Get an empty list
+	filters, err := s.store.GetLogFilters(s.ctx)
+	c.Assert(err, IsNil)
+	c.Assert(filters, NotNil)
+	c.Assert(len(filters), Equals, 0)
+
+	filter1_1 := LogFilter{
+		Name:    "filter1",
+		Version: "1",
+		Filter:  "filter value1",
+	}
+	filter2_1 := LogFilter{
+		Name:    "filter2",
+		Version: "1",
+		Filter:  "filter value2",
+	}
+	filter1_2 := LogFilter{
+		Name:    "filter1",
+		Version: "2",
+		Filter:  "filter value1",
+	}
+	filter2_2 := LogFilter{
+		Name:    "filter2",
+		Version: "2",
+		Filter:  "filter value2",
+	}
+
+	err = s.store.Put(s.ctx, &filter1_1)
+	c.Assert(err, IsNil)
+	err = s.store.Put(s.ctx, &filter2_1)
+	c.Assert(err, IsNil)
+	err = s.store.Put(s.ctx, &filter1_2)
+	c.Assert(err, IsNil)
+	err = s.store.Put(s.ctx, &filter2_2)
+	c.Assert(err, IsNil)
+
+	filter1_1.DatabaseVersion++
+	filter2_1.DatabaseVersion++
+	filter1_2.DatabaseVersion++
+	filter2_2.DatabaseVersion++
+
+	filters, err = s.store.GetLogFilters(s.ctx)
+	c.Assert(err, IsNil)
+	c.Assert(filters, NotNil)
+	c.Assert(len(filters), Equals, 4)
+	c.Assert(*(filters[0]), DeepEquals, filter1_1)
+	c.Assert(*(filters[1]), DeepEquals, filter2_1)
+	c.Assert(*(filters[2]), DeepEquals, filter1_2)
+	c.Assert(*(filters[3]), DeepEquals, filter2_2)
 }

--- a/domain/logfilter/validation.go
+++ b/domain/logfilter/validation.go
@@ -1,0 +1,39 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logfilter
+
+import (
+	"strings"
+
+	"github.com/control-center/serviced/validation"
+)
+
+// ValidEntity validates LogFilter fields
+func (lf *LogFilter) ValidEntity() error {
+	trimmed := strings.TrimSpace(lf.Name)
+	violations := validation.NewValidationError()
+	violations.Add(validation.NotEmpty("LogFilter.Name", lf.Name))
+	violations.Add(validation.StringsEqual(lf.Name, trimmed, "leading and trailing spaces not allowed for LogFilter name"))
+
+	trimmed = strings.TrimSpace(lf.Version)
+	violations.Add(validation.NotEmpty("LogFilter.Version", lf.Version))
+	violations.Add(validation.StringsEqual(lf.Version, trimmed, "leading and trailing spaces not allowed for LogFilter version"))
+
+	violations.Add(validation.NotEmpty("LogFilter.Filter", lf.Filter))
+
+	if len(violations.Errors) > 0 {
+		return violations
+	}
+	return nil
+}

--- a/domain/logfilter/validation_test.go
+++ b/domain/logfilter/validation_test.go
@@ -1,0 +1,65 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package logfilter
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type validationSuite struct{}
+
+var _ = Suite(&validationSuite{})
+
+
+func (s *validationSuite) TestLogFilter_Success(c *C) {
+	filter := LogFilter{
+		Name:    "filter name",
+		Version: "1.0",
+		Filter:  "filter it",
+	}
+	err := filter.ValidEntity()
+	c.Assert(err, IsNil)
+}
+
+func (s *validationSuite) TestLogFilter_NonBlankName(c *C) {
+	filter := LogFilter{
+		Name:    "",
+		Version: "1.0",
+		Filter:  "filter it",
+	}
+	err := filter.ValidEntity()
+	c.Assert(err, NotNil)
+}
+
+func (s *validationSuite) TestLogFilter_NonBlankVersion(c *C) {
+	filter := LogFilter{
+		Name:    "filter name",
+		Version: "",
+		Filter:  "filter it",
+	}
+	err := filter.ValidEntity()
+	c.Assert(err, NotNil)
+}
+
+func (s *validationSuite) TestLogFilter_NonBlankFilter(c *C) {
+	filter := LogFilter{
+		Name:    "filter name",
+		Version: "1.0",
+		Filter:  "",
+	}
+	err := filter.ValidEntity()
+	c.Assert(err, NotNil)
+}

--- a/domain/properties/validation_test.go
+++ b/domain/properties/validation_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package properties
 
 import (

--- a/domain/registry/validation_test.go
+++ b/domain/registry/validation_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package registry
 
 import (

--- a/facade/facade.go
+++ b/facade/facade.go
@@ -31,6 +31,7 @@ import (
 	"github.com/control-center/serviced/logging"
 	"github.com/control-center/serviced/metrics"
 	"github.com/control-center/serviced/scheduler/servicestatemanager"
+	"github.com/control-center/serviced/domain/logfilter"
 )
 
 type MetricsClient interface {
@@ -47,33 +48,35 @@ var _ FacadeInterface = &Facade{}
 // New creates an initialized Facade instance
 func New() *Facade {
 	return &Facade{
-		auditLogger:   audit.NewLogger(),
-		hostStore:     host.NewStore(),
-		hostkeyStore:  hostkey.NewStore(),
-		registryStore: registry.NewStore(),
-		poolStore:     pool.NewStore(),
-		serviceStore:  service.NewStore(),
-		configStore:   serviceconfigfile.NewStore(),
-		templateStore: servicetemplate.NewStore(),
-		userStore:     user.NewStore(),
-		serviceCache:  NewServiceCache(),
-		poolCache:     NewPoolCache(),
-		hostRegistry:  auth.NewHostExpirationRegistry(),
-		deployments:   NewPendingDeploymentMgr(),
-		zzk:           getZZK(),
+		auditLogger:    audit.NewLogger(),
+		hostStore:      host.NewStore(),
+		hostkeyStore:   hostkey.NewStore(),
+		registryStore:  registry.NewStore(),
+		poolStore:      pool.NewStore(),
+		serviceStore:   service.NewStore(),
+		configStore:    serviceconfigfile.NewStore(),
+		templateStore:  servicetemplate.NewStore(),
+		logFilterStore: logfilter.NewStore(),
+		userStore:      user.NewStore(),
+		serviceCache:   NewServiceCache(),
+		poolCache:      NewPoolCache(),
+		hostRegistry:   auth.NewHostExpirationRegistry(),
+		deployments:    NewPendingDeploymentMgr(),
+		zzk:            getZZK(),
 	}
 }
 
 // Facade is an entrypoint to available controlplane methods
 type Facade struct {
-	hostStore     host.Store
-	hostkeyStore  hostkey.Store
-	registryStore registry.ImageRegistryStore
-	poolStore     pool.Store
-	templateStore servicetemplate.Store
-	serviceStore  service.Store
-	configStore   serviceconfigfile.Store
-	userStore     user.Store
+	hostStore      host.Store
+	hostkeyStore   hostkey.Store
+	registryStore  registry.ImageRegistryStore
+	poolStore      pool.Store
+	templateStore  servicetemplate.Store
+	logFilterStore logfilter.Store
+	serviceStore   service.Store
+	configStore    serviceconfigfile.Store
+	userStore      user.Store
 
 	auditLogger   audit.Logger
 	zzk           ZZK
@@ -122,6 +125,8 @@ func (f *Facade) SetConfigStore(store serviceconfigfile.Store) { f.configStore =
 func (f *Facade) SetUserStore(store user.Store) { f.userStore = store }
 
 func (f *Facade) SetTemplateStore(store servicetemplate.Store) { f.templateStore = store }
+
+func (f *Facade) SetLogFilterStore(store logfilter.Store) { f.logFilterStore = store }
 
 func (f *Facade) SetHealthCache(hcache *health.HealthStatusCache) { f.hcache = hcache }
 

--- a/facade/facade_unit_test.go
+++ b/facade/facade_unit_test.go
@@ -30,6 +30,7 @@ import (
 	servicemocks "github.com/control-center/serviced/domain/service/mocks"
 	configmocks "github.com/control-center/serviced/domain/serviceconfigfile/mocks"
 	templatemocks "github.com/control-center/serviced/domain/servicetemplate/mocks"
+	logfiltermocks "github.com/control-center/serviced/domain/logfilter/mocks"
 	"github.com/control-center/serviced/facade"
 	zzkmocks "github.com/control-center/serviced/facade/mocks"
 	"github.com/control-center/serviced/metrics"
@@ -51,6 +52,7 @@ type FacadeUnitTest struct {
 	serviceStore     *servicemocks.Store
 	configStore      *configmocks.Store
 	templateStore    *templatemocks.Store
+	logFilterStore   *logfiltermocks.Store
 	metricsClient    *zzkmocks.MetricsClient
 	hostauthregistry *authmocks.HostExpirationRegistryInterface
 }
@@ -106,6 +108,9 @@ func (ft *FacadeUnitTest) SetUpTest(c *C) {
 
 	ft.templateStore = &templatemocks.Store{}
 	ft.Facade.SetTemplateStore(ft.templateStore)
+
+	ft.logFilterStore = &logfiltermocks.Store{}
+	ft.Facade.SetLogFilterStore(ft.logFilterStore)
 
 	ft.zzk = &zzkmocks.ZZK{}
 	ft.Facade.SetZZK(ft.zzk)

--- a/facade/logfilter.go
+++ b/facade/logfilter.go
@@ -121,3 +121,7 @@ func (f *Facade) BootstrapLogFilters(ctx datastore.Context) (bool, error) {
 
 	return logFiltersCreated, nil
 }
+
+func (f *Facade) GetLogFilters(ctx datastore.Context) ([]*logfilter.LogFilter, error) {
+	return f.logFilterStore.GetLogFilters(ctx)
+}

--- a/facade/logfilter.go
+++ b/facade/logfilter.go
@@ -1,0 +1,79 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package facade
+
+import (
+
+)
+import (
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain/logfilter"
+	"github.com/control-center/serviced/domain/servicetemplate"
+	"github.com/Sirupsen/logrus"
+)
+
+func (f *Facade) UpdateLogFilters(ctx datastore.Context, serviceTemplate *servicetemplate.ServiceTemplate) error {
+	logger := plog.WithFields(logrus.Fields{
+		"templateid": serviceTemplate.ID,
+		"templatename": serviceTemplate.Name,
+		"templateversion": serviceTemplate.Version,
+	})
+	action := "find"
+	filterDefs := getFilterDefinitions(serviceTemplate.Services)
+	for name, value := range filterDefs {
+		logFilter, err := f.logFilterStore.Get(ctx, name, serviceTemplate.Version)
+		if err == nil {
+			logFilter.Filter = value
+			err = f.logFilterStore.Put(ctx, logFilter)
+			action = "update"
+		} else if err != nil && datastore.IsErrNoSuchEntity(err) {
+			newFilter := &logfilter.LogFilter{
+				Name:    name,
+				Version: serviceTemplate.Version,
+				Filter:  value,
+			}
+			err = f.logFilterStore.Put(ctx, newFilter)
+			action = "add"
+		}
+		if err != nil {
+			logger.WithError(err).WithFields(logrus.Fields{
+				"action": action,
+				"filtername": name,
+			}).Error("Failed to add/update log filter")
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (f *Facade) RemoveLogFilters(ctx datastore.Context, serviceTemplate *servicetemplate.ServiceTemplate) error {
+	logger := plog.WithFields(logrus.Fields{
+		"templateid": serviceTemplate.ID,
+		"templatename": serviceTemplate.Name,
+		"templateversion": serviceTemplate.Version,
+	})
+	filterDefs := getFilterDefinitions(serviceTemplate.Services)
+	for name, _ := range filterDefs {
+		err := f.logFilterStore.Delete(ctx, name, serviceTemplate.Version)
+		// ignore not-found errors, but stop on anything other failure
+		if err != nil && !datastore.IsErrNoSuchEntity(err) {
+			logger.WithError(err).WithFields(logrus.Fields{
+				"filtername": name,
+			}).Error("Failed to remove log filter")
+			return err
+		}
+	}
+	return nil
+}

--- a/facade/logfilter.go
+++ b/facade/logfilter.go
@@ -51,6 +51,11 @@ func (f *Facade) UpdateLogFilters(ctx datastore.Context, serviceTemplate *servic
 			}).Error("Failed to add/update log filter")
 			return err
 		}
+		logger.WithFields(logrus.Fields{
+			"action": action,
+			"filtername": name,
+			"filterversion": serviceTemplate.Version,
+		}).Debug("Saved LogFilter")
 	}
 
 	return nil

--- a/facade/logfilter_test.go
+++ b/facade/logfilter_test.go
@@ -1,0 +1,135 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build integration
+
+package facade
+
+import (
+	"github.com/control-center/serviced/domain/servicedefinition"
+	"github.com/control-center/serviced/domain/servicetemplate"
+	. "gopkg.in/check.v1"
+)
+
+// Add a service template with no log filters
+//	run bootstrap
+//	Expect false returned and no log filters exist
+func (ft *FacadeIntegrationTest) TestFacade_LogFilterBootstrap_NoFilters(c *C) {
+	var (
+		result bool
+		err    error
+	)
+
+	template := servicetemplate.ServiceTemplate{
+		ID:          "",
+		Name:        "bootstrap template1",
+		Description: "test bootstrap template1",
+		Version:     "1.0",
+		Services: []servicedefinition.ServiceDefinition{
+			servicedefinition.ServiceDefinition {
+				Name: "service1",
+				Launch: "manual",
+			},
+		},
+	}
+
+	_, err = ft.Facade.AddServiceTemplate(ft.CTX, template, false)
+	c.Assert(err, IsNil)
+
+	result, err = ft.Facade.BootstrapLogFilters(ft.CTX)
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, false)
+
+	_, err = ft.Facade.logFilterStore.Get(ft.CTX, "filter1", template.Version)
+	c.Assert(err, ErrorMatches, "No such entity.*")
+}
+
+
+// Add a service template with log filters
+//	run bootstrap
+//	Expect false returned and log filters exist
+func (ft *FacadeIntegrationTest) TestFacade_LogFilterBootstrap_ExistingFilters(c *C) {
+	var (
+		result bool
+		err    error
+	)
+	template := servicetemplate.ServiceTemplate{
+		ID:          "",
+		Name:        "bootstrap template2",
+		Description: "test bootstrap template2",
+		Version:     "1.0",
+		Services: []servicedefinition.ServiceDefinition{
+			servicedefinition.ServiceDefinition {
+				Name: "service1",
+				Launch: "manual",
+				LogFilters: map[string]string{
+					"filter1": "some filter",
+				},
+			},
+		},
+	}
+
+	_, err = ft.Facade.AddServiceTemplate(ft.CTX, template, false)
+	c.Assert(err, IsNil)
+
+	result, err = ft.Facade.BootstrapLogFilters(ft.CTX)
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, false)
+
+	_, err = ft.Facade.logFilterStore.Get(ft.CTX, "filter1", template.Version)
+	c.Assert(err, IsNil)
+}
+
+// Add a service template with log filters
+//	remove the filters to simulate older implementations
+//	run bootstrap
+//	Expect true returned and log filters exist
+func (ft *FacadeIntegrationTest) TestFacade_LogFilterBootstrap_AddsFilters(c *C) {
+	var (
+		result bool
+		err    error
+	)
+	template := servicetemplate.ServiceTemplate{
+		ID:          "",
+		Name:        "bootstrap template2",
+		Description: "test bootstrap template2",
+		Version:     "1.0",
+		Services: []servicedefinition.ServiceDefinition{
+			servicedefinition.ServiceDefinition {
+				Name: "service1",
+				Launch: "manual",
+				LogFilters: map[string]string{
+					"filter1": "some filter",
+				},
+			},
+		},
+	}
+
+	_, err = ft.Facade.AddServiceTemplate(ft.CTX, template, false)
+	c.Assert(err, IsNil)
+
+	err = ft.Facade.RemoveLogFilters(ft.CTX, &template)
+	c.Assert(err, IsNil)
+
+	// Sanity check to prove the filters were really removed so that we're sure that
+	//   the following BootstrapLogFilters was responsible for adding the filters
+	_, err = ft.Facade.logFilterStore.Get(ft.CTX, "filter1", template.Version)
+	c.Assert(err, ErrorMatches, "No such entity.*")
+
+	result, err = ft.Facade.BootstrapLogFilters(ft.CTX)
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, true)
+
+	_, err = ft.Facade.logFilterStore.Get(ft.CTX, "filter1", template.Version)
+	c.Assert(err, IsNil)
+}

--- a/facade/logfilter_unit_test.go
+++ b/facade/logfilter_unit_test.go
@@ -1,0 +1,153 @@
+// Copyright 2017 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package facade_test
+
+import (
+	"errors"
+
+	"github.com/control-center/serviced/datastore"
+	"github.com/control-center/serviced/domain/logfilter"
+	"github.com/control-center/serviced/domain/servicedefinition"
+	"github.com/control-center/serviced/domain/servicetemplate"
+	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/mock"
+)
+
+func (ft *FacadeUnitTest) Test_UpdateLogFilters_AddsNewFilters(c *C) {
+	template := buildTestTemplate()
+	var addResult error
+	ft.setupAddFilter(c, template, addResult)
+
+	err := ft.Facade.UpdateLogFilters(ft.ctx, template)
+
+	c.Assert(err, IsNil)
+}
+
+func (ft *FacadeUnitTest) Test_UpdateLogFilters_AddFails(c *C) {
+	template := buildTestTemplate()
+	addResult := errors.New("mock add failed")
+	ft.setupAddFilter(c, template, addResult)
+
+	err := ft.Facade.UpdateLogFilters(ft.ctx, template)
+
+	c.Assert(err, NotNil)
+	c.Assert(err, Equals, addResult)
+}
+
+func (ft *FacadeUnitTest) Test_UpdateLogFilters_UpdatesExistingFilters(c *C) {
+	template := buildTestTemplate()
+	var updateResult error
+	ft.setupUpdateFilter(c, template, updateResult)
+
+	err := ft.Facade.UpdateLogFilters(ft.ctx, template)
+
+	c.Assert(err, IsNil)
+}
+
+func (ft *FacadeUnitTest) Test_UpdateLogFilters_UpdateFails(c *C) {
+	template := buildTestTemplate()
+	updateResult := errors.New("mock update failed")
+	ft.setupUpdateFilter(c, template, updateResult)
+
+	err := ft.Facade.UpdateLogFilters(ft.ctx, template)
+
+	c.Assert(err, NotNil)
+	c.Assert(err, Equals, updateResult)
+}
+
+func (ft *FacadeUnitTest) Test_UpdateLogFilters_GenericGetFailure(c *C) {
+	template := buildTestTemplate()
+	getError := errors.New("mock get failed")
+	ft.logFilterStore.On("Get", ft.ctx, "filter1", template.Version).Return(nil, getError)
+
+	err := ft.Facade.UpdateLogFilters(ft.ctx, template)
+
+	c.Assert(err, NotNil)
+	c.Assert(err, Equals, getError)
+}
+
+func (ft *FacadeUnitTest) Test_RemoveLogFilters_RemovesFilters(c *C) {
+	template := buildTestTemplate()
+	ft.logFilterStore.On("Delete", ft.ctx, "filter1", template.Version).Return(nil)
+
+	err := ft.Facade.RemoveLogFilters(ft.ctx, template)
+
+	c.Assert(err, IsNil)
+}
+
+func (ft *FacadeUnitTest) Test_RemoveLogFilters_IgnoresNoSuchEntity(c *C) {
+	template := buildTestTemplate()
+	removeError := datastore.ErrNoSuchEntity{}
+	ft.logFilterStore.On("Delete", ft.ctx, "filter1", template.Version).Return(removeError)
+
+	err := ft.Facade.RemoveLogFilters(ft.ctx, template)
+
+	c.Assert(err, IsNil)
+}
+
+func (ft *FacadeUnitTest) Test_RemoveLogFilters_ReportsUnexpectedErrors(c *C) {
+	template := buildTestTemplate()
+	removeError := errors.New("mock delete failed")
+	ft.logFilterStore.On("Delete", ft.ctx, "filter1", template.Version).Return(removeError)
+
+	err := ft.Facade.RemoveLogFilters(ft.ctx, template)
+
+	c.Assert(err, NotNil)
+	c.Assert(err, Equals, removeError)
+}
+
+func buildTestTemplate() *servicetemplate.ServiceTemplate {
+	return &servicetemplate.ServiceTemplate{
+		ID:      "tid1",
+		Name:    "template1",
+		Version: "1.0",
+		Services: []servicedefinition.ServiceDefinition{
+			servicedefinition.ServiceDefinition {
+				Name: "service1",
+				LogFilters: map[string]string{
+					"filter1": "new filter",
+				},
+			},
+		},
+	}
+}
+
+func (ft *FacadeUnitTest) setupAddFilter(c *C, template *servicetemplate.ServiceTemplate, result error) {
+	ft.logFilterStore.On("Get", ft.ctx, "filter1", template.Version).Return(nil, datastore.ErrNoSuchEntity{})
+	ft.logFilterStore.On("Put", ft.ctx, mock.AnythingOfType("*logfilter.LogFilter")).
+		Run(func(args mock.Arguments) {
+			filter := args.Get(1).(*logfilter.LogFilter)
+			c.Assert(filter.Version, Equals, template.Version)
+			c.Assert(filter.Filter, Equals, template.Services[0].LogFilters["filter1"])
+		}).
+		Return(result)
+}
+
+func (ft *FacadeUnitTest) setupUpdateFilter(c *C, template *servicetemplate.ServiceTemplate, result error) {
+	existingFilter := &logfilter.LogFilter{
+		Name: "filter1",
+		Version: template.Version,
+		Filter: "old filter",
+	}
+	ft.logFilterStore.On("Get", ft.ctx, "filter1", template.Version).Return(existingFilter, nil)
+	ft.logFilterStore.On("Put", ft.ctx, existingFilter).
+		Run(func(args mock.Arguments) {
+			filter := args.Get(1).(*logfilter.LogFilter)
+			c.Assert(filter.Version, Equals, template.Version)
+			c.Assert(filter.Filter, Equals, template.Services[0].LogFilters["filter1"])
+		}).
+		Return(result)
+}

--- a/facade/logstash.go
+++ b/facade/logstash.go
@@ -181,23 +181,6 @@ func writeLogstashConfiguration(templates map[string]servicetemplate.ServiceTemp
 	return nil
 }
 
-func getFilterDefinitions(services []servicedefinition.ServiceDefinition) map[string]string {
-	filterDefs := make(map[string]string)
-	for _, service := range services {
-		for name, value := range service.LogFilters {
-			filterDefs[name] = value
-		}
-
-		if len(service.Services) > 0 {
-			subFilterDefs := getFilterDefinitions(service.Services)
-			for name, value := range subFilterDefs {
-				filterDefs[name] = value
-			}
-		}
-	}
-	return filterDefs
-}
-
 func getFiltersFromTemplates(services []servicedefinition.ServiceDefinition, filterDefs map[string]string, logFiles *[]string) string {
 	filters := ""
 	for _, svc := range services {

--- a/facade/logstash_test.go
+++ b/facade/logstash_test.go
@@ -21,16 +21,37 @@
 package facade
 
 import (
-	"github.com/control-center/serviced/domain/servicedefinition"
-
-	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
-	"testing"
+
+	"github.com/control-center/serviced/domain/logfilter"
+	"github.com/control-center/serviced/domain/servicedefinition"
+	"github.com/control-center/serviced/domain/service"
+
+	. "gopkg.in/check.v1"
 )
 
-func getTestingService() servicedefinition.ServiceDefinition {
+var _ = Suite(&LogStashTest{})
+
+type LogStashTest struct {
+	cache        *serviceCache
+	//serviceStore *servicemocks.Store
+	//unusedCTX    datastore.Context
+}
+
+func (t *LogStashTest) SetUpTest(c *C) {
+	t.cache = NewServiceCache()
+	//t.serviceStore = &servicemocks.Store{}
+}
+
+func (t *LogStashTest) TearDownTest(c *C) {
+	t.cache = nil
+	//t.serviceStore = nil
+}
+
+
+func getTestServiceDefinition() servicedefinition.ServiceDefinition {
 	service := servicedefinition.ServiceDefinition{
 		Name:        "testsvc",
 		Description: "Top level service. This directory is part of a unit test.",
@@ -143,222 +164,550 @@ func getTestingService() servicedefinition.ServiceDefinition {
 }
 
 
-func getTestingServiceWithAuditEnabled() servicedefinition.ServiceDefinition {
-	service := servicedefinition.ServiceDefinition{
-		Name:        "testsvc",
-		Description: "Top level service. This directory is part of a unit test.",
-		LogFilters: map[string]string{
-			"Pepe": "My Test Filter",
-		},
-		Services: []servicedefinition.ServiceDefinition{
-			servicedefinition.ServiceDefinition{
-				Name:    "s1",
-				Command: "/usr/bin/python -m SimpleHTTPServer",
-				ImageID: "ubuntu",
-				ConfigFiles: map[string]servicedefinition.ConfigFile{
-					"/etc/my.cnf": servicedefinition.ConfigFile{Filename: "/etc/my.cnf", Content: "\n# SAMPLE config file for mysql\n\n[mysqld]\n\ninnodb_buffer_pool_size = 16G\n\n"},
-				},
-				LogConfigs: []servicedefinition.LogConfig{
-					servicedefinition.LogConfig{
-						Path: "/tmp/foo",
-						Type: "foo",
-						Filters: []string{
-							"Pepe",
-						},
-						IsAudit: true,
-					},
-				},
-				LogFilters: map[string]string{
-					"Pepe2": "My Second Filter",
-				},
-				Services: []servicedefinition.ServiceDefinition{
-					servicedefinition.ServiceDefinition{
-						Name:    "s1child",
-						Command: "/usr/bin/python -m SimpleHTTPServer",
-						ImageID: "ubuntu",
-						LogConfigs: []servicedefinition.LogConfig{
-							servicedefinition.LogConfig{
-								Path: "/tmp/foo2",
-								Type: "foo2",
-								Filters: []string{
-									"Pepe4",
-								},
-								IsAudit: true,
-							},
-						},
-						LogFilters: map[string]string{
-							"Pepe4": "My Fourth Filter",
-						},
-					},
-
-				},
-			},
-			servicedefinition.ServiceDefinition{
-				Name:    "s2",
-				Command: "/usr/bin/python -m SimpleHTTPServer",
-				ImageID: "ubuntu",
-				LogConfigs: []servicedefinition.LogConfig{
-					servicedefinition.LogConfig{
-						Path: "/tmp/foo",
-						Type: "foo",
-						Filters: []string{
-							"Pepe3",
-						},
-					},
-				},
-				LogFilters: map[string]string{
-					"Pepe3": "My Third Filter",
-				},
-				Services: []servicedefinition.ServiceDefinition{
-					servicedefinition.ServiceDefinition{
-						Name:    "s2child",
-						Command: "/usr/bin/python -m SimpleHTTPServer",
-						ImageID: "ubuntu",
-						LogConfigs: []servicedefinition.LogConfig{
-							servicedefinition.LogConfig{
-								Path: "/tmp/foo2",
-								Type: "foo2",
-								Filters: []string{
-									"Pepe4",
-								},
-								IsAudit: true,
-							},
-						},
-						LogFilters: map[string]string{
-							"Pepe4": "My Fourth Filter",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	return service
-}
-
-
-func TestGettingFilterDefinitionsFromServiceDefinitions(t *testing.T) {
+func (t *LogStashTest) TestGettingFilterDefinitionsFromServiceDefinitions(c *C) {
 	services := make([]servicedefinition.ServiceDefinition, 1)
-	services[0] = getTestingService()
+	services[0] = getTestServiceDefinition()
 	filterDefs := getFilterDefinitions(services)
 
 	// make sure we find the specific filter definition we are looking for
-	if filterDefs["Pepe"] != "My Test Filter" {
-		t.Error("Was unable to extract the filter definition")
-	}
+	c.Assert(filterDefs["Pepe"], Equals, "My Test Filter")
 
 	// make sure the number matches the number we define
-	if len(filterDefs) != 4 {
-		t.Error(fmt.Sprintf("Found %d instead of 4 filter definitions", len(filterDefs)))
-	}
+	c.Assert(len(filterDefs), Equals, 4)
 }
 
-func TestConstructingFilterString(t *testing.T) {
-	services := make([]servicedefinition.ServiceDefinition, 1)
-	services[0] = getTestingService()
-	filterDefs := getFilterDefinitions(services)
-	typeFilter := []string{}
-	filters := getFiltersFromTemplates(services, filterDefs, &typeFilter)
-	testString := "My Test Filter"
-
-	// make sure our test filter definition is in the constructed filters
-	if !strings.Contains(filters, testString) {
-		t.Error(fmt.Sprintf("Was unable to find %s in the filters", testString))
+func (t *LogStashTest) Test_getFilterSection_WithNoServiceLogs(c *C) {
+	logInfo := serviceLogInfo{}
+	logFilters := []*logfilter.LogFilter{
+		&logfilter.LogFilter{
+			Name: "filter1",
+			Version: "0",
+			Filter: "some filter string",
+		},
 	}
+
+	logFiles := []string{}
+	result := getFilterSection(logInfo, logFilters, &logFiles)
+
+	c.Assert(len(result), Equals, 0)
+	c.Assert(len(logFiles), Equals, 0)
 }
 
-func TestGetAuditLogSectionForNoservice(t *testing.T) {
-	services := []servicedefinition.ServiceDefinition{}
-	auditLogTypes := []string{}
-	auditLogSection := getAuditLogSectionFromTemplates(services, &auditLogTypes)
-	if len(auditLogSection) > 0 {
-		t.Error(fmt.Sprintf("Audit Log Section should be empty but it is not %d", len(auditLogSection)))
+func (t *LogStashTest) Test_getFilterSection_WithNoLogFilters(c *C) {
+	logInfo := serviceLogInfo{
+		Name: "service1",
+		Version: "1.0",
+		LogConfigs: []servicedefinition.LogConfig{
+			servicedefinition.LogConfig{
+				Path: "/var/log/something",
+				Filters: []string{"filter1"},
+			},
+		},
 	}
+	logFilters := []*logfilter.LogFilter{}
+
+	logFiles := []string{}
+	result := getFilterSection(logInfo, logFilters, &logFiles)
+
+	c.Assert(len(result), Equals, 0)
+	c.Assert(len(logFiles), Equals, 0)
 }
 
-func TestGetAuditLogSectionForServicesNotEnabledAudit(t *testing.T) {
-	services := make([]servicedefinition.ServiceDefinition, 1)
-	services[0] = getTestingService()
-	auditableTypes := []string{}
-	auditLogSection := getAuditLogSectionFromTemplates(services, &auditableTypes)
-	if len(auditLogSection) != 0 {
-		t.Error(fmt.Sprintf("expected am empty auditLogSection , but found %d size : AuditLogSection = %s", len(auditLogSection), auditLogSection))
+func (t *LogStashTest) Test_getFilterSection_WithUndefinedFilter(c *C) {
+	version := "1.0"
+	logInfo := serviceLogInfo{
+		Name: "service1",
+		Version: version,
+		LogConfigs: []servicedefinition.LogConfig{
+			servicedefinition.LogConfig{
+				Path: "/var/log/something",
+				Filters: []string{"undefined"},
+			},
+		},
 	}
-}
-func TestMultipleTypesForAuditLogging(t *testing.T){
-	services := make([]servicedefinition.ServiceDefinition, 1)
-	services[0] = getTestingServiceWithAuditEnabled()
-	auditableTypes := []string{}
-	auditLogSection := getAuditLogSectionFromTemplates(services, &auditableTypes)
-	fieldTypeCount := strings.Count(auditLogSection, "if [fields][type]")
-	if fieldTypeCount !=2 {
-		t.Error(fmt.Sprintf("expected 2 for two different LogCoongfig Types, but found %d : AuditLogSection = %s", fieldTypeCount, auditLogSection))
+	filterName := "filter1"
+	logFilters := []*logfilter.LogFilter{
+		&logfilter.LogFilter{
+			Name: filterName,
+			Version: version,
+			Filter: "fitler me something",
+		},
 	}
-}
 
-func TestNoDuplicateAuditTypes(t *testing.T) {
-	services := make([]servicedefinition.ServiceDefinition, 1)
-	services[0] = getTestingServiceWithAuditEnabled()
-	auditableTypes := []string{}
-	auditLogSection := getAuditLogSectionFromTemplates(services, &auditableTypes)
-	auditTypeCount := strings.Count(auditLogSection, "if [fields][type] == \"foo2\"")
-	if auditTypeCount !=1 {
-		t.Error(fmt.Sprintf("expected only 1 section for 'foo2' type, but found %d: AuditLogSection = %s ", auditTypeCount, auditLogSection))
-	}
+	logFiles := []string{}
+	result := getFilterSection(logInfo, logFilters, &logFiles)
+
+	c.Assert(len(result), Equals, 0)
+	c.Assert(len(logFiles), Equals, 0)
 }
 
-func TestNoDuplicateFilters(t *testing.T) {
-	services := make([]servicedefinition.ServiceDefinition, 1)
-	services[0] = getTestingService()
-	filterDefs := getFilterDefinitions(services)
-	typeFilter := []string{}
-	filters := getFiltersFromTemplates(services, filterDefs, &typeFilter)
-
-	filterCount := strings.Count(filters, "if [file] == \"/tmp/foo2\"")
-	if filterCount != 1 {
-		t.Error(fmt.Sprintf("expected only 1 filter for 'foo2', but found %d: filters=%s", filterCount, filters))
+func (t *LogStashTest) Test_getFilterSection_Simple(c *C) {
+	version := "1.0"
+	filterName1 := "filter1"
+	filterName2 := "filter2"
+	logInfo := serviceLogInfo{
+		Name: "service1",
+		Version: version,
+		LogConfigs: []servicedefinition.LogConfig{
+			servicedefinition.LogConfig{
+				Path: "/var/log/something",
+				Filters: []string{filterName1},
+			},
+			servicedefinition.LogConfig{
+				Path: "/var/log/something/else",
+				Filters: []string{filterName2},
+			},
+		},
 	}
+	logFilters := []*logfilter.LogFilter{
+		&logfilter.LogFilter{
+			Name: filterName1,
+			Version: version,
+			Filter: "filter def 1",
+		},
+		&logfilter.LogFilter{
+			Name: filterName2,
+			Version: version,
+			Filter: "filter def 2",
+		},
+	}
+
+	logFiles := []string{}
+	result := getFilterSection(logInfo, logFilters, &logFiles)
+
+	c.Assert(len(result), Not(Equals), 0)
+	c.Assert(strings.Contains(result, logFilters[0].Filter), Equals, true)
+	c.Assert(strings.Contains(result, logFilters[1].Filter), Equals, true)
+
+	c.Assert(len(logFiles), Equals, 2)
+	c.Assert(logFiles[0], Equals, logInfo.LogConfigs[0].Path)
+	c.Assert(logFiles[1], Equals, logInfo.LogConfigs[1].Path)
 }
 
-func TestWritingConfigFile(t *testing.T) {
+func (t *LogStashTest) Test_getFilterSection_NoDups(c *C) {
+	version := "1.0"
+	filterName1 := "filter1"
+	filterName2 := "filter2"
+	logInfo := serviceLogInfo{
+		Name: "service1",
+		Version: version,
+		LogConfigs: []servicedefinition.LogConfig{
+			servicedefinition.LogConfig{
+				Path: "/var/log/something",
+				Filters: []string{filterName1},
+			},
+			servicedefinition.LogConfig{
+				Path: "/var/log/something/else",
+				Filters: []string{filterName2},
+			},
+		},
+	}
+	logFilters := []*logfilter.LogFilter{
+		&logfilter.LogFilter{
+			Name: filterName1,
+			Version: version,
+			Filter: "filter def 1",
+		},
+		&logfilter.LogFilter{
+			Name: filterName2,
+			Version: version,
+			Filter: "filter def 2",
+		},
+	}
+
+	// Add the first path and verify it's not added to the result
+	logFiles := []string{logInfo.LogConfigs[0].Path}
+	result := getFilterSection(logInfo, logFilters, &logFiles)
+
+	c.Assert(len(result), Not(Equals), 0)
+	c.Assert(strings.Contains(result, logFilters[1].Filter), Equals, true)
+	c.Assert(strings.Contains(result, logFilters[0].Filter), Equals, false)
+
+	c.Assert(len(logFiles), Equals, 2)
+	c.Assert(logFiles[0], Equals, logInfo.LogConfigs[0].Path)
+	c.Assert(logFiles[1], Equals, logInfo.LogConfigs[1].Path)
+}
+
+func (t *LogStashTest) Test_addServiceLogs_WithNoServices(c *C) {
+	serviceLogs := map[string]serviceLogInfo{}
+
+	addServiceLogs("1.0", []service.Service{}, serviceLogs)
+
+	c.Assert(len(serviceLogs), Equals, 0)
+}
+
+func (t *LogStashTest) Test_addServiceLogs_WithNoLogFiles(c *C) {
+	version := "1.0"
+	serviceLogs := map[string]serviceLogInfo{}
+	svcs := []service.Service{
+		service.Service{
+			ID: "id1",
+			Name: "service1",
+			Version: version,
+			LogConfigs: []servicedefinition.LogConfig{},
+		},
+	}
+	addServiceLogs(version, svcs, serviceLogs)
+
+	c.Assert(len(serviceLogs), Equals, 0)
+}
+
+func (t *LogStashTest) Test_addServiceLogs_WithNewServices(c *C) {
+	version := "1.0"
+	svcs := getTestServices(version)
+	serviceLogs := map[string]serviceLogInfo{}
+
+	addServiceLogs(version, svcs, serviceLogs)
+
+	c.Assert(len(serviceLogs), Equals, len(svcs))
+}
+
+// Verify that when serviceLogs already contains older services, then those services are
+// replaced by newer ones
+func (t *LogStashTest) Test_addServiceLogs_ReplacesOlderServices(c *C) {
+	newVersion := "2.0.1"
+	svcs := getTestServices(newVersion)
+
+	oldVersion := "2.0.0"
+	serviceLogs := getTestServiceLogs(oldVersion)
+
+	addServiceLogs(svcs[0].Version, svcs, serviceLogs)
+
+	c.Assert(len(serviceLogs), Equals, len(svcs))
+
+	logInfo, ok := serviceLogs["service1"]
+	c.Assert(ok, Equals, true)
+	c.Assert(logInfo.Version, Equals, newVersion)
+	c.Assert(logInfo.LogConfigs[0].Filters, DeepEquals, svcs[0].LogConfigs[0].Filters)
+
+	logInfo, ok = serviceLogs["service2"]
+	c.Assert(ok, Equals, true)
+	c.Assert(logInfo.Version, Equals, newVersion)
+	c.Assert(logInfo.LogConfigs[0].Filters, DeepEquals, svcs[1].LogConfigs[0].Filters)
+}
+
+// Verify that when serviceLogs already has newer services, then those services are not
+// replaced by older ones
+func (t *LogStashTest) Test_addServiceLogs_KeepsNewerServices(c *C) {
+	oldVersion := "1.0.1"
+	svcs := getTestServices(oldVersion)
+
+	newVersion := "2.0.0"
+	serviceLogs := getTestServiceLogs(newVersion)
+
+	addServiceLogs(svcs[0].Version, svcs, serviceLogs)
+
+	c.Assert(len(serviceLogs), Equals, len(svcs))
+
+	logInfo, ok := serviceLogs["service1"]
+	c.Assert(ok, Equals, true)
+	c.Assert(logInfo.Version, Equals, newVersion)
+	c.Assert(logInfo.LogConfigs[0].Filters[0], Equals, "log-filter1")
+
+	logInfo, ok = serviceLogs["service2"]
+	c.Assert(ok, Equals, true)
+	c.Assert(logInfo.Version, Equals, newVersion)
+	c.Assert(logInfo.LogConfigs[0].Filters[0], Equals, "log-filter2")
+}
+
+// Verify that when serviceLogs already has services with the same version, then those services are
+// replaced by ones in the new call to addServiceLogs
+func (t *LogStashTest) Test_addServiceLogs_UpdatesServices(c *C) {
+	version := "1.0.1"
+	svcs := getTestServices(version)
+	serviceLogs := getTestServiceLogs(version)
+
+	addServiceLogs(svcs[0].Version, svcs, serviceLogs)
+
+	c.Assert(len(serviceLogs), Equals, len(svcs))
+
+	logInfo, ok := serviceLogs["service1"]
+	c.Assert(ok, Equals, true)
+	c.Assert(logInfo.Version, Equals, version)
+	c.Assert(logInfo.LogConfigs[0].Filters[0], Equals, "log-filter1")
+
+	logInfo, ok = serviceLogs["service2"]
+	c.Assert(ok, Equals, true)
+	c.Assert(logInfo.Version, Equals, version)
+	c.Assert(logInfo.LogConfigs[0].Filters[0], Equals, "log-filter2")
+}
+
+func (t *LogStashTest) Test_addServiceLogs_AccumulatesServices(c *C) {
+	version1 := "1.0.1"
+	svcs := getTestServices(version1)
+	svcs[0].Name = "otherService1"
+	svcs[1].Name = "otherService2"
+
+	version2 := "1.0.2"
+	serviceLogs := getTestServiceLogs(version2)
+
+	addServiceLogs(svcs[0].Version, svcs, serviceLogs)
+
+	c.Assert(len(serviceLogs), Equals, 4)
+
+	logInfo, ok := serviceLogs["otherService1"]
+	c.Assert(ok, Equals, true)
+	c.Assert(logInfo.Version, Equals, version1)
+	c.Assert(logInfo.LogConfigs[0].Filters[0], Equals, "svc-filter1")
+
+	logInfo, ok = serviceLogs["otherService2"]
+	c.Assert(ok, Equals, true)
+	c.Assert(logInfo.Version, Equals, version1)
+	c.Assert(logInfo.LogConfigs[0].Filters[0], Equals, "svc-filter2")
+
+	logInfo, ok = serviceLogs["service1"]
+	c.Assert(ok, Equals, true)
+	c.Assert(logInfo.Version, Equals, version2)
+	c.Assert(logInfo.LogConfigs[0].Filters[0], Equals, "log-filter1")
+
+	logInfo, ok = serviceLogs["service2"]
+	c.Assert(ok, Equals, true)
+	c.Assert(logInfo.Version, Equals, version2)
+	c.Assert(logInfo.LogConfigs[0].Filters[0], Equals, "log-filter2")
+}
+
+func (t *LogStashTest) Test_findNewestFilter_WithNoFilters(c *C) {
+	logFilters := []*logfilter.LogFilter{}
+	logInfo := serviceLogInfo{
+		Version: "1.0",
+	}
+	result, found := findNewestFilter("filterName", logInfo, logFilters)
+
+	c.Assert(found, Equals, false)
+	c.Assert(len(result), Equals, 0)
+}
+
+func (t *LogStashTest) Test_findNewestFilter_SimpleMatch(c *C) {
+	filterName := "filter1"
+	version := "1.0"
+	expectedFilter := "filterValue"
+	logFilters := []*logfilter.LogFilter{
+		&logfilter.LogFilter{
+			Name: filterName,
+			Version: version,
+			Filter: expectedFilter,
+		},
+	}
+	logInfo := serviceLogInfo{
+		Version: version,
+	}
+
+	result, found := findNewestFilter(filterName, logInfo, logFilters)
+
+	c.Assert(found, Equals, true)
+	c.Assert(result, Equals, expectedFilter)
+}
+
+func (t *LogStashTest) Test_findNewestFilter_IgnoreOlder(c *C) {
+	filterName := "filter1"
+	version := "1.0"
+	expectedFilter := "filterValue"
+	logFilters := []*logfilter.LogFilter{
+		&logfilter.LogFilter{
+			Name: filterName,
+			Version: "0.9",
+			Filter: "wrong filterValue",
+		},
+		&logfilter.LogFilter{
+			Name: filterName,
+			Version: version,
+			Filter: expectedFilter,
+		},
+	}
+	logInfo := serviceLogInfo{
+		Version: version,
+	}
+
+	result, found := findNewestFilter(filterName, logInfo, logFilters)
+
+	c.Assert(found, Equals, true)
+	c.Assert(result, Equals, expectedFilter)
+}
+
+func (t *LogStashTest) Test_findNewestFilter_IgnoreNewer(c *C) {
+	filterName := "filter1"
+	version := "1.0"
+	expectedFilter := "filterValue"
+	logFilters := []*logfilter.LogFilter{
+		&logfilter.LogFilter{
+			Name: filterName,
+			Version: "2.0",
+			Filter: "wrong filterValue",
+		},
+		&logfilter.LogFilter{
+			Name: filterName,
+			Version: version,
+			Filter: expectedFilter,
+		},
+	}
+	logInfo := serviceLogInfo{
+		Version: version,
+	}
+
+	result, found := findNewestFilter(filterName, logInfo, logFilters)
+
+	c.Assert(found, Equals, true)
+	c.Assert(result, Equals, expectedFilter)
+}
+
+func (t *LogStashTest) Test_findNewestFilter_PickFromMixedVersions(c *C) {
+	filterName := "filter1"
+	expectedFilter := "filterValue"
+	logFilters := []*logfilter.LogFilter{
+		&logfilter.LogFilter{
+			Name: filterName,
+			Version: "1.0",
+			Filter: "wrong filterValue",
+		},
+		&logfilter.LogFilter{
+			Name: filterName,
+			Version: "2.0",
+			Filter: expectedFilter,
+		},
+	}
+	logInfo := serviceLogInfo{
+		Version: "1.5",
+	}
+
+	result, found := findNewestFilter(filterName, logInfo, logFilters)
+
+	c.Assert(found, Equals, true)
+	c.Assert(result, Equals, expectedFilter)
+}
+
+func (t *LogStashTest) Test_findNewestFilter_PickFromOlderVersions(c *C) {
+	filterName := "filter1"
+	expectedFilter := "filterValue"
+	logFilters := []*logfilter.LogFilter{
+		&logfilter.LogFilter{
+			Name: filterName,
+			Version: "0.9",
+			Filter: "wrong filterValue",
+		},
+		&logfilter.LogFilter{
+			Name: filterName,
+			Version: "1.0",
+			Filter: expectedFilter,
+		},
+	}
+	logInfo := serviceLogInfo{
+		Version: "1.5",
+	}
+
+	result, found := findNewestFilter(filterName, logInfo, logFilters)
+
+	c.Assert(found, Equals, true)
+	c.Assert(result, Equals, expectedFilter)
+}
+
+func (t *LogStashTest) Test_findNewestFilter_PickFromNewerVersions(c *C) {
+	filterName := "filter1"
+	expectedFilter := "filterValue"
+	logFilters := []*logfilter.LogFilter{
+		&logfilter.LogFilter{
+			Name: filterName,
+			Version: "2.0",
+			Filter: "wrong filterValue",
+		},
+		&logfilter.LogFilter{
+			Name: filterName,
+			Version: "3.0",
+			Filter: expectedFilter,
+		},
+	}
+	logInfo := serviceLogInfo{
+		Version: "1.5",
+	}
+
+	result, found := findNewestFilter(filterName, logInfo, logFilters)
+
+	c.Assert(found, Equals, true)
+	c.Assert(result, Equals, expectedFilter)
+}
+
+func  (t *LogStashTest) TestWritingConfigFile(c *C) {
 	filters := "This is my test filter"
 	auditLogSection := "Audit Log Section string"
 	tmpfile, err := ioutil.TempFile("", "logstash_test.conf")
-	t.Logf("Created tempfile: %s", tmpfile.Name())
-	if err != nil {
-		t.Logf("could not create tempfile: %s", err)
-		t.FailNow()
-	}
+	c.Logf("Created tempfile: %s", tmpfile.Name())
+	c.Assert(err, IsNil)
+
 	defer tmpfile.Close()
 	defer os.Remove(tmpfile.Name())
 	_, err = tmpfile.Write([]byte("${FILTER_SECTION}"))
+	c.Assert(err, IsNil)
 	_, err = tmpfile.Write([]byte("${AUDIT_SECTION"))
-	if err != nil {
-		t.Logf("%s", err)
-		t.FailNow()
-	}
+	c.Assert(err, IsNil)
 	err = tmpfile.Sync()
-	if err != nil {
-		t.Logf("%s", err)
-		t.FailNow()
-	}
+	c.Assert(err, IsNil)
 
-	if err = writeLogStashConfigFile(filters, auditLogSection, tmpfile.Name()); err != nil {
-		t.Errorf("error calling writeLogStashConfigFile: %s", err)
-		t.Fail()
-	}
+	err = writeLogStashConfigFile(filters, auditLogSection, tmpfile.Name())
+	c.Assert(err, IsNil)
 
 	// read the contents
 	contents, err := ioutil.ReadFile(tmpfile.Name())
-	if err != nil {
-		t.Error(fmt.Sprintf("Unable to read output file %v", err))
-	}
+	c.Assert(err, IsNil)
 
 	// make sure our filter and auditLogSection string is in it
 	if !strings.Contains(string(contents), filters) && !strings.Contains(string(contents), auditLogSection) {
-		t.Logf("Read in contents: %s", string(contents))
-		t.Log(filters)
-		t.Error("Was unable to write the logstash conf file")
+		c.Logf("Read in contents: %s", string(contents))
+		c.Log(filters)
+		c.Error("Was unable to write the logstash conf file")
 
+	}
+}
+
+func getTestServices(version string) []service.Service {
+	return []service.Service{
+		service.Service{
+			ID: "id1",
+			Name: "service1",
+			Version: version,
+			LogConfigs: []servicedefinition.LogConfig{
+				servicedefinition.LogConfig{
+					Path: "/var/log/log1",
+					Filters: []string{"svc-filter1"},
+				},
+
+			},
+		},
+		service.Service{
+			ID: "id2",
+			Name: "service2",
+			Version: version,
+			LogConfigs: []servicedefinition.LogConfig{
+				servicedefinition.LogConfig{
+					Path: "/var/log/log2",
+					Filters: []string{"svc-filter2"},
+				},
+			},
+		},
+	}
+}
+
+func getTestServiceLogs(version string) map[string]serviceLogInfo {
+	return map[string]serviceLogInfo{
+		"service1": serviceLogInfo{
+			Name: "service1",
+			ID: "id1",
+			Version: version,
+			LogConfigs: []servicedefinition.LogConfig{
+				servicedefinition.LogConfig{
+					Path: "/var/log/log1",
+					Filters: []string{"log-filter1"},
+				},
+			},
+		},
+		"service2": serviceLogInfo{
+			Name: "service2",
+			ID: "id2",
+			Version: version,
+			LogConfigs: []servicedefinition.LogConfig{
+				servicedefinition.LogConfig{
+					Path: "/var/log/log2",
+					Filters: []string{"log-filter2"},
+				},
+			},
+		},
 	}
 }

--- a/facade/service_test.go
+++ b/facade/service_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	. "gopkg.in/check.v1"
+	"github.com/control-center/serviced/domain/logfilter"
 )
 
 var (
@@ -1263,6 +1264,127 @@ func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_ModifiedWithEndpoint
 
 	err = ft.Facade.MigrateServices(ft.CTX, request)
 	t.Assert(err, IsNil)
+}
+
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_AddsLogFilter(t *C) {
+	filter := logfilter.LogFilter{
+		Name:	"filter1",
+		Filter: "some filter",
+		Version: "1.0",
+	}
+	err := ft.setupMigrationTestWithoutEndpoints(t)
+	t.Assert(err, IsNil)
+
+	svc, err := ft.Facade.GetService(ft.CTX, "original_service_id_tenant")
+	t.Assert(err, IsNil)
+
+	request := dao.ServiceMigrationRequest{
+		ServiceID: svc.ID,
+		LogFilters: map[string]logfilter.LogFilter{
+			filter.Name: filter,
+		},
+	}
+
+	err = ft.Facade.MigrateServices(ft.CTX, request)
+	t.Assert(err, IsNil)
+
+	var result *logfilter.LogFilter
+	result, err = ft.Facade.logFilterStore.Get(ft.CTX, filter.Name, filter.Version)
+	t.Assert(err, IsNil)
+	t.Assert(result.Filter, Equals, filter.Filter)
+}
+
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_AddsLogFilterVersion(t *C) {
+	err := ft.setupMigrationTestWithoutEndpoints(t)
+	t.Assert(err, IsNil)
+
+	filter1 := logfilter.LogFilter{
+		Name:	"filter1",
+		Filter: "some filter",
+		Version: "1.0",
+	}
+	err = ft.Facade.logFilterStore.Put(ft.CTX, &filter1)
+
+	svc, err := ft.Facade.GetService(ft.CTX, "original_service_id_tenant")
+	t.Assert(err, IsNil)
+
+	filter2 := filter1
+	filter2.Filter = "some new filter"
+	filter2.Version = "2.0"
+	request := dao.ServiceMigrationRequest{
+		ServiceID: svc.ID,
+		LogFilters: map[string]logfilter.LogFilter{
+			filter2.Name: filter2,
+		},
+	}
+
+	err = ft.Facade.MigrateServices(ft.CTX, request)
+	t.Assert(err, IsNil)
+
+	var result *logfilter.LogFilter
+	result, err = ft.Facade.logFilterStore.Get(ft.CTX, filter1.Name, filter1.Version)
+	t.Assert(err, IsNil)
+
+	result, err = ft.Facade.logFilterStore.Get(ft.CTX, filter2.Name, filter2.Version)
+	t.Assert(err, IsNil)
+	t.Assert(result.Filter, Equals, filter2.Filter)
+}
+
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_UpdatesLogFilter(t *C) {
+	err := ft.setupMigrationTestWithoutEndpoints(t)
+	t.Assert(err, IsNil)
+
+	filter := logfilter.LogFilter{
+		Name:	"filter1",
+		Filter: "some filter",
+		Version: "1.0",
+	}
+	err = ft.Facade.logFilterStore.Put(ft.CTX, &filter)
+
+	svc, err := ft.Facade.GetService(ft.CTX, "original_service_id_tenant")
+	t.Assert(err, IsNil)
+
+	filter.Filter = "some new filter"
+	request := dao.ServiceMigrationRequest{
+		ServiceID: svc.ID,
+		LogFilters: map[string]logfilter.LogFilter{
+			filter.Name: filter,
+		},
+	}
+
+	err = ft.Facade.MigrateServices(ft.CTX, request)
+	t.Assert(err, IsNil)
+
+	var result *logfilter.LogFilter
+	result, err = ft.Facade.logFilterStore.Get(ft.CTX, filter.Name, filter.Version)
+	t.Assert(err, IsNil)
+	t.Assert(result.Filter, Equals, filter.Filter)
+}
+
+func (ft *FacadeIntegrationTest) TestFacade_MigrateServices_FailsLogFilter(t *C) {
+	filter := logfilter.LogFilter{
+		Name:	"filter1",
+		Filter: "some filter",
+	}
+	err := ft.setupMigrationTestWithoutEndpoints(t)
+	t.Assert(err, IsNil)
+
+	svc, err := ft.Facade.GetService(ft.CTX, "original_service_id_tenant")
+	t.Assert(err, IsNil)
+
+	request := dao.ServiceMigrationRequest{
+		ServiceID: svc.ID,
+		LogFilters: map[string]logfilter.LogFilter{
+			filter.Name: filter,
+		},
+	}
+
+	err = ft.Facade.MigrateServices(ft.CTX, request)
+	t.Assert(err, Not(IsNil))
+	t.Assert(strings.Contains(err.Error(), "empty string for LogFilter.Version"), Equals, true)
+
+	_, err = ft.Facade.logFilterStore.Get(ft.CTX, filter.Name, filter.Version)
+	t.Assert(datastore.IsErrNoSuchEntity(err), Equals, true)
 }
 
 func (ft *FacadeIntegrationTest) TestFacade_ResolveServicePath(c *C) {

--- a/serviced-tests.py
+++ b/serviced-tests.py
@@ -37,7 +37,7 @@ def elastic_server(port):
         # TODO: Get image name from serviced binary or isvcs.go
         # TODO: Wait for start more betterly
         cmd = ["docker", "run", "-d", "--name", container_name,
-               "-p", "%d:9200" % port, "zenoss/serviced-isvcs:v38",
+               "-p", "%d:9200" % port, "zenoss/serviced-isvcs:v59",
                "/opt/elasticsearch-0.90.9/bin/elasticsearch", "-f",
                "-Des.cluster.name=%s" % container_name,
                "-Dmulticast.enabled=false",


### PR DESCRIPTION
There is a comment in the Jira with a link to the design doc. The basic stages of this PR are:
* Various refactors just to do general code cleanup
* Create a new Store in elastic for LogFilters
* On startup, copy LogFilters from any existing templates into the new Store
* On template-add, save the LogFilters in the new store
* Use the new LogFilter store to populate logstash.conf
* Add LogFilters as part of the ServiceMigrationRequest

The corresponding changes to the service migration SDK are here - https://github.com/control-center/service-migration/pull/66