### PR TITLE
CC-4559: Set up platform services to use TLS 1.3 version

### DIFF
--- a/utils/tls.go
+++ b/utils/tls.go
@@ -187,6 +187,8 @@ func tlsVersionStringToUint(version string) (uint16, error) {
 		return tls.VersionTLS11, nil
 	case "VERSIONTLS12":
 		return tls.VersionTLS12, nil
+	case "VERSIONTLS13":
+		return tls.VersionTLS13, nil
 	default:
 		return 0, fmt.Errorf("Invalid TLS version %s", version)
 	}


### PR DESCRIPTION
From mac os host and nmap results are: 

```
nmap --script ssl-cert,ssl-enum-ciphers -p 443 10.88.123.185                                                                                                                                                                                                                ✔  took 20s  at 12:46:14 
Starting Nmap 7.95 ( https://nmap.org ) at 2024-10-17 12:46 EEST
Nmap scan report for hbase.master-10-88-123-185 (10.88.123.185)
Host is up (0.24s latency).

PORT    STATE SERVICE
443/tcp open  https
| ssl-enum-ciphers:
|   TLSv1.3:
|     ciphers:
|       TLS_AKE_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
|       TLS_AKE_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
|     cipher preference: server
|_  least strength: A
| ssl-cert: Subject: commonName=zenoss5.master-10-88-123-185/organizationName=Zenoss/stateOrProvinceName=Texas/countryName=US
| Subject Alternative Name: DNS:zenoss5.master-10-88-123-185, DNS:*.zenoss5.master-10-88-123-185
| Issuer: commonName=zenoss5.master-10-88-123-185/organizationName=Zenoss/stateOrProvinceName=Texas/countryName=US
| Public Key type: rsa
| Public Key bits: 4096
| Signature Algorithm: sha256WithRSAEncryption
| Not valid before: 2024-10-17T08:49:50
| Not valid after:  2029-10-16T08:49:50
| MD5:   c985:3822:4d65:49f4:8cc0:5a62:91c5:9f20
|_SHA-1: 33a7:cf76:cbad:fa4e:f9f3:fef7:dd46:2500:29ef:0137

Nmap done: 1 IP address (1 host up) scanned in 4.84 seconds
```
with serviced config: 
```
echo "SERVICED_TLS_MIN_VERSION=VersionTLS13" >> /etc/default/serviced
echo "SERVICED_MUX_TLS_MIN_VERSION=VersionTLS13" >> /etc/default/serviced
echo "SERVICED_RPC_TLS_MIN_VERSION=VersionTLS13" >> /etc/default/serviced
```
