### PR TITLE
serviced-service tool manages service definitions.

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,6 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Turn off modules.
+# Starting with Go 1.17, modules are required and this variable is ignored.
+GO111MODULE = off
+export GO111MODULE
+
 VERSION := $(shell cat ./VERSION)
 DATE := $(shell date -u '+%a_%b_%d_%H:%M:%S_%Z_%Y')
 GO_VERSION := $(shell go version | awk '{print $$3}')
@@ -30,8 +35,8 @@ GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 GOBUILD_TAGS  ?= $(shell bash build-tags.sh)
 GOBUILD_FLAGS ?= -tags "$(GOBUILD_TAGS)"
 
-GOVETTARGETS := $(shell go list -f '{{.Dir}}' ./... | grep -v /vendor/ | grep -v '/serviced$$')
-GOSOURCEFILES := $(shell find `go list -f '{{.Dir}}' ./... | grep -v /vendor/` -maxdepth 1 -name \*.go)
+GOVETTARGETS = $(shell GO111MODULE=off go list -f '{{.Dir}}' ./... | grep -v /vendor/ | grep -v '/serviced$$')
+GOSOURCEFILES = $(shell find `GO111MODULE=off go list -f '{{.Dir}}' ./... | grep -v /vendor/` -maxdepth 1 -name \*.go)
 
 # jenkins default, jenkins-${JOB_NAME}-${BUILD_NUMBER}
 BUILD_TAG ?= 0
@@ -72,7 +77,7 @@ INSTALL_TEMPLATES_ONLY = 0
 PKG         = $(default_PKG) # deb | rpm | tgz
 default_PKG = deb
 
-build_TARGETS = build_isvcs build_js $(GOBIN)/serviced $(GOBIN)/serviced-storage $(GOBIN)/serviced-controller
+build_TARGETS = build_isvcs build_js $(GOBIN)/serviced $(GOBIN)/serviced-storage $(GOBIN)/serviced-controller $(GOBIN)/serviced-service
 
 # Define GOPATH for containerized builds.
 #
@@ -169,6 +174,9 @@ $(GOBIN)/serviced-controller: $(GOSOURCEFILES) | $(GOBIN)
 $(GOBIN)/serviced-storage: $(GOSOURCEFILES) | $(GOBIN)
 	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS} -o $@ ./tools/serviced-storage
 
+$(GOBIN)/serviced-service: $(GOSOURCEFILES) | $(GOBIN)
+	$(GO) build $(GOBUILD_FLAGS) ${LDFLAGS} -o $@ ./tools/serviced-service
+
 .PHONY: serviced
 serviced: $(GOBIN)/serviced
 
@@ -178,8 +186,11 @@ serviced-controller: $(GOBIN)/serviced-controller
 .PHONY: serviced-storage
 serviced-storage: $(GOBIN)/serviced-storage
 
+.PHONY: serviced-service
+serviced-service: $(GOBIN)/serviced-service
+
 .PHONY: go
-go: $(GOBIN)/serviced $(GOBIN)/serviced-controller $(GOBIN)/serviced-storage
+go: $(GOBIN)/serviced $(GOBIN)/serviced-controller $(GOBIN)/serviced-storage $(GOBIN)/serviced-service
 
 #
 # BUILD_VERSION is the version of the serviced-build docker image
@@ -509,6 +520,7 @@ clean_serviced:
 	rm -rf $(GOBIN)/serviced
 	rm -rf $(GOBIN)/serviced-storage
 	rm -rf $(GOBIN)/serviced-controller
+	rm -rf $(GOBIN)/serviced-service
 
 .PHONY: clean_pkg
 clean_pkg:

