### PR TITLE
CC-4356 Fix handling of resource_already_exists_exception in postIndex

### DIFF
--- a/datastore/elastic/driver.go
+++ b/datastore/elastic/driver.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/control-center/serviced/datastore"
@@ -385,14 +384,14 @@ func (ed *elasticDriver) postIndex() error {
 
 	errResponse := true
 	if resp.StatusCode == 400 {
-		//ignore if 400 and IndexAlreadyExistsException
+		//ignore if 400 and resource_already_exists_exception
 		var result map[string]interface{}
 		err = json.Unmarshal(body, &result)
 		if err == nil {
-			if errString, found := result["error"]; found {
-				switch errString.(type) {
+			if errType, found := result["error"].(map[string]interface{})["type"]; found {
+				switch errType.(type) {
 				case string:
-					if strings.Contains(errString.(string), "IndexAlreadyExistsException") {
+					if errType.(string) == "resource_already_exists_exception" {
 						errResponse = false
 					}
 				}


### PR DESCRIPTION
In the new version of elasticsearch the API was changed. Earlier response
on bad request had the following form:
```
{
    "error":"IndexAlreadyExistsException[[controlplane] already exists]",
    "status":400
}
```

After elasticsearch upgrade, response on bad request has the following form:
```
{
    "error":
    {
        "root_cause":
        [
            {
                "type":"resource_already_exists_exception",
                "reason":"index [controlplane/RZG88vytQb6u2pkVR4Uzbg] already exists",
                "index_uuid":"RZG88vytQb6u2pkVR4Uzbg","index":"controlplane"
            }
        ],
        "type":"resource_already_exists_exception",
        "reason":"index [controlplane/RZG88vytQb6u2pkVR4Uzbg] already exists",
        "index_uuid":"RZG88vytQb6u2pkVR4Uzbg",
        "index":"controlplane"
    },
    "status":400
}
```

This commit updates code to handle new response in postIndex