### PR TITLE
lvs output can contain a rounding symbol. Force units to h to prevent that

### DIFF
--- a/pkg/rpm/preupgrade
+++ b/pkg/rpm/preupgrade
@@ -233,7 +233,7 @@ def get_tpool_stats(config):
     Returns a mapping representing data for the serviced thinpool.
     """
     thinpooldev = config.get("SERVICED_DM_THINPOOLDEV", "serviced")
-    cmd = "lvs -o lv_size,data_percent,lv_metadata_size,metadata_percent %s 2>/dev/null | grep -vi lsize || true" % thinpooldev
+    cmd = "lvs -o lv_size,data_percent,lv_metadata_size,metadata_percent %s --units h 2>/dev/null | grep -vi lsize || true" % thinpooldev
     stats = subprocess.check_output(cmd, shell=True).strip()
     if not stats:
         return {}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-4019
Cherry-picked from https://github.com/control-center/serviced/pull/3659

The units on some systems for /etc/lvm/lvm.conf is set to "r" which can output the lvs sizes with a rounding symbol, ie: "root ubuntu -wi-ao---- <232.41g" The size parser doesn't recognize the less-than sign, causing it to fail the prein upgrade check.
