### PR TITLE
Clean up orphan images at first startup >= 1.5.0

### DIFF
--- a/facade/service_unit_test.go
+++ b/facade/service_unit_test.go
@@ -279,6 +279,31 @@ func (ft *FacadeUnitTest) Test_GetEvaluatedServiceFails(c *C) {
 	c.Assert(err, Equals, expectedError)
 }
 
+func (ft *FacadeUnitTest) Test_CheckRemoveRegistryImage_RemovesImage(c *C) {
+	imageID := "imageID"
+
+	// Expectations: if we get 0 from GetServiceCountByImage..
+	ft.serviceStore.On("GetServiceCountByImage", ft.ctx, imageID).Return(0, nil)
+	// .. then we should call Delete on the registryStore.
+	ft.registryStore.On("Delete", ft.ctx, imageID).Return(nil)
+
+	err := ft.Facade.CheckRemoveRegistryImage(ft.ctx, imageID)
+
+	c.Assert(err, IsNil)
+}
+
+func (ft *FacadeUnitTest) Test_CheckRemoveRegistryImage_KeepsImage(c *C) {
+	imageID := "imageID"
+
+	// Expectations: if we get 1 from GetServiceCountByImage..
+	// .. then it should exit without calling Delete on the registry store.
+	ft.serviceStore.On("GetServiceCountByImage", ft.ctx, imageID).Return(1, nil)
+
+	err := ft.Facade.CheckRemoveRegistryImage(ft.ctx, imageID)
+
+	c.Assert(err, IsNil)
+}
+
 // Test that the 'getService' function defined by facade.evaluateService() works properly on failure
 func (ft *FacadeUnitTest) Test_GetEvaluatedServiceGetParentFails(c *C) {
 	parentID := "parentServiceID"

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -13,6 +13,11 @@
 
 package utils
 
+import (
+	"strings"
+	"fmt"
+)
+
 // StringSliceEquals compare two string slices for equality
 func StringSliceEquals(lhs []string, rhs []string) bool {
 	if lhs == nil && rhs == nil {
@@ -48,4 +53,36 @@ func StringInSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// Compare two version strings by splitting by '.', making the slices the same length, then
+// padding the strings with 0's.  The string comparison will now work against numeric
+// versioning, as well as "1.5.2b1" style strings.
+func CompareVersions(v1, v2 string) int {
+	maxlen := 1
+	s1 := strings.Split(v1, ".")
+	s2 := strings.Split(v2, ".")
+	for _, s := range append(s1, s2...) {
+		if len(s) > maxlen {
+			maxlen = len(s)
+		}
+	}
+	if len(s1) > len(s2) {
+		t := make([]string, len(s1))
+		copy(t, s2)
+		s2 = t
+	}
+	if len(s2) > len(s1) {
+		t := make([]string, len(s2))
+		copy(t, s1)
+		s1 = t
+	}
+	format := fmt.Sprintf("%%0%ds", maxlen)
+	for i := 0; i < len(s1); i++ {
+		scomp := strings.Compare(fmt.Sprintf(format, s1[i]), fmt.Sprintf(format, s2[i]))
+		if scomp != 0 {
+			return scomp
+		}
+	}
+	return 0
 }

--- a/utils/strings_test.go
+++ b/utils/strings_test.go
@@ -44,3 +44,18 @@ func TestStringSliceEquals(t *testing.T) {
 		t.Fatalf("Expect %+v == %+v", []string{"a", "b", "c"}, []string{"a", "b", "c"})
 	}
 }
+
+func TestCompareVersions(t *testing.T) {
+	expectations := []struct{ v1, v2 string; expected int }{
+		{ "1.4.0", "1.5.0", -1 },
+		{ "1.5.0", "1.4.0", 1 },
+		{ "1.5.0", "1.5.0", 0 },
+		{ "1.05.00.0156", "1.0.221.9289", 1 },
+		{ "1.5.0", "1.5.0b", -1 },
+	}
+	for _, e := range expectations {
+		if CompareVersions(e.v1, e.v2) != e.expected {
+			t.Fatalf("Expected utils.CompareVersions(\"%s\", \"%s\") to return %d", e.v1, e.v2, e.expected)
+		}
+	}
+}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3597
If the last run version of CC is under 1.5.0, there may be orphan entries in the image registry (post-1.5.0 these are automatically removed when the last service using the image is removed).  We need to clear these out on upgrading to 1.5.0+ from an earlier version to avoid potentially hitting an image conflict error when installing services with matching image tags.