### PR TITLE
Add timezone support to serviced shell

### DIFF
--- a/cli/cmd/pool_test.go
+++ b/cli/cmd/pool_test.go
@@ -280,7 +280,7 @@ func TestServicedCLI_CmdPoolAdd_perm(t *testing.T) {
 	test := EmptyPoolAPI()
 	assertPerm := func(poolID string, expected pool.Permission) {
 		if p, err := test.GetResourcePool(poolID); err != nil {
-			t.Fatalf("GetResourcePool(\"%s\"): %s", err.Error())
+			t.Fatalf("GetResourcePool(\"%s\"): %s", poolID, err.Error())
 		} else {
 			if p.Permissions != expected {
 				t.Fatalf("Unexpected Permission for %s: %d != %d", poolID, p.Permissions, expected)
@@ -419,7 +419,7 @@ func TestServicedCLI_CmdPoolSetPermission(t *testing.T) {
 	test := EmptyPoolAPI()
 	assertPerm := func(poolID string, expected pool.Permission) {
 		if p, err := test.GetResourcePool(poolID); err != nil {
-			t.Fatalf("GetResourcePool(\"%s\"): %s", err.Error())
+			t.Fatalf("GetResourcePool(\"%s\"): %s", poolID, err.Error())
 		} else {
 			if p.Permissions != expected {
 				t.Fatalf("Unexpected Permission for %s: %d != %d", poolID, p.Permissions, expected)

--- a/isvcs/manager.go
+++ b/isvcs/manager.go
@@ -175,7 +175,7 @@ func (m *Manager) GetHealthStatus(name string, instIndex int) (IServiceHealthRes
 			"isvc": 		name,
 			"instIndex":	instIndex,
 		}).Error("Instance index out of range")
-		return IServiceHealthResult{}, fmt.Errorf("Instance index out of range %i", instIndex)
+		return IServiceHealthResult{}, fmt.Errorf("Instance index out of range %d", instIndex)
 	}
 
 	return result, nil

--- a/rpc/rpcutils/client_test.go
+++ b/rpc/rpcutils/client_test.go
@@ -356,7 +356,7 @@ func (s *MySuite) TestConcurrentClientCalls(c *C) {
 	echoStrings := make([]string, numCalls)
 
 	for i := 0; i < numCalls; i++ {
-		echoStrings[i] = fmt.Sprintf("String%s", i)
+		echoStrings[i] = fmt.Sprintf("String%d", i)
 	}
 	wg := sync.WaitGroup{}
 	for _, s := range echoStrings {

--- a/shell/interfaces.go
+++ b/shell/interfaces.go
@@ -35,6 +35,7 @@ type ProcessServer struct {
 	actor ProcessActor
 }
 
+// ProcessConfig - Configuration of process running the shell
 type ProcessConfig struct {
 	ServiceID   string
 	IsTTY       bool

--- a/shell/interfaces.go
+++ b/shell/interfaces.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Shell package.
+// Package shell - Run serviced shells
 package shell
 
 import (
@@ -20,12 +20,14 @@ import (
 	"time"
 )
 
-// Describes whether a process terminated normally or abnormally
+// Termination - Describes whether a process terminated normally or abnormally
 type Termination int
 
 const (
-	NORMAL   Termination = iota // Process terminated normally
-	ABNORMAL                    // Process terminated abnormally
+	// NORMAL - Process terminated normally
+	NORMAL Termination = iota
+	// ABNORMAL - Process terminated abnormally
+	ABNORMAL
 )
 
 type ProcessServer struct {

--- a/shell/server.go
+++ b/shell/server.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/control-center/go-socket.io"
 
+	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/logging"
 	worker "github.com/control-center/serviced/rpc/agent"
 	"github.com/control-center/serviced/rpc/master"
@@ -37,15 +38,15 @@ import (
 var (
 	empty interface{}
 
+	// ErrShellDisabled - Shell disabled error message
 	ErrShellDisabled = errors.New("shell has been disabled for this service")
 
 	plog = logging.PackageLogger()
 )
 
 const (
-	PROCESSKEY      string = "process"
+	PROCESSKEY string = "process"
 )
-
 
 func NewProcessForwarderServer(addr string) *ProcessServer {
 	server := &ProcessServer{
@@ -59,6 +60,7 @@ func NewProcessForwarderServer(addr string) *ProcessServer {
 	return server
 }
 
+// NewProcessExecutorServer - Create and return a processServer instance
 func NewProcessExecutorServer(masterAddress, agentAddress, dockerRegistry, controllerBinary string) *ProcessServer {
 	server := &ProcessServer{
 		sio:   socketio.NewSocketIOServer(&socketio.Config{}),
@@ -72,13 +74,13 @@ func NewProcessExecutorServer(masterAddress, agentAddress, dockerRegistry, contr
 	return server
 }
 
-func (p *ProcessServer) Handle(pattern string, handler http.Handler) error {
-	p.sio.Handle(pattern, handler)
+func (s *ProcessServer) Handle(pattern string, handler http.Handler) error {
+	s.sio.Handle(pattern, handler)
 	return nil
 }
 
-func (p *ProcessServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	p.sio.ServeHTTP(w, r)
+func (s *ProcessServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.sio.ServeHTTP(w, r)
 }
 
 func (s *ProcessServer) onProcess(ns *socketio.NameSpace, cfg *ProcessConfig) {
@@ -313,6 +315,7 @@ func parseMountArg(arg string) (hostPath, containerPath string, err error) {
 
 }
 
+// StartDocker - Start a docker container
 func StartDocker(cfg *ProcessConfig, masterAddress, workerAddress, dockerRegistry, controller string) (*exec.Cmd, error) {
 	logger := plog.WithFields(log.Fields{
 		"masteraddress":   masterAddress,
@@ -335,8 +338,9 @@ func StartDocker(cfg *ProcessConfig, masterAddress, workerAddress, dockerRegistr
 		return nil, err
 	}
 
-	// can we create a shell for this service?
 	logger = logger.WithField("servicename", svc.Name)
+
+	// can we create a shell for this service?
 	if svc.DisableShell {
 		logger.Warning("Shell commands are disabled for service")
 		return nil, ErrShellDisabled
@@ -352,7 +356,9 @@ func StartDocker(cfg *ProcessConfig, masterAddress, workerAddress, dockerRegistr
 		return nil, err
 	}
 	defer workerClient.Close()
+
 	logger = logger.WithField("imageid", svc.ImageID)
+
 	logger.Info("Connected to delegate; pulling image")
 	image, err := workerClient.PullImage(dockerRegistry, svc.ImageID, time.Minute)
 	if err != nil {
@@ -361,52 +367,63 @@ func StartDocker(cfg *ProcessConfig, masterAddress, workerAddress, dockerRegistr
 	}
 	logger.Info("Pulled image, setting up shell")
 
-	dir, binary := filepath.Split(controller)
-	servicedVolume := fmt.Sprintf("%s:/serviced", dir)
-
-	// bind mount the pwd
-	dir, err = os.Getwd()
-	pwdVolume := fmt.Sprintf("%s:/mnt/pwd", dir)
-
-	// get the shell command
-	shellcmd := cfg.Command
-	if cfg.Command == "" {
-		shellcmd = "su -"
-	}
-
-	// get the serviced command
-	svcdcmd := fmt.Sprintf("/serviced/%s", binary)
-
-	// get the proxy command
-	proxycmd := []string{
-		svcdcmd,
-		fmt.Sprintf("--logtostderr=%t", cfg.LogToStderr),
-		"--autorestart=false",
-		"--disable-metric-forwarding",
-		fmt.Sprintf("--logstash=%t", cfg.LogStash.Enable),
-		fmt.Sprintf("--logstash-settle-time=%s", cfg.LogStash.SettleTime),
-		svc.ID,
-		"0",
-		shellcmd,
-	}
-
 	// get the docker start command
 	docker, err := exec.LookPath("docker")
 	if err != nil {
 		logger.WithError(err).Error("Docker not found")
 		return nil, err
 	}
-	resourceBinding := fmt.Sprintf("%s:%s", utils.ResourcesDir(), utils.RESOURCES_CONTAINER_DIRECTORY )
-	argv := []string{"run", "-v", servicedVolume, "-v", pwdVolume, "-v", resourceBinding, "-u", "root", "-w", "/"}
+
+	argv := buildDockerArgs(osWrapImpl{}, svc, cfg, controller, docker, image)
+	logger.Debugf("command: docker %+v", argv)
+	logger.Info("Shell initialized for service, starting")
+	return exec.Command(docker, argv...), nil
+}
+
+// Wrap the use of os.Getwd and os.Getenv so that the output of those
+// functions can be controlled for testing purposes.
+type osWrap interface {
+	Getwd() (string, error)
+	Getenv(key string) string
+}
+
+type osWrapImpl struct {
+}
+
+func (osWrapImpl) Getwd() (string, error) {
+	return os.Getwd()
+}
+
+func (osWrapImpl) Getenv(key string) string {
+	return os.Getenv(key)
+}
+
+func buildDockerArgs(wrap osWrap, svc *service.Service, cfg *ProcessConfig, controller string, docker string, image string) []string {
+	argv := []string{"run", "-u", "root", "-w", "/"}
+
+	dir, binary := filepath.Split(controller)
+	servicedVolume := fmt.Sprintf("%s:/serviced", dir)
+
+	// bind mount the current directory
+	dir, _ = wrap.Getwd()
+	pwdVolume := fmt.Sprintf("%s:/mnt/pwd", dir)
+
+	resourceBinding := fmt.Sprintf("%s:%s", utils.ResourcesDir(), utils.RESOURCES_CONTAINER_DIRECTORY)
+
+	// add the mount volume arguments
+	argv = append(
+		argv,
+		"-v", servicedVolume,
+		"-v", pwdVolume,
+		"-v", resourceBinding,
+	)
 	for _, mount := range cfg.Mount {
-		hostPath, containerPath, err := parseMountArg(mount)
-		if err != nil {
-			return nil, err
+		hostPath, containerPath, _ := parseMountArg(mount)
+		if len(hostPath) == 0 {
+			continue
 		}
 		argv = append(argv, "-v", fmt.Sprintf("%s:%s", hostPath, containerPath))
 	}
-
-	argv = append(argv, cfg.Envv...)
 
 	if cfg.SaveAs != "" {
 		argv = append(argv, fmt.Sprintf("--name=%s", cfg.SaveAs))
@@ -418,17 +435,43 @@ func StartDocker(cfg *ProcessConfig, masterAddress, workerAddress, dockerRegistr
 		argv = append(argv, "-i", "-t")
 	}
 
-	argv = append(argv, "-e", fmt.Sprintf("SERVICED_VERSION=%s ", servicedversion.Version))
-	argv = append(argv, "-e", fmt.Sprintf("SERVICED_NOREGISTRY=%s", os.Getenv("SERVICED_NOREGISTRY")))
-	argv = append(argv, "-e", fmt.Sprintf("SERVICED_IS_SERVICE_SHELL=true"))
-	argv = append(argv, "-e", fmt.Sprintf("SERVICED_SERVICE_IMAGE=%s", image))
-	//The SERVICED_UI_PORT environment variable is deprecated and services should always use port 443 to contact serviced from inside a container
-	argv = append(argv, "-e", "SERVICED_UI_PORT=443")
+	// Add the environment variables
+	argv = append(
+		argv,
+		"-e", fmt.Sprintf("SERVICED_VERSION=%s ", servicedversion.Version),
+		"-e", fmt.Sprintf("SERVICED_NOREGISTRY=%s", wrap.Getenv("SERVICED_NOREGISTRY")),
+		"-e", "SERVICED_IS_SERVICE_SHELL=true",
+		"-e", fmt.Sprintf("SERVICED_SERVICE_IMAGE=%s", image),
+		//The SERVICED_UI_PORT environment variable is deprecated and services
+		//should always use port 443 to contact serviced from inside a container
+		"-e", "SERVICED_UI_PORT=443",
+	)
+	tz := wrap.Getenv("TZ")
+	if len(tz) > 0 {
+		argv = append(argv, "-e", fmt.Sprintf("TZ=%s", tz))
+	}
 
 	argv = append(argv, image)
-	argv = append(argv, proxycmd...)
 
-	logger.Debugf("command: docker %+v", argv)
-	logger.Info("Shell initialized for service, starting")
-	return exec.Command(docker, argv...), nil
+	// get the shell command
+	shellcmd := cfg.Command
+	if cfg.Command == "" {
+		shellcmd = "su -"
+	}
+
+	// get the proxy command
+	argv = append(
+		argv,
+		fmt.Sprintf("/serviced/%s", binary),
+		fmt.Sprintf("--logtostderr=%t", cfg.LogToStderr),
+		"--autorestart=false",
+		"--disable-metric-forwarding",
+		fmt.Sprintf("--logstash=%t", cfg.LogStash.Enable),
+		fmt.Sprintf("--logstash-settle-time=%s", cfg.LogStash.SettleTime),
+		svc.ID,
+		"0",
+		shellcmd,
+	)
+
+	return argv
 }

--- a/shell/server.go
+++ b/shell/server.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/control-center/go-socket.io"
 
-	"github.com/control-center/serviced/domain/service"
 	"github.com/control-center/serviced/logging"
 	worker "github.com/control-center/serviced/rpc/agent"
 	"github.com/control-center/serviced/rpc/master"
@@ -45,8 +44,6 @@ var (
 
 const (
 	PROCESSKEY      string = "process"
-	MAXBUFFER       int    = 8192
-	DOCKER_ENDPOINT        = "unix:///var/run/docker.sock"
 )
 
 
@@ -331,8 +328,9 @@ func StartDocker(cfg *ProcessConfig, masterAddress, workerAddress, dockerRegistr
 	}
 	defer masterClient.Close()
 	logger.Info("Connected to master")
-	svc := &service.Service{}
-	if svc, err = masterClient.GetService(cfg.ServiceID); err != nil {
+
+	svc, err := masterClient.GetService(cfg.ServiceID)
+	if err != nil {
 		logger.WithError(err).Error("Could not get services")
 		return nil, err
 	}

--- a/shell/server_test.go
+++ b/shell/server_test.go
@@ -1,0 +1,183 @@
+// Copyright 2019 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package shell
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/control-center/serviced/domain/service"
+	"github.com/control-center/serviced/servicedversion"
+	"github.com/control-center/serviced/utils"
+)
+
+type osMock struct {
+	wd string
+	env map[string]string
+}
+
+func (m osMock) Getwd() (string, error) {
+	return m.wd, nil
+}
+
+func (m osMock) Getenv(key string) string {
+	return m.env[key]
+}
+
+func makeOsMock(tz string) osMock {
+	mock := osMock{
+		wd: "/home/zenoss",
+		env: map[string]string{
+			"SERVICED_NOREGISTRY": "1",
+		},
+	}
+	if len(tz) > 0 {
+		mock.env["TZ"] = tz
+	}
+	return mock
+}
+
+func makeService() service.Service {
+	return service.Service{
+		ID: "abcd-1234",
+		Name: "Abcd",
+		ImageID: "imageAbcd",
+		DisableShell: false,
+	}
+}
+
+func makeProcessConfig(isTTY bool, saveAs string, command string) ProcessConfig {
+	config := ProcessConfig{
+		IsTTY: isTTY,
+		Mount: []string{
+			"/home/dir/source,/mnt/src",
+			"/opt/zenoss",
+		},
+		LogToStderr: true,
+		LogStash: struct {
+			Enable bool
+			SettleTime time.Duration
+		}{
+			Enable: true,
+			SettleTime: 1000000,
+		},
+	}
+	if len(saveAs) > 0 {
+		config.SaveAs = saveAs
+	}
+	if len(command) > 0 {
+		config.Command = command
+	}
+	return config
+}
+
+func makeExpectedResult(image string, o *osMock, s *service.Service, c *ProcessConfig) []string {
+	volumeCurrentDir := fmt.Sprintf("%s:/mnt/pwd", o.wd)
+	volumeResources := fmt.Sprintf(
+		"%s:%s", utils.ResourcesDir(), utils.RESOURCES_CONTAINER_DIRECTORY,
+	)
+	servicedVersion := fmt.Sprintf("SERVICED_VERSION=%s ", servicedversion.Version)
+	servicedNoRegistry := fmt.Sprintf("SERVICED_NOREGISTRY=%s", o.env["SERVICED_NOREGISTRY"])
+	servicedServiceImage := fmt.Sprintf("SERVICED_SERVICE_IMAGE=%s", image)
+
+	expected := []string{
+		"run", "-u", "root", "-w", "/",
+		"-v", "/opt/serviced/bin/:/serviced",
+		"-v", volumeCurrentDir,
+		"-v", volumeResources,
+		"-v", "/home/dir/source:/mnt/src",
+		"-v", "/opt/zenoss:/opt/zenoss",
+	}
+
+	if len(c.SaveAs) > 0 {
+		expected = append(expected, "--name=imageName")
+	} else {
+		expected = append(expected, "--rm")
+	}
+
+	if c.IsTTY {
+		expected = append(expected, "-i", "-t")
+	}
+
+	expected = append(
+		expected,
+		"-e", servicedVersion,
+		"-e", servicedNoRegistry,
+		"-e", "SERVICED_IS_SERVICE_SHELL=true",
+		"-e", servicedServiceImage,
+		"-e", "SERVICED_UI_PORT=443",
+	)
+
+	val, ok := o.env["TZ"]
+	if ok {
+		expected = append(expected, "-e", fmt.Sprintf("TZ=%s", val))
+	}
+
+	expected = append(
+		expected,
+		image,
+		"/serviced/serviced-controller",
+		"--logtostderr=true",
+		"--autorestart=false",
+		"--disable-metric-forwarding",
+		"--logstash=true",
+		"--logstash-settle-time=1ms",
+		"abcd-1234",
+		"0",
+	)
+
+	if len(c.Command) > 0 {
+		expected = append(expected, c.Command)
+	} else {
+		expected = append(expected, "su -")
+	}
+
+	return expected
+}
+
+func TestBuildDockerArgs(t *testing.T) {
+	controller := "/opt/serviced/bin/serviced-controller"
+	docker := "/usr/bin/docker"
+	image := "baseImage"
+
+	svc := makeService()
+
+	cases := []struct{
+		id string
+		mock osMock
+		cfg ProcessConfig
+	}{
+		{"Case0", makeOsMock(""), makeProcessConfig(true, "imageName", "bash")},
+		{"Case1", makeOsMock(""), makeProcessConfig(true, "", "bash")},
+		{"Case2", makeOsMock(""), makeProcessConfig(false, "", "bash")},
+		{"Case3", makeOsMock(""), makeProcessConfig(false, "", "")},
+		{"Case4", makeOsMock("TZ"), makeProcessConfig(false, "", "")},
+		{"Case5", makeOsMock("TZ"), makeProcessConfig(true, "", "")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			expected := makeExpectedResult(image, &tc.mock, &svc, &tc.cfg)
+			actual := buildDockerArgs(tc.mock, &svc, &tc.cfg, controller, docker, image)
+
+			assert := assert.New(t)
+			assert.NotNil(actual)
+			assert.Equal(expected, actual)
+		})
+	}
+}

--- a/web/servicetemplateresource_test.go
+++ b/web/servicetemplateresource_test.go
@@ -251,7 +251,7 @@ func (s *TestWebSuite) TestRestDeployAppTemplateStatusFails(c *C) {
 		On("DeployTemplateStatus", deploymentID, lastStatus, time.Duration(timeout)*time.Millisecond).
 		Return("", expectedError)
 
-	fmt.Printf("%+x\n%s\n%+x\n", payload, requestJSON, request)
+	fmt.Printf("%+x\n%s\n%+v\n", payload, requestJSON, request)
 	restDeployAppTemplateStatus(&(s.writer), &request, s.ctx)
 
 	s.assertAltServerError(c, expectedError)


### PR DESCRIPTION
With this fix, running `zendev devshell` will set the container's timezone to the `TZ` option set in serviced's config file.

Fixes CC-4178.