### PR TITLE
Use TLS for api-key-proxy with serviced

### DIFF
--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -41,7 +41,7 @@ const (
 	OTSDB_BT_REPO      = "zenoss/isvcs-metrics-bigtable"
 	OTSDB_BT_TAG       = "v1"
 	API_KEY_PROXY_REPO = "gcr.io/zing-registry-188222/api-key-proxy"
-	API_KEY_PROXY_TAG  = "2018-07-26-0"
+	API_KEY_PROXY_TAG  = "2018-08-01-1"
 )
 
 type IServiceHealthResult struct {
@@ -188,6 +188,7 @@ func setIsvcsEnv() error {
 		apiProxyVars := []string{
 			"api-key-proxy:KEYPROXY_PROXY_LISTENER_PORT=" + options.KeyProxyListenPort,
 			"api-key-proxy:KEYPROXY_PROXY_LOCATION_USES_TLS=true",
+			"api-key-proxy:KEYPROXY_SERVE_TLS=true",
 			fmt.Sprintf("api-key-proxy:KEYPROXY_ZPROXY_LOCATION=%s", proxyToAddr),
 			fmt.Sprintf("api-key-proxy:KEYPROXY_JSON_SERVER=%s", options.KeyProxyJsonServer),
 		}


### PR DESCRIPTION
We've updated the api-key-proxy image to conditionally use TLS. We want TLS for serviced. To that end, we've done the following here:
* updated `API_KEY_PROXY_TAG` to pick up the new image
* Set an environment variable on the isvc container to tell it to serve TLS (`KEYPROXY_SERVE_TLS=true`)
* Updated the proxyURL to use https instead of http
* Updated the healthcheck so that it ignores insecure certificate errors (because we're using a self-signed cert on api-key-proxy).