--- a/tools/serviced-service/compile.go
+++ b/tools/serviced-service/compile.go
@@ -1,0 +1,114 @@
+// Copyright 2020 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/jessevdk/go-flags"
+
+	"github.com/control-center/serviced/cli/api"
+	template "github.com/control-center/serviced/domain/servicetemplate"
+	version "github.com/control-center/serviced/servicedversion"
+)
+
+// Compile is the subcommand for compiling a directory of service templates
+type Compile struct {
+	MapArgs     []string `long:"map" description:"Map a given image name to another"`
+	ExcludeArgs []string `long:"exclude" short:"x" description:"Exclude service or service folder"`
+	Args        struct {
+		Path flags.Filename `positional-arg-name:"PATH" description:"Path to template directory"`
+	} `positional-args:"yes" required:"yes"`
+}
+
+// Execute compiles the template directory
+func (c *Compile) Execute(args []string) error {
+	App.initializeLogging()
+	path := string(c.Args.Path)
+	log.Info("Path ", path)
+	imageMaps := api.ImageMap{}
+	for _, arg := range c.MapArgs {
+		if err := imageMaps.Set(arg); err != nil {
+			return err
+		}
+	}
+	for src, target := range imageMaps {
+		log.Info("Replace ", src, " with ", target)
+	}
+	if err := cmdCompile(path, imageMaps, c.ExcludeArgs); err != nil {
+		return err
+	}
+	return nil
+}
+
+type metaTemplate struct {
+	template.ServiceTemplate
+	ServicedVersion version.ServicedVersion
+	TemplateVersion map[string]string
+}
+
+// serviced-service compile DIR [[--map IMAGE,IMAGE] ...]
+func cmdCompile(path string, maps api.ImageMap, exclusions []string) error {
+	cfg := api.CompileTemplateConfig{
+		Dir: path,
+		Map: maps,
+	}
+
+	driver := api.New()
+
+	if template, err := driver.CompileServiceTemplate(cfg); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	} else if template == nil {
+		fmt.Fprintln(os.Stderr, "received nil template")
+	} else {
+		cmd := fmt.Sprintf("cd %s && git rev-parse HEAD", path)
+		commit, err := exec.Command("sh", "-c", cmd).Output()
+		if err != nil {
+			commit = []byte("unknown")
+		}
+		cmd = fmt.Sprintf("cd %s && git config --get remote.origin.url", path)
+		repo, err := exec.Command("sh", "-c", cmd).Output()
+		if err != nil {
+			repo = []byte("unknown")
+		}
+		cmd = fmt.Sprintf("cd %s && git rev-parse --abbrev-ref HEAD", path)
+		branch, err := exec.Command("sh", "-c", cmd).Output()
+		if err != nil {
+			branch = []byte("unknown")
+		}
+		cmd = fmt.Sprintf("cd %s && git describe --always", path)
+		tag, err := exec.Command("sh", "-c", cmd).Output()
+		if err != nil {
+			tag = []byte("unknown")
+		}
+		templateVersion := map[string]string{
+			"repo":   strings.Trim(string(repo), "\n"),
+			"branch": strings.Trim(string(branch), "\n"),
+			"tag":    strings.Trim(string(tag), "\n"),
+			"commit": strings.Trim(string(commit), "\n"),
+		}
+		mTemplate := metaTemplate{*template, version.GetVersion(), templateVersion}
+		jsonTemplate, err := json.MarshalIndent(mTemplate, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal template: %s", err)
+		}
+		fmt.Println(string(jsonTemplate))
+	}
+	return nil
+}

--- a/tools/serviced-service/deploy.go
+++ b/tools/serviced-service/deploy.go
@@ -1,0 +1,150 @@
+// Copyright 2020 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/control-center/serviced/domain/service"
+	definition "github.com/control-center/serviced/domain/servicedefinition"
+	template "github.com/control-center/serviced/domain/servicetemplate"
+)
+
+// Deploy is the subcommand for converting a service template into service definitions.
+type Deploy struct {
+	TenantID string `long:"tenant-id" default:"" description:"Tenant ID"`
+	Args     struct {
+		File flags.Filename `positional-arg-name:"TEMPLATE_FILE" description:"Template file"`
+	} `positional-args:"yes" required:"yes"`
+}
+
+// Execute converts a template file into service definitions.
+func (c *Deploy) Execute(args []string) error {
+	App.initializeLogging()
+	filepath := string(c.Args.File)
+
+	var err error
+
+	var tmpl *template.ServiceTemplate
+	tmpl, err = LoadTemplate(filepath)
+	if err != nil {
+		return err
+	}
+
+	var services = NewServiceList()
+	err = deploy(services, c.TenantID, "default", "test", "", false, tmpl.Services[0])
+	if err != nil {
+		return err
+	}
+
+	marshaled, err := json.MarshalIndent(services, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal template: %s", err)
+	}
+	fmt.Println(string(marshaled))
+
+	return nil
+}
+
+type deployInfo struct {
+	parentID string
+	template definition.ServiceDefinition
+}
+
+func deploy(
+	services *ServiceList,
+	tenantID, poolID, deploymentID, parentID string,
+	overwrite bool,
+	sd definition.ServiceDefinition,
+) error {
+	var err error
+	var queue = []deployInfo{}
+
+	queue = append(queue, deployInfo{parentID: parentID, template: sd})
+
+	var info deployInfo
+	var newsvc, oldsvc *service.Service
+	var child definition.ServiceDefinition
+
+	for len(queue) > 0 {
+		info, queue = queue[0], queue[1:]
+		newsvc, err = service.BuildService(
+			info.template, info.parentID, poolID, int(service.SVCStop), deploymentID,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"Could not build service from template %s: %s", info.template.Name, err,
+			)
+		}
+		if tenantID == "" {
+			tenantID = newsvc.ID
+		}
+
+		// Create a fake deployed image ID
+		if info.template.ImageID != "" {
+			newsvc.ImageID = makeImageID(tenantID, info.template)
+		}
+
+		oldsvc, err = services.FindChild(newsvc.ParentServiceID, newsvc.Name)
+		if err != nil {
+			return err
+		}
+		if oldsvc != nil {
+			if overwrite {
+				newsvc.ID = oldsvc.ID
+				newsvc.CreatedAt = oldsvc.CreatedAt
+
+			} else {
+				path, err := services.GetServicePath(oldsvc.ID)
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf("Service already exists: %s", path)
+			}
+		} else {
+			err = services.Append(*newsvc) // Copy the service into the ServiceList
+			if err != nil {
+				return err
+			}
+			err = newsvc.EvaluateEndpointTemplates(
+				services.GetService,
+				services.FindChildService,
+				0,
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to evaluate endpoint templates for service %s: %s",
+					info.template.Name, err,
+				)
+			}
+		}
+
+		// Add the service template's child services to the queue for processing.
+		for _, child = range info.template.Services {
+			queue = append(queue, deployInfo{parentID: newsvc.ID, template: child})
+		}
+	}
+	return nil
+}
+
+func makeImageID(tenantID string, tmpl definition.ServiceDefinition) string {
+	imageName := strings.Split(tmpl.ImageID, ":")[0]
+	parts := strings.Split(imageName, "/")
+	imageBaseName := parts[len(parts)-1]
+	return fmt.Sprintf("localhost:5000/%s/%s:latest", tenantID, imageBaseName)
+}

