### PR TITLE
CC-4464: fix metrics query and consumer

### DIFF
--- a/isvcs/isvc.go
+++ b/isvcs/isvc.go
@@ -35,7 +35,7 @@ var (
 
 const (
 	IMAGE_REPO         = "zenoss/serviced-isvcs"
-	IMAGE_TAG          = "v72"
+	IMAGE_TAG          = "v73"
 	ZK_IMAGE_REPO      = "zenoss/isvcs-zookeeper"
 	ZK_IMAGE_TAG       = "v16"
 	OTSDB_BT_REPO      = "zenoss/isvcs-metrics-bigtable"


### PR DESCRIPTION
The new versions of central-query and metric-consumer are not compatible with old openTSDB