### PR TITLE
CC-4162: Fix 'slice bounds out of range' in recvLoop on big responses

### DIFF
--- a/vendor/github.com/control-center/go-zookeeper/zk/conn.go
+++ b/vendor/github.com/control-center/go-zookeeper/zk/conn.go
@@ -653,7 +653,7 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 
 		if res.Xid == -1 {
 			res := &watcherEvent{}
-			_, err := decodePacket(buf[16:16+blen], res)
+			_, err := decodePacket(buf[16:blen], res)
 			if err != nil {
 				return err
 			}
@@ -710,7 +710,7 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 				if res.Err != 0 {
 					err = res.Err.toError()
 				} else {
-					_, err = decodePacket(buf[16:16+blen], req.recvStruct)
+					_, err = decodePacket(buf[16:blen], req.recvStruct)
 				}
 				if req.recvFunc != nil {
 					req.recvFunc(req, &res, err)


### PR DESCRIPTION
https://github.com/control-center/go-zookeeper/pull/6