--- a/tools/serviced-service/main.go
+++ b/tools/serviced-service/main.go
@@ -1,0 +1,142 @@
+// Copyright 2020 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+serviced-service COMMAND ARGS
+
+Commands:
+	compile PATH
+		Compiles service templates in a directory into a single template file
+
+	deploy TEMPLATE_FILE
+		Converts a template into service definitions
+
+	update TEMPLATE_FILE SOURCE_FILE CHANGES
+		Applies the modifications in the CHANGES file to the SOURCE file.
+
+	version
+		Prints the version to stdout
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/jessevdk/go-flags"
+
+	"github.com/control-center/serviced/servicedversion"
+	"github.com/zenoss/glog"
+)
+
+var (
+	// Version is the version of this app
+	Version string
+	// GoVersion is the version of go compiler
+	GoVersion string
+	// Date is when the app was compiled
+	Date string
+	// Gitcommit is the git ref of source code that was compiled
+	Gitcommit string
+	// Gitbranch was the branch the source code is found in
+	Gitbranch string
+	// Buildtag is just some text identifying the build
+	Buildtag string
+
+	name = "serviced-service"
+	// App is the root object of the application
+	App = &ServicedService{
+		name:   name,
+		Parser: flags.NewNamedParser(name, flags.Default),
+	}
+)
+
+func init() {
+	servicedversion.Version = Version
+	servicedversion.GoVersion = GoVersion
+	servicedversion.Date = Date
+	servicedversion.Gitcommit = Gitcommit
+	servicedversion.Gitbranch = Gitbranch
+	servicedversion.Buildtag = Buildtag
+
+	App.version = fmt.Sprintf("%s - %s", servicedversion.Version, servicedversion.Gitcommit)
+
+	App.Parser.AddGroup("Global Options", "Global options", &App.Options)
+	App.Parser.AddCommand(
+		"compile",
+		"Convert a directory of templates into a single template",
+		"Convert a directory of templates into a single template",
+		&Compile{},
+	)
+	App.Parser.AddCommand(
+		"deploy",
+		"Convert a service template into service definitions",
+		"Convert a service template into service definitions",
+		&Deploy{},
+	)
+	App.Parser.AddCommand(
+		"update",
+		"Update service definitions",
+		"Update service definitions from an update file",
+		&Update{},
+	)
+	App.Parser.AddCommand(
+		"version",
+		"Print the version and exit",
+		"Print the version and exit",
+		&ServicedServiceVersion{},
+	)
+}
+
+// ServicedServiceOptions are the options for ServicedService
+type ServicedServiceOptions struct {
+	Verbose []bool `short:"v" description:"Display verbose logging"`
+}
+
+// ServicedService is the root data structure for the application
+type ServicedService struct {
+	name    string
+	version string
+	Parser  *flags.Parser
+	Options ServicedServiceOptions
+}
+
+// Run organizes the options for the application
+func (s *ServicedService) Run() {
+	// Set up some initial logging for the sake of parser errors
+	s.initializeLogging()
+	// if _, err := s.Parser.AddGroup("Basic Options", "Basic options", &s.Options); err != nil {
+	// 	log.WithFields(log.Fields{"exitcode": 1}).Fatal("Unable to add option group")
+	// 	os.Exit(1)
+	// }
+	s.Parser.Parse()
+}
+
+// initializeLogging initializes the logger for the application
+func (s *ServicedService) initializeLogging() {
+	log.SetOutput(os.Stderr)
+	level := log.WarnLevel + log.Level(len(App.Options.Verbose))
+	log.SetLevel(level)
+
+	// Include glog output if verbosity is enabled
+	if len(App.Options.Verbose) > 0 {
+		glog.SetToStderr(true)
+		glog.SetVerbosity(len(App.Options.Verbose))
+	}
+}
+
+func main() {
+	App.Run()
+}

