### PR TITLE
CC-4419 Skipping Elasticsearch export on delegate hosts

### DIFF
--- a/pkg/rpm/postupgrade
+++ b/pkg/rpm/postupgrade
@@ -127,25 +127,24 @@ fi
 
 touch /etc/cron.d/cron_zenossdbpack
 
-echo "Creating a backup of elasticsearch-serviced data in $HOST_ISVCS_DIR"
-cp -ar $HOST_ISVCS_DIR/elasticsearch-serviced $HOST_ISVCS_DIR/elasticsearch-serviced.backup
-
 echo "Creating a backup of zookeeper data in $HOST_ISVCS_DIR"
 cp -ar $HOST_ISVCS_DIR/zookeeper $HOST_ISVCS_DIR/zookeeper.backup
-
-echo "Starting docker container elasticsearch-serviced ..."
-docker run --rm -d --name $SVC_NAME -p 9200:9200 \
-  -v $HOST_ES_DATA_DIR:$CONTAINER_ES_DATA_DIR zenoss/serviced-isvcs:v63 \
-  sh -c "$ELASTIC_BIN -f -Des.node.name=$NODE_NAME \
-  -Des.cluster.name=$CLUSTER_NAME"
 
 #
 # CC-4419: If Elasticsearch configuration file and data folder does not exist
 # on the delegate that migration shouldn't start
 #
-if [[ ! -d $HOST_ES_DATA_DIR ] || [ ! $CLUSTER_NAME ]]; then
+if [[ ! -d $HOST_ES_DATA_DIR ] || [ -z $CLUSTER_NAME ]]; then
     echo "Skipping elasticsearch export on delegate hosts"
 else
+    echo "Creating a backup of elasticsearch-serviced data in $HOST_ISVCS_DIR"
+    cp -ar $HOST_ISVCS_DIR/elasticsearch-serviced $HOST_ISVCS_DIR/elasticsearch-serviced.backup
+
+    echo "Starting docker container elasticsearch-serviced ..."
+    docker run --rm -d --name $SVC_NAME -p 9200:9200 \
+      -v $HOST_ES_DATA_DIR:$CONTAINER_ES_DATA_DIR zenoss/serviced-isvcs:v63 \
+      sh -c "$ELASTIC_BIN -f -Des.node.name=$NODE_NAME \
+      -Des.cluster.name=$CLUSTER_NAME"
 
     if check_elasticsearch; then
         report "SUCCESS" "Container started within timeout"
@@ -158,39 +157,39 @@ else
     else
         report "FAILURE" "Export failed try make the export manual"
     fi
-fi
 
-echo "Stopping the container with old elasticsearch"
-docker stop $SVC_NAME
+    echo "Stopping the container with old elasticsearch"
+    docker stop $SVC_NAME
+fi
 
 echo "Copying stub snapshot.0 file to zookeeper storage dir for migration"
 echo "from 3.4.x to 3.5.5 version according to the issue ZOOKEEPER-3056"
 mv $HOME_SERVICED/isvcs/resources/zookeeper/snapshot.0 \
   $HOST_ISVCS_DIR/zookeeper/data/version-2/
 
