### PR TITLE
Remove space in struct field tag.

### DIFF
--- a/metrics/performance.go
+++ b/metrics/performance.go
@@ -101,7 +101,7 @@ type V2PerformanceData struct {
 
 type V2ResultData struct {
 	Datapoints []V2Datapoint     `json:"datapoints"`
-	Metric     string            `json:"metric, omitempty"`
+	Metric     string            `json:"metric,omitempty"`
 	Tags       map[string]string `json:"tags,omitempty"`
 }
 


### PR DESCRIPTION
Golang v1.10 (and probably later) doesn't like spaces in the tag names.

Fixes CC-4129.