### PR TITLE
Adds "addme" method to serviced

### DIFF
--- a/auth/localkeys.go
+++ b/auth/localkeys.go
@@ -255,9 +255,7 @@ func LoadKeyPairFromFile(filename string) (public crypto.PublicKey, private cryp
 // LoadCommonRSAKeyPairPEM loads the common keys from a specific file.
 func LoadCommonRSAKeyPairPEM(headers map[string]string) (public []byte, private []byte, err error) {
 	keyfile := filepath.Join(config.GetOptions().EtcPath, CommonKeyFilename)
-	log.Infof("Loading common keypair from %s \n", keyfile)
 	publicKey, privateKey, err := LoadKeyPairFromFile(keyfile)
-	log.Infof("Loaded private and public keys:\n    %+v\n    %+v\n", publicKey, privateKey)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/auth/localkeys.go
+++ b/auth/localkeys.go
@@ -34,6 +34,7 @@ import (
 const (
 	DelegateKeyFileName = "delegate.keys"
 	MasterKeyFileName   = ".keys/master.keys"
+	CommonKeyFilename   = "common.key"
 )
 
 var (
@@ -249,6 +250,26 @@ func LoadKeyPairFromFile(filename string) (public crypto.PublicKey, private cryp
 		return nil, nil, err
 	}
 	return LoadRSAKeyPairPackage(data)
+}
+
+// LoadCommonRSAKeyPairPEM loads the common keys from a specific file.
+func LoadCommonRSAKeyPairPEM(headers map[string]string) (public []byte, private []byte, err error) {
+	keyfile := filepath.Join(config.GetOptions().EtcPath, CommonKeyFilename)
+	log.Infof("Loading common keypair from %s \n", keyfile)
+	publicKey, privateKey, err := LoadKeyPairFromFile(keyfile)
+	log.Infof("Loaded private and public keys:\n    %+v\n    %+v\n", publicKey, privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	if private, err = PEMFromRSAPrivateKey(privateKey, headers); err != nil {
+		log.Errorf("Error loading private key: %+v\n", err)
+		return nil, nil, err
+	}
+	if public, err = PEMFromRSAPublicKey(publicKey, headers); err != nil {
+		log.Errorf("Error loading public key: %+v\n", err)
+		return nil, nil, err
+	}
+	return public, private, nil
 }
 
 // LoadDelegateKeysFromPEM loads the local delegate keys (master public, delegate private)

--- a/cli/api/apimocks/API.go
+++ b/cli/api/apimocks/API.go
@@ -53,6 +53,38 @@ func (_m *API) AddHost(_a0 api.HostConfig) (*host.Host, []byte, error) {
 	return r0, r1, r2
 }
 
+// AddHostPrivate provides a mock function with given fields: _a0
+func (_m *API) AddHostPrivate(_a0 api.HostConfig) (*host.Host, []byte, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *host.Host
+	if rf, ok := ret.Get(0).(func(api.HostConfig) *host.Host); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*host.Host)
+		}
+	}
+
+	var r1 []byte
+	if rf, ok := ret.Get(1).(func(api.HostConfig) []byte); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]byte)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(api.HostConfig) error); ok {
+		r2 = rf(_a0)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // AddPublicEndpointPort provides a mock function with given fields: serviceid, endpointName, portAddr, usetls, protocol, isEnabled, restart
 func (_m *API) AddPublicEndpointPort(serviceid string, endpointName string, portAddr string, usetls bool, protocol string, isEnabled bool, restart bool) (*servicedefinition.Port, error) {
 	ret := _m.Called(serviceid, endpointName, portAddr, usetls, protocol, isEnabled, restart)
@@ -233,16 +265,16 @@ func (_m *API) RemoveIP(args []string) error {
 
 // SetIP provides a mock function with given fields: _a0
 func (_m *API) SetIP(_a0 api.IPConfig) error {
-        ret := _m.Called(_a0)
+	ret := _m.Called(_a0)
 
-        var r0 error
-        if rf, ok := ret.Get(0).(func(api.IPConfig) error); ok {
-                r0 = rf(_a0)
-        } else {
-                r0 = ret.Error(0)
-        }
+	var r0 error
+	if rf, ok := ret.Get(0).(func(api.IPConfig) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
 
-        return r0
+	return r0
 }
 
 // AttachServiceInstance provides a mock function with given fields: serviceID, instanceID, command, args

--- a/cli/api/host.go
+++ b/cli/api/host.go
@@ -172,7 +172,7 @@ func (a *api) AddHost(config HostConfig) (*host.Host, []byte, error) {
 	}
 }
 
-// Adds a new host and uses a common key to register it.
+// Adds a new host and uses a common key to register it. Returns the host and the master's public key.
 func (a *api) AddHostPrivate(config HostConfig) (*host.Host, []byte, error) {
 	// if a nat is configured then we connect rpc to the nat, otherwise
 	// connect to the host address.

--- a/cli/api/host.go
+++ b/cli/api/host.go
@@ -23,7 +23,6 @@ import (
 	"github.com/control-center/serviced/rpc/agent"
 	"github.com/control-center/serviced/rpc/master"
 	"github.com/control-center/serviced/utils"
-	//"github.com/control-center/serviced/logging"
 )
 
 // HostConfig is the deserialized object from the command-line
@@ -44,12 +43,6 @@ type AuthHost struct {
 	host.Host
 	Authenticated bool
 }
-
-/*
-var (
-	log = logging.PackageLogger()
-)
-*/
 
 func getAuthInfo(client master.ClientInterface, hosts []host.Host) ([]AuthHost, error) {
 	hostIDs := []string{}
@@ -183,17 +176,15 @@ func (a *api) AddHost(config HostConfig) (*host.Host, []byte, error) {
 func (a *api) AddHostPrivate(config HostConfig) (*host.Host, []byte, error) {
 	// if a nat is configured then we connect rpc to the nat, otherwise
 	// connect to the host address.
-	log.Infof("REX AddHostPrivate %+v\n", config)
 	var rpcAddress string
 	if len(config.Nat.Host) > 0 {
 		rpcAddress = config.Nat.String()
 	} else {
 		rpcAddress = config.Address.String()
 	}
-	log.Infof("REX rpcAddress: %+v\n", rpcAddress)
 	agentClient, err := a.connectAgent(rpcAddress)
 	if err != nil {
-		log.Errorf("REX Couldn't get the agent: %+v\n", err)
+		log.Errorf("Couldn't connect to the agent: %+v\n", err)
 		return nil, nil, err
 	}
 
@@ -209,25 +200,19 @@ func (a *api) AddHostPrivate(config HostConfig) (*host.Host, []byte, error) {
 		return nil, nil, err
 	}
 
-	log.Infof("Built a host! %+v\n", h)
-
 	masterClient, err := a.connectMaster()
 	if err != nil {
-		log.Errorf("REX Couldn't the connection to master: %+v\n", err)
+		log.Errorf("Couldn't connect to master: %+v\n", err)
 		return nil, nil, err
 	}
-	log.Infof("REX Got the connection to master! %+v\n", masterClient)
-
-	host_ := h
 
 	var masterPublicKey []byte
 	if masterPublicKey, err = masterClient.AddHostPrivate(*h); err != nil {
-		log.Errorf("REX AHP failed: %+v\n", err)
+		log.Errorf("AddHostPrivate failed: %+v\n", err)
 		return nil, nil, err
 	}
 
-	log.Infof("REX GOT IT!, %+v", masterPublicKey)
-	return host_, masterPublicKey, nil
+	return h, masterPublicKey, nil
 }
 
 // Removes an existing host by its id

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -25,8 +25,8 @@ import (
 	template "github.com/control-center/serviced/domain/servicetemplate"
 	"github.com/control-center/serviced/isvcs"
 	"github.com/control-center/serviced/metrics"
-	"github.com/control-center/serviced/utils"
 	"github.com/control-center/serviced/script"
+	"github.com/control-center/serviced/utils"
 	"github.com/control-center/serviced/volume"
 )
 
@@ -42,6 +42,7 @@ type API interface {
 	GetHost(string) (*host.Host, error)
 	GetHostMap() (map[string]host.Host, error)
 	AddHost(HostConfig) (*host.Host, []byte, error)
+	AddHostPrivate(HostConfig) (*host.Host, []byte, error)
 	RemoveHost(string) error
 	GetHostMemory(string) (*metrics.MemoryUsageStats, error)
 	SetHostMemory(HostUpdateConfig) error

--- a/cli/cmd/host.go
+++ b/cli/cmd/host.go
@@ -323,25 +323,25 @@ func (c *ServicedCli) cmdHostAddPrivate(ctx *cli.Context) {
 	if len(args) < 2 {
 		fmt.Printf("Incorrect Usage.\n\n")
 		cli.ShowCommandHelp(ctx, "add-private")
-		return
+		os.Exit(1)
 	}
 
 	var address utils.URL
 	if err := address.Set(args[0]); err != nil {
 		fmt.Println(err)
-		return
+		os.Exit(1)
 	}
 	if ip := net.ParseIP(address.Host); ip == nil {
 		// Host did not parse, try resolving
 		addr, err := net.ResolveTCPAddr("tcp", args[0])
 		if err != nil {
 			fmt.Printf("Could not resolve %s.\n\n", args[0])
-			return
+			os.Exit(1)
 		}
 		address.Host = addr.IP.String()
 		if strings.HasPrefix(address.Host, "127.") {
 			fmt.Printf("%s must not resolve to a loopback address\n\n", args[0])
-			return
+			os.Exit(1)
 		}
 	}
 
@@ -351,20 +351,20 @@ func (c *ServicedCli) cmdHostAddPrivate(ctx *cli.Context) {
 	if len(natString) > 0 {
 		if err := nat.Set(natString); err != nil {
 			fmt.Println(err)
-			return
+			os.Exit(1)
 		}
 		if natip := net.ParseIP(nat.Host); natip == nil {
 			// NAT did not parse, try resolving
 			addr, err := net.ResolveTCPAddr("tcp", natString)
 			if err != nil {
 				fmt.Printf("Could not resolve nat address (%s): %s\n", natString, err)
-				return
+				os.Exit(1)
 			}
 			nat.Host = addr.IP.String()
 		}
 		if strings.HasPrefix(nat.Host, "127.") {
 			fmt.Printf("The nat address %s must not resolve to a loopback address\n", natString)
-			return
+			os.Exit(1)
 		}
 	}
 
@@ -378,10 +378,10 @@ func (c *ServicedCli) cmdHostAddPrivate(ctx *cli.Context) {
 	host, keyblock, err := c.driver.AddHostPrivate(cfg)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return
+		os.Exit(1)
 	} else if keyblock == nil {
 		fmt.Fprintln(os.Stderr, "received nil key")
-		return
+		os.Exit(1)
 	}
 
 	c.outputCommonKey(host, nat, keyblock)

--- a/cli/cmd/host.go
+++ b/cli/cmd/host.go
@@ -384,7 +384,6 @@ func (c *ServicedCli) cmdHostAddPrivate(ctx *cli.Context) {
 		return
 	}
 
-	//c.outputCommonKey(keyblock)
 	c.outputCommonKey(host, nat, keyblock)
 }
 

--- a/cli/cmd/key.go
+++ b/cli/cmd/key.go
@@ -173,7 +173,6 @@ func (c *ServicedCli) outputDelegateKey(host *host.Host, nat utils.URL, keyData 
 }
 
 func (c *ServicedCli) outputCommonKey(host *host.Host, nat utils.URL, keyData []byte) {
-	//keyfileName := auth.DelegateKeyFileName
 	keyfileName := filepath.Join(config.GetOptions().EtcPath, auth.DelegateKeyFileName)
 	c.outputDelegateKey(host, nat, keyData, keyfileName, true)
 }

--- a/cli/cmd/key.go
+++ b/cli/cmd/key.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	"github.com/codegangsta/cli"
+	"github.com/control-center/serviced/auth"
+	"github.com/control-center/serviced/config"
 	"github.com/control-center/serviced/domain/host"
 	"github.com/control-center/serviced/utils"
 	"net"
@@ -168,4 +170,10 @@ func (c *ServicedCli) outputDelegateKey(host *host.Host, nat utils.URL, keyData 
 		fmt.Println("Wrote delegate key file to", keyfileName)
 	}
 	fmt.Println(host.ID)
+}
+
+func (c *ServicedCli) outputCommonKey(host *host.Host, nat utils.URL, keyData []byte) {
+	//keyfileName := auth.DelegateKeyFileName
+	keyfileName := filepath.Join(config.GetOptions().EtcPath, auth.DelegateKeyFileName)
+	c.outputDelegateKey(host, nat, keyData, keyfileName, true)
 }

--- a/cli/cmd/key.go
+++ b/cli/cmd/key.go
@@ -172,6 +172,7 @@ func (c *ServicedCli) outputDelegateKey(host *host.Host, nat utils.URL, keyData 
 	fmt.Println(host.ID)
 }
 
+// Registers a host with the given keydata, and stores the key at the location designated by auth.DelegateKeyFileName
 func (c *ServicedCli) outputCommonKey(host *host.Host, nat utils.URL, keyData []byte) {
 	keyfileName := filepath.Join(config.GetOptions().EtcPath, auth.DelegateKeyFileName)
 	c.outputDelegateKey(host, nat, keyData, keyfileName, true)

--- a/facade/host.go
+++ b/facade/host.go
@@ -61,6 +61,8 @@ func (f *Facade) AddHost(ctx datastore.Context, entity *host.Host) ([]byte, erro
 	return key, alog.Error(err)
 }
 
+// AddHost registers a host with serviced. Returns the host's _public_ key.
+// Returns an error if host already exists or if the host's IP is a virtual IP.
 func (f *Facade) AddHostPrivate(ctx datastore.Context, entity *host.Host) ([]byte, error) {
 	defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.AddHostPrivate"))
 	alog := f.auditLogger.Message(ctx, "Adding Host").Action(audit.Add).Entity(entity)
@@ -129,16 +131,6 @@ func (f *Facade) addHost(ctx datastore.Context, entity *host.Host) ([]byte, erro
 }
 
 func (f *Facade) addHostPrivate(ctx datastore.Context, entity *host.Host) ([]byte, error) {
-	/*
-		exists, err := f.GetHost(ctx, entity.ID)
-		if err != nil {
-			return nil, err
-		}
-		if exists != nil {
-			return nil, fmt.Errorf("host already exists: %s", entity.ID)
-		}
-	*/
-
 	// validate Pool exists
 	pool, err := f.GetResourcePool(ctx, entity.PoolID)
 	if err != nil {

--- a/facade/host.go
+++ b/facade/host.go
@@ -65,7 +65,7 @@ func (f *Facade) AddHost(ctx datastore.Context, entity *host.Host) ([]byte, erro
 // Returns an error if host already exists or if the host's IP is a virtual IP.
 func (f *Facade) AddHostPrivate(ctx datastore.Context, entity *host.Host) ([]byte, error) {
 	defer ctx.Metrics().Stop(ctx.Metrics().Start("Facade.AddHostPrivate"))
-	alog := f.auditLogger.Message(ctx, "Adding Host").Action(audit.Add).Entity(entity)
+	alog := f.auditLogger.Message(ctx, "Adding Host with common key").Action(audit.Add).Entity(entity)
 	glog.V(2).Infof("Facade.AddHostPrivate: %v", entity)
 	if err := f.DFSLock(ctx).LockWithTimeout("add host", userLockTimeout); err != nil {
 		glog.Warningf("Cannot add host: %s", err)
@@ -148,15 +148,6 @@ func (f *Facade) addHostPrivate(ctx datastore.Context, entity *host.Host) ([]byt
 			return nil, fmt.Errorf("pool already has a virtual ip %s", ip.IPAddress)
 		}
 	}
-
-	/*
-		ec := newEventCtx()
-		err = nil
-		defer f.afterEvent(afterHostAdd, ec, entity, err)
-		if err = f.beforeEvent(beforeHostAdd, ec, entity); err != nil {
-			return nil, err
-		}
-	*/
 
 	// Load the shared key.
 	commonPEMBlock, err := f.useCommonKey(ctx, entity)

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -80,6 +80,8 @@ type FacadeInterface interface {
 
 	AddHost(ctx datastore.Context, entity *host.Host) ([]byte, error)
 
+	AddHostPrivate(ctx datastore.Context, entity *host.Host) ([]byte, error)
+
 	GetHost(ctx datastore.Context, hostID string) (*host.Host, error)
 
 	GetHosts(ctx datastore.Context) ([]host.Host, error)
@@ -210,9 +212,9 @@ type FacadeInterface interface {
 
 	GetServiceNamePath(ctx datastore.Context, serviceID string) (tenantID string, servicePath string, err error)
 
-	StartService(ctx datastore.Context, request dao.ScheduleServiceRequest)(int, error)
+	StartService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error)
 
-	RestartService(ctx datastore.Context, request dao.ScheduleServiceRequest)(int, error)
+	RestartService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error)
 
-	StopService(ctx datastore.Context, request dao.ScheduleServiceRequest)(int, error)
+	StopService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error)
 }

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -44,6 +44,29 @@ func (_m *FacadeInterface) AddHost(ctx datastore.Context, entity *host.Host) ([]
 	return r0, r1
 }
 
+// AddHostPrivate provides a mock function with given fields: ctx, entity
+func (_m *FacadeInterface) AddHostPrivate(ctx datastore.Context, entity *host.Host) ([]byte, error) {
+	ret := _m.Called(ctx, entity)
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(datastore.Context, *host.Host) []byte); ok {
+		r0 = rf(ctx, entity)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(datastore.Context, *host.Host) error); ok {
+		r1 = rf(ctx, entity)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // AddPublicEndpointPort provides a mock function with given fields: ctx, serviceid, endpointName, portAddr, usetls, protocol, isEnabled, restart
 func (_m *FacadeInterface) AddPublicEndpointPort(ctx datastore.Context, serviceid string, endpointName string, portAddr string, usetls bool, protocol string, isEnabled bool, restart bool) (*servicedefinition.Port, error) {
 	ret := _m.Called(ctx, serviceid, endpointName, portAddr, usetls, protocol, isEnabled, restart)
@@ -189,7 +212,7 @@ func (_m *FacadeInterface) RemoveIPs(ctx datastore.Context, args []string) error
 	if rf, ok := ret.Get(0).(func(datastore.Context, []string) error); ok {
 		r0 = rf(ctx, args)
 	} else {
-		 r0 = ret.Error(0)
+		r0 = ret.Error(0)
 	}
 
 	return r0
@@ -197,16 +220,16 @@ func (_m *FacadeInterface) RemoveIPs(ctx datastore.Context, args []string) error
 
 // SetIPs  provides a mock function with given fields: ctx, assignmentRequest
 func (_m *FacadeInterface) SetIPs(ctx datastore.Context, assignmentRequest addressassignment.AssignmentRequest) error {
-        ret := _m.Called(ctx, assignmentRequest)
+	ret := _m.Called(ctx, assignmentRequest)
 
-        var r0 error
-        if rf, ok := ret.Get(0).(func(datastore.Context, addressassignment.AssignmentRequest) error); ok {
-                r0 = rf(ctx, assignmentRequest)
-        } else {
-                r0 = ret.Error(0)
-        }
+	var r0 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, addressassignment.AssignmentRequest) error); ok {
+		r0 = rf(ctx, assignmentRequest)
+	} else {
+		r0 = ret.Error(0)
+	}
 
-        return r0
+	return r0
 }
 
 // ClearEmergencyStopFlag provides a mock function with given fields: ctx, serviceID
@@ -1498,7 +1521,7 @@ func (_m *FacadeInterface) SetHostExpiration(ctx datastore.Context, hostID strin
 }
 
 //StartService provides a mock function with given fields: ctx, ScheduleServiceRequest
-func (_m *FacadeInterface) StartService(ctx datastore.Context,  request dao.ScheduleServiceRequest) (int, error) {
+func (_m *FacadeInterface) StartService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error) {
 
 	ret := _m.Called(ctx, request)
 
@@ -1520,7 +1543,7 @@ func (_m *FacadeInterface) StartService(ctx datastore.Context,  request dao.Sche
 }
 
 //StopService provides a mock function with given fields: ctx, ScheduleServiceRequest
-func (_m *FacadeInterface) StopService(ctx datastore.Context,  request dao.ScheduleServiceRequest) (int, error) {
+func (_m *FacadeInterface) StopService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error) {
 
 	ret := _m.Called(ctx, request)
 
@@ -1540,8 +1563,9 @@ func (_m *FacadeInterface) StopService(ctx datastore.Context,  request dao.Sched
 
 	return r0, r1
 }
+
 //RestartService provides a mock function with given fields: ctx, ScheduleServiceRequest
-func (_m *FacadeInterface) RestartService(ctx datastore.Context,  request dao.ScheduleServiceRequest) (int, error) {
+func (_m *FacadeInterface) RestartService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error) {
 
 	ret := _m.Called(ctx, request)
 
@@ -1561,7 +1585,6 @@ func (_m *FacadeInterface) RestartService(ctx datastore.Context,  request dao.Sc
 
 	return r0, r1
 }
-
 
 // SyncServiceRegistry provides a mock function with given fields: ctx, svc
 func (_m *FacadeInterface) SyncServiceRegistry(ctx datastore.Context, svc *service.Service) error {
@@ -1745,13 +1768,13 @@ func (_m *FacadeInterface) GetServiceNamePath(ctx datastore.Context, serviceID s
 	}
 
 	var r1 string
-        if rf, ok := ret.Get(0).(func(datastore.Context, string) string); ok {
-                r1 = rf(ctx, serviceID)
-        } else {
-                if ret.Get(0) != nil {
-                        r1 = ret.Get(0).(string)
-                }
-        }
+	if rf, ok := ret.Get(0).(func(datastore.Context, string) string); ok {
+		r1 = rf(ctx, serviceID)
+	} else {
+		if ret.Get(0) != nil {
+			r1 = ret.Get(0).(string)
+		}
+	}
 
 	var r2 error
 	if rf, ok := ret.Get(1).(func(datastore.Context, string) error); ok {

--- a/rpc/master/hosts_client.go
+++ b/rpc/master/hosts_client.go
@@ -56,6 +56,15 @@ func (c *Client) AddHost(host host.Host) ([]byte, error) {
 	return response, nil
 }
 
+//AddHost adds and registers a host with an agreed-upon shared secret keypair
+func (c *Client) AddHostPrivate(host host.Host) ([]byte, error) {
+	response := []byte{}
+	if err := c.call("AddHostPrivate", host, &response); err != nil {
+		return []byte{}, err
+	}
+	return response, nil
+}
+
 //UpdateHost updates a host
 func (c *Client) UpdateHost(host host.Host) error {
 	return c.call("UpdateHost", host, nil)

--- a/rpc/master/hosts_client.go
+++ b/rpc/master/hosts_client.go
@@ -56,7 +56,7 @@ func (c *Client) AddHost(host host.Host) ([]byte, error) {
 	return response, nil
 }
 
-//AddHost adds and registers a host with an agreed-upon shared secret keypair
+//AddHost adds and registers a host with an agreed-upon shared secret keypair. Returns master's public key.
 func (c *Client) AddHostPrivate(host host.Host) ([]byte, error) {
 	response := []byte{}
 	if err := c.call("AddHostPrivate", host, &response); err != nil {

--- a/rpc/master/hosts_server.go
+++ b/rpc/master/hosts_server.go
@@ -73,6 +73,16 @@ func (s *Server) AddHost(host host.Host, hostReply *[]byte) error {
 	return nil
 }
 
+//AddHostPrivate adds the host using a shared key approved of beforehand and returns the master's public key.
+func (s *Server) AddHostPrivate(host host.Host, hostReply *[]byte) error {
+	masterPublicKey, err := s.f.AddHostPrivate(s.context(), &host)
+	if err != nil {
+		return err
+	}
+	*hostReply = masterPublicKey
+	return nil
+}
+
 // UpdateHost updates the host
 func (s *Server) UpdateHost(host host.Host, _ *struct{}) error {
 	return s.f.UpdateHost(s.context(), &host)

--- a/rpc/master/interface.go
+++ b/rpc/master/interface.go
@@ -16,11 +16,11 @@ package master
 import (
 	"time"
 
+	"github.com/control-center/serviced/domain/addressassignment"
 	"github.com/control-center/serviced/domain/applicationendpoint"
 	"github.com/control-center/serviced/domain/host"
 	"github.com/control-center/serviced/domain/pool"
 	"github.com/control-center/serviced/domain/service"
-	"github.com/control-center/serviced/domain/addressassignment"
 	"github.com/control-center/serviced/domain/servicedefinition"
 	"github.com/control-center/serviced/domain/servicetemplate"
 	"github.com/control-center/serviced/domain/user"
@@ -50,6 +50,9 @@ type ClientInterface interface {
 
 	// AddHost adds a Host
 	AddHost(h host.Host) ([]byte, error)
+
+	// AddHostPrivate adds a Host and registers it with a shared key
+	AddHostPrivate(h host.Host) ([]byte, error)
 
 	// UpdateHost updates a host
 	UpdateHost(h host.Host) error
@@ -242,7 +245,7 @@ type ClientInterface interface {
 	// Assignment management functions
 
 	// Remove the IP assignment of a service's endpoints
-	RemoveIPs(args []string)  error
+	RemoveIPs(args []string) error
 
 	// Assigns an IP address to a services that haven't IP Assignment by default
 	SetIPs(request addressassignment.AssignmentRequest) error

--- a/rpc/master/mocks/ClientInterface.go
+++ b/rpc/master/mocks/ClientInterface.go
@@ -43,6 +43,29 @@ func (_m *ClientInterface) AddHost(h host.Host) ([]byte, error) {
 	return r0, r1
 }
 
+// AddHostPrivate provides a mock function with given fields: h
+func (_m *ClientInterface) AddHostPrivate(h host.Host) ([]byte, error) {
+	ret := _m.Called(h)
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(host.Host) []byte); ok {
+		r0 = rf(h)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(host.Host) error); ok {
+		r1 = rf(h)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // AddPublicEndpointPort provides a mock function with given fields: serviceid, endpointName, portAddr, usetls, protocol, isEnabled, restart
 func (_m *ClientInterface) AddPublicEndpointPort(serviceid string, endpointName string, portAddr string, usetls bool, protocol string, isEnabled bool, restart bool) (*servicedefinition.Port, error) {
 	ret := _m.Called(serviceid, endpointName, portAddr, usetls, protocol, isEnabled, restart)
@@ -421,11 +444,11 @@ func (_m *ClientInterface) GetEvaluatedService(serviceID string, instanceID int)
 	}
 
 	var r2 string
-        if rf, ok := ret.Get(1).(func(string, int) string); ok {
-                r2 = rf(serviceID, instanceID)
-        } else {
-                r2 = ret.Get(1).(string)
-        }
+	if rf, ok := ret.Get(1).(func(string, int) string); ok {
+		r2 = rf(serviceID, instanceID)
+	} else {
+		r2 = ret.Get(1).(string)
+	}
 
 	var r3 error
 	if rf, ok := ret.Get(2).(func(string, int) error); ok {
@@ -1161,7 +1184,7 @@ func (_m *ClientInterface) WaitService(serviceIDs []string, state service.Desire
 
 func (_m *ClientInterface) RemoveIPs(args []string) error {
 	ret := _m.Called(args)
-        var r0 error
+	var r0 error
 	if rf, ok := ret.Get(0).(func([]string) error); ok {
 		r0 = rf(args)
 	} else {
@@ -1171,16 +1194,16 @@ func (_m *ClientInterface) RemoveIPs(args []string) error {
 }
 
 func (_m *ClientInterface) SetIPs(assignmentRequest addressassignment.AssignmentRequest) error {
-        ret := _m.Called(assignmentRequest)
+	ret := _m.Called(assignmentRequest)
 
-        var r0 error
-        if rf, ok := ret.Get(0).(func(addressassignment.AssignmentRequest) error); ok {
-                r0 = rf(assignmentRequest)
-        } else {
-                r0 = ret.Error(0)
-        }
+	var r0 error
+	if rf, ok := ret.Get(0).(func(addressassignment.AssignmentRequest) error); ok {
+		r0 = rf(assignmentRequest)
+	} else {
+		r0 = ret.Error(0)
+	}
 
-        return r0
+	return r0
 }
 
 var _ master.ClientInterface = (*ClientInterface)(nil)

--- a/rpc/rpcutils/authcodec.go
+++ b/rpc/rpcutils/authcodec.go
@@ -28,7 +28,13 @@ import (
 
 var (
 	// RPC Calls that do not require authentication or who handle authentication separately:
-	NonAuthenticatingCalls = []string{"Master.AuthenticateHost", "Agent.BuildHost", "ControlCenterAgent.Ping"}
+	NonAuthenticatingCalls = []string{
+		"Master.AuthenticateHost",
+		"Agent.BuildHost",
+		"ControlCenterAgent.Ping",
+		"Agent.AddHostPrivate",
+		"Master.AddHostPrivate",
+	}
 	// RPC calls that do not require admin access:
 	NonAdminRequiredCalls = map[string]struct{}{
 		"Master.GetHost":                         struct{}{},
@@ -45,6 +51,8 @@ var (
 		"ControlCenterAgent.ReportHealthStatus":  struct{}{},
 		"ControlCenterAgent.ReportInstanceDead":  struct{}{},
 		"ControlCenterAgent.SendLogMessage":      struct{}{},
+		"ControlCenterAgent.AddHostPrivate":      struct{}{},
+		//"Master.AddHostPrivate":                  struct{}{},
 	}
 	endian = binary.BigEndian
 

--- a/rpc/rpcutils/authcodec.go
+++ b/rpc/rpcutils/authcodec.go
@@ -32,7 +32,6 @@ var (
 		"Master.AuthenticateHost",
 		"Agent.BuildHost",
 		"ControlCenterAgent.Ping",
-		"Agent.AddHostPrivate",
 		"Master.AddHostPrivate",
 	}
 	// RPC calls that do not require admin access:

--- a/rpc/rpcutils/authcodec.go
+++ b/rpc/rpcutils/authcodec.go
@@ -52,7 +52,6 @@ var (
 		"ControlCenterAgent.ReportInstanceDead":  struct{}{},
 		"ControlCenterAgent.SendLogMessage":      struct{}{},
 		"ControlCenterAgent.AddHostPrivate":      struct{}{},
-		//"Master.AddHostPrivate":                  struct{}{},
 	}
 	endian = binary.BigEndian
 

--- a/servicedversion/servicedversion.go
+++ b/servicedversion/servicedversion.go
@@ -23,8 +23,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/control-center/serviced/utils"
 	"github.com/control-center/serviced/logging"
+	"github.com/control-center/serviced/utils"
 )
 
 var (

--- a/web/hostresource.go
+++ b/web/hostresource.go
@@ -156,11 +156,11 @@ func restGetServiceMonitoringProfile(w *rest.ResponseWriter, r *rest.Request, ct
 	}
 
 	mp.MetricConfigs = append(mp.MetricConfigs, *config)
-	if svc, err := facade.GetService(dataCtx, serviceID);err != nil {
-	        restServerError(w, err)
-	        return
+	if svc, err := facade.GetService(dataCtx, serviceID); err != nil {
+		restServerError(w, err)
+		return
 	} else if svc.Instances > 0 {
-	 	mp.GraphConfigs = append(mp.GraphConfigs, getInternalGraphConfigs(serviceID)...)
+		mp.GraphConfigs = append(mp.GraphConfigs, getInternalGraphConfigs(serviceID)...)
 	}
 
 	// we want to try to include monitoring data for the tenant, as well


### PR DESCRIPTION
A delegate host can now add itself to a main host
with a new add-private / "addme" command, which also
registers the host using an agreed-upon keypair stored at
/opt/serviced/etc/common.key