### PR TITLE
ZING-1632 - fix leaking connections from api_key_proxy healthcheck

### DIFF
--- a/isvcs/api_key_proxy.go
+++ b/isvcs/api_key_proxy.go
@@ -161,7 +161,7 @@ func CheckURL(TestURL string) error {
 	defer tlsTransport.CloseIdleConnections()
 
 	resp, err := tlsClient.Get(TestURL)
-	if resp != nil {
+	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	}
 	if err != nil {


### PR DESCRIPTION
We recently discovered that the api_key_proxy isvc was leaking connections, which led to failing healthchecks after a system has been up for a little less than 10 days. 

This PR addresses that by being more aggressive about reading the body (even if error is non-nil), and also by allocating the Transport object in a global scope, rather than each time the function is called.