-echo "Preparing the host for data import to new elasticsearch storage"
-rm -rf ${HOST_ES_DATA_DIR:?}/*
-groupadd -f elastic -g 1001
-id -u 1001 &>/dev/null || useradd elastic -u 1001 -g 1001
-chown 1001:1001 -R $HOST_ES_DATA_DIR
-
 echo "Setting persistent vm.max_map_count in the sysctl.conf"
 echo vm.max_map_count=262144 >> /etc/sysctl.conf
 sysctl --system
-
-echo "Starting container with new elasticsearch"
-docker run --rm -d --name $SVC_NAME -p 9200:9200 \
-  -v $HOST_ES_DATA_DIR:$CONTAINER_ES_DATA_DIR zenoss/serviced-isvcs:v67 \
-  su elastic -c "$ELASTIC_BIN -Ecluster.initial_master_nodes=$NODE_NAME \
-  -Enode.name=$NODE_NAME -Ecluster.name=$CLUSTER_NAME"
-
 #
 # CC-4419: If Elasticsearch configuration file and data folder does not exist
 # on the delegate that migration shouldn't start
 #
-if [[ ! -d $HOST_ES_DATA_DIR ] || [ ! $CLUSTER_NAME ]]; then
+if [[ ! -d $HOST_ES_DATA_DIR ] || [ -z $CLUSTER_NAME ]]; then
     echo "Skipping elasticsearch import on delegate hosts"
 else
+
+    echo "Preparing the host for data import to new elasticsearch storage"
+    rm -rf ${HOST_ES_DATA_DIR:?}/*
+    groupadd -f elastic -g 1001
+    id -u 1001 &>/dev/null || useradd elastic -u 1001 -g 1001
+    chown 1001:1001 -R $HOST_ES_DATA_DIR
+
+    echo "Starting container with new elasticsearch"
+    docker run --rm -d --name $SVC_NAME -p 9200:9200 \
+      -v $HOST_ES_DATA_DIR:$CONTAINER_ES_DATA_DIR zenoss/serviced-isvcs:v67 \
+      su elastic -c "$ELASTIC_BIN -Ecluster.initial_master_nodes=$NODE_NAME \
+      -Enode.name=$NODE_NAME -Ecluster.name=$CLUSTER_NAME"
+
 
     if check_elasticsearch; then
         report "SUCCESS" "Container started within timeout"
@@ -201,10 +200,11 @@ else
     echo "Importing data to new elasticsearch"
     $HOME_SERVICED/bin/elastic -i -c $HOME_SERVICED/etc/es_cluster.ini \
       -f $HOST_ISVCS_DIR/elasticsearch_data.json
-fi
 
-echo "Stopping the container with new elasticsearch"
-docker stop $SVC_NAME
+    echo "Stopping the container with new elasticsearch"
+    docker stop $SVC_NAME
+
+fi
 
 echo "Removing data from old Hbase version"
 rm -rf /opt/serviced/var/isvcs/opentsdb/*

--- a/pkg/rpm/postupgrade
+++ b/pkg/rpm/postupgrade
@@ -134,7 +134,7 @@ cp -ar $HOST_ISVCS_DIR/zookeeper $HOST_ISVCS_DIR/zookeeper.backup
 # CC-4419: If Elasticsearch configuration file and data folder does not exist
 # on the delegate that migration shouldn't start
 #
-if [[ ! -d $HOST_ES_DATA_DIR ] || [ -z $CLUSTER_NAME ]]; then
+if [[ ! -d $HOST_ES_DATA_DIR || -z $CLUSTER_NAME ]]; then
     echo "Skipping elasticsearch export on delegate hosts"
 else
     echo "Creating a backup of elasticsearch-serviced data in $HOST_ISVCS_DIR"
@@ -174,7 +174,7 @@ sysctl --system
 # CC-4419: If Elasticsearch configuration file and data folder does not exist
 # on the delegate that migration shouldn't start
 #
-if [[ ! -d $HOST_ES_DATA_DIR ] || [ -z $CLUSTER_NAME ]]; then
+if [[ ! -d $HOST_ES_DATA_DIR || -z $CLUSTER_NAME ]]; then
     echo "Skipping elasticsearch import on delegate hosts"
 else
 

--- a/pkg/rpm/postupgrade
+++ b/pkg/rpm/postupgrade
@@ -10,6 +10,7 @@ CONTAINER_ES_DIR=/opt/elasticsearch-serviced
 SVC_NAME=/serviced-isvcs_elasticsearch-serviced
 NODE_NAME=elasticsearch-serviced
 CLUSTER_NAME=$(cat $HOST_ISVCS_DIR/elasticsearch-serviced.clustername)
+CLUSTER_NAME_FILE=$HOST_ISVCS_DIR/elasticsearch-serviced.clustername
 HOST_ES_DATA_DIR=$HOST_ISVCS_DIR/elasticsearch-serviced/data
 CONTAINER_ES_DATA_DIR=$CONTAINER_ES_DIR/data
 ELASTIC_BIN=$CONTAINER_ES_DIR/bin/elasticsearch
@@ -139,16 +140,25 @@ docker run --rm -d --name $SVC_NAME -p 9200:9200 \
   sh -c "$ELASTIC_BIN -f -Des.node.name=$NODE_NAME \
   -Des.cluster.name=$CLUSTER_NAME"
 
-if check_elasticsearch; then
-    report "SUCCESS" "Container started within timeout"
+#
+# CC-4419: If Elasticsearch configuration file and data folder does not exist
+# on the delegate that migration shouldn't start
+#
+if [[ ! -d $HOST_ES_DATA_DIR ] || [ ! -f $CLUSTER_NAME_FILE ]]; then
+    echo "Skipping elasticsearch export on delegate hosts"
 else
-    report "FAILURE" "Container failed to start within 120 seconds"
-fi
 
-if migrate_elasticsearch; then
-    report "SUCCESS" "Export completed"
-else
-    report "FAILURE" "Export failed try make the export manual"
+    if check_elasticsearch; then
+        report "SUCCESS" "Container started within timeout"
+    else
+        report "FAILURE" "Container failed to start within 120 seconds"
+    fi
+
+    if migrate_elasticsearch; then
+        report "SUCCESS" "Export completed"
+    else
+        report "FAILURE" "Export failed try make the export manual"
+    fi
 fi
 
 echo "Stopping the container with old elasticsearch"

--- a/pkg/rpm/postupgrade
+++ b/pkg/rpm/postupgrade
@@ -10,7 +10,6 @@ CONTAINER_ES_DIR=/opt/elasticsearch-serviced
 SVC_NAME=/serviced-isvcs_elasticsearch-serviced
 NODE_NAME=elasticsearch-serviced
 CLUSTER_NAME=$(cat $HOST_ISVCS_DIR/elasticsearch-serviced.clustername)
-CLUSTER_NAME_FILE=$HOST_ISVCS_DIR/elasticsearch-serviced.clustername
 HOST_ES_DATA_DIR=$HOST_ISVCS_DIR/elasticsearch-serviced/data
 CONTAINER_ES_DATA_DIR=$CONTAINER_ES_DIR/data
 ELASTIC_BIN=$CONTAINER_ES_DIR/bin/elasticsearch
@@ -144,7 +143,7 @@ docker run --rm -d --name $SVC_NAME -p 9200:9200 \
 # CC-4419: If Elasticsearch configuration file and data folder does not exist
 # on the delegate that migration shouldn't start
 #
-if [[ ! -d $HOST_ES_DATA_DIR ] || [ ! -f $CLUSTER_NAME_FILE ]]; then
+if [[ ! -d $HOST_ES_DATA_DIR ] || [ ! -f $CLUSTER_NAME ]]; then
     echo "Skipping elasticsearch export on delegate hosts"
 else
 
@@ -185,15 +184,24 @@ docker run --rm -d --name $SVC_NAME -p 9200:9200 \
   su elastic -c "$ELASTIC_BIN -Ecluster.initial_master_nodes=$NODE_NAME \
   -Enode.name=$NODE_NAME -Ecluster.name=$CLUSTER_NAME"
 
-if check_elasticsearch; then
-    report "SUCCESS" "Container started within timeout"
+#
+# CC-4419: If Elasticsearch configuration file and data folder does not exist
+# on the delegate that migration shouldn't start
+#
+if [[ ! -d $HOST_ES_DATA_DIR ] || [ ! -f $CLUSTER_NAME ]]; then
+    echo "Skipping elasticsearch import on delegate hosts"
 else
-    report "FAILURE" "Container failed to start within 120 seconds"
-fi
 
-echo "Importing data to new elasticsearch"
-$HOME_SERVICED/bin/elastic -i -c $HOME_SERVICED/etc/es_cluster.ini \
-  -f $HOST_ISVCS_DIR/elasticsearch_data.json
+    if check_elasticsearch; then
+        report "SUCCESS" "Container started within timeout"
+    else
+        report "FAILURE" "Container failed to start within 120 seconds"
+    fi
+
+    echo "Importing data to new elasticsearch"
+    $HOME_SERVICED/bin/elastic -i -c $HOME_SERVICED/etc/es_cluster.ini \
+      -f $HOST_ISVCS_DIR/elasticsearch_data.json
+fi
 
 echo "Stopping the container with new elasticsearch"
 docker stop $SVC_NAME

--- a/pkg/rpm/postupgrade
+++ b/pkg/rpm/postupgrade
@@ -143,7 +143,7 @@ docker run --rm -d --name $SVC_NAME -p 9200:9200 \
 # CC-4419: If Elasticsearch configuration file and data folder does not exist
 # on the delegate that migration shouldn't start
 #
-if [[ ! -d $HOST_ES_DATA_DIR ] || [ ! -f $CLUSTER_NAME ]]; then
+if [[ ! -d $HOST_ES_DATA_DIR ] || [ ! $CLUSTER_NAME ]]; then
     echo "Skipping elasticsearch export on delegate hosts"
 else
 
@@ -188,7 +188,7 @@ docker run --rm -d --name $SVC_NAME -p 9200:9200 \
 # CC-4419: If Elasticsearch configuration file and data folder does not exist
 # on the delegate that migration shouldn't start
 #
-if [[ ! -d $HOST_ES_DATA_DIR ] || [ ! -f $CLUSTER_NAME ]]; then
+if [[ ! -d $HOST_ES_DATA_DIR ] || [ ! $CLUSTER_NAME ]]; then
     echo "Skipping elasticsearch import on delegate hosts"
 else
 


### PR DESCRIPTION
Fixes CC-4419

Added condition for skipping elasticsearch migrations if
the delegate host doesn't have Elasticsearch cluster
configuration for CC