### PR TITLE
Add the close_timeout setting to filebeat

### DIFF
--- a/container/logstash.go
+++ b/container/logstash.go
@@ -70,6 +70,7 @@ func writeLogstashAgentConfig(hostID string, hostIPs string, svcPath string, ser
 		prospectorsConf = prospectorsConf + `
     - ignore_older: 10m
       close_inactive: 5m
+      close_timeout: 15m
       paths:
         - %s
       fields: %s`


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3893

When the harvester/logstash can't keep up and there's high log activity resulting in log file rotation, filebeat doesn't release the file descriptor.  This prevents the disk space from being recovered and fills the volume.

With the "close_timeout 15m" setting added, the harvester will exit after 15 minutes.  If there's additional disk activity for the file, the harvester will resume where it left off.  Obe disadvantage of this is if the harvester stops in the middle of a multiline message, only the second (resumed) part of the multiline  message will get logged to logstash.  All file descriptors are properly released.

I tested that if ignore_older and close_timeout are both set (close_timeout to a higher value), and the log file is idle for a long time, remove, and additional logging is done, that the new logging is picked up.  I also tested that if these are set and the file is removed while logging is active (causes lsof open deleted file handles) and a new harvester created for the new logging, then close_timeout time passes and the file handles are closed.

Adding "close_renamed: true" did not resolve the problem.
Adding "clean_removed: true" did not resolve the problem.
filebeat doesn't restart internal counters/harvesters with SIGHUP