### PR TITLE
CC-4423 Upgrade СС 1.8.0 to 1.9.0 failure

### DIFF
--- a/pkg/rpm/postupgrade
+++ b/pkg/rpm/postupgrade
@@ -14,6 +14,7 @@ HOST_ES_DATA_DIR=$HOST_ISVCS_DIR/elasticsearch-serviced/data
 CONTAINER_ES_DATA_DIR=$CONTAINER_ES_DIR/data
 ELASTIC_BIN=$CONTAINER_ES_DIR/bin/elasticsearch
 SERVICED_LOG_DIR=/var/log/serviced
+PREUPGRADE_SERVICED_VER_FILE=/tmp/preupgrade-serviced-version.txt
 
 ################################################################################
 report() {
@@ -57,6 +58,14 @@ migrate_elasticsearch() {
         -f $HOST_ISVCS_DIR/elasticsearch_data.json &>/dev/null
     err=$?
     return $err
+}
+
+version_greater_equal() {
+    if [[ "$(printf '%s\n' "$2" "$1" | sort -V | head -n1)" = "$2" ]]; then 
+        return 0
+    else
+        return 1
+    fi
 }
 ################################################################################
 
@@ -126,6 +135,17 @@ if [[ -f /etc/cron.d/cron_zenossdbpack.backup ]]; then
 fi
 
 touch /etc/cron.d/cron_zenossdbpack
+
+# if preupgrade version of serviced >= 1.8.0 then ES and Zookeeper data
+# don't require migration
+if [[ -f $PREUPGRADE_SERVICED_VER_FILE ]]; then
+    PREUPGRADE_SERVICED_VER=$(cat $PREUPGRADE_SERVICED_VER_FILE)
+    echo "Preupgrade serviced version: $PREUPGRADE_SERVICED_VER"
+    if version_greater_equal $PREUPGRADE_SERVICED_VER "1.8.0"; then
+        echo "ElasticSearch and Zookeeper data don't require migration"
+        exit 0
+    fi
+fi
 
 echo "Creating a backup of elasticsearch-serviced data in $HOST_ISVCS_DIR"
 cp -ar $HOST_ISVCS_DIR/elasticsearch-serviced $HOST_ISVCS_DIR/elasticsearch-serviced.backup

--- a/pkg/rpm/preupgrade
+++ b/pkg/rpm/preupgrade
@@ -26,6 +26,7 @@ import sys
 
 
 SERVICED_CONFIG="/etc/default/serviced"
+SERVICED_VERSION_FILE="/tmp/preupgrade-serviced-version.txt"
 C_RESET  = '\033[0m'
 C_BOLD   = C_RESET + '\033[1m'
 C_WARN   = C_RESET + '\033[93m'
@@ -349,6 +350,22 @@ def get_docker_version():
     return version
 
 
+def get_serviced_version():
+    """
+    Returns the version of serviced currently installed
+    """
+    # awk/grep isn't grabbing just the version.. parse it out.
+    version = subprocess.check_output("serviced version | grep '^Version' | head -1 || true", shell=True).strip()
+    version = [s for s in version.split(' ') if not s == '']
+    if not version:
+        return
+    if len(version) > 1:
+        version = version[1].strip()
+    else:
+        version = version[0].strip()
+    return version
+
+
 def show_help():
     """
     Displays steps for downgrading docker from the now upgraded version to the version
@@ -381,6 +398,12 @@ def show_help():
         print '\nDocker and Control Center need to be restarted after rolling back the upgrade.%s\n' % C_RESET
     else:
         print 'If you cannot immediately expand storage, you can start Control Center now without upgrading.%s\n' % C_RESET
+
+# Save the preupgrade serviced version to check whether ElasticSearch and Zookeeper data should be migrated after upgrade
+serviced_version = get_serviced_version()
+if serviced_version:
+    with open(SERVICED_VERSION_FILE, 'w+') as file:
+        file.write(serviced_version)
 
 
 # If the os environment variable NOCHECK is set, skip this entirely.


### PR DESCRIPTION
Added check for serviced version. If preupgrade serviced version >= 1.8.0
then we don't need to migrate ElasticSearch and Zookeeper data