### PR TITLE
CC-3870 Emergency shutdown replaces config files with originals

### DIFF
--- a/facade/service.go
+++ b/facade/service.go
@@ -1498,6 +1498,10 @@ func (f *Facade) clearEmergencyStopFlag(ctx datastore.Context, tenantID, service
 
 	cleared := 0
 	for _, svc := range svcs {
+		// CC-3871 preserve config changes after clearEmergencyStopFlag call
+		if err = f.fillServiceConfigs(ctx, svc); err != nil {
+			glog.Errorf("%s", err)
+		}
 		svc.EmergencyShutdown = false
 		f.SetServicesCurrentState(ctx, service.SVCCSStopped, svc.ID)
 		err = f.updateService(ctx, tenantID, *svc, false, false)
@@ -2554,6 +2558,10 @@ func (f *Facade) GetServicesForScheduling(ctx datastore.Context, ids []string) [
 		if err != nil {
 			glog.Warningf("Could not get service with id %s: %s", id, err)
 		} else {
+			// CC-3871 preserve config changes after Emergency shutdown
+			if err := f.fillServiceConfigs(ctx, &svc); err != nil {
+				glog.Errorf("%s", err)
+			}
 			services = append(services, &svc)
 		}
 	}

--- a/facade/service.go
+++ b/facade/service.go
@@ -1500,7 +1500,7 @@ func (f *Facade) clearEmergencyStopFlag(ctx datastore.Context, tenantID, service
 	for _, svc := range svcs {
 		// CC-3871 preserve config changes after clearEmergencyStopFlag call
 		if err = f.fillServiceConfigs(ctx, svc); err != nil {
-			glog.Errorf("%s", err)
+			plog.WithError(err).Error("Failed to fill service configs")
 		}
 		svc.EmergencyShutdown = false
 		f.SetServicesCurrentState(ctx, service.SVCCSStopped, svc.ID)
@@ -2560,7 +2560,7 @@ func (f *Facade) GetServicesForScheduling(ctx datastore.Context, ids []string) [
 		} else {
 			// CC-3871 preserve config changes after Emergency shutdown
 			if err := f.fillServiceConfigs(ctx, &svc); err != nil {
-				glog.Errorf("%s", err)
+				plog.WithError(err).Error("Failed to fill service configs")
 			}
 			services = append(services, &svc)
 		}


### PR DESCRIPTION
[Jira](https://jira.zenoss.com/browse/CC-3870)
The fix adds additional calls to `fillServiceConfigs` for both emergency stoping / clearing emergency flag flows for preserving current configs.