### PR TITLE
do not call auth0 if an authorization is in progress

### DIFF
--- a/web/ui/src/common/miscUtils.js
+++ b/web/ui/src/common/miscUtils.js
@@ -107,7 +107,7 @@
 
                 if (utils.useAuth0()) {
                     if (AUTH_IN_PROGRESS) {
-                        console.info("unauthorized(): auth in progress - do nothing.")
+                        console.info("unauthorized(): auth in progress - do nothing.");
                     } else {
                         AUTH_IN_PROGRESS = true;
                         // first, see if we already have a login session

--- a/web/ui/src/common/miscUtils.js
+++ b/web/ui/src/common/miscUtils.js
@@ -6,6 +6,7 @@
     "use strict";
 
     var TIMEMULTIPLIER = {w: 6048e5, d: 864e5, h: 36e5, m: 6e4, s: 1e3,  ms: 1};
+    var AUTH_IN_PROGRESS = false;
 
     angular.module("miscUtils", [])
     .factory("miscUtils", [ "$parse", "log", "angularAuth0",
@@ -105,22 +106,32 @@
                 log.error('You don\'t appear to be logged in.');
 
                 if (utils.useAuth0()) {
-                    // first, see if we already have a login session
-                    angularAuth0.checkSession({}, (err, result) => {
-                        if (err) {
-                            // no session or some other error - kick back to auth0 login
-                            console.error("auth0 checkSession() returned an error: " + JSON.stringify(err));
-                            angularAuth0.authorize();
-                        } else if (result && result.idToken && result.accessToken) {
-                            // we got a session refresh from auth0. Update the token cookies and carry on.
-                            window.sessionStorage.setItem("auth0AccessToken", result.accessToken);
-                            window.sessionStorage.setItem("auth0IDToken", result.idToken);
-                        } else {
-                            // refresh worked, but didn't have tokens. Kick back to login screen.
-                            window.location.href = "/#/login";
-                            window.location.reload();
-                        }
-                    });
+                    if (AUTH_IN_PROGRESS) {
+                        console.info("unauthorized(): auth in progress - do nothing.")
+                    } else {
+                        AUTH_IN_PROGRESS = true;
+                        // first, see if we already have a login session
+                        console.info("calling Auth0 checkSession()");
+                        angularAuth0.checkSession({}, (err, result) => {
+                            if (err) {
+                                // no session or some other error - kick back to auth0 login
+                                console.error("auth0 checkSession() returned an error: " + JSON.stringify(err));
+                                AUTH_IN_PROGRESS = false;
+                                console.info("calling Auth0 authorize()");
+                                angularAuth0.authorize();
+                            } else if (result && result.idToken && result.accessToken) {
+                                // we got a session refresh from auth0. Update the token cookies and carry on.
+                                window.sessionStorage.setItem("auth0AccessToken", result.accessToken);
+                                window.sessionStorage.setItem("auth0IDToken", result.idToken);
+                                AUTH_IN_PROGRESS = false;
+                            } else {
+                                // refresh worked, but didn't have tokens. Kick back to login screen.
+                                AUTH_IN_PROGRESS = false;
+                                window.location.href = "/#/login";
+                                window.location.reload();
+                            }
+                        });
+                    }
                 } else {
                     // show the login page and then refresh so we lose any incorrect state. CC-279
                     window.location.href = "/#/login";


### PR DESCRIPTION
Before GalaxZ, we had an issue with auth0 calls tripping a rate limit (calls to get JSON Web Token Keys are limited to 20 per second). Switching off auth0 for CC seemed to help. 

Serviced already caches the jwtk tokens, so the next most likely culprit is the UI. When a serviced call comes back with a 401 (which it does when the access token is expired), the UI triggers a call to `unauthorized()`. If we're using Auth0, the `unauthorized()` call makes a call to the `checkSession()` function in the [Auth0 json API](https://auth0.com/docs/libraries/auth0js/v9#using-checksession-to-acquire-new-tokens). 

This PR adds a flag, `AUTH_IN_PROGRESS`,  to the `unauthorized()` method. We set it when we make the call to `checkSession()`, and clear it in each of the callback handler cases. If the flag is set, we don't make the call to `checkSession()`, since one is already in progress. 

This fix will reduce the number of calls to Auth0, and hopefully mitigate the issue of exceeding the rate limit on jwtk calls.