### PR TITLE
Use bash when running services as a non-root ruser

### DIFF
--- a/userinfo/userinfo.go
+++ b/userinfo/userinfo.go
@@ -23,8 +23,10 @@ import (
 
 // Info has user info
 type Info struct {
-       UID uint32
-       GID uint32
+	UID      uint32
+	GID      uint32
+	HomeDir  string
+	Username string
 }
 
 func isMemeberOf(u *osuser.User, group *osuser.Group) (bool, error) {
@@ -93,10 +95,15 @@ func New(u string) (*Info, error) {
 		}
 
 		gid, err = strconv.Atoi(groupids[0])
-			if err != nil {
-				return nil, err
-			}
+		if err != nil {
+			return nil, err
 		}
+	}
 
-	return &Info{UID: uint32(uid), GID: uint32(gid)}, nil
+	return &Info{
+		UID:      uint32(uid),
+		GID:      uint32(gid),
+		HomeDir:  user.HomeDir,
+		Username: user.Username,
+	}, nil
 }


### PR DESCRIPTION
When serviced launches a service using a non-root user (given by the RunAs field), explicitly use the bash login shell to execute the Startup command.

Helps fix ZEN-32408.

Using a bash login shell to run services (as user zenoss) provides an environment that most Zenoss applications expect to be running in.

Also fixes zeneventserver's behavior in a zendev environment (it wouldn't start).