### PR TITLE
CC-4438 Healthcheck status is unknown for some services after RPM upgrade

### DIFF
--- a/pkg/rpm/postinstall
+++ b/pkg/rpm/postinstall
@@ -27,5 +27,8 @@ if ! (python -c "import sys; sys.exit(0 if \"${LIBDEVMAPPER}\".endswith('.1') el
     [ -f "${LIBDEVMAPPER}.1" -o -h "${LIBDEVMAPPER}.1" ] || ln -sf ${LIBDEVMAPPER} ${LIBDEVMAPPER}.1
     ldconfig
 fi
+
+echo fs.inotify.max_user_instances=16384 > /etc/sysctl.d/99-inotify.conf
+echo fs.inotify.max_user_watches=640000 >> /etc/sysctl.d/99-inotify.conf
 echo vm.max_map_count=262144 >> /etc/sysctl.conf
 sysctl --system

--- a/pkg/rpm/postupgrade
+++ b/pkg/rpm/postupgrade
@@ -143,6 +143,11 @@ fi
 
 touch /etc/cron.d/cron_zenossdbpack
 
+echo "Setting higher fs.inotify limits"
+echo fs.inotify.max_user_instances=16384 > /etc/sysctl.d/99-inotify.conf
+echo fs.inotify.max_user_watches=640000 >> /etc/sysctl.d/99-inotify.conf
+sysctl --system
+
 # if preupgrade version of serviced >= 1.8.0 then ES and Zookeeper data
 # don't require migration
 if [[ -f $PREUPGRADE_SERVICED_VER_FILE ]]; then


### PR DESCRIPTION
Increase the fs.inotify limits by writing new limits to /etc/sysctl.d/99-inotify.conf.
If the file already contains limits that are added manually, it will be overridden.