--- a/tools/serviced-service/migrate.go
+++ b/tools/serviced-service/migrate.go
@@ -1,0 +1,181 @@
+// Copyright 2020 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	// log "github.com/Sirupsen/logrus"
+	"fmt"
+	"time"
+
+	"github.com/control-center/serviced/dao"
+	// "github.com/control-center/serviced/domain"
+	"github.com/control-center/serviced/domain/logfilter"
+	"github.com/control-center/serviced/domain/service"
+	// definition "github.com/control-center/serviced/domain/servicedefinition"
+	// "github.com/control-center/serviced/utils"
+)
+
+// MigrationContext is an entity for migrating services
+type MigrationContext struct {
+	services *ServiceList
+	filters  map[string]logfilter.LogFilter
+}
+
+// NewMigrationContext returns a new MigrationContext entity.
+func NewMigrationContext(services *ServiceList, filters map[string]logfilter.LogFilter) *MigrationContext {
+	return &MigrationContext{
+		services: services,
+		filters:  filters,
+	}
+}
+
+// Migrate performs a batch migration on a group of services.
+func (mc *MigrationContext) Migrate(req dao.ServiceMigrationRequest) (ServiceList, error) {
+
+	var err error
+
+	if err = mc.validate(req); err != nil {
+		return nil, err
+	}
+
+	// Migrate log filters
+	for _, filter := range req.LogFilters {
+		existing, found := mc.filters[filter.Name]
+		if !found {
+			mc.filters[filter.Name] = filter
+		} else {
+			existing.Filter = filter.Filter
+		}
+	}
+
+	// Process modified services
+	for _, svc := range req.Modified {
+		if err := mc.Update(svc); err != nil {
+			return nil, err
+		}
+	}
+
+	// Process newly added services
+	for _, svc := range req.Added {
+		if err := mc.Add(svc); err != nil {
+			return nil, err
+		}
+	}
+
+	// Process deployment requests for services from service definitions.
+	for _, sdreq := range req.Deploy {
+		if err := mc.Deploy(sdreq); err != nil {
+			return nil, err
+		}
+	}
+
+	return *mc.services, nil
+}
+
+// Update migrates an existing service; return error if the service does not exist
+func (mc *MigrationContext) Update(updated *service.Service) error {
+	// Updating an existing service effectively replaces the existing service with the given service.
+
+	var err error
+	var original *service.Service
+
+	original, err = mc.services.Get(updated.ID)
+	if err != nil {
+		return err
+	}
+
+	if updated.OriginalConfigs == nil {
+		updated.OriginalConfigs = original.OriginalConfigs
+	}
+	if updated.ConfigFiles == nil {
+		updated.ConfigFiles = original.ConfigFiles
+	}
+
+	updated.UpdatedAt = time.Now()
+
+	// The Put function will overwrite an existing service.
+	mc.services.Put(*updated)
+
+	return nil
+}
+
+// Add adds a service; return error if service already exists
+func (mc *MigrationContext) Add(svc *service.Service) error {
+	// Adding a service just adds the service.
+	// The service will behave as if it had been already deployed.
+
+	// var err error
+
+	// svc.ID, err = utils.NewUUID36()
+	// if err != nil {
+	// 	return err
+	// }
+
+	// if err := mc.validateAdd(svc); err != nil {
+	// 	return err
+	// }
+
+	svc.UpdatedAt = time.Now()
+	svc.CreatedAt = svc.UpdatedAt
+
+	mc.services.Append(*svc)
+
+	return nil
+}
+
+// Deploy converts a service definition to a service and deploys it under a specific service.
+func (mc *MigrationContext) Deploy(req *dao.ServiceDeploymentRequest) error {
+	var parent *service.Service
+	var err error
+
+	// Get the tenant ID (this is also the ID of the root service)
+	tenantID := mc.services.GetTenantID()
+	if tenantID == "" {
+		return fmt.Errorf("No tenant ID found")
+	}
+
+	if req.ParentID == "" {
+		return fmt.Errorf("No parent service ID specified")
+	}
+
+	// Get the parent service
+	parent, err = mc.services.Get(req.ParentID)
+	if err != nil {
+		return err
+	}
+
+	// Do some pool validation
+	var poolID = parent.PoolID
+	if req.PoolID != "" {
+		poolID = req.PoolID
+	}
+	if poolID == "" {
+		poolID = parent.PoolID
+	}
+
+	err = mc.validateName(req.Service.Name, req.ParentID)
+	if err != nil {
+		return err
+	}
+
+	return deploy(
+		mc.services,
+		tenantID,
+		poolID,
+		parent.DeploymentID,
+		parent.ID,
+		true,
+		req.Service,
+	)
+}

