### PR TITLE
CC-4511: Cloud Snapshot Causing Serviced to Crash on Master Server

### DIFF
--- a/datastore/elastic/connection.go
+++ b/datastore/elastic/connection.go
@@ -205,12 +205,12 @@ func (ec *elasticConnection) elasticGet(id string) (elasticResponse, error) {
 
 	res, err = ec.client.Get(ec.index, id)
 
-	defer res.Body.Close()
-
 	if err != nil {
 		plog.Errorf("Error getting response: %s", err)
 		return retval, err
 	}
+
+	defer res.Body.Close()
 
 	if res.IsError() {
 		var e map[string]interface{}


### PR DESCRIPTION
Panic errors have multiple start points for occurring but the single root cause.
It's easily fixed and could be included in the CC release, without any risk of regression and testing difficulties. 
But please note, the general problem that happens after snapshot action is not only with corrupted code, we won't ever see it while the Elasticsearch connection is ok. It seems, in this case - it isn't, so the issue requires additional info about the health of the CC containers especially the elacticsearch-serviced container and their internal logs while the panic errors are occurring.