### PR TITLE
Fixes problems with CC RPM promote job

### DIFF
--- a/pkg/reversion/rpm/reversion.sh
+++ b/pkg/reversion/rpm/reversion.sh
@@ -22,7 +22,11 @@ set -e
 set -x
 
 cd /tmp
-yum install --downloadonly --downloaddir=/tmp --enablerepo=${SOURCE_CLASS} serviced-${SOURCE_VERSION}-${SOURCE_RELEASE}
+yum install --setopt=obsoletes=0 \
+    --downloadonly \
+    --downloaddir=/tmp \
+    --enablerepo=${SOURCE_CLASS} \
+    serviced-${SOURCE_VERSION}-${SOURCE_RELEASE}
 
 ESCAPED_VERSION=`echo "$TARGET_VERSION" | sed 's/\./\\./g'`
 VERSION_SED_CMD="s/^Version:.*/Version:${ESCAPED_VERSION}/"


### PR DESCRIPTION
During promotion of the CC 1.4.0 RPM from unstable to testing, we ran into this problem with the docker dependencies. Adding `--setopt=obsoletes=0` to the yum command used to download the CC source RPM seems to have fixed it.
```
--> Processing Dependency: docker-ce-selinux >= 17.03.1.ce-1.el7.centos for package: docker-ce-17.03.1.ce-1.el7.centos.x86_64
Package docker-ce-selinux is obsoleted by docker-ce, but obsoleting package does not provide for requirements
---> Package libpath_utils.x86_64 0:0.2.1-27.el7 will be installed
---> Package libselinux-utils.x86_64 0:2.5-6.el7 will be installed
---> Package libtalloc.x86_64 0:2.1.6-1.el7 will be installed
---> Package libtevent.x86_64 0:0.9.28-1.el7 will be installed
--> Finished Dependency Resolution
Error: Package: docker-ce-17.03.1.ce-1.el7.centos.x86_64 (docker-ce-stable)
           Requires: docker-ce-selinux >= 17.03.1.ce-1.el7.centos
           Available: docker-ce-selinux-17.03.0.ce-1.el7.centos.noarch (docker-ce-stable)
               docker-ce-selinux = 17.03.0.ce-1.el7.centos
           Available: docker-ce-selinux-17.03.1.ce-1.el7.centos.noarch (docker-ce-stable)
               docker-ce-selinux = 17.03.1.ce-1.el7.centos
           Available: docker-ce-selinux-17.03.2.ce-1.el7.centos.noarch (docker-ce-stable)
               docker-ce-selinux = 17.03.2.ce-1.el7.centos
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
Build step 'Execute shell' marked build as failure
Archiving artifacts
```