--- a/tools/serviced-service/service.go
+++ b/tools/serviced-service/service.go
@@ -1,0 +1,242 @@
+// Copyright 2020 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/control-center/serviced/domain/service"
+)
+
+// ServiceList is a collection of Service entities
+type ServiceList []service.Service
+
+// NewServiceList returns a new ServiceList entity.
+func NewServiceList() *ServiceList {
+	return &ServiceList{}
+}
+
+type stringsetvaluetype struct{}
+type stringset map[string]stringsetvaluetype
+
+var stringsetvalue stringsetvaluetype
+
+func newStringSet() stringset {
+	return make(stringset)
+}
+
+func (ss stringset) Contains(item string) bool {
+	_, found := ss[item]
+	return found
+}
+
+func (ss stringset) Add(item string) {
+	ss[item] = stringsetvalue
+}
+
+// UnmarshalJSON transforms a JSON encoded byte array into a ServiceList
+func (ss *ServiceList) UnmarshalJSON(b []byte) error {
+	var decoded []service.Service
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		return err
+	}
+	ss.Extend(decoded...)
+	return nil
+}
+
+// indexOf returns the index of the identified service in the ServiceList.
+// A value of -1 is returned if the service is not found.
+func (ss *ServiceList) indexOf(serviceID string) int {
+	for idx, existing := range *ss {
+		if existing.ID == serviceID {
+			return idx
+		}
+	}
+	return -1
+}
+
+// Extend adds one or more services to ServiceList.
+func (ss *ServiceList) Extend(items ...service.Service) error {
+	var serviceIDs = newStringSet()
+	var posn int
+	for _, svc := range items {
+		if !serviceIDs.Contains(svc.ID) {
+			serviceIDs.Add(svc.ID)
+		} else {
+			return fmt.Errorf("At least two services with the same ID, %v, were given", svc.ID)
+		}
+		posn = ss.indexOf(svc.ID)
+		if posn >= 0 {
+			return fmt.Errorf("Service %v already exists", svc.ID)
+		}
+	}
+	for _, svc := range items {
+		*ss = append(*ss, svc)
+	}
+	return nil
+}
+
+// Append adds a service to the ServiceList.
+// An error is returned if a service with the same ID already exists.
+func (ss *ServiceList) Append(svc service.Service) error {
+	var posn = ss.indexOf(svc.ID)
+	if posn >= 0 {
+		return fmt.Errorf("Service already in list")
+	}
+	*ss = append(*ss, svc)
+	if _, err := ss.Get(svc.ID); err != nil {
+		return fmt.Errorf("Service was not added to list  name=%v ID=%v", svc.Name, svc.ID)
+	}
+	return nil
+}
+
+// Put adds the service.
+// This function will overwrite a duplicate service.
+func (ss *ServiceList) Put(svc service.Service) {
+	var posn = ss.indexOf(svc.ID)
+	if posn >= 0 {
+		(*ss)[posn] = svc
+	} else {
+		*ss = append(*ss, svc)
+	}
+}
+
+// Len returns the number of items in the store.
+func (ss *ServiceList) Len() int {
+	return len(*ss)
+}
+
+// At returns the service at the given index.
+// An error is returned if the position is out of range.
+func (ss *ServiceList) At(posn uint) (*service.Service, error) {
+	if posn >= uint(len(*ss)) {
+		return nil, fmt.Errorf("Index out of range At(%v) with length %v", posn, len(*ss))
+	}
+	return &(*ss)[posn], nil
+}
+
+// Get returns the identified service.
+// An error is returned if the service is not found.
+func (ss *ServiceList) Get(serviceID string) (*service.Service, error) {
+	for idx, svc := range *ss {
+		if svc.ID == serviceID {
+			return &(*ss)[idx], nil
+		}
+	}
+	return nil, fmt.Errorf("Service not found with ID '%v'", serviceID)
+}
+
+// GetService returns a service having the given ID.
+func (ss *ServiceList) GetService(serviceID string) (service.Service, error) {
+	svc, err := ss.Get(serviceID)
+	if err != nil {
+		return service.Service{}, err
+	}
+	return *svc, nil
+}
+
+// GetServicePath returns the service's path.
+func (ss *ServiceList) GetServicePath(serviceID string) (string, error) {
+	var err error
+	var svc *service.Service
+
+	svc, err = ss.Get(serviceID)
+	if err != nil {
+		return "", err
+	}
+	if svc.ParentServiceID == "" {
+		return fmt.Sprintf("/%s", svc.Name), nil
+	}
+
+	var segments = []string{svc.Name}
+	for svc.ParentServiceID != "" {
+		svc, err = ss.Get(svc.ParentServiceID)
+		if err != nil {
+			return "", err
+		}
+		segments = append([]string{svc.Name}, segments...)
+	}
+	return fmt.Sprintf("/%s", strings.Join(segments, "/")), nil
+}
+
+// GetTenantID returns the tenant ID.
+// The tenant ID is the same ID as the service having no parent.
+func (ss *ServiceList) GetTenantID() string {
+	for _, svc := range *ss {
+		if svc.ParentServiceID == "" {
+			return svc.ID
+		}
+	}
+	return ""
+}
+
+// FindChild returns the service on the indicated path
+func (ss *ServiceList) FindChild(parentID, name string) (*service.Service, error) {
+	parentID = strings.TrimSpace(parentID)
+	name = strings.TrimSpace(name)
+
+	if name == "" {
+		return nil, fmt.Errorf("Empty service name not allowed")
+	}
+
+	for _, svc := range *ss {
+		if svc.ParentServiceID == parentID && svc.Name == name {
+			return &svc, nil
+		}
+	}
+	return nil, nil
+}
+
+// FindChildService returns the named service having the indicated parent service.
+func (ss *ServiceList) FindChildService(parentID, name string) (service.Service, error) {
+	svc, err := ss.FindChild(parentID, name)
+	if err != nil {
+		return service.Service{}, err
+	}
+	return *svc, nil
+}
+
+// Iterator returns an iterator over the ServiceList.
+func (ss *ServiceList) Iterator() *ServiceListIterator {
+	return &ServiceListIterator{
+		store: ss,
+		posn:  0,
+	}
+}
+
+// ServiceListIterator is an iterator over a ServiceList.
+type ServiceListIterator struct {
+	store *ServiceList
+	posn  uint
+}
+
+// Next advances the iterator and returns true if successful.
+func (ssi *ServiceListIterator) Next() bool {
+	if ssi.posn == uint(len(*(ssi.store))) {
+		return false
+	}
+	ssi.posn = ssi.posn + 1
+	return true
+}
+
+// Item returns the item the iterator currently points at.
+func (ssi *ServiceListIterator) Item() *service.Service {
+	value, err := ssi.store.At(ssi.posn - 1)
+	if err != nil {
+		panic(err)
+	}
+	return value
+}

