### PR TITLE
Update emergency shutdown html url

### DIFF
--- a/web/ui/src/Services/appNameDirective.js
+++ b/web/ui/src/Services/appNameDirective.js
@@ -22,7 +22,7 @@
             <div class="emergencyTooltip">
               <h3>Emergency Shutdown</h3>
               <div>due to low disk space.</div>
-              <a href="/static/doc/feature/manage/emer-sdown-overview.html" type="button" class="btn btn-danger">
+              <a href="/static/doc/feature/state/emergency-shutdown.html" type="button" class="btn btn-danger">
                 <span ng-show="icon" class="glyphicon glyphicon-book"></span>
                 More Info
               </a>


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3794
Fix the url for emergency shutdown docs.
Appears to be a regression from the last docs rev at https://github.com/control-center/serviced/pull/3610