### PR TITLE
Expose 'service pause' to the serviced cli.

### DIFF
--- a/cli/api/apimocks/API.go
+++ b/cli/api/apimocks/API.go
@@ -1544,6 +1544,27 @@ func (_m *API) StopService(_a0 api.SchedulerConfig) (int, error) {
 	return r0, r1
 }
 
+// pauseService provides a mock function with given fields: _a0
+func (_m *API) PauseService(_a0 api.SchedulerConfig) (int, error) {
+	ret := _m.Called(_a0)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(api.SchedulerConfig) int); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(api.SchedulerConfig) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // StopServiceInstance provides a mock function with given fields: serviceID, instanceID
 func (_m *API) StopServiceInstance(serviceID string, instanceID int) error {
 	ret := _m.Called(serviceID, instanceID)

--- a/cli/api/interfaces.go
+++ b/cli/api/interfaces.go
@@ -78,6 +78,7 @@ type API interface {
 	RestartService(SchedulerConfig) (int, error)
 	RebalanceService(SchedulerConfig) (int, error)
 	StopService(SchedulerConfig) (int, error)
+	PauseService(SchedulerConfig) (int, error)
 	AssignIP(IPConfig) error
 	GetEndpoints(serviceID string, reportImports, reportExports, validate bool) ([]applicationendpoint.EndpointReport, error)
 	ResolveServicePath(path string) ([]service.ServiceDetails, error)

--- a/cli/api/service.go
+++ b/cli/api/service.go
@@ -382,6 +382,18 @@ func (a *api) StopService(config SchedulerConfig) (int, error) {
 	return affected, err
 }
 
+// PauseService stops a service
+func (a *api) PauseService(config SchedulerConfig) (int, error) {
+	client, err := a.connectDAO()
+	if err != nil {
+		return 0, err
+	}
+
+	var affected int
+	err = client.PauseService(dao.ScheduleServiceRequest{config.ServiceIDs, config.AutoLaunch, config.Synchronous}, &affected)
+	return affected, err
+}
+
 // AssignIP assigns an IP address to a service
 func (a *api) AssignIP(config IPConfig) error {
 	client, err := a.connectDAO()

--- a/dao/client/cp_client.go
+++ b/dao/client/cp_client.go
@@ -154,6 +154,10 @@ func (s *ControlClient) StopService(request dao.ScheduleServiceRequest, affected
 	return s.rpcClient.Call("ControlCenter.StopService", request, affected, 0)
 }
 
+func (s *ControlClient) PauseService(request dao.ScheduleServiceRequest, affected *int) (err error) {
+	return s.rpcClient.Call("ControlCenter.PauseService", request, affected, 0)
+}
+
 func (s *ControlClient) WaitService(request dao.WaitServiceRequest, _ *int) (err error) {
 	return s.rpcClient.Call("ControlCenter.WaitService", request, nil, 0)
 }

--- a/dao/elasticsearch/service.go
+++ b/dao/elasticsearch/service.go
@@ -187,6 +187,12 @@ func (this *ControlPlaneDao) StopService(request dao.ScheduleServiceRequest, aff
 	return err
 }
 
+// pause the provided service
+func (this *ControlPlaneDao) PauseService(request dao.ScheduleServiceRequest, affected *int) (err error) {
+	*affected, err = this.facade.PauseService(datastore.Get(), request)
+	return err
+}
+
 // WaitService waits for the given service IDs to reach a particular state
 func (this *ControlPlaneDao) WaitService(request dao.WaitServiceRequest, _ *int) (err error) {
 	return this.facade.WaitService(datastore.Get(), request.DesiredState, request.Timeout, request.Recursive, request.ServiceIDs...)

--- a/dao/interface.go
+++ b/dao/interface.go
@@ -181,6 +181,9 @@ type ControlPlane interface {
 	// Schedule the given service to stop
 	StopService(request ScheduleServiceRequest, affected *int) error
 
+	// Schedule the given service to pause
+	PauseService(request ScheduleServiceRequest, affected *int) error
+
 	// Stop a running instance of a service
 	StopRunningInstance(request HostServiceRequest, unused *int) error
 

--- a/dao/mocks/ControlPlane.go
+++ b/dao/mocks/ControlPlane.go
@@ -179,6 +179,18 @@ func (_m *ControlPlane) StopService(request dao.ScheduleServiceRequest, affected
 
 	return r0
 }
+func (_m *ControlPlane) PauseService(request dao.ScheduleServiceRequest, affected *int) error {
+	ret := _m.Called(request, affected)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(dao.ScheduleServiceRequest, *int) error); ok {
+		r0 = rf(request, affected)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
 func (_m *ControlPlane) StopRunningInstance(request dao.HostServiceRequest, unused *int) error {
 	ret := _m.Called(request, unused)
 

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -217,4 +217,6 @@ type FacadeInterface interface {
 	RestartService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error)
 
 	StopService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error)
+
+	PauseService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error)
 }

--- a/facade/mocks/FacadeInterface.go
+++ b/facade/mocks/FacadeInterface.go
@@ -1564,6 +1564,28 @@ func (_m *FacadeInterface) StopService(ctx datastore.Context, request dao.Schedu
 	return r0, r1
 }
 
+//PauseService provides a mock function with given fields: ctx, ScheduleServiceRequest
+func (_m *FacadeInterface) PauseService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error) {
+
+	ret := _m.Called(ctx, request)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(datastore.Context, dao.ScheduleServiceRequest) int); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(0).(func(datastore.Context, dao.ScheduleServiceRequest) error); ok {
+		r1 = rf(ctx, request)
+	} else {
+		r1 = ret.Error(0)
+	}
+
+	return r0, r1
+}
+
 //RestartService provides a mock function with given fields: ctx, ScheduleServiceRequest
 func (_m *FacadeInterface) RestartService(ctx datastore.Context, request dao.ScheduleServiceRequest) (int, error) {
 


### PR DESCRIPTION
Similar to 'serviced service start/stop', this allows the cli to ask a service to pause, with the same available options (recurse, syncronous). 

In order to un-pause services once they have reached paused state, issue a 'serviced service start' command.