### PR TITLE
CC-4209 Disable OOMKiller on Databases

### DIFF
--- a/dita/topics/svcdef-object.dita
+++ b/dita/topics/svcdef-object.dita
@@ -121,6 +121,16 @@
                 extended privileges. </entry>
           </row>
           <row>
+            <entry><codeph>OomKillDisable</codeph></entry>
+            <entry><codeph>true</codeph> or <codeph>false</codeph></entry>
+            <entry>Whether to disable OOM Killer for the container or not.</entry>
+          </row>
+          <row>
+            <entry><codeph>OomScoreAdj</codeph></entry>
+            <entry>int64</entry>
+            <entry>Tune containers OOM preferences (-1000 to 1000)</entry>
+          </row>
+          <row>
             <entry><codeph>ConfigFiles</codeph></entry>
             <entry>Objects</entry>
             <entry>The configuration file templates to install in containers (in which instances of

--- a/domain/service/service.go
+++ b/domain/service/service.go
@@ -251,6 +251,8 @@ type Service struct {
 	MonitoringProfile domain.MonitorProfile
 	MemoryLimit       float64
 	CPUShares         int64
+	OomKillDisable    bool
+	OomScoreAdj       int64
 	PIDFile           string
 	// StartLevel represents the order in which services are started and stopped
 	// in normal operations.  All services of a given level start before any services
@@ -393,6 +395,8 @@ func BuildService(sd servicedefinition.ServiceDefinition, parentServiceID string
 	svc.PIDFile = sd.PIDFile
 	svc.StartLevel = sd.StartLevel
 	svc.EmergencyShutdownLevel = sd.EmergencyShutdownLevel
+	svc.OomKillDisable = sd.OomKillDisable
+	svc.OomScoreAdj = sd.OomScoreAdj
 
 	svc.Endpoints = make([]ServiceEndpoint, 0)
 	for _, ep := range sd.Endpoints {

--- a/domain/servicedefinition/servicedefinition.go
+++ b/domain/servicedefinition/servicedefinition.go
@@ -64,6 +64,8 @@ type ServiceDefinition struct {
 	MonitoringProfile      domain.MonitorProfile         // An optional list of queryable metrics, graphs, and thresholds
 	MemoryLimit            float64
 	CPUShares              int64
+	OomKillDisable         bool                   // Whether to disable OOM Killer for the container or not
+	OomScoreAdj            int64                  // Tune containers OOM preferences (-1000 to 1000)
 	PIDFile                string // An optional path or command to generate a path for a PID file to which signals are relayed.
 	StartLevel             uint   // Services start in the order implied by this field (low to high) and stopped in reverse order
 	EmergencyShutdownLevel uint   // In case of low storage, Services stopped in the order implied by this field (low to high)

--- a/node/container.go
+++ b/node/container.go
@@ -829,6 +829,12 @@ func (a *HostAgent) createContainerConfig(tenantID string, svc *service.Service,
 		hcfg.Privileged = true
 	}
 
+	if svc.OomKillDisable {
+		hcfg.OOMKillDisable = true
+	}
+
+	hcfg.OomScoreAdj = int(svc.OomScoreAdj)
+
 	// Memory and CpuShares should never be negative
 	if svc.MemoryLimit < 0 {
 		cfg.Memory = 0

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -64,6 +64,8 @@ type ContainerState struct {
 		Entrypoint      []string
 		NetworkDisabled bool
 		Privileged      bool
+		OomKillDisable  bool
+		OomScoreAdj     int
 	}
 	State struct {
 		Running   bool


### PR DESCRIPTION
Also, in addition, will update `zenoss-service` to provide `OomScoreAdj` and `OomKillDisable` parameters for services