### PR TITLE
update serviced to take either array of strings or string for audience

### DIFF
--- a/auth/auth0.go
+++ b/auth/auth0.go
@@ -25,22 +25,24 @@ type jwtAuth0Claims struct {
 	Subject   string      `json:"sub,omitempty"`
 }
 
+// Parse the interface{} that populates Audience - we get string from some certs, and an array of strings (which parses as an array of interfaces) from others.
 func (t *jwtAuth0Claims) CheckAudience(expected string) bool {
-	if audstr, ok := t.Audience.(string); ok {
-		return audstr == expected
+	// String
+	if audienceString, ok := t.Audience.(string); ok {
+		return audienceString == expected
 	}
-	if audstrary, ok := t.Audience.([]string); ok {
-	    return utils.StringInSlice(expected, audstrary)
+	// Array of strings - not likely to show up, but here for completeness
+	if audienceStringArray, ok := t.Audience.([]string); ok {
+	    return utils.StringInSlice(expected, audienceStringArray)
 	}
-	if audifrary, ok := t.Audience.([]interface{}); ok {
-		if audstrary, ok := utils.InterfaceArrayToStringArray(audifrary); ok {
-			return utils.StringInSlice(expected, audstrary)
+	// Array of interfaces (which is really an array of strings
+	if audienceIterfaceArray, ok := t.Audience.([]interface{}); ok {
+		// Convert to string array
+		if audienceStringArray, ok := utils.InterfaceArrayToStringArray(audienceIterfaceArray); ok {
+			return utils.StringInSlice(expected, audienceStringArray)
 		}
 	}
-
-	// An unexpected type. We'll get the type name for the error
-	//name := reflect.TypeOf(t.Audience)
-	log.Error("Unexpected Audience type")
+	log.Error("Unexpected type for Audience in JWT claims")
 	return false
 }
 

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -170,9 +170,8 @@ func (d *daemon) getEsClusterName(name string) string {
 func (d *daemon) startISVCS() {
 	options := config.GetOptions()
 	startZK := options.StartZK
-	startAPIKeyProxy := options.StartAPIKeyProxy
 	bigtable := options.BigTableMetrics
-	isvcs.Init(options.ESStartupTimeout, options.DockerLogDriver, convertStringSliceToMap(options.DockerLogConfigList), d.docker, startZK, bigtable, startAPIKeyProxy)
+	isvcs.Init(options.ESStartupTimeout, options.DockerLogDriver, convertStringSliceToMap(options.DockerLogConfigList), d.docker, startZK, bigtable)
 	isvcs.Mgr.SetVolumesDir(options.IsvcsPath)
 	servicedClusterName := d.getEsClusterName("elasticsearch-serviced")
 	if err := isvcs.Mgr.SetConfigurationOption("elasticsearch-serviced", "cluster", servicedClusterName); err != nil {

--- a/cli/api/daemon.go
+++ b/cli/api/daemon.go
@@ -170,8 +170,9 @@ func (d *daemon) getEsClusterName(name string) string {
 func (d *daemon) startISVCS() {
 	options := config.GetOptions()
 	startZK := options.StartZK
+	startAPIKeyProxy := options.StartAPIKeyProxy
 	bigtable := options.BigTableMetrics
-	isvcs.Init(options.ESStartupTimeout, options.DockerLogDriver, convertStringSliceToMap(options.DockerLogConfigList), d.docker, startZK, bigtable)
+	isvcs.Init(options.ESStartupTimeout, options.DockerLogDriver, convertStringSliceToMap(options.DockerLogConfigList), d.docker, startZK, bigtable, startAPIKeyProxy)
 	isvcs.Mgr.SetVolumesDir(options.IsvcsPath)
 	servicedClusterName := d.getEsClusterName("elasticsearch-serviced")
 	if err := isvcs.Mgr.SetConfigurationOption("elasticsearch-serviced", "cluster", servicedClusterName); err != nil {

--- a/cli/api/options.go
+++ b/cli/api/options.go
@@ -129,6 +129,7 @@ func GetDefaultOptions(cfg utils.ConfigReader) config.Options {
 		OutboundIP:                 cfg.StringVal("OUTBOUND_IP", ""),
 		GCloud:                     cfg.BoolVal("GCLOUD", false),
 		StartZK:                    cfg.BoolVal("START_ZK", true),
+		StartAPIKeyProxy:           cfg.BoolVal("START_API_KEY_PROXY", false),
 		BigTableMetrics:            cfg.BoolVal("BIGTABLE_METRICS", false),
 		DockerDNS:                  cfg.StringSlice("DOCKER_DNS", []string{}),
 		Master:                     cfg.BoolVal("MASTER", false),

--- a/cli/api/options.go
+++ b/cli/api/options.go
@@ -200,6 +200,9 @@ func GetDefaultOptions(cfg utils.ConfigReader) config.Options {
 		Auth0Group:    cfg.StringVal("AUTH0_GROUP", ""),
 		Auth0ClientID: cfg.StringVal("AUTH0_CLIENT_ID", ""),
 		Auth0Scope:    cfg.StringVal("AUTH0_SCOPE", ""),
+		// Parameters for api-key-proxy isvc configuration
+		KeyProxyJsonServer:   cfg.StringVal("KEYPROXY_JSON_SERVER", ""),
+		KeyProxyListenPort:   cfg.StringVal("KEYPROXY_LISTEN_PORT", ":6443"), 
 	}
 
 	options.Endpoint = cfg.StringVal("ENDPOINT", "")

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -229,6 +229,7 @@ func getRuntimeOptions(cfg utils.ConfigReader, ctx *cli.Context) config.Options 
 	options := config.Options{
 		GCloud:                     cfg.BoolVal("GCLOUD", false),
 		StartZK:                    cfg.BoolVal("START_ZK", true),
+		StartAPIKeyProxy:           cfg.BoolVal("START_API_KEY_PROXY", false),
 		BigTableMetrics:            cfg.BoolVal("BIGTABLE_METRICS", false),
 		DockerRegistry:             ctx.GlobalString("docker-registry"),
 		NFSClient:                  ctx.GlobalString("nfs-client"),

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -160,6 +160,8 @@ func New(driver api.API, config utils.ConfigReader, logControl logging.LogContro
 		cli.StringFlag{"auth0-group", defaultOps.Auth0Group, "Group configured for application in Auth0"},
 		cli.StringFlag{"auth0-client-id", defaultOps.Auth0ClientID, "Client ID of Auth0 application"},
 		cli.StringFlag{"auth0-scope", defaultOps.Auth0Scope, "Scope to request in Auth0"},
+		cli.StringFlag{"keyproxy-json-server", defaultOps.KeyProxyJsonServer, "URL for API key server (cc auth token endpoint)"},
+		cli.StringFlag{"keyproxy-listen-port", defaultOps.KeyProxyListenPort, "Port for API key proxy to listen on"},
 	}
 
 	c.initVersion()
@@ -312,6 +314,8 @@ func getRuntimeOptions(cfg utils.ConfigReader, ctx *cli.Context) config.Options 
 		Auth0Group:                 ctx.String("auth0-group"),
 		Auth0ClientID:              ctx.String("auth0-client-id"),
 		Auth0Scope:                 ctx.String("auth0-scope"),
+		KeyProxyJsonServer:         ctx.String("keyproxy-json-server"),
+		KeyProxyListenPort:         ctx.String("keyproxy-listen-port"),
 	}
 
 	// Long story, but due to the way codegangsta handles bools and the way we start system services vs

--- a/config/options.go
+++ b/config/options.go
@@ -128,6 +128,7 @@ type Options struct {
 	BackupEstimatedCompression float64           // Best guess for tgz compression ratio (uncompressed size / compressed size) used to determine whether sufficient disk space is available for taking a backup
 	BackupMinOverhead          string            // Warn user if estimated backup size would leave less than this amount of space free
 	StartZK                    bool              // Should ZooKeeper ISVC be started
+	StartAPIKeyProxy           bool              // Should API Key Proxy ISVC be started
 	BigTableMetrics            bool              // Should serviced metrics be stored in gcp bigtable
 	Auth0Domain                string            // Domain configured for tenant in Auth0. Ref: https://auth0.com/docs/getting-started/the-basics#domain
 	Auth0Audience              string            // Audience configured for application (?) in Auth0

--- a/config/options.go
+++ b/config/options.go
@@ -134,6 +134,9 @@ type Options struct {
 	Auth0Group                 string            // Group membership required in Auth0 token for login
 	Auth0ClientID              string            // ClientID of Auth0 Application
 	Auth0Scope                 string            // Auth0 Scope for request.
+	KeyProxyJsonServer         string            // Address of api-key-server endpoint for getting CC Access tokens
+	KeyProxyListenPort         string            // Port where api-key-proxy will listen 
+
 }
 
 // GetOptions returns a COPY of the global options struct

--- a/isvcs/api_key_proxy.go
+++ b/isvcs/api_key_proxy.go
@@ -37,7 +37,7 @@ func initApiKeyProxy() {
 	logger := log.WithFields(logrus.Fields{"isvc": "APIKeyProxy"})
 
 	startApiKeyProxy := config.GetOptions().StartAPIKeyProxy
-	logger.WithField("StartAPIKeyProxy", startApiKeyProxy).Info("initApiKeyProxy()")
+	logger.WithField("StartAPIKeyProxy", startApiKeyProxy).Debug("initApiKeyProxy()")
 
 	var err error
 	command := `/bin/supervisord -n -c etc/api-key-proxy/supervisord.conf`

--- a/isvcs/api_key_proxy.go
+++ b/isvcs/api_key_proxy.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Serviced Authors.
+// Copyright 2018 The Serviced Authors.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/isvcs/api_key_proxy.go
+++ b/isvcs/api_key_proxy.go
@@ -13,11 +13,22 @@
 
 package isvcs
 
+import (
+	"errors"
+	"fmt"
+	"github.com/Sirupsen/logrus"
+	"github.com/control-center/serviced/config"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+)
+
 var apiKeyProxy *IService
 
-//const (
-//	apikeyproxyport = 6443
-//)
+const API_KEY_PROXY_SERVER_HEALTHCHECK_NAME = "api-key-server-running"
+const API_KEY_PROXY_SERVER_INTERNAL_API_HEALTHCHECK_NAME = "internal-api-reachable"
+
 func getKeyProxyPort() uint16 {
 	return 6443
 }
@@ -29,22 +40,121 @@ func initApiKeyProxy() {
 
 	apiKeyPortBinding := portBinding{
 		HostIp:         "0.0.0.0",
-		HostIpOverride: "", // TODO: verify that api key proxy should always be open
+		HostIpOverride: "",
 		HostPort:       getKeyProxyPort(),
 	}
 
-	apiKeyProxy, err = NewIService(
-		IServiceDefinition{
-			ID:           ApiKeyProxyISVC.ID,
-			Name:         "api-key-proxy",
-			Repo:         API_KEY_PROXY_REPO,
-			Tag:          API_KEY_PROXY_TAG,
-			Command:      func() string { return command },
-			PortBindings: []portBinding{apiKeyPortBinding},
-			Volumes:      map[string]string{},
-			StartGroup:   1,
-		})
+	keyServerReachableHealthCheck := healthCheckDefinition{
+		healthCheck: SetKeyServerReachableHealthCheck(),
+		Interval:    DEFAULT_HEALTHCHECK_INTERVAL,
+		Timeout:     DEFAULT_HEALTHCHECK_TIMEOUT,
+	}
+	keyProxyAnsweringHealthCheck := healthCheckDefinition{
+		healthCheck: SetKeyProxyAnsweringHealthCheck(),
+		Interval:    DEFAULT_HEALTHCHECK_INTERVAL,
+		Timeout:     DEFAULT_HEALTHCHECK_TIMEOUT,
+	}
+
+	healthChecks := []map[string]healthCheckDefinition{
+		map[string]healthCheckDefinition{
+			"API Key Server Reachable": keyServerReachableHealthCheck,
+			"API Key Proxy Answering":  keyProxyAnsweringHealthCheck,
+		},
+	}
+
+	ApiKeyProxy := IServiceDefinition{
+		ID:           ApiKeyProxyISVC.ID,
+		Name:         "api-key-proxy",
+		Repo:         API_KEY_PROXY_REPO,
+		Tag:          API_KEY_PROXY_TAG,
+		Command:      func() string { return command },
+		PortBindings: []portBinding{apiKeyPortBinding},
+		Volumes:      map[string]string{},
+		StartGroup:   1,
+		HealthChecks: healthChecks,
+	}
+
+	apiKeyProxy, err = NewIService(ApiKeyProxy)
 	if err != nil {
 		log.WithError(err).Fatal("Unable to initialize API Key Server internal service container")
 	}
+}
+
+func SetKeyServerReachableHealthCheck() HealthCheckFunction {
+	return func(halt <-chan struct{}) error {
+		logger := log.WithFields(logrus.Fields{"HealthCheckName": API_KEY_PROXY_SERVER_HEALTHCHECK_NAME})
+		TestURL := config.GetOptions().KeyProxyJsonServer + "RUOK"
+		for {
+			select {
+			case <-halt:
+				logger.Debug("Stopped health checks for API Key Proxy Server")
+				return nil
+			default:
+				if err := CheckURL(TestURL); err != nil {
+					logger.WithError(err).
+						WithFields(logrus.Fields{"TestURL": TestURL}).
+						Debug("Bad response from Key server.")
+					time.Sleep(1 * time.Second)
+					continue
+				}
+				logger.Debug("API Key Server checked in healthy")
+				return nil
+			}
+		}
+	}
+}
+
+func getProxyURL() string {
+	servicedIP := getDockerIP()
+	port := strings.TrimLeft(config.GetOptions().KeyProxyListenPort, ":")
+	proxyURL := fmt.Sprintf("http://%s:%s", servicedIP, port)
+	return proxyURL
+}
+
+func SetKeyProxyAnsweringHealthCheck() HealthCheckFunction {
+	return func(halt <-chan struct{}) error {
+		logger := log.WithFields(logrus.Fields{"HealthCheckName": API_KEY_PROXY_SERVER_INTERNAL_API_HEALTHCHECK_NAME})
+		TestURL := fmt.Sprintf("%s%s", getProxyURL(), "/apiproxy/RUOK")
+		logger.WithFields(logrus.Fields{"TestURL": TestURL}).Debug("Starting Key Proxy Server check")
+		for {
+			select {
+			case <-halt:
+				logger.Debug("Stopped health checks for API Key Proxy Server Internal API Check")
+				return nil
+			default:
+				if err := CheckURL(TestURL); err != nil {
+					logger.WithError(err).
+						WithFields(logrus.Fields{"TestURL": TestURL}).
+						Debug("Bad response from Serviced API server.")
+					time.Sleep(1 * time.Second)
+					continue
+				}
+				logger.Debug("API Key Proxy checked in healthy")
+				return nil
+			}
+		}
+	}
+}
+
+func CheckURL(TestURL string) error {
+	logger := log.WithFields(logrus.Fields{"URL": TestURL})
+	resp, err := http.Get(TestURL)
+	if err != nil {
+		logger.
+			WithError(err).
+			Debug("GET operation returned error.")
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		logger.
+			WithFields(logrus.Fields{
+				"StatusCode": resp.StatusCode,
+				"Body":       string(body)}).
+			Debug("Received response other than 200 (OK)")
+		e := errors.New(fmt.Sprintf("Status code %d received from %s.", resp.StatusCode, string(body)))
+		return e
+	}
+	return nil
 }

--- a/isvcs/api_key_proxy.go
+++ b/isvcs/api_key_proxy.go
@@ -1,0 +1,50 @@
+// Copyright 2014 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package isvcs
+
+var apiKeyProxy *IService
+
+//const (
+//	apikeyproxyport = 6443
+//)
+func getKeyProxyPort() uint16 {
+	return 6443
+}
+
+func initApiKeyProxy() {
+
+	var err error
+	command := `/bin/supervisord -n -c etc/api-key-proxy/supervisord.conf`
+
+	apiKeyPortBinding := portBinding{
+		HostIp:         "0.0.0.0",
+		HostIpOverride: "", // TODO: verify that api key proxy should always be open
+		HostPort:       getKeyProxyPort(),
+	}
+
+	apiKeyProxy, err = NewIService(
+		IServiceDefinition{
+			ID:           ApiKeyProxyISVC.ID,
+			Name:         "api-key-proxy",
+			Repo:         API_KEY_PROXY_REPO,
+			Tag:          API_KEY_PROXY_TAG,
+			Command:      func() string { return command },
+			PortBindings: []portBinding{apiKeyPortBinding},
+			Volumes:      map[string]string{},
+			StartGroup:   1,
+		})
+	if err != nil {
+		log.WithError(err).Fatal("Unable to initialize API Key Server internal service container")
+	}
+}

--- a/isvcs/container.go
+++ b/isvcs/container.go
@@ -53,6 +53,7 @@ var (
 	ErrNotRunning       = errors.New("isvc: not running")
 	ErrRunning          = errors.New("isvc: running")
 	ErrBadContainerSpec = errors.New("isvc: bad service specification")
+	ErrNoDockerIP       = errors.New("isvc: unable to get IP for docker interface")
 
 	loggedHostIPOverride bool
 )

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -33,12 +33,12 @@ var (
 )
 
 const (
-	IMAGE_REPO          = "zenoss/serviced-isvcs"
-	IMAGE_TAG           = "v61"
-	ZK_IMAGE_REPO       = "zenoss/isvcs-zookeeper"
-	ZK_IMAGE_TAG        = "v10"
-	OTSDB_BT_REPO       = "zenoss/isvcs-metrics-bigtable"
-	OTSDB_BT_TAG        = "v1"
+	IMAGE_REPO         = "zenoss/serviced-isvcs"
+	IMAGE_TAG          = "v61"
+	ZK_IMAGE_REPO      = "zenoss/isvcs-zookeeper"
+	ZK_IMAGE_TAG       = "v10"
+	OTSDB_BT_REPO      = "zenoss/isvcs-metrics-bigtable"
+	OTSDB_BT_TAG       = "v1"
 	API_KEY_PROXY_REPO = "zenosszing/api-key-proxy"
 	API_KEY_PROXY_TAG  = "latest"
 )

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -65,7 +65,7 @@ func PreInit(bigtable bool) error {
 	return nil
 }
 
-func Init(esStartupTimeoutInSeconds int, dockerLogDriver string, dockerLogConfig map[string]string, dockerAPI docker.Docker, startZK bool, bigtable bool, startApiKeyProxy bool) {
+func Init(esStartupTimeoutInSeconds int, dockerLogDriver string, dockerLogConfig map[string]string, dockerAPI docker.Docker, startZK bool, bigtable bool) {
 	if err := PreInit(bigtable); err != nil {
 		log.WithFields(logrus.Fields{
 			"isvc": "PreInit",
@@ -125,7 +125,7 @@ func Init(esStartupTimeoutInSeconds int, dockerLogDriver string, dockerLogConfig
 			"isvc": "kibana",
 		}).WithError(err).Fatal("Unable to register internal service")
 	}
-	if startApiKeyProxy {
+	if config.GetOptions().StartAPIKeyProxy {
 		apiKeyProxy.docker = dockerAPI
 		if err := Mgr.Register(apiKeyProxy); err != nil {
 			log.WithFields(logrus.Fields{

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -25,9 +25,6 @@ import (
 	"os"
 	"strings"
 	"time"
-	"bytes"
-	"regexp"
-	"os/exec"
 )
 
 var (
@@ -154,32 +151,6 @@ func InitServices(isvcNames []string, dockerLogDriver string, dockerLogConfig ma
 			}
 		}
 	}
-}
-
-// Get the IP of the docker0 interface, which can be used to access the serviced API from inside the container.
-// inspiration: the following is used for the same purpose during deploy/provision:
-// ip addr show docker0 | grep inet | grep -v inet6 | awk '{print $2}' | awk -F / '{print $1}'
-func getDockerIP() string {
-	// Execute 'ip -4 -br addr show docker0'
-	c1 := exec.Command("ip", "-4", "-br", "addr", "show", "docker0")
-	var out bytes.Buffer
-	c1.Stdout = &out
-	err := c1.Run()
-	if err != nil {
-		log.WithField("command", c1).Infof("Error calling command: %s", err)
-		return ""
-	}
-	outstr := out.String()
-	// use a regex to extract the ip address from the result.
-	// We're expecting something that looks like: ###.###.###.###/##
-	// We use a capture group to exclude the trailing /##.
-	re := regexp.MustCompile(`(\d+\.\d+\.\d+\.\d+)/\d+`)
-	addr := re.FindStringSubmatch(outstr)
-	if addr != nil && len(addr) > 1 {
-		return addr[1]
-	}
-	log.WithFields(logrus.Fields{"match": addr, "output": outstr,}).Info("Output was not as expected")
-	return ""
 }
 
 func shouldRunApiProxy() bool {

--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -41,7 +41,7 @@ const (
 	OTSDB_BT_REPO      = "zenoss/isvcs-metrics-bigtable"
 	OTSDB_BT_TAG       = "v1"
 	API_KEY_PROXY_REPO = "zenosszing/api-key-proxy"
-	API_KEY_PROXY_TAG  = "latest"
+	API_KEY_PROXY_TAG  = "2018-07-26-0"
 )
 
 type IServiceHealthResult struct {

--- a/isvcs/mock.go
+++ b/isvcs/mock.go
@@ -31,6 +31,7 @@ var LogstashISVC s.Service
 var OpentsdbISVC s.Service
 var DockerRegistryISVC s.Service
 var KibanaISVC s.Service
+var ApiKeyProxyISVC s.Service
 var ISVCSMap map[string]*s.Service
 
 var InternalServicesIRS dao.RunningService
@@ -41,6 +42,7 @@ var LogstashIRS dao.RunningService
 var OpentsdbIRS dao.RunningService
 var DockerRegistryIRS dao.RunningService
 var KibanaIRS dao.RunningService
+var ApiKeyProxyIRS dao.RunningService
 var IRSMap map[string]*dao.RunningService
 
 func init() {
@@ -939,6 +941,123 @@ func init() {
 			},
 		},
 	}
+	ApiKeyProxyIRS = dao.RunningService{
+		Name:         "API Key Proxy",
+		Description:  "Internal API Key Proxy",
+		ID:           "isvc-api-key-proxy",
+		ServiceID:    "isvc-api-key-proxy",
+		DesiredState: 1,
+		StartedAt:    time.Now(),
+	}
+	ApiKeyProxyISVC = s.Service{
+		Name:            "API Key Proxy",
+		ID:              "isvc-api-key-proxy",
+		Startup:         "KEYPROXY_ZPROXY_LOCATION=https://localhost:443 KEYPROXY_PROXY_LOCATION_USES_TLS=true",
+		Description:     "Internal API key proxy",
+		ParentServiceID: "isvc-internalservices",
+		DesiredState:    1,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+		MonitoringProfile: domain.MonitorProfile{
+			MetricConfigs: []domain.MetricConfig{
+				domain.MetricConfig{
+					ID:          "cpu",
+					Name:        "CPU Usage",
+					Description: "CPU Statistics",
+					Metrics: []domain.Metric{
+						domain.Metric{ID: "docker.usageinkernelmode", Name: "CPU System"},
+						domain.Metric{ID: "docker.usageinusermode", Name: "CPU User"},
+					},
+				},
+				domain.MetricConfig{
+					ID:          "memory",
+					Name:        "Memory Usage",
+					Description: "Memory Usage Statistics",
+					Metrics: []domain.Metric{
+						domain.Metric{ID: "cgroup.memory.totalrss", Name: "Total RSS Memory"},
+					},
+				},
+			},
+			GraphConfigs: []domain.GraphConfig{
+				domain.GraphConfig{
+					ID:     "cpuUsage",
+					Name:   "CPU Usage",
+					Footer: false,
+					Format: "%4.2f",
+					MaxY:   nil,
+					MinY:   &zero,
+					Range: &domain.GraphConfigRange{
+						End:   "0s-ago",
+						Start: "1h-ago",
+					},
+					YAxisLabel: "% Used",
+					ReturnSet:  "EXACT",
+					Type:       "area",
+					Tags:       map[string][]string{"isvcname": []string{"api-key-proxy"}},
+					Units:      "Percent",
+					DataPoints: []domain.DataPoint{
+						domain.DataPoint{
+							ID:           "system",
+							MetricSource: "cpu",
+							Aggregator:   "avg",
+							Fill:         false,
+							Format:       "%4.2f",
+							Legend:       "CPU (System)",
+							Metric:       "docker.usageinkernelmode",
+							Name:         "CPU (System)",
+							Rate:         false,
+							Type:         "area",
+						},
+						domain.DataPoint{
+							ID:           "system",
+							MetricSource: "cpu",
+							Aggregator:   "avg",
+							Fill:         false,
+							Format:       "%4.2f",
+							Legend:       "CPU (User)",
+							Metric:       "docker.usageinusermode",
+							Name:         "CPU (User)",
+							Rate:         false,
+							Type:         "area",
+						},
+					},
+				},
+				domain.GraphConfig{
+					ID:     "memoryUsage",
+					Name:   "Memory Usage",
+					Footer: false,
+					Format: "%4.2f",
+					MaxY:   nil,
+					MinY:   &zero,
+					Range: &domain.GraphConfigRange{
+						End:   "0s-ago",
+						Start: "1h-ago",
+					},
+					YAxisLabel: "bytes",
+					ReturnSet:  "EXACT",
+					Type:       "area",
+					Tags:       map[string][]string{"isvcname": []string{"api-key-proxy"}},
+					Units:      "Bytes",
+					Base:       1024,
+					DataPoints: []domain.DataPoint{
+						domain.DataPoint{
+							ID:           "rssmemory",
+							MetricSource: "memory",
+							Aggregator:   "avg",
+							Fill:         false,
+							Format:       "%4.2f",
+							Legend:       "Memory Usage",
+							Metric:       "cgroup.memory.totalrss",
+							Name:         "Memory Usage",
+							Rate:         false,
+							Type:         "area",
+						},
+					},
+				},
+			},
+		},
+	}
+
 
 	ISVCSMap = map[string]*s.Service{
 		"isvc-internalservices":       &InternalServicesISVC,
@@ -949,6 +1068,7 @@ func init() {
 		"isvc-opentsdb":               &OpentsdbISVC,
 		"isvc-docker-registry":        &DockerRegistryISVC,
 		"isvc-kibana":                 &KibanaISVC,
+		"isvc-api-key-proxy":         &ApiKeyProxyISVC,
 	}
 
 	IRSMap = map[string]*dao.RunningService{
@@ -960,6 +1080,7 @@ func init() {
 		"isvc-opentsdb":               &OpentsdbIRS,
 		"isvc-docker-registry":        &DockerRegistryIRS,
 		"isvc-kibana":                 &KibanaIRS,
+		"isvc-api-key-proxy":         &ApiKeyProxyIRS,
 	}
 }
 
@@ -970,4 +1091,5 @@ func InitAllIsvcs(bigtable bool) {
 	initElasticSearch()
 	initDockerRegistry()
 	initKibana()
+	initApiKeyProxy()
 }

--- a/isvcs/mock.go
+++ b/isvcs/mock.go
@@ -1068,7 +1068,7 @@ func init() {
 		"isvc-opentsdb":               &OpentsdbISVC,
 		"isvc-docker-registry":        &DockerRegistryISVC,
 		"isvc-kibana":                 &KibanaISVC,
-		"isvc-api-key-proxy":         &ApiKeyProxyISVC,
+		"isvc-api-key-proxy":          &ApiKeyProxyISVC,
 	}
 
 	IRSMap = map[string]*dao.RunningService{
@@ -1080,7 +1080,7 @@ func init() {
 		"isvc-opentsdb":               &OpentsdbIRS,
 		"isvc-docker-registry":        &DockerRegistryIRS,
 		"isvc-kibana":                 &KibanaIRS,
-		"isvc-api-key-proxy":         &ApiKeyProxyIRS,
+		"isvc-api-key-proxy":          &ApiKeyProxyIRS,
 	}
 }
 

--- a/isvcs/utils.go
+++ b/isvcs/utils.go
@@ -16,6 +16,10 @@ package isvcs
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"bytes"
+	"regexp"
+	"github.com/Sirupsen/logrus"
 )
 
 var randomSource string
@@ -44,4 +48,31 @@ func uuid() string {
 	b := make([]byte, 16)
 	f.Read(b)
 	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+
+// Get the IP of the docker0 interface, which can be used to access the serviced API from inside the container.
+// inspiration: the following is used for the same purpose during deploy/provision:
+// ip addr show docker0 | grep inet | grep -v inet6 | awk '{print $2}' | awk -F / '{print $1}'
+func getDockerIP() string {
+	// Execute 'ip -4 -br addr show docker0'
+	c1 := exec.Command("ip", "-4", "-br", "addr", "show", "docker0")
+	var out bytes.Buffer
+	c1.Stdout = &out
+	err := c1.Run()
+	if err != nil {
+		log.WithField("command", c1).Infof("Error calling command: %s", err)
+		return ""
+	}
+	outstr := out.String()
+	// use a regex to extract the ip address from the result.
+	// We're expecting something that looks like: ###.###.###.###/##
+	// We use a capture group to exclude the trailing /##.
+	re := regexp.MustCompile(`(\d+\.\d+\.\d+\.\d+)/\d+`)
+	addr := re.FindStringSubmatch(outstr)
+	if addr != nil && len(addr) > 1 {
+		return addr[1]
+	}
+	log.WithFields(logrus.Fields{"match": addr, "output": outstr,}).Info("Output was not as expected")
+	return ""
 }

--- a/isvcs/utils.go
+++ b/isvcs/utils.go
@@ -14,12 +14,12 @@
 package isvcs
 
 import (
+	"bytes"
 	"fmt"
+	"github.com/Sirupsen/logrus"
 	"os"
 	"os/exec"
-	"bytes"
 	"regexp"
-	"github.com/Sirupsen/logrus"
 )
 
 var randomSource string
@@ -50,7 +50,6 @@ func uuid() string {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 }
 
-
 // Get the IP of the docker0 interface, which can be used to access the serviced API from inside the container.
 // inspiration: the following is used for the same purpose during deploy/provision:
 // ip addr show docker0 | grep inet | grep -v inet6 | awk '{print $2}' | awk -F / '{print $1}'
@@ -73,6 +72,6 @@ func getDockerIP() string {
 	if addr != nil && len(addr) > 1 {
 		return addr[1]
 	}
-	log.WithFields(logrus.Fields{"match": addr, "output": outstr,}).Info("Output was not as expected")
+	log.WithFields(logrus.Fields{"match": addr, "output": outstr}).Info("Output was not as expected")
 	return ""
 }

--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -307,5 +307,9 @@
 # Address of server for API keys (http://${JSON_API_ILB_IP}:9090/ccAccessToken)
 # SERVICED_KEYPROXY_JSON_SERVER=
 
+# Enable or disable key proxy server (only applicable where proxy server is running)
+# SERVICED_START_API_KEY_PROXY=false
+
 # Port for API key proxy to listen on (:6443)
-# SERVICED_KEYPROXY_LISTEN_PORT=
+# SERVICED_KEYPROXY_LISTEN_PORT=:6443
+

--- a/pkg/serviced.default
+++ b/pkg/serviced.default
@@ -303,3 +303,9 @@
 
 # Client ID for Auth0 application object (https://manage.auth0.com/#/applications)
 # SERVICED_AUTH0_CLIENT_ID=
+
+# Address of server for API keys (http://${JSON_API_ILB_IP}:9090/ccAccessToken)
+# SERVICED_KEYPROXY_JSON_SERVER=
+
+# Port for API key proxy to listen on (:6443)
+# SERVICED_KEYPROXY_LISTEN_PORT=

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -45,6 +45,20 @@ func StringSliceEquals(lhs []string, rhs []string) bool {
 	return true
 }
 
+// Extract all strings from an array of interfaces. If the input array contains items that are not strings, set the output flag (allConverted) to false.
+func InterfaceArrayToStringArray(inArray []interface{}) ([]string, bool) {
+	var outArray []string
+	allConverted := true
+	for _, item := range inArray {
+		if istr, ok := item.(string); ok {
+			outArray = append(outArray, istr)
+		} else {
+			allConverted = false
+		}
+	}
+	return outArray, allConverted
+}
+
 //StringInSlice test if a string exists in a slice
 func StringInSlice(a string, list []string) bool {
 	for _, b := range list {

--- a/web/resources.go
+++ b/web/resources.go
@@ -103,6 +103,7 @@ func getISVCS() []service.Service {
 	services = append(services, isvcs.OpentsdbISVC)
 	services = append(services, isvcs.DockerRegistryISVC)
 	services = append(services, isvcs.KibanaISVC)
+	services = append(services, isvcs.ApiKeyProxyISVC)
 	return services
 }
 
@@ -116,6 +117,7 @@ func getIRS() []dao.RunningService {
 	services = append(services, isvcs.OpentsdbIRS)
 	services = append(services, isvcs.DockerRegistryIRS)
 	services = append(services, isvcs.KibanaIRS)
+	services = append(services, isvcs.ApiKeyProxyIRS)
 	return services
 }
 

--- a/web/resources.go
+++ b/web/resources.go
@@ -34,6 +34,7 @@ import (
 	"github.com/control-center/serviced/servicedversion"
 	"github.com/control-center/serviced/utils"
 	"github.com/control-center/serviced/volume"
+	"github.com/control-center/serviced/config"
 )
 
 var empty interface{}
@@ -103,7 +104,9 @@ func getISVCS() []service.Service {
 	services = append(services, isvcs.OpentsdbISVC)
 	services = append(services, isvcs.DockerRegistryISVC)
 	services = append(services, isvcs.KibanaISVC)
-	services = append(services, isvcs.ApiKeyProxyISVC)
+	if config.GetOptions().StartAPIKeyProxy {
+		services = append(services, isvcs.ApiKeyProxyISVC)
+	}
 	return services
 }
 
@@ -117,7 +120,9 @@ func getIRS() []dao.RunningService {
 	services = append(services, isvcs.OpentsdbIRS)
 	services = append(services, isvcs.DockerRegistryIRS)
 	services = append(services, isvcs.KibanaIRS)
-	services = append(services, isvcs.ApiKeyProxyIRS)
+	if config.GetOptions().StartAPIKeyProxy {
+		services = append(services, isvcs.ApiKeyProxyIRS)
+	}
 	return services
 }
 


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZING-709

First part of ZING-709. We had to update the audience string checks in auth0.go. The tokens we had been working with (identity tokens, I believe) had audience specified as an array of strings, but the tokens coming from the api-key-server are single strings only.

This PR will build a version of serviced that will work with the ZING-709 changes in api-key-server and api-key-proxy. To complete the ticket, we'll need to add the api-key-proxy to serviced as an isvc. 