--- a/tools/serviced-service/template.go
+++ b/tools/serviced-service/template.go
@@ -1,0 +1,39 @@
+// Copyright 2020 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	template "github.com/control-center/serviced/domain/servicetemplate"
+)
+
+// LoadTemplate loads the named service template file.
+func LoadTemplate(filepath string) (*template.ServiceTemplate, error) {
+	var input *os.File
+	var err error
+
+	if input, err = os.Open(filepath); err != nil {
+		return nil, err
+	}
+	defer input.Close()
+
+	var tmpl template.ServiceTemplate
+	if err = json.NewDecoder(input).Decode(&tmpl); err != nil {
+		return nil, fmt.Errorf("Could not read template: %s", err)
+	}
+	return &tmpl, nil
+}

--- a/tools/serviced-service/update.go
+++ b/tools/serviced-service/update.go
@@ -1,0 +1,133 @@
+// Copyright 2020 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/control-center/serviced/dao"
+	"github.com/control-center/serviced/domain/logfilter"
+	definition "github.com/control-center/serviced/domain/servicedefinition"
+	template "github.com/control-center/serviced/domain/servicetemplate"
+)
+
+// Update is the subcommand for updating definitions
+type Update struct {
+	Args struct {
+		TemplateFile flags.Filename `positional-arg-name:"TEMPLATE_FILE" description:"Compiled service template file (to get log filters)"`
+		ServicesFile flags.Filename `positional-arg-name:"SERVICES_FILE" description:"Deployed service definitions file"`
+		UpdateFile   flags.Filename `positional-arg-name:"UPDATE_FILE" description:"Update file (produced by servicemigration)"`
+	} `positional-args:"yes" required:"yes"`
+}
+
+// Execute compiles the template directory
+func (c *Update) Execute(args []string) error {
+	App.initializeLogging()
+	templatefile := string(c.Args.TemplateFile)
+	servicesfile := string(c.Args.ServicesFile)
+	updatefile := string(c.Args.UpdateFile)
+
+	template, err := LoadTemplate(templatefile)
+	if err != nil {
+		return err
+	}
+	filters := extractLogFilters(template)
+
+	services, err := loadDefinitions(servicesfile)
+	if err != nil {
+		return err
+	}
+
+	updates, err := loadUpdates(updatefile)
+	if err != nil {
+		return err
+	}
+
+	migrator := NewMigrationContext(services, filters)
+
+	var migratedServices ServiceList
+	migratedServices, err = migrator.Migrate(updates)
+	if err != nil {
+		return err
+	}
+
+	marshaled, err := json.MarshalIndent(migratedServices, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated services: %s", err)
+	}
+	fmt.Println(string(marshaled))
+
+	return nil
+}
+
+func extractLogFilters(tmpl *template.ServiceTemplate) map[string]logfilter.LogFilter {
+	var queue = []definition.ServiceDefinition{}
+	for _, svc := range tmpl.Services {
+		queue = append(queue, svc)
+	}
+	var svc, child definition.ServiceDefinition
+
+	var filters = make(map[string]logfilter.LogFilter)
+	for len(queue) > 0 {
+		svc, queue = queue[0], queue[1:]
+		for name, value := range svc.LogFilters {
+			filters[name] = logfilter.LogFilter{
+				Name:    name,
+				Filter:  value,
+				Version: tmpl.Version,
+			}
+		}
+		for _, child = range svc.Services {
+			queue = append(queue, child)
+		}
+	}
+	return filters
+}
+
+func loadDefinitions(filepath string) (*ServiceList, error) {
+	var input *os.File
+	var err error
+
+	if input, err = os.Open(filepath); err != nil {
+		return nil, err
+	}
+	defer input.Close()
+
+	var services = NewServiceList()
+	if err = json.NewDecoder(input).Decode(services); err != nil {
+		return nil, fmt.Errorf("Could not read service definitions: %s", err)
+	}
+	return services, nil
+}
+
+func loadUpdates(filepath string) (dao.ServiceMigrationRequest, error) {
+	var input *os.File
+	var err error
+	var updates dao.ServiceMigrationRequest
+
+	if input, err = os.Open(filepath); err != nil {
+		return updates, err
+	}
+	defer input.Close()
+
+	if err = json.NewDecoder(input).Decode(&updates); err != nil {
+		return updates, fmt.Errorf("Could not read service updates: %s", err)
+	}
+
+	return updates, nil
+}

