### PR TITLE
Add information for service lock/unlock failures

### DIFF
--- a/zzk/service/lock.go
+++ b/zzk/service/lock.go
@@ -33,7 +33,7 @@ type ErrLockServiceFailure struct {
 }
 
 func (e ErrLockServiceFailure) Error() string {
-	return fmt.Sprintf("% failed for service %s with pool %s: %s", e.locktype, e.serviceid, e.pool, e.err)
+	return fmt.Sprintf("%s failed for service %s with pool %s: %s", e.locktype, e.serviceid, e.pool, e.err)
 }
 
 func NewLockServiceFailure(serviceid, pool string, err error) ErrLockServiceFailure {


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3766

"coord-client: node does not exist" isn't enough information to diagnose problems when locking nodes.  This adds additional information to the error to help in debugging the problem (like a host assigned to an invalid pool).