### PR TITLE
CC-4183: serviced service rm doesn't return fail code when service do…

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -112,6 +112,7 @@ Note: on a local developer setup, please set the following in your env or at cmd
 ```
 SERVICED_ETC_PATH=$(zendev root)/opt_serviced/etc
 SERVICED_ISVCS_PATH=$(zendev root)/opt_serviced/var/isvcs 
+SERVICED_BINARY=$(which serviced)
 ```
 
 #### UI acceptance

--- a/cli/cmd/service.go
+++ b/cli/cmd/service.go
@@ -1277,7 +1277,8 @@ func (c *ServicedCli) cmdServiceRemove(ctx *cli.Context) {
 	svc, _, err := c.searchForService(ctx.Args().First(), ctx.Bool("no-prefix-match"))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		c.exit(1)
+		// Don't return an error if the service doesn't exist. Philosophically not a error
+		c.exit(0)
 		return
 	}
 	serviceID := svc.ID


### PR DESCRIPTION
…esn't exist to fix merge tests, and a doc enhancement for running acceptance tests