### PR TITLE
Feature/cc 4012

### DIFF
--- a/domain/applicationendpoint/applicationendpoint.go
+++ b/domain/applicationendpoint/applicationendpoint.go
@@ -26,14 +26,14 @@ type ApplicationEndpoint struct {
 	Application    string
 	Purpose        string
 	HostID         string
-	HostIP         string
+	HostIP         string // Host where the endpoint is running. Used to determine if it's running locally or if we need to mux it
 	HostPort       uint16
 	ContainerID    string
-	ContainerIP    string
-	ContainerPort  uint16
+	ContainerIP    string // The container IP that we're routing to (usually a container except for the cc api endpoint)
+	ContainerPort  uint16 // The container port that we're routing to
 	Protocol       string
 	VirtualAddress string
-	ProxyPort      uint16
+	ProxyPort      uint16 // The port in the container we're listening on
 }
 
 type EndpointReport struct {

--- a/node/agent_proxy.go
+++ b/node/agent_proxy.go
@@ -129,18 +129,24 @@ func (a *HostAgent) addControlPlaneEndpoint(endpoints map[string][]applicationen
 	endpoint := applicationendpoint.ApplicationEndpoint{}
 	endpoint.ServiceID = "controlplane"
 	endpoint.Application = "controlplane"
-	endpoint.ContainerIP = "127.0.0.1"
-	port, err := strconv.Atoi(a.uiport[1:])
+	hoststr := strings.Split(a.uiport, ":")[0]
+	if len(hoststr) == 0 {
+		// Fall back to using the master host if an interface for the uiport isn't specified.
+		hoststr = strings.Split(a.master, ":")[0]
+	}
+	portstr := strings.Split(a.uiport, ":")[1]
+	port, err := strconv.Atoi(portstr)
 	if err != nil {
 		glog.Errorf("Unable to interpret ui port.")
 		return
 	}
 	endpoint.ContainerPort = uint16(port)
+	endpoint.ContainerIP = hoststr
 	// control center should always be reachable in a container on
 	// port SERVICED_UI_ENDPOINT_PROXY via http. SERVICED_UI_ENDPOINT_PROXY
 	// proxies to SERVICED_UI_ENDPOINT via https
 	endpoint.ProxyPort = uint16(SERVICED_UI_ENDPOINT)
-	endpoint.HostPort = uint16(port)
+	endpoint.HostPort = uint16(port) //unused
 	endpoint.HostIP = strings.Split(a.master, ":")[0]
 	endpoint.Protocol = "tcp"
 	a.addEndpoint(key, endpoint, endpoints)


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-4012
Cherry-picked from https://github.com/control-center/serviced/pull/3654

CC was mapping the CC API endpoint to 127.0.0.1 which doesn't work when a specific interface is given. It also assumed that SERVICED_UI_PORT was in the form ":####" which failed when an interface was specified.
