### PR TITLE
Add deadlock detection support to healthchecks

### DIFF
--- a/domain/service/validation.go
+++ b/domain/service/validation.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The Serviced Authors.
+// Copyright 2014-2018 The Serviced Authors.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -48,6 +48,10 @@ func (s *Service) ValidEntity() error {
 
 	for _, ep := range s.Endpoints {
 		vErr.Add(ep.ValidEntity())
+	}
+
+	for _, hc := range s.HealthChecks {
+		vErr.Add(hc.ValidEntity())
 	}
 
 	if vErr.HasError() {

--- a/health/validation.go
+++ b/health/validation.go
@@ -1,0 +1,31 @@
+// Copyright 2018 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"fmt"
+	"github.com/control-center/serviced/validation"
+)
+
+func (hc HealthCheck) ValidEntity() error {
+	violations := validation.NewValidationError()
+	if len(hc.KillExitCodes) > 0 && hc.KillCountLimit == 0 {
+		violations.Add(fmt.Errorf("the KillCountLimit must be set if KillExitCodes are specified"))
+	}
+
+	if violations.HasError() {
+		return violations
+	}
+	return nil
+}

--- a/health/validation_test.go
+++ b/health/validation_test.go
@@ -1,0 +1,39 @@
+// Copyright 2018 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package health_test
+
+import (
+	. "github.com/control-center/serviced/health"
+	. "gopkg.in/check.v1"
+)
+
+type ValidationSuite struct{}
+
+var _ = Suite(&ValidationSuite{})
+
+func (vs *ValidationSuite) Test_Validation_Invalid_HealthCheck(c *C) {
+	// health checks with kill exit codes must set a kill limit
+	hc := HealthCheck{
+		KillExitCodes: []int{28},
+	}
+	err := hc.ValidEntity()
+	c.Assert(err, NotNil)
+
+	// make sure this is valid if we specify the limit
+	hc.KillCountLimit = 3
+	err = hc.ValidEntity()
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
https://jira.zenoss.com/browse/CC-3559

Add support to Control Center to detect specific error codes in the healthcheck, and restart if it detects that error code n-times in a row.