--- a/tools/serviced-service/validate.go
+++ b/tools/serviced-service/validate.go
@@ -1,0 +1,301 @@
+// Copyright 2020 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/control-center/serviced/dao"
+	"github.com/control-center/serviced/domain"
+	// "github.com/control-center/serviced/domain/logfilter"
+	"github.com/control-center/serviced/domain/service"
+	definition "github.com/control-center/serviced/domain/servicedefinition"
+	"github.com/control-center/serviced/utils"
+)
+
+func (mc *MigrationContext) validate(req dao.ServiceMigrationRequest) error {
+	var svcAll []service.Service
+
+	// Validate service updates
+	for _, svc := range req.Modified {
+		if _, err := mc.validateUpdate(svc); err != nil {
+			return err
+		}
+		svcAll = append(svcAll, *svc)
+	}
+
+	// Validate service adds
+	for _, svc := range req.Added {
+		if err := mc.validateAdd(svc); err != nil {
+			return err
+		} else if svc.ID, err = utils.NewUUID36(); err != nil {
+			return err
+		}
+		svcAll = append(svcAll, *svc)
+	}
+
+	// Validate service deployments
+	for _, sdreq := range req.Deploy {
+		err := mc.validateDeployment(sdreq.ParentID, &sdreq.Service)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Validate service migration
+	if err := mc.validateMigration(svcAll, req.ServiceID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateUpdate enforces constraints on the updated Service.
+// The original Service is returned.
+func (mc *MigrationContext) validateUpdate(updated *service.Service) (*service.Service, error) {
+
+	var err error
+	var original *service.Service
+
+	// Verify that the service being updated exists.
+	original, err = mc.services.Get(updated.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the name changed, verify that the new name does not already exist.
+	if updated.Name != original.Name {
+		if err := mc.validateName(updated.Name, updated.ParentServiceID); err != nil {
+			return nil, err
+		}
+	}
+
+	// Set read-only fields
+	updated.CreatedAt = original.CreatedAt
+	updated.DeploymentID = original.DeploymentID
+
+	// remove any BuiltIn enabled monitoring configs
+	metricConfigs := []domain.MetricConfig{}
+	for _, mcfg := range updated.MonitoringProfile.MetricConfigs {
+		if mcfg.ID == "metrics" {
+			continue
+		}
+		metrics := []domain.Metric{}
+		for _, m := range mcfg.Metrics {
+			if !m.BuiltIn {
+				metrics = append(metrics, m)
+			}
+		}
+		mcfg.Metrics = metrics
+		metricConfigs = append(metricConfigs, mcfg)
+	}
+	updated.MonitoringProfile.MetricConfigs = metricConfigs
+
+	graphs := []domain.GraphConfig{}
+	for _, g := range updated.MonitoringProfile.GraphConfigs {
+		if !g.BuiltIn {
+			graphs = append(graphs, g)
+		}
+	}
+	updated.MonitoringProfile.GraphConfigs = graphs
+
+	if err := validateServiceOptions(updated); err != nil {
+		return nil, err
+	}
+
+	return original, nil
+}
+
+// Validates that the service doesn't have invalid options specified.
+func validateServiceOptions(svc *service.Service) error {
+	// ChangeOption RestartAllOnInstanceChanged and HostPolicy RequireSeparate are invalid together.
+	var changeOptions = definition.ChangeOptions(svc.ChangeOptions)
+	if svc.HostPolicy == definition.RequireSeparate &&
+		changeOptions.Contains(definition.RestartAllOnInstanceChanged) {
+		return fmt.Errorf(
+			"HostPolicy RequireSeparate cannot be used with ChangeOption RestartAllOnInstanceChanged",
+		)
+	}
+	return nil
+}
+
+// Ensures the DeploymentID matches the parent's DeploymentID
+func (mc *MigrationContext) validateDeploymentID(svc *service.Service) error {
+	if svc.ParentServiceID != "" {
+		parentSvc, err := mc.services.Get(svc.ParentServiceID)
+		if err != nil {
+			return err
+		}
+		svc.DeploymentID = parentSvc.DeploymentID
+	}
+	return nil
+}
+
+func (mc *MigrationContext) validateName(name string, parentID string) error {
+	existing, err := mc.services.FindChild(parentID, name)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		path, err := mc.services.GetServicePath(name)
+		if err != nil {
+			path = fmt.Sprintf("%v", err)
+		}
+		return fmt.Errorf("Service already exists on path.  path=%s", path)
+	}
+	return nil
+}
+
+func (mc *MigrationContext) validateAdd(svc *service.Service) error {
+	if svc.ParentServiceID == "" {
+		return fmt.Errorf("Cannot add a root service  name=%s", svc.Name)
+	}
+
+	var err error
+
+	// Verify that the service ID does not already exist
+	_, err = mc.services.Get(svc.ID)
+	if err != nil {
+		return err
+	}
+
+	err = mc.validateName(svc.Name, svc.ParentServiceID)
+	if err != nil {
+		return err
+	}
+
+	if err := validateServiceOptions(svc); err != nil {
+		return err
+	}
+
+	// remove any BuiltIn enabled monitoring configs
+	metricConfigs := []domain.MetricConfig{}
+	for _, mc := range svc.MonitoringProfile.MetricConfigs {
+		if mc.ID == "metrics" {
+			continue
+		}
+
+		metrics := []domain.Metric{}
+		for _, m := range mc.Metrics {
+			if !m.BuiltIn {
+				metrics = append(metrics, m)
+			}
+		}
+		mc.Metrics = metrics
+		metricConfigs = append(metricConfigs, mc)
+	}
+	svc.MonitoringProfile.MetricConfigs = metricConfigs
+
+	graphs := []domain.GraphConfig{}
+	for _, g := range svc.MonitoringProfile.GraphConfigs {
+		if !g.BuiltIn {
+			graphs = append(graphs, g)
+		}
+	}
+	svc.MonitoringProfile.GraphConfigs = graphs
+
+	// set service defaults
+	svc.DesiredState = int(service.SVCStop)         // new services must always be stopped
+	svc.CurrentState = string(service.SVCCSStopped) // new services are always stopped
+
+	// manage service configurations
+	if svc.OriginalConfigs == nil || len(svc.OriginalConfigs) == 0 {
+		if svc.ConfigFiles != nil {
+			svc.OriginalConfigs = svc.ConfigFiles
+		} else {
+			svc.OriginalConfigs = make(map[string]definition.ConfigFile)
+		}
+	}
+
+	return nil
+}
+
+// validateDeployment returns the services that will be deployed
+func (mc *MigrationContext) validateDeployment(
+	parentID string, sd *definition.ServiceDefinition,
+) error {
+	var err error
+	var parent *service.Service
+
+	parent, err = mc.services.Get(parentID)
+	if err != nil {
+		return err
+	}
+
+	return deploy(
+		mc.services,
+		mc.services.GetTenantID(),
+		parent.PoolID,
+		parent.DeploymentID,
+		parentID,
+		false,
+		*sd,
+	)
+}
+
+// validateMigration makes sure there are no collisions with the added/modified services.
+func (mc *MigrationContext) validateMigration(svcs []service.Service, tenantID string) error {
+	svcParentMapNameMap := make(map[string]map[string]struct{})
+	endpointMap := make(map[string]string)
+	for _, svc := range svcs {
+		// check for name uniqueness within the set of new/modified/deployed services
+		if svcNameMap, ok := svcParentMapNameMap[svc.ParentServiceID]; ok {
+			if _, ok := svcNameMap[svc.Name]; ok {
+				return fmt.Errorf(
+					"Collision for service name %s and parent %s", svc.Name, svc.ParentServiceID,
+				)
+			}
+			svcParentMapNameMap[svc.ParentServiceID][svc.Name] = struct{}{}
+		} else {
+			svcParentMapNameMap[svc.ParentServiceID] = make(map[string]struct{})
+		}
+
+		// check for endpoint name uniqueness within the set of new/modified/deployed services
+		for _, ep := range svc.Endpoints {
+			if ep.Purpose == "export" {
+				if _, ok := endpointMap[ep.Application]; ok {
+					return fmt.Errorf(
+						"Endpoint %s in migrated service %s is a duplicate of an endpoint in one "+
+							"of the other migrated services",
+						ep.Application, svc.Name,
+					)
+				}
+				endpointMap[ep.Application] = svc.ID
+			}
+		}
+	}
+
+	// Check whether migrated services' endpoints conflict with existing services.
+	var iter = mc.services.Iterator()
+	for iter.Next() {
+		svc := iter.Item()
+		for _, ep := range svc.Endpoints {
+			if ep.Purpose != "export" {
+				continue
+			}
+			newsvcID, ok := endpointMap[ep.Application]
+			if !ok {
+				continue
+			}
+			if newsvcID != svc.ID {
+				return fmt.Errorf(
+					"Endpoint %s in migrated service %s is a duplicate of an endpoint in one "+
+						"of the other migrated services",
+					ep.Application, svc.Name,
+				)
+			}
+		}
+	}
+	return nil
+}

--- a/tools/serviced-service/version.go
+++ b/tools/serviced-service/version.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Serviced Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+)
+
+// ServicedServiceVersion is the versioning command for the application
+type ServicedServiceVersion struct{}
+
+// Execute prints the application version to stdout and exits
+func (c *ServicedServiceVersion) Execute(args []string) error {
+	fmt.Println(App.version)
+	return nil
+}


### PR DESCRIPTION
The serviced-service tool can be used to compile a directory of templates into a single template file, convert a template into service definitions, and apply migrations to service definitions.  This functionality is performed offline without communicating with the serviced server or with an elasticsearch database.