### PR TITLE
Remove images from our elastic store when removing services, if no other services are using it

### DIFF
--- a/dao/elasticsearch/controlplanedao_test.go
+++ b/dao/elasticsearch/controlplanedao_test.go
@@ -383,6 +383,7 @@ func (dt *DaoTest) TestDao_UpdateServiceWithConfigFile(t *C) {
 	svc.PoolID = "default"
 	svc.Launch = "auto"
 	svc.DeploymentID = "deployment_id"
+	svc.ImageID = "image_id"
 	svc.OriginalConfigs = map[string]servicedefinition.ConfigFile{"testname": confFile}
 
 	err = dt.Dao.AddService(*svc, &id)

--- a/domain/service/mocks/Store.go
+++ b/domain/service/mocks/Store.go
@@ -164,6 +164,27 @@ func (_m *Store) GetServicesByPool(ctx datastore.Context, poolID string) ([]serv
 
 	return r0, r1
 }
+func (_m *Store) GetServiceCountByImage(ctx datastore.Context, imageID string) (int, error) {
+	ret := _m.Called(ctx, imageID)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) int); ok {
+		r0 = rf(ctx, imageID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(int)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {
+		r1 = rf(ctx, imageID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
 func (_m *Store) GetServicesByDeployment(ctx datastore.Context, deploymentID string) ([]service.Service, error) {
 	ret := _m.Called(ctx, deploymentID)
 

--- a/facade/host_test.go
+++ b/facade/host_test.go
@@ -183,6 +183,7 @@ func (s *FacadeIntegrationTest) Test_HostRemove(t *C) {
 	s1.PoolID = "poolid"
 	s1.DeploymentID = "deployment_id"
 	s1.Launch = "manual"
+	s1.ImageID = "image_id"
 	s1.Endpoints = []service.ServiceEndpoint{
 		service.ServiceEndpoint{},
 	}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3597
The problem is that we store the image details in an elastic store.  If you try to add a different image with the same tag, but different layers, you get an image conflict error.  Impact 5.1.x are all tagged as "Impact_5.1:latest", so you got this error when up/downgrading impact in the same install.  This will 
remove images from our elastic store when removing services, if no other services are using it.. allowing Impact to install again without errors.